### PR TITLE
Feat: Introduce the caching layer when loading SQL models

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "requests",
         "rich",
         "ruamel.yaml",
-        "sqlglot~=11.5.4",
+        "sqlglot~=11.5.5",
         "fsspec",
     ],
     extras_require={

--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -19,10 +19,6 @@ IGNORE_PATTERNS = [
     ".ipynb_checkpoints/*",
 ]
 """Ignore patterns"""
-CACHE_PATH = ".cache"
-"""Cache path"""
-TABLE_INFO_CACHE = "table_info_cache"
-"""Table info cache"""
 DATA_VERSION_LIMIT = 10
 """Data version limit"""
 DEFAULT_TIME_COLUMN_FORMAT = "%Y-%m-%d"
@@ -38,3 +34,4 @@ HOOKS = "hooks"
 MACROS = "macros"
 MODELS = "models"
 TESTS = "tests"
+CACHE = ".cache"

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -201,7 +201,7 @@ class Context(BaseContext):
     ):
         self.console = console or get_console()
 
-        self._sqlmesh_path = Path.home() / ".sqlmesh"
+        self.sqlmesh_path = Path.home() / ".sqlmesh"
 
         self.configs = self._load_configs(
             config or "config",
@@ -888,7 +888,7 @@ class Context(BaseContext):
         if isinstance(config, Config):
             return {path: config for path in paths}
 
-        lookup_paths = [self._sqlmesh_path / "config.yml", self._sqlmesh_path / "config.yaml"]
+        lookup_paths = [self.sqlmesh_path / "config.yml", self.sqlmesh_path / "config.yaml"]
 
         return {
             path: load_config_from_paths(

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -8,6 +8,7 @@ import os
 import sys
 import types
 import typing as t
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -19,7 +20,7 @@ from sqlmesh.core.audit import Audit
 from sqlmesh.core.dialect import parse
 from sqlmesh.core.hooks import HookRegistry, hook
 from sqlmesh.core.macros import MacroRegistry, macro
-from sqlmesh.core.model import Model, SeedModel, load_model
+from sqlmesh.core.model import Model, ModelCache, SeedModel, load_model
 from sqlmesh.core.model import model as model_registry
 from sqlmesh.utils import UniqueKeyDict
 from sqlmesh.utils.dag import DAG
@@ -79,6 +80,18 @@ class Loader(abc.ABC):
         self._path_mtimes.clear()
         self._dag = DAG()
 
+        config_mtimes: t.Dict[Path, t.List[float]] = defaultdict(list)
+        for context_path, config in self._context.configs.items():
+            for config_file in context_path.glob("config.*"):
+                self._track_file(config_file)
+                config_mtimes[context_path].append(self._path_mtimes[config_file])
+
+        for config_file in context.sqlmesh_path.glob("config.*"):
+            self._track_file(config_file)
+            config_mtimes[context.sqlmesh_path].append(self._path_mtimes[config_file])
+
+        self._config_mtimes = {path: max(mtimes) for path, mtimes in config_mtimes.items()}
+
         macros, hooks = self._load_scripts()
         models = self._load_models(macros, hooks)
         for model in models.values():
@@ -135,6 +148,8 @@ class SqlMeshLoader(Loader):
         standard_hooks = hook.get_registry()
         standard_macros = macro.get_registry()
 
+        macros_max_mtime: t.Optional[float] = None
+
         for context_path, config in self._context.configs.items():
             for path in itertools.chain(
                 self._glob_paths(context_path / c.MACROS, config=config, extension=".py"),
@@ -142,6 +157,14 @@ class SqlMeshLoader(Loader):
             ):
                 if self._import_python_file(path, context_path):
                     self._track_file(path)
+                    macro_file_mtime = self._path_mtimes[path]
+                    macros_max_mtime = (
+                        max(macros_max_mtime, macro_file_mtime)
+                        if macros_max_mtime
+                        else macro_file_mtime
+                    )
+
+        self._macros_max_mtime = macros_max_mtime
 
         hooks = hook.get_registry()
         macros = macro.get_registry()
@@ -165,18 +188,25 @@ class SqlMeshLoader(Loader):
         self, macros: MacroRegistry, hooks: HookRegistry
     ) -> UniqueKeyDict[str, Model]:
         """Loads the sql models into a Dict"""
+        model_cache = ModelCache(self._context.path / c.CACHE)
+
         models: UniqueKeyDict = UniqueKeyDict("models")
         for context_path, config in self._context.configs.items():
-            for path in self._glob_paths(context_path / c.MODELS, config=config, extension=".sql"):
+            models_path = context_path / c.MODELS
+            for path in self._glob_paths(models_path, config=config, extension=".sql"):
                 self._track_file(path)
-                with open(path, "r", encoding="utf-8") as file:
-                    try:
-                        expressions = parse(
-                            file.read(), default_dialect=config.model_defaults.dialect
-                        )
-                    except SqlglotError as ex:
-                        raise ConfigError(f"Failed to parse a model definition at '{path}': {ex}")
-                    model = load_model(
+
+                def _load() -> Model:
+                    with open(path, "r", encoding="utf-8") as file:
+                        try:
+                            expressions = parse(
+                                file.read(), default_dialect=config.model_defaults.dialect
+                            )
+                        except SqlglotError as ex:
+                            raise ConfigError(
+                                f"Failed to parse a model definition at '{path}': {ex}."
+                            )
+                    return load_model(
                         expressions,
                         defaults=config.model_defaults.dict(),
                         macros=macros,
@@ -186,11 +216,19 @@ class SqlMeshLoader(Loader):
                         dialect=config.model_defaults.dialect,
                         time_column_format=config.time_column_format,
                     )
-                    models[model.name] = model
 
-                    if isinstance(model, SeedModel):
-                        seed_path = model.seed_path
-                        self._track_file(seed_path)
+                cache_entry_name = "__".join(path.relative_to(models_path).parts).replace(
+                    ".sql", ""
+                )
+                cache_entry_id = self._model_cache_entry_id(path, context_path)
+
+                model = model_cache.get_or_load(cache_entry_name, cache_entry_id, _load)
+                model._path = path
+                models[model.name] = model
+
+                if isinstance(model, SeedModel):
+                    seed_path = model.seed_path
+                    self._track_file(seed_path)
 
         return models
 
@@ -265,3 +303,12 @@ class SqlMeshLoader(Loader):
                     break
             else:
                 yield filepath
+
+    def _model_cache_entry_id(self, model_path: Path, context_path: Path) -> str:
+        mtimes = [
+            self._path_mtimes[model_path],
+            self._macros_max_mtime,
+            self._config_mtimes.get(context_path),
+            self._config_mtimes.get(self._context.sqlmesh_path),
+        ]
+        return str(int(max([m for m in mtimes if m is not None])))

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -323,4 +323,4 @@ class SqlMeshLoader(Loader):
                 self._loader._config_mtimes.get(self._context_path),
                 self._loader._config_mtimes.get(self._loader._context.sqlmesh_path),
             ]
-            return str(int(max([m for m in mtimes if m is not None])))
+            return str(int(max(m for m in mtimes if m is not None)))

--- a/sqlmesh/core/model/__init__.py
+++ b/sqlmesh/core/model/__init__.py
@@ -1,3 +1,4 @@
+from sqlmesh.core.model.cache import ModelCache
 from sqlmesh.core.model.common import parse_model_name
 from sqlmesh.core.model.decorator import model
 from sqlmesh.core.model.definition import (

--- a/sqlmesh/core/model/cache.py
+++ b/sqlmesh/core/model/cache.py
@@ -16,6 +16,12 @@ class SqlModelCacheEntry(PydanticModel):
 
 
 class ModelCache:
+    """File-based cache implementation for model definitions.
+
+    Args:
+        path: The path to the cache folder.
+    """
+
     def __init__(self, path: Path):
         self.path = path
         self._file_cache: FileCache[SqlModelCacheEntry] = FileCache(
@@ -25,6 +31,16 @@ class ModelCache:
         )
 
     def get_or_load(self, name: str, entry_id: str, loader: t.Callable[[], Model]) -> Model:
+        """Returns an existing cached model definition or loads and caches a new one.
+
+        Args:
+            name: The name of the entry.
+            entry_id: The unique entry identifier. Used for cache invalidation.
+            loader: Used to load a new model definition when no cached instance was found.
+
+        Returns:
+            The model definition.
+        """
         cache_entry = self._file_cache.get(name, entry_id)
         if cache_entry:
             model = cache_entry.model

--- a/sqlmesh/core/model/cache.py
+++ b/sqlmesh/core/model/cache.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import typing as t
+from pathlib import Path
+
+from sqlglot import exp
+
+from sqlmesh.core.model.definition import Model, SqlModel
+from sqlmesh.utils.cache import FileCache
+from sqlmesh.utils.pydantic import PydanticModel
+
+
+class SqlModelCacheEntry(PydanticModel):
+    model: SqlModel
+    rendered_query: t.Dict
+
+
+class ModelCache:
+    def __init__(self, path: Path):
+        self.path = path
+        self._file_cache: FileCache[SqlModelCacheEntry] = FileCache(
+            path,
+            SqlModelCacheEntry,
+            prefix="model_definition",
+        )
+
+    def get_or_load(self, name: str, entry_id: str, loader: t.Callable[[], Model]) -> Model:
+        cache_entry = self._file_cache.get(name, entry_id)
+        if cache_entry:
+            model = cache_entry.model
+            model._query_renderer.update_cache(exp.Expression.load(cache_entry.rendered_query))
+            return model
+
+        loaded_model = loader()
+        if isinstance(loaded_model, SqlModel):
+            new_entry = SqlModelCacheEntry(
+                model=loaded_model, rendered_query=loaded_model.render_query().dump()
+            )
+            self._file_cache.put(name, entry_id, new_entry)
+
+        return loaded_model

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -619,7 +619,7 @@ class SqlModel(_Model):
 
         if self._columns_to_types is None:
             self._columns_to_types = {
-                expression.alias_or_name: expression.type
+                expression.alias_or_name: expression.type or exp.DataType.build("unknown")
                 for expression in self._query_renderer.render().expressions
             }
 

--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -265,7 +265,7 @@ def _dbt_macro_registry() -> JinjaMacroRegistry:
             continue
         context = DbtContext(project_root=project_file.parent, jinja_macros=JinjaMacroRegistry())
         package = PackageLoader(context).load()
-        registry.add_macros(package.macros, package="dbt")
+        registry.add_macros(package.macro_infos, package="dbt")
 
     return registry
 

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -74,7 +74,7 @@ class DbtLoader(Loader):
                 ]
             )
 
-        macros_max_mtime: t.Optional[float] = max(macros_mtimes) if macros_mtimes else None
+        macros_max_mtime = max(macros_mtimes) if macros_mtimes else None
         yaml_max_mtimes = self._compute_yaml_max_mtime_per_subfolder(self._context.path)
         cache = DbtLoader._Cache(self, project, macros_max_mtime, yaml_max_mtimes)
 

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -141,7 +141,9 @@ class DbtLoader(Loader):
     ) -> t.Optional[float]:
         project_root = project.context.project_root
 
