### PR TITLE
fix: Specify python3 for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: docs
 
 install-dev:
-	pip install -e ".[dev,web]"
+	pip3 install -e ".[dev,web]"
 
 install-pre-commit:
 	pre-commit install
@@ -31,10 +31,10 @@ it-test-docker: core-it-test airflow-it-test-docker-with-env
 test: unit-test it-test doc-test
 
 package:
-	pip install wheel && python setup.py sdist bdist_wheel
+	pip3 install wheel && python3 setup.py sdist bdist_wheel
 
 publish: package
-	pip install twine && python -m twine upload dist/*
+	pip3 install twine && python3 -m twine upload dist/*
 
 develop:
 	python3 setup.py develop


### PR DESCRIPTION
It looks like our Airflow integration tests run in an Ubuntu container and that container's python defaults to python 2. So we can replace all of the python/pip references to python3/pip3. It looks like that is what we did to get Airflow working in the first place: https://github.com/TobikoData/sqlmesh/blob/main/examples/airflow/Makefile#L12

Error CI job: https://app.circleci.com/pipelines/github/TobikoData/sqlmesh/3111/workflows/bc3d7a7f-01cb-46ee-bbdd-dc9bad76eeac/jobs/19482