### PR TITLE
fix: forall with only one criteria

### DIFF
--- a/examples/sushi/models/waiter_as_customer_by_day.sql
+++ b/examples/sushi/models/waiter_as_customer_by_day.sql
@@ -7,7 +7,8 @@ MODEL (
   owner jen,
   cron '@daily',
   audits (
-    not_null(columns=[waiter_id])
+    not_null(columns = [waiter_id]),
+    forall(criteria = [LENGTH(waiter_name) > 0])
   )
 );
 

--- a/sqlmesh/core/audit/builtin.py
+++ b/sqlmesh/core/audit/builtin.py
@@ -72,7 +72,7 @@ WHERE @REDUCE(
     @criteria,
     c -> NOT (c)
   ),
-  (l, r) -> (l) OR (r)
+  (l, r) -> l OR r
 )
     """,
 )

--- a/sqlmesh/core/audit/builtin.py
+++ b/sqlmesh/core/audit/builtin.py
@@ -68,8 +68,11 @@ forall_audit = Audit(
 SELECT *
 FROM @this_model
 WHERE @REDUCE(
-  @criteria,
-  (l, r) -> NOT (l) OR NOT (r)
+  @EACH(
+    @criteria,
+    c -> NOT (c)
+  ),
+  (l, r) -> (l) OR (r)
 )
     """,
 )

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -222,9 +222,18 @@ def test_number_of_rows_audit(model: Model):
 def test_forall_audit(model: Model):
     rendered_query_a = builtin.forall_audit.render_query(
         model,
+        criteria=[parse_one("a >= b")],
+    )
+    assert (
+        rendered_query_a.sql()
+        == "SELECT * FROM (SELECT * FROM db.test_model AS test_model WHERE test_model.ds <= '1970-01-01' AND test_model.ds >= '1970-01-01') AS _q_0 WHERE NOT (_q_0.a >= _q_0.b)"
+    )
+
+    rendered_query_a = builtin.forall_audit.render_query(
+        model,
         criteria=[parse_one("a >= b"), parse_one("c + d - e < 1.0")],
     )
     assert (
         rendered_query_a.sql()
-        == "SELECT * FROM (SELECT * FROM db.test_model AS test_model WHERE test_model.ds <= '1970-01-01' AND test_model.ds >= '1970-01-01') AS _q_0 WHERE NOT (_q_0.a >= _q_0.b) OR NOT (_q_0.c + _q_0.d - _q_0.e < 1.0)"
+        == "SELECT * FROM (SELECT * FROM db.test_model AS test_model WHERE test_model.ds <= '1970-01-01' AND test_model.ds >= '1970-01-01') AS _q_0 WHERE (NOT (_q_0.a >= _q_0.b)) OR (NOT (_q_0.c + _q_0.d - _q_0.e < 1.0))"
     )

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -235,5 +235,5 @@ def test_forall_audit(model: Model):
     )
     assert (
         rendered_query_a.sql()
-        == "SELECT * FROM (SELECT * FROM db.test_model AS test_model WHERE test_model.ds <= '1970-01-01' AND test_model.ds >= '1970-01-01') AS _q_0 WHERE (NOT (_q_0.a >= _q_0.b)) OR (NOT (_q_0.c + _q_0.d - _q_0.e < 1.0))"
+        == "SELECT * FROM (SELECT * FROM db.test_model AS test_model WHERE test_model.ds <= '1970-01-01' AND test_model.ds >= '1970-01-01') AS _q_0 WHERE NOT (_q_0.a >= _q_0.b) OR NOT (_q_0.c + _q_0.d - _q_0.e < 1.0)"
     )


### PR DESCRIPTION
Apply the `NOT` predicate before `REDUCE` to handle cases where only one criteria is specified.