### PR TITLE
[DBT] Capture all config fields before rendering them

### DIFF
--- a/sqlmesh/core/config/base.py
+++ b/sqlmesh/core/config/base.py
@@ -123,6 +123,7 @@ class BaseConfig(PydanticModel):
             else:
                 updated_fields[field] = getattr(other, field)
 
+        # Assign each field to trigger assignment validators
         updated = self.copy()
         for field, value in updated_fields.items():
             setattr(updated, field, value)

--- a/sqlmesh/core/config/base.py
+++ b/sqlmesh/core/config/base.py
@@ -123,4 +123,8 @@ class BaseConfig(PydanticModel):
             else:
                 updated_fields[field] = getattr(other, field)
 
-        return self.copy(update=updated_fields)
+        updated = self.copy()
+        for field, value in updated_fields.items():
+            setattr(updated, field, value)
+
+        return updated

--- a/sqlmesh/dbt/basemodel.py
+++ b/sqlmesh/dbt/basemodel.py
@@ -142,19 +142,15 @@ class BaseModelConfig(GeneralConfig):
 
     @property
     def all_sql(self) -> SqlStr:
-        return SqlStr("\n".join([self.hook_sql, self.sql_no_config]))
+        return SqlStr("\n".join(self.pre_hook + [self.sql_no_config] + self.post_hook))
 
     @property
     def sql_no_config(self) -> SqlStr:
         return SqlStr("")
 
     @property
-    def sql_config(self) -> SqlStr:
+    def sql_embedded_config(self) -> SqlStr:
         return SqlStr("")
-
-    @property
-    def hook_sql(self) -> SqlStr:
-        return SqlStr("\n".join(self.pre_hook + self.post_hook))
 
     @property
     def table_schema(self) -> str:
@@ -352,7 +348,9 @@ class ModelSqlRenderer(t.Generic[BMC]):
 
             return self.jinja_env.from_string(nodes.Template([nodes.Output([node])])).render()
 
-        for call in self.jinja_env.parse(self._enriched_config.sql_config).find_all(nodes.Call):
+        for call in self.jinja_env.parse(self._enriched_config.sql_embedded_config).find_all(
+            nodes.Call
+        ):
             if not isinstance(call.node, nodes.Name) or call.node.name != "config":
                 continue
             config = config.update_with(

--- a/sqlmesh/dbt/basemodel.py
+++ b/sqlmesh/dbt/basemodel.py
@@ -274,7 +274,6 @@ class ModelSqlRenderer(t.Generic[BMC]):
         self.config = config
 
         self._captured_dependencies: Dependencies = Dependencies()
-        self._captured_config: t.Optional[str] = None
         self._rendered_sql: t.Optional[str] = None
         self._enriched_config: BMC = config.copy()
         self._parsed_sql: t.Optional[nodes.Template] = None
@@ -284,12 +283,12 @@ class ModelSqlRenderer(t.Generic[BMC]):
             jinja_globals={
                 **context.jinja_globals,
                 **date_dict(c.EPOCH, c.EPOCH, c.EPOCH),
+                "config": lambda *args, **kwargs: "",
                 "ref": self._ref,
                 "var": self._var,
                 "source": self._source,
                 "this": self.config.relation_info,
                 "schema": self.config.table_schema,
-                "config": lambda *args, **kwargs: "",
             },
             engine_adapter=None,
         )

--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -143,10 +143,6 @@ def no_log(msg: str, info: bool = False) -> str:
     return ""
 
 
-def config(*args: t.Any, **kwargs: t.Any) -> str:
-    return ""
-
-
 def generate_var(variables: t.Dict[str, t.Any]) -> t.Callable:
     def var(name: str, default: t.Optional[str] = None) -> str:
         return variables.get(name, default)
