### PR TITLE
Attach workspace when publishing Python package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ jobs:
     resource_class: small
     steps:
       - checkout
+      - attach_workspace:
+          at: web/client
       - run:
           name: Publish Python package
           command: make publish


### PR DESCRIPTION
Attach workspace so the IDE will get picked up by the publish job.