### PR TITLE
Feat: Add execution config for BigQuery

### DIFF
--- a/docs/integrations/engines.md
+++ b/docs/integrations/engines.md
@@ -2,19 +2,25 @@
 
 # BigQuery
 ## BigQuery - Local/Built-in Scheduler
-| Option          | Description                                                                                   |  Type  | Required |
-|-----------------|-----------------------------------------------------------------------------------------------|:------:|:--------:|
-| `method`        | Connection methods. Can be `oath`, `oauth-secrets`, `service-account`, `service-account-json` | string |    N     |
-| `project`       | The name of the GCP project                                                                   | string |    N     |
-| `location`      | The location of for the datasets (can be regional or multi-regional)                          | string |    Y     |
-| `keyfile`       | Path to the keyfile to be used with service-account method                                    | string |    Y     |
-| `keyfile_json`  | Keyfile information provided inline (not recommended)                                         |  dict  |    N     |
-| `token`         | Oath secret auth token                                                                        | string |    N     |
-| `refresh_token` | Oath secret auth refresh_token                                                                | string |    N     |
-| `client_id`     | Oath secret auth client_id                                                                    | string |    N     |
-| `client_secret` | Oath secret auth client_secret                                                                | string |    N     |
-| `token_uri`     | Oath secret auth token_uri                                                                    | string |    N     |
-| `scopes`        | Oath secret auth scopes                                                                       |  list  |    N     |
+| Option                          | Description                                                                                   |  Type  | Required |
+|---------------------------------|-----------------------------------------------------------------------------------------------|:------:|:--------:|
+| `method`                        | Connection methods. Can be `oath`, `oauth-secrets`, `service-account`, `service-account-json` | string |    N     |
+| `project`                       | The name of the GCP project                                                                   | string |    N     |
+| `location`                      | The location of for the datasets (can be regional or multi-regional)                          | string |    Y     |
+| `keyfile`                       | Path to the keyfile to be used with service-account method                                    | string |    Y     |
+| `keyfile_json`                  | Keyfile information provided inline (not recommended)                                         |  dict  |    N     |
+| `token`                         | Oath secret auth token                                                                        | string |    N     |
+| `refresh_token`                 | Oath secret auth refresh_token                                                                | string |    N     |
+| `client_id`                     | Oath secret auth client_id                                                                    | string |    N     |
+| `client_secret`                 | Oath secret auth client_secret                                                                | string |    N     |
+| `token_uri`                     | Oath secret auth token_uri                                                                    | string |    N     |
+| `scopes`                        | Oath secret auth scopes                                                                       |  list  |    N     |
+| `job_creation_timeout_seconds`  | The maximum amount of time, in seconds, to wait for the underlying job to be created.         |  int   |    N     |
+| `job_execution_timeout_seconds` | The maximum amount of time, in seconds, to wait for the underlying job to complete.           |  int   |    N     |
+| `job_retries`                   | The number of times to retry the underlying job if it fails. (Default: `1`)                   |  int   |    N     |
+| `priority`                      | The priority of the underlying job. (Default: `INTERACTIVE`)                                  | string |    N     |
+| `maximum_bytes_billed`          | The maximum number of bytes to be billed for the underlying job.                              |  int   |    N     |
+
 
 ## BigQuery - Airflow Scheduler
 **Engine Name:** `bigquery`

--- a/sqlmesh/core/engine_adapter/__init__.py
+++ b/sqlmesh/core/engine_adapter/__init__.py
@@ -17,9 +17,6 @@ from sqlmesh.core.engine_adapter.shared import TransactionType
 from sqlmesh.core.engine_adapter.snowflake import SnowflakeEngineAdapter
 from sqlmesh.core.engine_adapter.spark import SparkEngineAdapter
 
