### PR TITLE
Fix: table and query tabs for editor Preview are not scrollable 

### DIFF
--- a/web/client/src/library/components/editor/EditorPreview.tsx
+++ b/web/client/src/library/components/editor/EditorPreview.tsx
@@ -82,11 +82,7 @@ export default function EditorPreview({
   }
 
   return (
-    <div
-      className={clsx(
-        'flex flex-col text-prose overflow-auto scrollbar scrollbar--vertical',
-      )}
-    >
+    <div className={clsx('flex flex-col text-prose w-full h-full')}>
       <Tab.Group
         onChange={setActiveTabIndex}
         selectedIndex={activeTabIndex < 0 ? activeTab : activeTabIndex}
@@ -137,7 +133,7 @@ export default function EditorPreview({
         <Tab.Panels className="w-full overflow-hidden">
           <Tab.Panel
             className={clsx(
-              'w-full h-full overflow-hidden pt-4 relative pl-2',
+              'w-full h-full pt-4 relative px-2',
               'ring-white ring-opacity-60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2',
             )}
           >


### PR DESCRIPTION
![Screenshot 2023-04-13 at 6 29 54 PM](https://user-images.githubusercontent.com/5644753/231918164-479276f0-720e-4d47-ad8d-7a2e52847898.jpg)
