### PR TITLE
feat: add `forall` audit

### DIFF
--- a/docs/concepts/audits.md
+++ b/docs/concepts/audits.md
@@ -113,6 +113,22 @@ MODEL (
 );
 ```
 
+### forall
+Ensures that a set of arbitrary boolean expressions are upheld (evaluate to `true`) for all rows in the model. For incremental models, this check only applies to a data interval that is being evaluated, not to the entire table.
+
+Example:
+```sql linenums="1"
+MODEL (
+  name sushi.items,
+  audits (
+    forall(criteria=[
+      price >= 0,
+      LENGTH(name) > 0
+    ])
+  )
+);
+```
+
 ## Running audits
 ### The CLI audit command
 

--- a/sqlmesh/core/audit/builtin.py
+++ b/sqlmesh/core/audit/builtin.py
@@ -69,7 +69,7 @@ SELECT *
 FROM @this_model
 WHERE @REDUCE(
   @criteria,
-  (l, r) -> NOT(@SQL(l)) OR NOT(@SQL(r))
+  (l, r) -> NOT (l) OR NOT (r)
 )
     """,
 )

--- a/sqlmesh/core/audit/builtin.py
+++ b/sqlmesh/core/audit/builtin.py
@@ -60,3 +60,16 @@ LIMIT @threshold + 1
 HAVING COUNT(*) <= @threshold
     """,
 )
+
+
+forall_audit = Audit(
+    name="forall",
+    query="""
+SELECT *
+FROM @this_model
+WHERE @REDUCE(
+  @criteria,
+  (l, r) -> NOT(@SQL(l)) OR NOT(@SQL(r))
+)
+    """,
+)

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -217,3 +217,14 @@ def test_number_of_rows_audit(model: Model):
         rendered_query.sql()
         == """SELECT 1 AS "1" FROM (SELECT * FROM db.test_model AS test_model WHERE test_model.ds <= '1970-01-01' AND test_model.ds >= '1970-01-01') AS _q_0 HAVING COUNT(*) <= 0 LIMIT 0 + 1"""
     )
+
+
+def test_forall_audit(model: Model):
+    rendered_query_a = builtin.forall_audit.render_query(
+        model,
+        criteria=[parse_one("a >= b"), parse_one("c + d - e < 1.0")],
+    )
+    assert (
+        rendered_query_a.sql()
+        == "SELECT * FROM (SELECT * FROM db.test_model AS test_model WHERE test_model.ds <= '1970-01-01' AND test_model.ds >= '1970-01-01') AS _q_0 WHERE NOT (_q_0.a >= _q_0.b) OR NOT (_q_0.c + _q_0.d - _q_0.e < 1.0)"
+    )


### PR DESCRIPTION
Add a built-in audit that allows arbitrary expressions that must hold for all rows in a model.