-if t.TYPE_CHECKING:
-    from sqlmesh.core.config.connection import BigQueryExecutionConfig
-
 DIALECT_TO_ENGINE_ADAPTER = {
     "spark": SparkEngineAdapter,
     "bigquery": BigQueryEngineAdapter,
@@ -41,7 +38,7 @@ def create_engine_adapter(
     connection_factory: t.Callable[[], t.Any],
     dialect: str,
     multithreaded: bool = False,
-    execution_config: t.Optional[BigQueryExecutionConfig] = None,
+    **kwargs: t.Any,
 ) -> EngineAdapter:
     dialect = dialect.lower()
     dialect = DIALECT_ALIASES.get(dialect, dialect)
@@ -65,15 +62,13 @@ def create_engine_adapter(
             connection_factory,
             dialect,
             multithreaded=multithreaded,
-            execution_config=execution_config,
+            **kwargs,
         )
     if engine_adapter is EngineAdapterWithIndexSupport:
         return EngineAdapterWithIndexSupport(
             connection_factory,
             dialect,
             multithreaded=multithreaded,
-            execution_config=execution_config,
+            **kwargs,
         )
-    return engine_adapter(
-        connection_factory, multithreaded=multithreaded, execution_config=execution_config
-    )
+    return engine_adapter(connection_factory, multithreaded=multithreaded, **kwargs)

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -37,6 +37,7 @@ from sqlmesh.utils.errors import SQLMeshError
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import TableName
+    from sqlmesh.core.config.connection import BigQueryExecutionConfig
     from sqlmesh.core.engine_adapter._typing import DF, QueryOrDF
     from sqlmesh.core.model.meta import IntervalUnit
 
@@ -69,10 +70,12 @@ class EngineAdapter:
         dialect: str = "",
         sql_gen_kwargs: t.Optional[t.Dict[str, Dialect | bool | str]] = None,
         multithreaded: bool = False,
+        execution_config: t.Optional[BigQueryExecutionConfig] = None,
     ):
         self.dialect = dialect.lower() or self.DIALECT
         self._connection_pool = create_connection_pool(connection_factory, multithreaded)
         self.sql_gen_kwargs = sql_gen_kwargs or {}
+        self._execution_config = execution_config
 
     @property
     def cursor(self) -> t.Any:
@@ -81,6 +84,10 @@ class EngineAdapter:
     @property
     def spark(self) -> t.Optional[PySparkSession]:
         return None
+
+    @property
+    def execution_config(self) -> t.Optional[BigQueryExecutionConfig]:
+        return self._execution_config
 
     def recycle(self) -> t.Any:
         """Closes all open connections and releases all allocated resources associated with any thread

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -37,7 +37,6 @@ from sqlmesh.utils.errors import SQLMeshError
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import TableName
-    from sqlmesh.core.config.connection import BigQueryExecutionConfig
     from sqlmesh.core.engine_adapter._typing import DF, QueryOrDF
     from sqlmesh.core.model.meta import IntervalUnit
 
@@ -70,12 +69,12 @@ class EngineAdapter:
         dialect: str = "",
         sql_gen_kwargs: t.Optional[t.Dict[str, Dialect | bool | str]] = None,
         multithreaded: bool = False,
-        execution_config: t.Optional[BigQueryExecutionConfig] = None,
+        **kwargs: t.Any,
     ):
         self.dialect = dialect.lower() or self.DIALECT
         self._connection_pool = create_connection_pool(connection_factory, multithreaded)
         self.sql_gen_kwargs = sql_gen_kwargs or {}
-        self._execution_config = execution_config
+        self._extra_config = kwargs
 
     @property
     def cursor(self) -> t.Any:
@@ -84,10 +83,6 @@ class EngineAdapter:
     @property
     def spark(self) -> t.Optional[PySparkSession]:
         return None
-
-    @property
-    def execution_config(self) -> t.Optional[BigQueryExecutionConfig]:
-        return self._execution_config
 
     def recycle(self) -> t.Any:
         """Closes all open connections and releases all allocated resources associated with any thread

--- a/sqlmesh/dbt/target.py
+++ b/sqlmesh/dbt/target.py
@@ -9,6 +9,7 @@ from pydantic import Field, root_validator
 from sqlmesh.core.config.connection import (
     BigQueryConnectionConfig,
     BigQueryConnectionMethod,
+    BigQueryPriority,
     ConnectionConfig,
     DatabricksSQLConnectionConfig,
     DuckDBConnectionConfig,
@@ -329,6 +330,11 @@ class BigQueryConfig(TargetConfig):
         "https://www.googleapis.com/auth/cloud-platform",
         "https://www.googleapis.com/auth/drive",
     )
+    job_execution_timeout_seconds: t.Optional[int] = None
+    job_retries: int = 1
+    job_retry_deadline_seconds: t.Optional[int] = None
+    priority: BigQueryPriority = BigQueryPriority.INTERACTIVE
+    maximum_bytes_billed: t.Optional[int] = None
 
     @root_validator
     def validate_schema(
@@ -356,4 +362,9 @@ class BigQueryConfig(TargetConfig):
             client_secret=self.client_secret,
             token_uri=self.token_uri,
             scopes=self.scopes,
+            job_execution_timeout_seconds=self.job_execution_timeout_seconds,
+            job_retries=self.job_retries,
+            job_retry_deadline_seconds=self.job_retry_deadline_seconds,
+            priority=self.priority,
+            maximum_bytes_billed=self.maximum_bytes_billed,
         )

