### PR TITLE
Check if a non-forward-only snapshot has paused forward-only parents during evaluation

### DIFF
--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -121,7 +121,7 @@ def test_paused_forward_only_parent(make_snapshot, mocker: MockerFixture):
 
     with pytest.raises(
         PlanError,
-        match=r"Modified model 'b' depends on a paused version of model 'a'.*",
+        match=r"Model 'b' depends on a paused version of model 'a'.*",
     ):
         Plan(context_diff_mock, dag, state_reader_mock, forward_only=False)
 


### PR DESCRIPTION
I could think of another edge case which involves forward-only snapshots. 

Even though we check whether a forward-only parent snapshot is paused during plan creation, there can be a multitude of scenarios when a parent is unpaused during plan creation but becomes paused later during evaluation. This PR fixes the issue by always checking this invariant during snapshot evaluation.