### PR TITLE
In Jinja Macro Registry parse individual macros instead of whole packages

### DIFF
--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -55,6 +55,10 @@ class UniqueKeyDict(dict, t.Mapping[KEY, VALUE]):
         super().__setitem__(k, v)
 
 
+class AttributeDict(dict, t.Mapping[KEY, VALUE]):
+    __getattr__ = dict.__getitem__
+
+
 class registry_decorator:
     """A decorator that registers itself."""
 

--- a/tests/utils/test_jinja.py
+++ b/tests/utils/test_jinja.py
@@ -41,6 +41,24 @@ macro_b_b
     ]
 
 
+def test_macro_registry_render_nested_self_package_references():
+    package_a = """
+{% macro macro_a_a() %}macro_a_a{% endmacro %}
+
+{% macro macro_a_b() %}{{ package_a.macro_a_a() }}{% endmacro %}
+
+{% macro macro_a_c() %}{{ package_a.macro_a_b() }}{% endmacro %}
+"""
+
+    extractor = MacroExtractor()
+    registry = JinjaMacroRegistry()
+
+    registry.add_macros(extractor.extract(package_a), package="package_a")
+
+    rendered = registry.build_environment().from_string("{{ package_a.macro_a_c() }}").render()
+    assert rendered == "macro_a_a"
+
+
 def test_macro_registry_render_different_vars():
     package_a = "{% macro macro_a_a() %}{{ external() }}{% endmacro %}"
 


### PR DESCRIPTION
I found a condition which my previous approach couldn't handle. It would fail if there is more than one nested call that have a self-package reference. Please see the new test case for more details.

With the new approach we handle each macro individually instead of attempting to parse them all at once into a single template.