### PR TITLE
Add support for private Jinja macros to the JinjamMacroRegistry

### DIFF
--- a/tests/utils/test_jinja.py
+++ b/tests/utils/test_jinja.py
@@ -64,6 +64,22 @@ def test_macro_registry_render_nested_self_package_references():
     assert rendered == "macro_a_a"
 
 
+def test_macro_registry_render_private_macros():
+    package_a = """
+{% macro _macro_a_a(flag) %}{% if not flag %}macro_a_a{% else %}{{ _macro_a_a(False) }}{% endif %}{% endmacro %}
+
+{% macro macro_a_b() %}{{ package_a._macro_a_a(True) }}{% endmacro %}
+"""
+
+    extractor = MacroExtractor()
+    registry = JinjaMacroRegistry()
+
+    registry.add_macros(extractor.extract(package_a), package="package_a")
+
+    rendered = registry.build_environment().from_string("{{ package_a.macro_a_b() }}").render()
+    assert rendered == "macro_a_a"
+
+
 def test_macro_registry_render_different_vars():
     package_a = "{% macro macro_a_a() %}{{ external() }}{% endmacro %}"
 


### PR DESCRIPTION
This is to support "private" macro definitions which are used in `dbt_utils`. The fix was necessary due to:

> If a macro name starts with an underscore, it’s not exported and can’t be imported.

https://jinja.palletsprojects.com/en/3.1.x/templates/#macros
