### PR TITLE
[Fix] Small fix after integration testing on GCS

### DIFF
--- a/sqlmesh/utils/transactional_file.py
+++ b/sqlmesh/utils/transactional_file.py
@@ -48,7 +48,7 @@ class TransactionalFile:
         self.path = path
         self.lock_prefix = f"{self.path}.lock"
         self.lock_path = f"{self.lock_prefix}.{lock_id()}"
-        proto = fs.protocol[0] if isinstance(fs.protocol, (list, tuple)) else (fs.protocol,)
+        proto = fs.protocol[0] if isinstance(fs.protocol, (list, tuple)) else fs.protocol
         self.get_mtime = self.mtime_dispatch.get(proto, self.mtime_dispatch["file"])
         self._fs = fs
         self._original_contents: t.Optional[bytes] = None


### PR DESCRIPTION
Small fix after integration testing on GCS. The noteworthy callout is that the `protocol` attached to a filesystem can be a str OR sequence so we need to normalize it, we should also support the associated aliases.

This implementation passed all tests against our live GCS too so its really nice 🎉  (obviously changing the test to use some random file path in our bucket instead of a `NamedTemporaryFile`. 