### PR TITLE
Convert kind to uppercase when formatting

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -483,7 +483,6 @@ def extend_sqlglot() -> None:
                     MacroVar: lambda self, e: f"@{e.name}",
                     Model: _model_sql,
                     ModelKind: _model_kind_sql,
-                    Jinja: lambda self, e: e.name,
                     PythonCode: lambda self, e: self.expressions(e),
                 }
             )

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -71,24 +71,6 @@ SELECT
   p + 1"""
     )
 
-    x = format_model_expressions(
-        parse_model(
-            """
-            MODEL(name a.b, kind FULL);
-
-            SELECT * FROM x WHERE y = {{ 1 }} ;"""
-        )
-    )
-    assert (
-        x
-        == """MODEL (
-  name a.b,
-  kind FULL
-);
-
-SELECT * FROM x WHERE y = {{ 1 }} ;"""
-    )
-
 
 def test_macro_format():
     assert parse_one("@EACH(ARRAY(1,2), x -> x)").sql() == "@EACH(ARRAY(1, 2), x -> x)"


### PR DESCRIPTION
This should be almost done, but there's a problem in `test_parse_model` I'm trying to resolve:

```python
assert isinstance(Model.parse_raw(model.json()).query, Jinja)
```

The query we get after `parse_raw` seems to have type `exp.Select`:

```python
        print(type(Model.parse_raw(model.json()).query))
>       assert 0 == 1
E       assert 0 == 1

tests/core/test_model.py:654: AssertionError
------------------------------------------------------------- Captured stdout call --------------------------------------------------------------
<class 'sqlglot.expressions.Select'>
```

Is this behavior expected?
