### PR TITLE
breaking: validate only correct model kinds support batch_size.

### DIFF
--- a/examples/wursthall/models/db/item_d.sql
+++ b/examples/wursthall/models/db/item_d.sql
@@ -5,7 +5,6 @@ MODEL (
   cron '@daily',
   owner jen,
   start '2022-06-01 00:00:00+00:00',
-  batch_size 200
 );
 
 SELECT

--- a/sqlmesh/core/model/__init__.py
+++ b/sqlmesh/core/model/__init__.py
@@ -19,3 +19,4 @@ from sqlmesh.core.model.kind import (
     TimeColumn,
 )
 from sqlmesh.core.model.meta import ModelMeta
+from sqlmesh.core.model.seed import Seed

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -62,6 +62,14 @@ class ModelKind(PydanticModel):
         return self.name not in (ModelKindName.VIEW, ModelKindName.EMBEDDED)
 
     @property
+    def supports_batch_size(self) -> bool:
+        """Whether or not this model supports the batch_size property."""
+        return self.name in (
+            ModelKindName.INCREMENTAL_BY_TIME_RANGE,
+            ModelKindName.INCREMENTAL_BY_UNIQUE_KEY,
+        )
+
+    @property
     def only_latest(self) -> bool:
         """Whether or not this model only cares about latest date to render."""
         return self.name in (ModelKindName.VIEW, ModelKindName.FULL)

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -234,9 +234,12 @@ class ModelMeta(PydanticModel):
     @root_validator
     def _kind_validator(cls, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
         kind = values.get("kind")
-        if kind and not kind.is_materialized:
-            if values.get("partitioned_by_"):
-                raise ValueError(f"partitioned_by field cannot be set for {kind} models")
+        if kind:
+            if not kind.is_materialized:
+                if values.get("partitioned_by_"):
+                    raise ValueError(f"partitioned_by field cannot be set for {kind} models")
+            if values.get("batch_size") and not kind.supports_batch_size:
+                raise ValueError(f"batch_size field cannot be set for {kind} models")
         return values
 
     @property

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -484,19 +484,6 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         if self.is_embedded_kind:
             return []
 
-        if self.is_full_kind or self.is_view_kind or self.is_seed_kind:
-            latest = latest or now()
-
-            latest_start, latest_end = self._inclusive_exclusive(
-                latest if is_date(latest) else self.model.cron_prev(self.model.cron_floor(latest)),
-                latest,
-            )
-            # if the latest ts is stored in the last interval, nothing is missing
-            # else returns the latest ts with the exclusive end ts.
-            if self.intervals and self.intervals[-1][1] >= latest_end:
-                return []
-            return [(latest_start, latest_end)]
-
         missing = []
         start_dt, end_dt = (to_datetime(ts) for ts in self._inclusive_exclusive(start, end))
         dates = tuple(croniter_range(start_dt, end_dt, self.model.normalized_cron()))

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -224,6 +224,7 @@ def change_model_kind(context: Context, kind: ModelKindName):
     if kind in (ModelKindName.VIEW, ModelKindName.EMBEDDED, ModelKindName.FULL):
         context.upsert_model(
             "sushi.items",
+            batch_size=None,
             partitioned_by=[],
             audits=[],
         )

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -966,3 +966,25 @@ def test_star_expansion(assert_exp_eq) -> None:
         ) AS model2
         """,
     )
+
+
+def test_batch_size_validation():
+    expressions = parse(
+        """
+        MODEL (
+            name db.seed,
+            kind SEED (
+              path '../seeds/waiter_names.csv',
+              batch_size 100,
+            ),
+            columns (
+              id double,
+              alias varchar
+            ),
+            batch_size 100,
+        );
+    """
+    )
+
+    with pytest.raises(ConfigError) as ex:
+        load_model(expressions, path=Path("./examples/sushi/models/test_model.sql"))

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -112,7 +112,6 @@ def test_to_sqlmesh_fields(sushi_test_project: Project):
         cron="@hourly",
         meta={"stamp": "bar", "dialect": "duckdb"},
         owner="Sally",
-        batch_size=2,
     )
     context = DbtContext(project_name="Foo")
     context.target = DuckDbConfig(schema="foo")
@@ -128,7 +127,6 @@ def test_to_sqlmesh_fields(sushi_test_project: Project):
     assert model.stamp == "bar"
     assert model.dialect == "duckdb"
     assert model.owner == "Sally"
-    assert model.batch_size == 2
 
 
 def test_model_config_sql_no_config():


### PR DESCRIPTION
fix: full refresh should respect all intervals to get upstream backfills