### PR TITLE
Cache the Jinja Environment instance in DBT context

### DIFF
--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -306,17 +306,14 @@ def create_builtin_globals(
     if variables is not None:
         builtin_globals["var"] = generate_var(variables)
 
-    builtin_globals.update(
-        {
-            **jinja_globals,
-            "builtins": AttributeDict(
-                {k: builtin_globals.get(k) for k in ("ref", "source", "config")}
-            ),
-        }
+    builtin_globals["builtins"] = AttributeDict(
+        {k: builtin_globals.get(k) for k in ("ref", "source", "config")}
     )
 
     if engine_adapter is not None:
-        adapter = RuntimeAdapter(engine_adapter, jinja_macros, jinja_globals=builtin_globals)
+        adapter = RuntimeAdapter(
+            engine_adapter, jinja_macros, jinja_globals={**builtin_globals, **jinja_globals}
+        )
         sql_execution = SQLExecution(adapter)
         builtin_globals.update(
             {

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -54,7 +54,7 @@ class DbtLoader(Loader):
         context = project.context.copy()
 
         for package_name, package in project.packages.items():
-            context.variables.update(package.variables)
+            context.add_variables(package.variables)
             context.add_models(package.models)
             context.add_seeds(package.seeds)
             context.add_sources(package.sources)

--- a/sqlmesh/dbt/profile.py
+++ b/sqlmesh/dbt/profile.py
@@ -92,7 +92,7 @@ class Profile:
         default_target = context.render(project_data.get("target"))
         if default_target not in targets:
             raise ConfigError(
-                f"Default target '#{default_target}' not specified in profiles for Project '{context.project_name}'."
+                f"Default target '{default_target}' not specified in profiles for Project '{context.project_name}'."
             )
 
         return (targets, default_target)

--- a/sqlmesh/dbt/target.py
+++ b/sqlmesh/dbt/target.py
@@ -202,7 +202,6 @@ class RedshiftConfig(TargetConfig):
             port=self.port,
             sslmode=self.sslmode,
             timeout=self.connect_timeout,
-            tcp_keepalive=self.keepalives_idle,
             concurrent_tasks=self.threads,
         )
 

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -56,7 +56,7 @@ class UniqueKeyDict(dict, t.Mapping[KEY, VALUE]):
 
 
 class AttributeDict(dict, t.Mapping[KEY, VALUE]):
-    __getattr__ = dict.__getitem__
+    __getattr__ = dict.get
 
 
 class registry_decorator:

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -39,6 +39,7 @@ def test_adapter_dispatch(sushi_dbt_project: Project):
 
     assert context.engine_adapter
     context.engine_adapter.dialect = "unknown"
+    context._jinja_environment = None
     assert context.render("{{ adapter.dispatch('current_engine', 'customers')() }}") == "default"
 
     with pytest.raises(ConfigError, match=r"Macro 'current_engine'.*was not found."):


### PR DESCRIPTION
This change slashes the load runtime for one of reference DBT projects from ~2 minutes 50 seconds down to ~2minutes 20 seconds.