### PR TITLE
Fix: Run plan in default event loop instead of an executor

### DIFF
--- a/web/server/api/endpoints/environments.py
+++ b/web/server/api/endpoints/environments.py
@@ -11,7 +11,9 @@ router = APIRouter()
 
 
 @router.get("")
-async def get_environments(context: Context = Depends(get_loaded_context)) -> t.Dict[str, Environment]:
+async def get_environments(
+    context: Context = Depends(get_loaded_context),
+) -> t.Dict[str, Environment]:
     """Get the environments"""
     environments = {env.name: env for env in context.state_reader.get_environments()}
     if c.PROD not in environments:

--- a/web/server/api/endpoints/environments.py
+++ b/web/server/api/endpoints/environments.py
@@ -11,7 +11,7 @@ router = APIRouter()
 
 
 @router.get("")
-def get_environments(context: Context = Depends(get_loaded_context)) -> t.Dict[str, Environment]:
+async def get_environments(context: Context = Depends(get_loaded_context)) -> t.Dict[str, Environment]:
     """Get the environments"""
     environments = {env.name: env for env in context.state_reader.get_environments()}
     if c.PROD not in environments:

--- a/web/server/main.py
+++ b/web/server/main.py
@@ -7,7 +7,6 @@ from fastapi.staticfiles import StaticFiles
 
 from web.server.api.endpoints import api_router
 from web.server.console import ApiConsole
-from web.server.settings import get_context, get_settings
 
 app = FastAPI()
 api_console = ApiConsole()
@@ -27,12 +26,6 @@ async def startup_event() -> None:
 
     app.state.console_listeners = []
     app.state.dispatch_task = asyncio.create_task(dispatch())
-
-    settings = get_settings()
-    context = await get_context(settings)
-    if context:
-        # Access state sync to create it and trigger a migration if needed
-        context.state_sync
 
 
 @app.on_event("shutdown")

--- a/web/server/main.py
+++ b/web/server/main.py
@@ -7,6 +7,7 @@ from fastapi.staticfiles import StaticFiles
 
 from web.server.api.endpoints import api_router
 from web.server.console import ApiConsole
+from web.server.settings import get_context, get_settings
 
 app = FastAPI()
 api_console = ApiConsole()
@@ -26,6 +27,12 @@ async def startup_event() -> None:
 
     app.state.console_listeners = []
     app.state.dispatch_task = asyncio.create_task(dispatch())
+
+    settings = get_settings()
+    context = await get_context(settings)
+    if context:
+        # Access state sync to create it and trigger a migration if needed
+        context.state_sync
 
 
 @app.on_event("shutdown")


### PR DESCRIPTION
This PR fixes a race condition on IDE startup when multiple requests access the state sync concurrently.