### PR TITLE
Start working on auto-deployment of API docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
             git commit -m "CI: Auto-generated documentation" -a | exit 0
       - run:
           name: Deploy API Documentation
+          command: |
             GITHUB_TOKEN="$GITHUB_TOKEN" \
             git push origin main
 


### PR DESCRIPTION
I tried to replicate what we do in SQLGlot for auto-deployment of API docs, but I'm not sure if this will work for CircleCI. The code is currently commented on purpose, until we figure out the right way to do this.

In SQLGlot, we use the github actions bot and `secrets.GITHUB_TOKEN` for authenticating the auto-push to main, but based on some links I found it seems like CircleCI uses a different authentication scheme.

cc: @izeigerman @tobymao 

- https://blog.jdblischak.com/posts/circleci-ssh/
- https://medium.com/@praveena.vennakula/github-circleci-authentication-ef1e85d24b0

Fixes #408