### PR TITLE
Set black min supported version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,9 @@ repos:
       - id: black
         name: black
         language: system
+        args:
+          - --target-version
+          - py37
         entry: black
         require_serial: true
         files: *files

--- a/sqlmesh/schedulers/airflow/operators/targets.py
+++ b/sqlmesh/schedulers/airflow/operators/targets.py
@@ -124,7 +124,7 @@ class SnapshotEvaluationTarget(
         self,
         context: Context,
         session: Session = util.PROVIDED_SESSION,
-        **kwargs: t.Any
+        **kwargs: t.Any,
     ) -> None:
         VariableStateSync(session).add_interval(
             self.snapshot.snapshot_id,
@@ -236,7 +236,7 @@ class SnapshotTableCleanupTarget(
         self,
         context: Context,
         session: Session = util.PROVIDED_SESSION,
-        **kwargs: t.Any
+        **kwargs: t.Any,
     ) -> None:
         _delete_xcom(
             common.SNAPSHOT_TABLE_CLEANUP_XCOM_KEY,


### PR DESCRIPTION
Black has a way of letting it know what min version we support to make sure our output is not only compatible but will also support those language features and above. Probably won't matter much but just adding it in case. 