### PR TITLE
Fix: Allow empty files in models folder and refetch lineage on model file change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
         ],
         "web": [
             "fastapi==0.95.0",
-            "hyperscript==0.0.1",
+            "watchfiles==0.19.0",
             "pyarrow==11.0.0",
             "uvicorn==0.21.1",
         ],

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -193,10 +193,10 @@ class SqlMeshLoader(Loader):
             cache = SqlMeshLoader._Cache(self, context_path)
 
             for path in self._glob_paths(context_path / c.MODELS, config=config, extension=".sql"):
-                self._track_file(path)
-
                 if not os.path.getsize(path):
                     continue
+
+                self._track_file(path)
 
                 def _load() -> Model:
                     with open(path, "r", encoding="utf-8") as file:

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -195,6 +195,9 @@ class SqlMeshLoader(Loader):
             for path in self._glob_paths(context_path / c.MODELS, config=config, extension=".sql"):
                 self._track_file(path)
 
+                if not os.path.getsize(path):
+                    continue
+
                 def _load() -> Model:
                     with open(path, "r", encoding="utf-8") as file:
                         try:
@@ -234,6 +237,9 @@ class SqlMeshLoader(Loader):
 
         for context_path, config in self._context.configs.items():
             for path in self._glob_paths(context_path / c.MODELS, config=config, extension=".py"):
+                if not os.path.getsize(path):
+                    continue
+
                 self._track_file(path)
                 self._import_python_file(path, context_path)
                 new = registry.keys() - registered

