### PR TITLE
Don't display empty intervals

### DIFF
--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -143,6 +143,8 @@ class Scheduler:
 
         dag = DAG[SchedulingUnit]()
         for snapshot, intervals in batches:
+            if not intervals:
+                continue
             upstream_dependencies = [
                 (p_sid, interval)
                 for p_sid in snapshot.parents
@@ -158,8 +160,7 @@ class Scheduler:
             sid = snapshot.snapshot_id
             for interval in intervals:
                 dag.add((sid, interval), upstream_dependencies)
-            if intervals:
-                self.console.start_snapshot_progress(snapshot.name, len(intervals))
+            self.console.start_snapshot_progress(snapshot.name, len(intervals))
 
         def evaluate_node(node: SchedulingUnit) -> None:
             assert latest


### PR DESCRIPTION
Currently if a change has upstream dependencies then we display them in the progress update even though they aren't affected by the backfill. This fix simply says we only want to display progress for models if they are intervals associated with it. 
Before:
<img width="994" alt="Screenshot 2022-12-28 at 3 51 28 PM" src="https://user-images.githubusercontent.com/6326532/210012192-3c970e4d-192e-4fcb-bb93-b8b9a91e8ec6.png">
After: 
<img width="886" alt="Screenshot 2022-12-29 at 1 20 27 PM" src="https://user-images.githubusercontent.com/6326532/210012222-864329bd-ce82-4fa9-9942-6fbf33605b5f.png">

