### PR TITLE
Fix CLI: enable --help without requiring context instantiation

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import typing as t
 
 import click
@@ -42,6 +43,10 @@ def cli(
     path = os.path.abspath(path)
     if ctx.invoked_subcommand == "init":
         ctx.obj = path
+        return
+
+    # Delegates the execution of the --help option to the corresponding subcommand
+    if "--help" in sys.argv:
         return
 
     context = Context(


### PR DESCRIPTION
Before:

```zsh
➜  sqlmesh git:(main) ✗ sqlmesh plan --help
Error: SQLMesh config could not be found. Point the cli to the right path with `sqlmesh --path`. If you haven't set up SQLMesh, run `sqlmesh init`.
```

After:

```zsh
➜  sqlmesh git:(fix_cli_help) sqlmesh plan --help
Usage: sqlmesh plan [OPTIONS] [ENVIRONMENT]

  Plan a migration of the current context's models with the given environment.

Options:
  -s, --start TEXT          The start datetime of the interval for which this
                            command will be applied.
  -e, --end TEXT            The end datetime of the interval for which this
                            command will be applied.
  -f, --from TEXT           The environment to base the plan on rather than
                            local files.
  --skip-tests TEXT         Skip tests prior to generating the plan if they
                            are defined.
  -r, --restate-model TEXT  Restate data for specified models and models
                            downstream from the one specified. For production
                            environment, all related model versions will have
                            their intervals wiped, but only the current
                            versions will be backfilled. For development
                            environment, only the current model versions will
                            be affected.
  --no-gaps                 Ensure that new snapshots have no data gaps when
                            comparing to existing snapshots for matching
                            models in the target environment.
  --skip-backfill           Skip the backfill step.
  --forward-only            Create a plan for forward-only changes.
  --no-prompts              Disable interactive prompts for the backfill time
                            range. Please note that if this flag is set and
                            there are uncategorized changes, plan creation
                            will fail.
  --auto-apply              Automatically apply the new plan after creation.
  --help                    Show this message and exit.
```