### PR TITLE
Add state sync reset

### DIFF
--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -179,6 +179,12 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
             )
         }
 
+    def reset(self) -> None:
+        """Resets the state store to the state when it was first initialized."""
+        self.engine_adapter.drop_table(self.snapshots_table)
+        self.engine_adapter.drop_table(self.environments_table)
+        self.init_schema()
+
     def _update_environment(self, environment: Environment) -> None:
         self.engine_adapter.delete_from(
             self.environments_table,


### PR DESCRIPTION
Figured it would make sense to add a public api endpoint for doing this reset. Example Airflow DAG: 
```python
import airflow
from airflow.models import DAG
from airflow.operators.python import PythonOperator

from sqlmesh.schedulers.airflow.util import scoped_state_sync


dag = DAG(
    dag_id="reset_sqlm_state",
    schedule_interval=None,
    start_date=airflow.utils.dates.days_ago(0),
)


def reset_sqlm_state():
    with scoped_state_sync() as state_sync:
        state_sync.reset()


reset_task = PythonOperator(
    task_id="reset_sqlm_state",
    python_callable=reset_sqlm_state,
    provide_context=True,
    dag=dag,
)
```