-        if not target_path.is_relative_to(project_root):
+        try:
+            target_path.absolute().relative_to(project_root.absolute())
+        except ValueError:
             return None
 
         mtimes = [

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -3,17 +3,21 @@ from __future__ import annotations
 import typing as t
 from pathlib import Path
 
+from sqlmesh.core import constants as c
 from sqlmesh.core.audit import Audit
 from sqlmesh.core.config import Config
 from sqlmesh.core.hooks import HookRegistry
 from sqlmesh.core.loader import Loader
 from sqlmesh.core.macros import MacroRegistry
-from sqlmesh.core.model import Model
+from sqlmesh.core.model import Model, ModelCache
 from sqlmesh.dbt.basemodel import BaseModelConfig
 from sqlmesh.dbt.context import DbtContext
+from sqlmesh.dbt.model import ModelConfig
 from sqlmesh.dbt.profile import Profile
 from sqlmesh.dbt.project import Project
+from sqlmesh.dbt.seed import SeedConfig
 from sqlmesh.utils import UniqueKeyDict
+from sqlmesh.utils.cache import FileCache
 
 
 def sqlmesh_config(project_root: t.Optional[Path] = None, **kwargs: t.Any) -> Config:
@@ -55,19 +59,53 @@ class DbtLoader(Loader):
 
         context = project.context.copy()
 
+        macros_max_mtime: t.Optional[float] = None
+
         for package_name, package in project.packages.items():
             context.jinja_macros.add_macros(
-                package.macros,
+                package.macro_infos,
                 package=package_name if package_name != context.project_name else None,
             )
+            macro_files_mtime = [
+                self._path_mtimes[m.path]
+                for m in package.macros.values()
+                if m.path in self._path_mtimes
+            ]
+            if macros_max_mtime is not None:
+                macros_max_mtime = max(macro_files_mtime + [macros_max_mtime])
+            else:
+                macros_max_mtime = max(macro_files_mtime)
+
+        cache_path = self._context.path / c.CACHE / context.target.name
+        model_cache = ModelCache(cache_path)
+        model_config_cache = FileCache(cache_path, ModelConfig, prefix="model_config")
+        seed_config_cache = FileCache(cache_path, SeedConfig, prefix="seed_config")
+
+        yaml_max_mtimes = self._compute_yaml_max_mtime_per_subfolder(self._context.path)
+
+        def _cache_entry_id(target_path: Path) -> str:
+            max_mtime = self._max_mtime_for_path(
+                target_path, project, yaml_max_mtimes, macros_max_mtime
+            )
+            return str(int(max_mtime)) if max_mtime is not None else "na"
 
         # First render all the config and discover dependencies
         for package in project.packages.values():
             context.variables = package.variables
 
             package.sources = {k: v.render_config(context) for k, v in package.sources.items()}
-            package.seeds = {k: v.render_config(context) for k, v in package.seeds.items()}
-            package.models = {k: v.render_config(context) for k, v in package.models.items()}
+            package.seeds = {
+                k: seed_config_cache.get_or_load(
+                    k, _cache_entry_id(v.path), lambda: v.render_config(context)
+                )
+                for k, v in package.seeds.items()
+            }
+            package.models = {
+                k: model_config_cache.get_or_load(
+                    k, _cache_entry_id(v.path), lambda: v.render_config(context)
+                )
+                for k, v in package.models.items()
+            }
 
             context.add_sources(package.sources)
             context.add_seeds(package.seeds)
@@ -77,11 +115,66 @@ class DbtLoader(Loader):
         for package in project.packages.values():
             context.variables = package.variables
             package_models: t.Dict[str, BaseModelConfig] = {**package.models, **package.seeds}
+
             models.update(
-                {model.model_name: model.to_sqlmesh(context) for model in package_models.values()}
+                {
+                    model.model_name: model_cache.get_or_load(
+                        model.table_name,
+                        _cache_entry_id(model.path),
+                        lambda: model.to_sqlmesh(context),
+                    )
+                    for model in package_models.values()
+                }
             )
 
         return models
 
     def _load_audits(self) -> UniqueKeyDict[str, Audit]:
         return UniqueKeyDict("audits")
+
+    def _max_mtime_for_path(
+        self,
+        target_path: Path,
+        project: Project,
+        yaml_max_mtimes: t.Dict[Path, float],
+        macros_max_mtime: t.Optional[float],
+    ) -> t.Optional[float]:
+        project_root = project.context.project_root
+
+        if not target_path.is_relative_to(project_root):
+            return None
+
+        mtimes = [
+            self._path_mtimes.get(target_path),
+            self._path_mtimes.get(project.profile.path),
+            # FIXME: take into account which macros are actually referenced in the target model.
+            macros_max_mtime,
+        ]
+
+        cursor = target_path
+        while cursor != project_root:
+            cursor = cursor.parent
+            mtimes.append(yaml_max_mtimes.get(cursor))
+
+        non_null_mtimes = [t for t in mtimes if t is not None]
+        return max(non_null_mtimes) if non_null_mtimes else None
+
+    def _compute_yaml_max_mtime_per_subfolder(self, root: Path) -> t.Dict[Path, float]:
+        if not root.is_dir():
+            return {}
+
+        result = {}
+        max_mtime: t.Optional[float] = None
+
+        for nested in root.iterdir():
+            if nested.is_dir():
+                result.update(self._compute_yaml_max_mtime_per_subfolder(nested))
+            elif nested.suffix.lower() in (".yaml", ".yml"):
+                yaml_mtime = self._path_mtimes.get(nested)
+                if yaml_mtime:
+                    max_mtime = max(max_mtime, yaml_mtime) if max_mtime is not None else yaml_mtime
+
+        if max_mtime is not None:
+            result[root] = max_mtime
+
+        return result

--- a/sqlmesh/dbt/project.py
+++ b/sqlmesh/dbt/project.py
@@ -71,7 +71,7 @@ class Project:
         if extra_fields:
             extra_str = ",".join(f"'{field}'" for field in extra_fields)
             logger.warning(
-                f"Warning: {profile.target.type} adapter does not currently support {extra_str}."
+                "%s adapter does not currently support %s", profile.target.type, extra_str
             )
 
         packages = {}

--- a/sqlmesh/utils/cache.py
+++ b/sqlmesh/utils/cache.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+import pickle
+import typing as t
+from pathlib import Path
+
+from sqlmesh.utils.errors import SQLMeshError
+from sqlmesh.utils.pydantic import PydanticModel
+
+logger = logging.getLogger(__name__)
+
+T = t.TypeVar("T", bound=PydanticModel)
+
+
+class FileCache(t.Generic[T]):
+    def __init__(
+        self,
+        path: Path,
+        entry_class: t.Type[T],
+        prefix: t.Optional[str] = None,
+    ):
+        self._path = path / prefix if prefix else path
+        self._entry_class = entry_class
+
+    def get_or_load(self, name: str, entry_id: str, loader: t.Callable[[], T]) -> T:
+        cached_entry = self.get(name, entry_id)
+        if cached_entry:
+            return cached_entry
+
+        loaded_entry = loader()
+        self.put(name, entry_id, loaded_entry)
+        return loaded_entry
+
+    def get(self, name: str, entry_id: str) -> t.Optional[T]:
+        cache_entry_path = self._cache_entry_path(name, entry_id)
+        if cache_entry_path.exists():
+            with open(cache_entry_path, "rb") as fd:
+                try:
+                    return self._entry_class.parse_obj(pickle.load(fd))
+                except Exception as ex:
+                    logger.warning("Failed to load a cache entry '%s': %s", name, ex)
+
+        return None
+
+    def put(self, name: str, entry_id: str, value: T) -> None:
+        if not self._path.exists():
+            self._path.mkdir(parents=True)
+        if not self._path.is_dir():
+            raise SQLMeshError(f"Cache path '{self._path}' is not a directory.")
+
+        for obsolete_cache_file in self._path.glob(f"{name}__*"):
+            obsolete_cache_file.unlink()
+
+        with open(self._cache_entry_path(name, entry_id), "wb") as fd:
+            pickle.dump(value.dict(), fd)
+
+    def _cache_entry_path(self, name: str, entry_id: str) -> Path:
+        try:
+            from sqlmesh._version import __version_tuple__
+
+            major, minor = __version_tuple__[0], __version_tuple__[1]
+        except ImportError:
+            major, minor = 0, 0
+        return self._path / f"{name}__{major}__{minor}__{entry_id}"

--- a/sqlmesh/utils/cache.py
+++ b/sqlmesh/utils/cache.py
@@ -29,6 +29,7 @@ class FileCache(t.Generic[T]):
         prefix: The prefix shared between all entries to distinguish them from other entries
             stored in the same cache folder.
     """
+
     def __init__(
         self,
         path: Path,

--- a/sqlmesh/utils/cache.py
+++ b/sqlmesh/utils/cache.py
@@ -5,12 +5,19 @@ import pickle
 import typing as t
 from pathlib import Path
 
+from sqlglot import __version__ as SQLGLOT_VERSION
+
 from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.pydantic import PydanticModel
 
 logger = logging.getLogger(__name__)
 
 T = t.TypeVar("T", bound=PydanticModel)
+
+
+SQLGLOT_VERSION_TUPLE = tuple(SQLGLOT_VERSION.split("."))
+SQLGLOT_MAJOR_VERSION = SQLGLOT_VERSION_TUPLE[0]
+SQLGLOT_MINOR_VERSION = SQLGLOT_VERSION_TUPLE[1]
 
 
 class FileCache(t.Generic[T]):
@@ -62,4 +69,5 @@ class FileCache(t.Generic[T]):
             major, minor = __version_tuple__[0], __version_tuple__[1]
         except ImportError:
             major, minor = 0, 0
-        return self._path / f"{name}__{major}__{minor}__{entry_id}"
+        entry_file_name = f"{name}__{major}__{minor}__{SQLGLOT_MAJOR_VERSION}__{SQLGLOT_MINOR_VERSION}__{entry_id}"
+        return self._path / entry_file_name

--- a/sqlmesh/utils/cache.py
+++ b/sqlmesh/utils/cache.py
@@ -21,6 +21,14 @@ SQLGLOT_MINOR_VERSION = SQLGLOT_VERSION_TUPLE[1]
 
 
 class FileCache(t.Generic[T]):
+    """Generic file-based cache implementation.
+
+    Args:
+        path: The path to the cache folder.
+        entry_class: The type of cached entries.
+        prefix: The prefix shared between all entries to distinguish them from other entries
+            stored in the same cache folder.
+    """
     def __init__(
         self,
         path: Path,
@@ -31,6 +39,16 @@ class FileCache(t.Generic[T]):
         self._entry_class = entry_class
 
     def get_or_load(self, name: str, entry_id: str, loader: t.Callable[[], T]) -> T:
+        """Returns an existing cached entry or loads and caches a new one.
+
+        Args:
+            name: The name of the entry.
+            entry_id: The unique entry identifier. Used for cache invalidation.
+            loader: Used to load a new entry when no cached instance was found.
+
+        Returns:
+            The entry.
+        """
         cached_entry = self.get(name, entry_id)
         if cached_entry:
             return cached_entry
@@ -40,6 +58,15 @@ class FileCache(t.Generic[T]):
         return loaded_entry
 
     def get(self, name: str, entry_id: str) -> t.Optional[T]:
+        """Returns a cached entry if exists.
+
+        Args:
+            name: The name of the entry.
+            entry_id: The unique entry identifier. Used for cache invalidation.
+
+        Returns:
+            The entry or None if no entry was found in the cache.
+        """
         cache_entry_path = self._cache_entry_path(name, entry_id)
         if cache_entry_path.exists():
             with open(cache_entry_path, "rb") as fd:
@@ -51,6 +78,13 @@ class FileCache(t.Generic[T]):
         return None
 
     def put(self, name: str, entry_id: str, value: T) -> None:
+        """Stores the given value in the cache.
+
+        Args:
+            name: The name of the entry.
+            entry_id: The unique entry identifier. Used for cache invalidation.
+            value: The value to store in the cache.
+        """
         if not self._path.exists():
             self._path.mkdir(parents=True)
         if not self._path.is_dir():

--- a/tests/dbt/conftest.py
+++ b/tests/dbt/conftest.py
@@ -14,7 +14,7 @@ def sushi_test_project(mocker: MockerFixture) -> Project:
     project = Project.load(DbtContext(project_root=Path("tests/fixtures/dbt/sushi_test")))
     for package_name, package in project.packages.items():
         project.context.jinja_macros.add_macros(
-            package.macros,
+            package.macro_infos,
             package=package_name if package_name != project.context.project_name else None,
         )
     return project

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from pytest_mock.plugin import MockerFixture
+
+from sqlmesh.utils.cache import FileCache
+from sqlmesh.utils.pydantic import PydanticModel
+
+
+class TestEntry(PydanticModel):
+    value: str
+
+
+def test_file_cache(tmp_path: Path, mocker: MockerFixture):
+    cache = FileCache(tmp_path, TestEntry)
+
+    test_entry_a = TestEntry(value="value_a")
+    test_entry_b = TestEntry(value="value_b")
+
+    loader = mocker.Mock(return_value=test_entry_a)
+
+    assert cache.get("test_name", "test_entry_a") is None
+
+    assert cache.get_or_load("test_name", "test_entry_a", loader) == test_entry_a
+    assert cache.get_or_load("test_name", "test_entry_a", loader) == test_entry_a
+    assert cache.get("test_name", "test_entry_a") == test_entry_a
+
+    cache.put("test_name", "test_entry_b", test_entry_b)
+    assert cache.get("test_name", "test_entry_b") == test_entry_b
+    assert cache.get_or_load("test_name", "test_entry_b", loader) == test_entry_b
+    assert cache.get("test_name", "test_entry_a") is None
+
+    assert cache.get("different_name", "test_entry_b") is None
+
+    loader.assert_called_once()


### PR DESCRIPTION
There is also an opportunity to cache the `python_env` after it's been compiled by `prepare_env` but this hasn't been addressed in this PR.