### PR TITLE
Fix: Show view name in models needing backfill

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -339,7 +339,7 @@ class TerminalConsole(Console):
         backfill = Tree("[bold]Models needing backfill (missing dates):")
         for missing in plan.missing_intervals:
             snapshot = plan.context_diff.snapshots[missing.snapshot_name]
-            view_name = snapshot.qualified_view_name.for_environment(plan.environment.name)
+            view_name = snapshot.qualified_view_name.for_environment(plan.environment_name)
             backfill.add(f"{view_name}: {missing.format_missing_range()}")
         self._print(backfill)
 

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -338,7 +338,9 @@ class TerminalConsole(Console):
             return
         backfill = Tree("[bold]Models needing backfill (missing dates):")
         for missing in plan.missing_intervals:
-            backfill.add(f"{missing.snapshot_name}: {missing.format_missing_range()}")
+            snapshot = plan.context_diff.snapshots[missing.snapshot_name]
+            view_name = snapshot.qualified_view_name.for_environment(plan.environment.name)
+            backfill.add(f"{view_name}: {missing.format_missing_range()}")
         self._print(backfill)
 
     def _prompt_backfill(self, plan: Plan, auto_apply: bool) -> None:

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -252,6 +252,10 @@ class Plan:
         )
 
     @property
+    def environment_name(self) -> str:
+        return self.context_diff.environment
+
+    @property
     def restatements(self) -> t.Set[str]:
         return self._restatements
 

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -73,7 +73,7 @@ class BuiltInPlanEvaluator(PlanEvaluator):
                 max_workers=self.backfill_concurrent_tasks,
                 console=self.console,
             )
-            is_run_successful = scheduler.run(plan.environment.name, plan.start, plan.end)
+            is_run_successful = scheduler.run(plan.environment_name, plan.start, plan.end)
             if not is_run_successful:
                 raise SQLMeshError("Plan application failed.")
 


### PR DESCRIPTION
Resolves: https://github.com/TobikoData/sqlmesh/issues/686

UI is already displaying this correctly. 

We still show model names in the modified section. I _think_ this separation makes sense. Conceptually it is like "Here is what is changed in terms of the code (model names) and then here is what is being applied in terms of data (the "table" references)." 

<img width="1478" alt="Screenshot 2023-04-11 at 9 00 53 AM" src="https://user-images.githubusercontent.com/6326532/231221793-70db39f2-dccd-477d-962a-6645e2285a7e.png">
<img width="697" alt="Screenshot 2023-04-11 at 8 50 46 AM" src="https://user-images.githubusercontent.com/6326532/231221804-599c18e8-11fb-4ed4-9e17-2cd7f946e744.png">
