### PR TITLE
Add tag filters to release jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,11 +89,14 @@ workflows:
       - gh-release:
           <<: *on_tag_filter
       - generate-openapi-spec:
+          <<: *on_tag_filter
           requires:
             - gh-release
       - ide-build:
+          <<: *on_tag_filter
           requires:
             - generate-openapi-spec
       - publish:
+          <<: *on_tag_filter
           requires:
             - ide-build


### PR DESCRIPTION
The filters were removed because I thought they were redundant with requires, but jobs after `gh-release` didn't trigger.