### PR TITLE
Add logic for recognizing jinja code in models

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "duckdb",
         "dateparser",
         "hyperscript",
+        "jinja2",
         "pandas",
         "pydantic",
         "requests",

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -9,6 +9,10 @@ class Model(exp.Expression):
     arg_types = {"expressions": True}
 
 
+class JinjaModel(exp.Expression):
+    """Stores a model file that contains Jinja code as a raw string."""
+
+
 class Audit(exp.Expression):
     arg_types = {"expressions": True}
 

--- a/sqlmesh/utils/jinja.py
+++ b/sqlmesh/utils/jinja.py
@@ -1,0 +1,5 @@
+import re
+
+# Captures one of the following patterns: "{{", "{#", "{%" and "{%-".
+# Q: this will also flag text that contains "{{" inside a string as Jinja. Is this a problem?
+JINJA_RE = re.compile("{({|#|(%(-)?))")


### PR DESCRIPTION
Posting this so I can get some early feedback; I plan to work on / refine it soon. Some points for discussion:

1. Do we want to support jinja in the model's metadata? If not, we might be able to parse just this part of the file in order to use the fields inside `Model.load` (e.g. `name` is needed to instantiate a model).

2. How do we want to handle model validation? As far as I can understand, the plan is to store SQL that may contain jinja as a string (see `JinjaModel`), so validation needs to happen every time we're about to render / execute it? Am I missing something here?

3. What about jinja context? Do we already have a rough plan of where we'll store the needed information to render correctly?

By the way, a simple way I found to render jinja code from a string is the following (for reference):

```python
>>> from jinja2 import Environment, BaseLoader
>>> template = Environment(loader=BaseLoader).from_string("Hello {{ name }}")
>>> rtemplate.render(**{"name": "foo"})
'Hello foo'
```


I'm happy to follow a different direction if this doesn't make much sense.