### PR TITLE
"Improve" Databricks Notebook Experience

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -113,7 +113,7 @@ class Console(abc.ABC):
 class TerminalConsole(Console):
     """A rich based implementation of the console"""
 
-    def __init__(self, console: t.Optional[RichConsole] = None) -> None:
+    def __init__(self, console: t.Optional[RichConsole] = None, **kwargs: t.Any) -> None:
         self.console: RichConsole = console or srich.console
         self.progress: t.Optional[Progress] = None
         self.tasks: t.Dict[str, t.Tuple[TaskID, int]] = {}
@@ -435,10 +435,12 @@ class NotebookMagicConsole(TerminalConsole):
     or capturing it and converting it into a widget.
     """
 
-    def __init__(self, display: t.Callable, console: t.Optional[RichConsole] = None) -> None:
+    def __init__(
+        self, display: t.Callable, console: t.Optional[RichConsole] = None, **kwargs: t.Any
+    ) -> None:
         import ipywidgets as widgets
 
-        super().__init__(console)
+        super().__init__(console, **kwargs)
         self.display = display
         self.missing_dates_output = widgets.Output()
         self.dynamic_options_after_categorization_output = widgets.VBox()
@@ -663,7 +665,7 @@ class DatabricksMagicConsole(TerminalConsole):
         return super()._confirm("", **kwargs)
 
 
-def get_console() -> TerminalConsole | DatabricksMagicConsole | NotebookMagicConsole:
+def get_console(**kwargs: t.Any) -> TerminalConsole | DatabricksMagicConsole | NotebookMagicConsole:
     """
     Returns the console that is appropriate for the current runtime environment.
 
@@ -678,4 +680,4 @@ def get_console() -> TerminalConsole | DatabricksMagicConsole | NotebookMagicCon
         RuntimeEnv.TERMINAL: TerminalConsole,
         RuntimeEnv.GOOGLE_COLAB: NotebookMagicConsole,
     }
-    return runtime_env_mapping[runtime_env]()
+    return runtime_env_mapping[runtime_env](**kwargs)

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -226,7 +226,7 @@ class SQLMeshMagics(Magics):
 
         # Since the magics share a context we want to clear out any state before generating a new plan
         console = self._context.console
-        self._context.console = get_console()
+        self._context.console = get_console(display=self.display)
 
         self._context.plan(
             args.environment,


### PR DESCRIPTION
Currently Databricks notebooks have a problem where after 5 minutes of applying a plan the progress bars stop updating. To the user there is no longer a visual indicating of what (if anything) is happening. It seems unacceptable to me. 

This solution solves this by having the plan application itself run in the main databricks thread. As a result databricks recognizes that it is running the whole time the plan is applying you will see it finish the different stages at the top of the cell. It also means that you know when it has finished or not based on when the cell is done running. The downside though is that: 
1. The UI now uses the CLI UI (since we can't use callbacks) and therefore it is a lot more clunky to use
2. Progress bars for the individual models no longer work at all at the bottom of the plan

For now it feels like we are picking our poison here but being able to know that the plan is running or not, and see spark stage updates as it executes, is a much better experience than not knowing what is happening at all even if that means a clunky UI. 
<img width="793" alt="Screenshot 2023-02-16 at 6 48 17 PM" src="https://user-images.githubusercontent.com/6326532/219537252-77fa2ce0-2f6e-47bc-8e80-1d43077908aa.png">
