### PR TITLE
Fix: Respect audit skip flag

### DIFF
--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -222,10 +222,12 @@ class Audit(AuditMeta, frozen=True):
 class AuditResult(PydanticModel):
     audit: Audit
     """The audit this result is for."""
-    count: int
-    """The number of records returned by the audit query."""
-    query: exp.Expression
-    """The rendered query used by the audit."""
+    count: t.Optional[int]
+    """The number of records returned by the audit query. This could be None if the audit was skipped."""
+    query: t.Optional[exp.Expression]
+    """The rendered query used by the audit. This could be None if the audit was skipped."""
+    skipped: bool = False
+    """Whether this audit was skipped or not."""
 
 
 def _raise_config_error(msg: str, path: pathlib.Path) -> None:

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -314,6 +314,9 @@ class SnapshotEvaluator:
         results = []
         for audit_name, audit_args in snapshot.model.audits:
             audit = audits_by_name[audit_name]
+            if audit.skip:
+                results.append(AuditResult(audit=audit, skipped=True))
+                continue
             query = audit.render_query(
                 snapshot,
                 start=start,


### PR DESCRIPTION
Example usage:
```
% sqlmesh --path examples/sushi --config local_config audit --model sushi.items
Found 3 audit(s).
accepted_values PASS.
not_null PASS.
assert_items_price_exceeds_threshold SKIPPED.

Finished with 0 audit errors and 1 audit skipped.
Done.
```