@@ -252,7 +248,6 @@ def _try_literal_eval(value: str) -> t.Any:
 
 BUILTIN_GLOBALS = {
     "api": Api(),
-    "config": config,
     "env_var": env_var,
     "exceptions": Exceptions(),
     "flags": Flags(),

--- a/sqlmesh/dbt/common.py
+++ b/sqlmesh/dbt/common.py
@@ -190,6 +190,7 @@ class DbtConfig(PydanticModel):
     class Config:
         extra = "allow"
         allow_mutation = True
+        validate_assignment = True
 
 
 class GeneralConfig(DbtConfig, BaseConfig):
@@ -285,7 +286,9 @@ class GeneralConfig(DbtConfig, BaseConfig):
 
         rendered = self.copy(deep=True)
         for name in rendered.__fields__:
-            setattr(rendered, name, render_value(getattr(rendered, name)))
+            value = getattr(rendered, name)
+            if value is not None:
+                setattr(rendered, name, render_value(value))
 
         return rendered
 

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -77,7 +77,7 @@ class ModelConfig(BaseModelConfig):
     bind: t.Optional[bool] = None
 
     # Private fields
-    _sql_config: t.Optional[SqlStr] = None
+    _sql_embedded_config: t.Optional[SqlStr] = None
     _sql_no_config: t.Optional[SqlStr] = None
 
     @validator(
@@ -168,11 +168,11 @@ class ModelConfig(BaseModelConfig):
         return self._sql_no_config
 
     @property
-    def sql_config(self) -> SqlStr:
-        if self._sql_config is None:
-            self._sql_config = SqlStr("")
+    def sql_embedded_config(self) -> SqlStr:
+        if self._sql_embedded_config is None:
+            self._sql_embedded_config = SqlStr("")
             self._extract_sql_config()
-        return self._sql_config
+        return self._sql_embedded_config
 
     def _extract_sql_config(self) -> None:
         def jinja_end(sql: str, start: int) -> int:
@@ -196,8 +196,10 @@ class ModelConfig(BaseModelConfig):
             if start == -1:
                 continue
             extracted = self._sql_no_config[start : jinja_end(self._sql_no_config, start)]
-            self._sql_config = SqlStr(
-                "\n".join([self._sql_config, extracted]) if self._sql_config else extracted
+            self._sql_embedded_config = SqlStr(
+                "\n".join([self._sql_embedded_config, extracted])
+                if self._sql_embedded_config
+                else extracted
             )
             self._sql_no_config = SqlStr(self._sql_no_config.replace(extracted, "").strip())
 

--- a/sqlmesh/dbt/source.py
+++ b/sqlmesh/dbt/source.py
@@ -50,6 +50,9 @@ class SourceConfig(GeneralConfig):
 
     @validator("columns", pre=True)
     def _validate_columns(cls, v: t.Any) -> t.Dict[str, ColumnConfig]:
+        if not isinstance(v, dict) or all(isinstance(col, ColumnConfig) for col in v.values()):
+            return v
+
         return yaml_to_columns(v)
 
     _FIELD_UPDATE_STRATEGY: t.ClassVar[t.Dict[str, UpdateStrategy]] = {

--- a/sqlmesh/utils/jinja.py
+++ b/sqlmesh/utils/jinja.py
@@ -121,7 +121,7 @@ def call_name(node: nodes.Expr) -> t.Tuple[str, ...]:
 
 
 def render_jinja(query: str, methods: t.Optional[t.Dict[str, t.Any]] = None) -> str:
-    return ENVIRONMENT.from_string(query).render(methods)
+    return ENVIRONMENT.from_string(query).render(methods or {})
 
 
 def find_call_names(node: nodes.Node, vars_in_scope: t.Set[str]) -> t.Iterator[t.Tuple[str, ...]]:

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -142,7 +142,7 @@ def test_model_config_sql_no_config():
 query"""
         )
         .render_config(context)
-        .sql.strip()
+        .sql_no_config.strip()
         == "query"
     )
 
@@ -159,7 +159,7 @@ query"""
 query"""
         )
         .render_config(context)
-        .sql.strip()
+        .sql_no_config.strip()
         == "query"
     )
 
@@ -168,7 +168,7 @@ query"""
             sql="""before {{config(materialized='table', post_hook=" {{ var('new') }} ")}} after"""
         )
         .render_config(context)
-        .sql.strip()
+        .sql_no_config.strip()
         == "before  after"
     )
 

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -212,6 +212,15 @@ def test_config_containing_jinja():
     assert sqlmesh_model.columns_to_types == column_types_to_sqlmesh(rendered.columns)
 
 
+def test_config_containing_method():
+    context = DbtContext()
+    context.jinja_macros.global_objs.update({"get_table_name": lambda: "foo"})
+    model = ModelConfig(sql="{{ config(alias=get_table_name()) }} SELECT 1 FROM a")
+
+    rendered = model.render_config(context)
+    assert rendered.alias == "foo"
+
+
 @pytest.mark.parametrize("model", ["sushi.waiters", "sushi.waiter_names"])
 def test_hooks(capsys, sushi_test_dbt_context: Context, model: str):
     waiters = sushi_test_dbt_context.models[model]

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -212,6 +212,22 @@ def test_config_containing_jinja():
     assert sqlmesh_model.columns_to_types == column_types_to_sqlmesh(rendered.columns)
 
 
+def test_config_containing_missing_dependency():
+    context = DbtContext()
+    model = ModelConfig(sql="{{ config(pre_hook=\"{{ print(ref('bar')) }}\") }} SELECT 1 FROM a")
+    with pytest.raises(ConfigError, match="'bar' was not found"):
+        model.render_config(context)
+
+    model = ModelConfig(sql='{{ config(pre_hook="{{ get_table_name() }}") }} SELECT 1 FROM a')
+    with pytest.raises(ConfigError, match="get_table_name"):
+        model.render_config(context)
+
+    model = ModelConfig(sql="{{ config(alias='{{ get_table_name() }}') }} SELECT 1 FROM a")
+    rendered = model.render_config(context)
+    assert rendered.alias == "{{ get_table_name() }}"
+    assert "get_table_name" not in [macro.name for macro in rendered._dependencies.macros]
+
+
 def test_config_containing_method():
     context = DbtContext()
     context.jinja_macros.global_objs.update({"get_table_name": lambda: "foo"})
@@ -219,6 +235,7 @@ def test_config_containing_method():
 
     rendered = model.render_config(context)
     assert rendered.alias == "foo"
+    assert "get_table_name" not in [macro.name for macro in rendered._dependencies.macros]
 
 
 @pytest.mark.parametrize("model", ["sushi.waiters", "sushi.waiter_names"])


### PR DESCRIPTION
- Jinja config() calls in the model should not be rendered (to match dbt behavior)
- Have update_with use assignment when modifying fields to trigger validators
- Enable validation on assignment for DbtConfig classes to validate new input and do any necessary type conversion.
- Fix some edge cases in extracting the Jinja config() calls from SqlModel queries
- Implement config jinja method (attribute dict of model's config) https://docs.getdbt.com/reference/dbt-jinja-functions/config