### PR TITLE
If a forward-only snapshot is unpaused use a production table name when construcing a table mapping for a child

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -380,7 +380,7 @@ class SnapshotEvaluator:
         if not snapshot.is_materialized or snapshot.is_new_version:
             return
 
-        tmp_table_name = snapshot.table_name(is_dev=True, for_read=True)
+        tmp_table_name = snapshot.table_name(is_dev=True)
         target_table_name = snapshot.table_name()
 
         schema_deltas = self._schema_diff_calculator.calculate(

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -299,6 +299,8 @@ def test_table_name(snapshot: Snapshot):
     assert snapshot.table_name(is_dev=True, for_read=False) == "sqlmesh.name__1_1"
     assert snapshot.table_name(is_dev=False, for_read=True) == "sqlmesh.name__1_1"
     assert snapshot.table_name(is_dev=True, for_read=True) == "sqlmesh.name__1_1"
+    assert snapshot.table_name_for_mapping(is_dev=False) == "sqlmesh.name__1_1"
+    assert snapshot.table_name_for_mapping(is_dev=True) == "sqlmesh.name__1_1"
 
     # Mimic an indirect non-breaking change.
     previous_data_version = snapshot.data_version
@@ -308,6 +310,8 @@ def test_table_name(snapshot: Snapshot):
     assert snapshot.table_name(is_dev=True, for_read=False) == "sqlmesh.name__1_2__temp"
     assert snapshot.table_name(is_dev=False, for_read=True) == "sqlmesh.name__1_1"
     assert snapshot.table_name(is_dev=True, for_read=True) == "sqlmesh.name__1_1"
+    assert snapshot.table_name_for_mapping(is_dev=False) == "sqlmesh.name__1_1"
+    assert snapshot.table_name_for_mapping(is_dev=True) == "sqlmesh.name__1_1"
 
     # Mimic a direct forward-only change.
     snapshot.fingerprint = "2_1"
@@ -316,3 +320,14 @@ def test_table_name(snapshot: Snapshot):
     assert snapshot.table_name(is_dev=True, for_read=False) == "sqlmesh.name__2_1__temp"
     assert snapshot.table_name(is_dev=False, for_read=True) == "sqlmesh.name__1_1"
     assert snapshot.table_name(is_dev=True, for_read=True) == "sqlmesh.name__2_1__temp"
+    assert snapshot.table_name_for_mapping(is_dev=False) == "sqlmesh.name__1_1"
+    assert snapshot.table_name_for_mapping(is_dev=True) == "sqlmesh.name__2_1__temp"
+
+    # Mimic a propmoted forward-only snapshot.
+    snapshot.set_unpaused_ts(to_datetime("2022-01-01"))
+    assert snapshot.table_name(is_dev=False, for_read=False) == "sqlmesh.name__1_1"
+    assert snapshot.table_name(is_dev=True, for_read=False) == "sqlmesh.name__2_1__temp"
+    assert snapshot.table_name(is_dev=False, for_read=True) == "sqlmesh.name__1_1"
+    assert snapshot.table_name(is_dev=True, for_read=True) == "sqlmesh.name__2_1__temp"
+    assert snapshot.table_name_for_mapping(is_dev=False) == "sqlmesh.name__1_1"
+    assert snapshot.table_name_for_mapping(is_dev=True) == "sqlmesh.name__1_1"


### PR DESCRIPTION
Unfortunately I couldn't implement this within the `def table_name` itself because it's also a part of the `SnapshotTableInfo` which must remain immutable, while the new logic relies on the current state of a snapshot (whether it's paused or unpaused) which may change at some point in future.