### PR TITLE
Chore: Add ability to enable a debug mode

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -8,6 +8,9 @@ Configuration options from different sources have the following order of precede
 2. Set in `config.yaml` in a project folder.
 3. Set in `config.yaml` in the `~/.sqlmesh` folder.
 
+## Debug mode
+To enable the debug mode set the `SQLMESH_DEBUG` environment variable to one of the following values: "1", "true", "t", "yes" or "y". Enabling this mode ensures that full backtraces are printed when using CLI. Additionally the default log level is set to `DEBUG` when this mode is enabled.
+
 ## Connections
 
 A dictionary of supported connections and their configurations. The key represents a unique connection name. If there is only one connection, its configuration can be provided directly, omitting the dictionary.

--- a/sqlmesh/__init__.py
+++ b/sqlmesh/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import typing as t
 from enum import Enum
 
 from sqlmesh.core.dialect import extend_sqlglot
@@ -112,10 +113,15 @@ class CustomFormatter(logging.Formatter):
         return formatter.format(record)
 
 
-def enable_logging(level: int = logging.INFO) -> None:
+def debug_mode_enabled() -> bool:
+    return os.environ.get("SQLMESH_DEBUG", "").lower() in ("1", "true", "t", "yes", "y")
+
+
+def enable_logging(level: t.Optional[int] = None) -> None:
     """Enable logging to send to stdout and color different levels"""
+    level = level or (logging.DEBUG if debug_mode_enabled() else logging.INFO)
     logger = logging.getLogger()
-    logger.setLevel(level)
+    logger.setLevel(level if not debug_mode_enabled() else logging.DEBUG)
     if not logger.hasHandlers():
         handler = logging.StreamHandler(sys.stdout)
         handler.setLevel(level)

--- a/sqlmesh/cli/__init__.py
+++ b/sqlmesh/cli/__init__.py
@@ -4,6 +4,7 @@ from functools import wraps
 import click
 from sqlglot.errors import SqlglotError
 
+from sqlmesh import debug_mode_enabled
 from sqlmesh.utils.concurrency import NodeExecutionFailedError
 from sqlmesh.utils.errors import SQLMeshError
 
@@ -23,4 +24,4 @@ def error_handler(
         except (SQLMeshError, SqlglotError, ValueError) as ex:
             raise click.ClickException(str(ex))
 
-    return wrapper
+    return wrapper if not debug_mode_enabled() else func


### PR DESCRIPTION
Enabling the debug mode ensures that full backtraces are printed in CLI and that the default log level is set to DEBUG.