### PR TITLE
fix: rename `values` parameter to `is_in`

### DIFF
--- a/docs/concepts/audits.md
+++ b/docs/concepts/audits.md
@@ -58,6 +58,20 @@ Notice how `column` and `threshold` parameters have been set at this point. Thes
 
 Note that the same audit can be applied more than once to the same model with different sets of parameters.
 
+### Naming
+Note that it is recommended to avoid using SQL keywords when naming audit parameters.
+When an audit uses a SQL keyword, it can be necessary to use quotes when using it.
+For example, assuming that `my_audit` uses a `values` parameter, invoking it will require quotes:
+
+```sql linenums="1"
+MODEL (
+  name sushi.items,
+  audits(
+    my_audit(column=a, "values"=[1,2,3])
+  )
+)
+```
+
 ## Built-in audits
 SQLMesh comes with a suite of built-in generic audits which covers a broad set of common use cases.
 
@@ -95,7 +109,7 @@ Example:
 MODEL (
   name sushi.items,
   audits (
-    accepted_values(column=name, values=['Hamachi', 'Unagi', 'Sake'])
+    accepted_values(column=name, is_in=['Hamachi', 'Unagi', 'Sake'])
   )
 );
 ```

--- a/examples/sushi/models/items.py
+++ b/examples/sushi/models/items.py
@@ -60,7 +60,7 @@ ITEMS = [
         "ds": "text",
     },
     audits=[
-        ("accepted_values", {"column": to_column("name"), "values": ITEMS}),
+        ("accepted_values", {"column": to_column("name"), "is_in": ITEMS}),
         ("not_null", {"columns": [to_column("name"), to_column("price")]}),
         ("assert_items_price_exceeds_threshold", {"price": 0}),
     ],

--- a/sqlmesh/core/audit/builtin.py
+++ b/sqlmesh/core/audit/builtin.py
@@ -46,7 +46,7 @@ accepted_values_audit = Audit(
     query="""
 SELECT *
 FROM @this_model
-WHERE @column NOT IN @values
+WHERE @column NOT IN @is_in
 """,
 )
 

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -200,7 +200,7 @@ def test_accepted_values_audit(model: Model):
     rendered_query = builtin.accepted_values_audit.render_query(
         model,
         column=exp.to_column("a"),
-        values=["value_a", "value_b"],
+        is_in=["value_a", "value_b"],
     )
     assert (
         rendered_query.sql()


### PR DESCRIPTION
Since `values` is a SQL keyword, it is not suitable as an audit parameter. This renames it to `is_in` which is close to the `IN` SQL keyword while not being one.

Fixes #702