### PR TITLE
fix: Drop columns before adding columns when altering table in Spark

### DIFF
--- a/sqlmesh/core/engine_adapter/base_spark.py
+++ b/sqlmesh/core/engine_adapter/base_spark.py
@@ -82,6 +82,16 @@ class BaseSparkEngineAdapter(EngineAdapter):
     ) -> None:
         alter_table = exp.AlterTable(this=exp.to_table(table_name))
 
+        if dropped_columns:
+            drop_columns = exp.Drop(
+                this=exp.Schema(
+                    expressions=[exp.to_identifier(column_name) for column_name in dropped_columns]
+                ),
+                kind="COLUMNS",
+            )
+            alter_table.set("actions", [drop_columns])
+            self.execute(alter_table)
+
         if added_columns:
             add_columns = exp.Schema(
                 expressions=[
@@ -93,16 +103,6 @@ class BaseSparkEngineAdapter(EngineAdapter):
                 ],
             )
             alter_table.set("actions", [add_columns])
-            self.execute(alter_table)
-
-        if dropped_columns:
-            drop_columns = exp.Drop(
-                this=exp.Schema(
-                    expressions=[exp.to_identifier(column_name) for column_name in dropped_columns]
-                ),
-                kind="COLUMNS",
-            )
-            alter_table.set("actions", [drop_columns])
             self.execute(alter_table)
 
     def _create_table_properties(

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -59,8 +59,8 @@ def test_alter_table(mocker: MockerFixture):
     cursor_mock.execute.assert_has_calls(
         [
             # 1st call.
-            call("""ALTER TABLE `test_table` ADD COLUMNS (`a` INT, `b` STRING)"""),
             call("""ALTER TABLE `test_table` DROP COLUMNS (`c`, `d`)"""),
+            call("""ALTER TABLE `test_table` ADD COLUMNS (`a` INT, `b` STRING)"""),
             # 2nd call.
             call("""ALTER TABLE `test_table` ADD COLUMNS (`e` DOUBLE)"""),
             # 3d call.


### PR DESCRIPTION
@crericha I suddenly realized there was one more place where the order of column alteration was incorrect.