--- a/sqlmesh/schedulers/airflow/operators/bigquery.py
+++ b/sqlmesh/schedulers/airflow/operators/bigquery.py
@@ -5,6 +5,7 @@ import typing as t
 from airflow.models import BaseOperator
 from airflow.utils.context import Context
 
+from sqlmesh.core.config.connection import BigQueryExecutionConfig
 from sqlmesh.schedulers.airflow.hooks.bigquery import SQLMeshBigQueryHook
 from sqlmesh.schedulers.airflow.operators.targets import BaseTarget
 
@@ -35,4 +36,11 @@ class SQLMeshBigQueryOperator(BaseOperator):
 
     def execute(self, context: Context) -> None:
         """Executes the desired target against the configured BigQuery connection"""
-        self._target.execute(context, lambda: self.get_db_hook().get_conn(), "bigquery")
+        self._target.execute(
+            context,
+            lambda: self.get_db_hook().get_conn(),
+            "bigquery",
+            BigQueryExecutionConfig(
+                job_retries=self.get_db_hook().num_retries,
+            ),
+        )

--- a/sqlmesh/schedulers/airflow/operators/bigquery.py
+++ b/sqlmesh/schedulers/airflow/operators/bigquery.py
@@ -5,7 +5,6 @@ import typing as t
 from airflow.models import BaseOperator
 from airflow.utils.context import Context
 
-from sqlmesh.core.config.connection import BigQueryExecutionConfig
 from sqlmesh.schedulers.airflow.hooks.bigquery import SQLMeshBigQueryHook
 from sqlmesh.schedulers.airflow.operators.targets import BaseTarget
 
@@ -40,7 +39,5 @@ class SQLMeshBigQueryOperator(BaseOperator):
             context,
             lambda: self.get_db_hook().get_conn(),
             "bigquery",
-            BigQueryExecutionConfig(
-                job_retries=self.get_db_hook().num_retries,
-            ),
+            job_retries=self.get_db_hook().num_retries,
         )

--- a/sqlmesh/schedulers/airflow/operators/targets.py
+++ b/sqlmesh/schedulers/airflow/operators/targets.py
@@ -6,7 +6,6 @@ from airflow.utils.context import Context
 from airflow.utils.session import provide_session
 from sqlalchemy.orm import Session
 
-from sqlmesh.core.config.connection import BigQueryExecutionConfig
 from sqlmesh.core.engine_adapter import create_engine_adapter
 from sqlmesh.core.snapshot import (
     Snapshot,
@@ -43,7 +42,7 @@ class BaseTarget(abc.ABC, t.Generic[CP]):
         context: Context,
         connection_factory: t.Callable[[], t.Any],
         dialect: str,
-        execution_config: t.Optional[BigQueryExecutionConfig] = None,
+        **kwargs: t.Any,
     ) -> None:
         """Executes this target.
 
@@ -52,7 +51,6 @@ class BaseTarget(abc.ABC, t.Generic[CP]):
             connection_factory: a callable which produces a new Database API compliant
                 connection on every call.
             dialect: The dialect with which this adapter is associated.
-            execution_config: Execution configuration for the target engine adapter.
         """
         payload = self._get_command_payload_or_skip(context)
         snapshot_evaluator = SnapshotEvaluator(
@@ -60,7 +58,7 @@ class BaseTarget(abc.ABC, t.Generic[CP]):
                 connection_factory,
                 dialect,
                 multithreaded=self.ddl_concurrent_tasks > 1,
-                execution_config=execution_config,
+                **kwargs,
             ),
             ddl_concurrent_tasks=self.ddl_concurrent_tasks,
         )


### PR DESCRIPTION
This BigQuery config required changing properties at execution time instead of connection properties that can be set when creating the connector. Therefore I introduced a concept of execution config and then that can be passed into the engine adapter to be available at execution time. 

Airflow only supports the `num_retries` config so that is all that gets passed into Airflow.

I also fixed a bug where BigQuery had it's concurrency set to 4. When using the built-in scheduler this creates a lot of errors trying to concurrently do updates against state table. Best to set to 1 for this case. 