### PR TITLE
Add support for various DBT macros

### DIFF
--- a/sqlmesh/dbt/__init__.py
+++ b/sqlmesh/dbt/__init__.py
@@ -1,1 +1,1 @@
-from sqlmesh.dbt.builtin import create_builtins
+from sqlmesh.dbt.builtin import create_builtin_filters, create_builtin_globals

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -22,7 +22,7 @@ from sqlmesh.core.model import (
     create_sql_model,
 )
 from sqlmesh.dbt.adapter import ParsetimeAdapter
-from sqlmesh.dbt.builtin import create_builtins
+from sqlmesh.dbt.builtin import create_builtin_globals
 from sqlmesh.dbt.column import (
     ColumnConfig,
     column_descriptions_to_sqlmesh,
@@ -347,7 +347,7 @@ class ModelSqlRenderer:
         self._rendered_sql: t.Optional[str] = None
         self._enriched_config: ModelConfig = config.copy()
 
-        self._jinja_globals = create_builtins(
+        self._jinja_globals = create_builtin_globals(
             jinja_macros=context.jinja_macros,
             jinja_globals={
                 **context.jinja_globals,

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from IPython.core.display import HTML, display
 from IPython.core.magic import Magics, line_cell_magic, line_magic, magics_class
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
+from ruamel.yaml import YAML
 
 from sqlmesh.core.console import get_console
 from sqlmesh.core.context import Context
@@ -15,7 +16,6 @@ from sqlmesh.core.test import ModelTestMetadata, get_all_model_tests
 from sqlmesh.utils.errors import MagicError, MissingContextException, SQLMeshError
 from sqlmesh.utils.yaml import dumps as yaml_dumps
 from sqlmesh.utils.yaml import load as yaml_load
-from sqlmesh.utils.yaml import yaml
 
 CONTEXT_VARIABLE_NAMES = [
     "context",
@@ -154,7 +154,7 @@ class SQLMeshMagics(Magics):
             content = yaml_load(file.read())
             content[args.test_name] = test_def
             file.seek(0)
-            yaml.dump(content, file)
+            YAML().dump(content, file)
             file.truncate()
 
     @magic_arguments()

--- a/sqlmesh/utils/yaml.py
+++ b/sqlmesh/utils/yaml.py
@@ -11,15 +11,13 @@ from ruamel.yaml import YAML, CommentedMap
 from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.jinja import ENVIRONMENT
 
-yaml = YAML()
-
 JINJA_METHODS = {
     "env_var": lambda key, default=None: getenv(key, default),
 }
 
 
 def load(
-    source: str | Path, raise_if_empty: bool = True, render_jinja: t.Optional[bool] = True
+    source: str | Path, raise_if_empty: bool = True, render_jinja: bool = True
 ) -> t.OrderedDict:
     """Loads a YAML object from either a raw string or a file."""
     path: t.Optional[Path] = None
@@ -32,7 +30,7 @@ def load(
     if render_jinja:
         source = ENVIRONMENT.from_string(source).render(JINJA_METHODS)
 
-    contents = yaml.load(source)
+    contents = YAML().load(source)
     if contents is None:
         if raise_if_empty:
             error_path = f" '{path}'" if path else ""
@@ -45,5 +43,5 @@ def load(
 def dumps(value: CommentedMap | OrderedDict) -> str:
     """Dumps a ruamel.yaml loaded object and converts it into a string"""
     result = io.StringIO()
-    yaml.dump(value, result)
+    YAML().dump(value, result)
     return result.getvalue()

--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -18,8 +18,7 @@ def test_yaml() -> None:
       password: "{{ env_var('__SQLMESH_TEST_ENV_PASSWORD__') }}"
 """
 
-    # Without Jinja rendering (uses ruamel.yaml.YAML methods directly)
-    assert contents == yaml.dumps(yaml.yaml.load(contents))
+    assert contents == yaml.dumps(yaml.load(contents, render_jinja=False))
 
     expected_contents = """profile:
   target: prod


### PR DESCRIPTION
This PR adds support for the following DBT macros and filters:
- adapter.create_schema
- adapter.drop_schema
- adapter.drop_relation
- as_bool
- as_native
- as_number
- as_text
- builtins
- fromjson
- fromyaml
- set
- set_strict
- tojson
- toyaml
- zip
- zip_strict