--- a/web/client/src/library/components/ide/IDE.tsx
+++ b/web/client/src/library/components/ide/IDE.tsx
@@ -62,6 +62,7 @@ export function IDE(): JSX.Element {
 
   useEffect(() => {
     const unsubscribeTasks = subscribe('tasks', updateTasks)
+    const unsubscribeModels = subscribe('models', setModels)
 
     void debouncedGetEnvironemnts()
     void debouncedGetFiles()
@@ -77,6 +78,7 @@ export function IDE(): JSX.Element {
       apiCancelGetEnvironments(client)
 
       unsubscribeTasks?.()
+      unsubscribeModels?.()
     }
   }, [])
 

--- a/web/client/src/models/file.ts
+++ b/web/client/src/models/file.ts
@@ -52,6 +52,10 @@ export class ModelFile extends ModelArtifact<InitialFile> {
     return this.type === 'model'
   }
 
+  get fingerprint(): string {
+    return this._content
+  }
+
   updateContent(newContent: string = ''): void {
     this._content = newContent
     this.content = newContent

--- a/web/server/api/endpoints/files.py
+++ b/web/server/api/endpoints/files.py
@@ -87,7 +87,7 @@ def get_files(
 def get_file(
     path: str = Depends(validate_path),
     settings: Settings = Depends(get_settings),
-    path_mapping: t.Dict[str, t.Any] = Depends(get_path_mapping),
+    path_mapping: t.Dict[Path, models.FileType] = Depends(get_path_mapping),
 ) -> models.File:
     """Get a file, including its contents."""
     try:
@@ -96,7 +96,7 @@ def get_file(
     except FileNotFoundError:
         raise HTTPException(status_code=HTTP_404_NOT_FOUND)
     return models.File(
-        name=os.path.basename(path), path=path, content=content, type=path_mapping.get(path)
+        name=os.path.basename(path), path=path, content=content, type=path_mapping.get(Path(path))
     )
 
 
@@ -117,8 +117,12 @@ async def write_file(
         (settings.project_path / path_or_new_path).write_text(content, encoding="utf-8")
 
     content = (settings.project_path / path_or_new_path).read_text()
+    path_mapping = await get_path_mapping(settings)
     return models.File(
-        name=os.path.basename(path_or_new_path), path=path_or_new_path, content=content
+        name=os.path.basename(path_or_new_path),
+        path=path_or_new_path,
+        content=content,
+        type=path_mapping.get(Path(path)),
     )
 
 

--- a/web/server/api/endpoints/files.py
+++ b/web/server/api/endpoints/files.py
@@ -107,6 +107,7 @@ async def write_file(
     path: str = Depends(validate_path),
     settings: Settings = Depends(get_settings),
     context: Context = Depends(get_context),
+    path_mapping: t.Dict[Path, models.FileType] = Depends(get_path_mapping),
 ) -> models.File:
     """Create, update, or rename a file."""
     path_or_new_path = path
@@ -117,7 +118,6 @@ async def write_file(
         (settings.project_path / path_or_new_path).write_text(content, encoding="utf-8")
 
     content = (settings.project_path / path_or_new_path).read_text()
-    path_mapping = await get_path_mapping(settings)
     return models.File(
         name=os.path.basename(path_or_new_path),
         path=path_or_new_path,

--- a/web/server/api/endpoints/plan.py
+++ b/web/server/api/endpoints/plan.py
@@ -78,7 +78,7 @@ async def run_plan(
                     [to_ds(t) for t in make_inclusive(start, end)]
                     for start, end in interval.merged_intervals
                 ][0],
-                batches=tasks[interval.snapshot_name] if interval.snapshot_name in tasks else 0,
+                batches=tasks.get(interval.snapshot_name, 0),
             )
             for interval in plan.missing_intervals
         ]

--- a/web/server/api/endpoints/plan.py
+++ b/web/server/api/endpoints/plan.py
@@ -78,7 +78,7 @@ async def run_plan(
                     [to_ds(t) for t in make_inclusive(start, end)]
                     for start, end in interval.merged_intervals
                 ][0],
-                batches=tasks[interval.snapshot_name],
+                batches=tasks[interval.snapshot_name] if interval.snapshot_name in tasks else 0,
             )
             for interval in plan.missing_intervals
         ]

--- a/web/server/main.py
+++ b/web/server/main.py
@@ -27,13 +27,13 @@ async def startup_event() -> None:
 
     app.state.console_listeners = []
     app.state.dispatch_task = asyncio.create_task(dispatch())
-
-    asyncio.create_task(watch_project(api_console.queue))
+    app.state.watch_task = asyncio.create_task(watch_project(api_console.queue))
 
 
 @app.on_event("shutdown")
 def shutdown_event() -> None:
     app.state.dispatch_task.cancel()
+    app.state.watch_task.cancel()
 
 
 @app.get("/health")

--- a/web/server/main.py
+++ b/web/server/main.py
@@ -7,6 +7,7 @@ from fastapi.staticfiles import StaticFiles
 
 from web.server.api.endpoints import api_router
 from web.server.console import ApiConsole
+from web.server.watcher import watch_project
 
 app = FastAPI()
 api_console = ApiConsole()
@@ -26,6 +27,8 @@ async def startup_event() -> None:
 
     app.state.console_listeners = []
     app.state.dispatch_task = asyncio.create_task(dispatch())
+
+    asyncio.create_task(watch_project(api_console.queue))
 
 
 @app.on_event("shutdown")

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -1,0 +1,37 @@
+import asyncio
+import json
+import typing as t
+from pathlib import Path
+
+from watchfiles import awatch
+
+from sqlmesh.core.context import Context
+from web.server.api.endpoints.models import get_models
+from web.server.settings import get_loaded_context, get_settings
+from web.server.sse import Event
+
+
+async def watch_project(queue: asyncio.Queue) -> None:
+    settings = get_settings()
+    context = await get_loaded_context(settings)
+
+    _get_path = _to_relative_path(context)
+
+    async for changes in awatch(settings.project_path):
+        context.load()
+
+        changed_models = []
+        output_models = []
+        changes_path = {_get_path(path) for type, path in changes if type == 2}
+
+        for model in get_models(context):
+            if model.path in changes_path:
+                changed_models.append(model)
+            output_models.append(model.dict())
+
+        if changed_models:
+            queue.put_nowait(Event(event="models", data=json.dumps(output_models)))
+
+
+def _to_relative_path(context: Context) -> t.Callable[[str], str]:
+    return lambda path: str(Path(path).relative_to(context.path))

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -1,11 +1,9 @@
 import asyncio
 import json
-import typing as t
 from pathlib import Path
 
 from watchfiles import awatch
 
-from sqlmesh.core.context import Context
 from web.server.api.endpoints.models import get_models
 from web.server.settings import get_loaded_context, get_settings
 from web.server.sse import Event
@@ -15,23 +13,20 @@ async def watch_project(queue: asyncio.Queue) -> None:
     settings = get_settings()
     context = await get_loaded_context(settings)
 
-    _get_path = _to_relative_path(context)
+    def _get_path(path: str) -> str:
+        return str(Path(path).relative_to(context.path))
 
     async for changes in awatch(settings.project_path):
         context.load()
 
+        changes_paths = {_get_path(path) for type, path in changes if type == 2}
         changed_models = []
         output_models = []
-        changes_path = {_get_path(path) for type, path in changes if type == 2}
 
         for model in get_models(context):
-            if model.path in changes_path:
+            if model.path in changes_paths:
                 changed_models.append(model)
             output_models.append(model.dict())
 
         if changed_models:
             queue.put_nowait(Event(event="models", data=json.dumps(output_models)))
-
-
-def _to_relative_path(context: Context) -> t.Callable[[str], str]:
-    return lambda path: str(Path(path).relative_to(context.path))

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -1,8 +1,7 @@
 import asyncio
 import json
-from pathlib import Path
 
-from watchfiles import Change, DefaultFilter, awatch
+from watchfiles import DefaultFilter, awatch
 
 from sqlmesh.core import constants as c
 from web.server.api.endpoints.models import get_models
@@ -14,15 +13,12 @@ async def watch_project(queue: asyncio.Queue) -> None:
     settings = get_settings()
     context = await get_loaded_context(settings)
 
-    class IgnorePatternsFilter(DefaultFilter):
-        ignore_patterns = context.config.ignore_patterns if context else c.IGNORE_PATTERNS
-
-        def __call__(self, change: Change, path: str) -> bool:
-            return super().__call__(change, path) and not any(
-                Path(path).match(pattern) for pattern in self.ignore_patterns
-            )
-
-    async for _ in awatch((context.path / c.MODELS).resolve(), watch_filter=IgnorePatternsFilter()):
+    async for _ in awatch(
+        (context.path / c.MODELS).resolve(),
+        watch_filter=DefaultFilter(
+            ignore_entity_patterns=context.config.ignore_patterns if context else c.IGNORE_PATTERNS
+        ),
+    ):
         context.load()
 
         queue.put_nowait(

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from watchfiles import awatch
 
+from sqlmesh.core import constants as c
 from web.server.api.endpoints.models import get_models
 from web.server.settings import get_loaded_context, get_settings
 from web.server.sse import Event
@@ -12,21 +13,18 @@ from web.server.sse import Event
 async def watch_project(queue: asyncio.Queue) -> None:
     settings = get_settings()
     context = await get_loaded_context(settings)
+    ignore_patterns = context.config.ignore_patterns if context else c.IGNORE_PATTERNS
 
-    def _get_path(path: str) -> str:
-        return str(Path(path).relative_to(context.path))
-
-    async for changes in awatch(settings.project_path):
+    async for changes in awatch((context.path / "models").resolve()):
         context.load()
 
-        changes_paths = {_get_path(path) for type, path in changes if type == 2}
-        changed_models = []
         output_models = []
 
-        for model in get_models(context):
-            if model.path in changes_paths:
-                changed_models.append(model)
-            output_models.append(model.dict())
+        for _, path in changes:
+            if any(Path(path).match(pattern) for pattern in ignore_patterns):
+                continue
 
-        if changed_models:
-            queue.put_nowait(Event(event="models", data=json.dumps(output_models)))
+            for model in get_models(context):
+                output_models.append(model.dict())
+
+        queue.put_nowait(Event(event="models", data=json.dumps(output_models)))


### PR DESCRIPTION
Currently if user tries to add new file to `model's` folder it immediately crushing and sending Error, even before user even have a chance to create a valid model.