### PR TITLE
Fix: Postgres `MERGE` should not qualify target table alias on `UPDATE`

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -60,6 +60,7 @@ class EngineAdapter:
     DEFAULT_BATCH_SIZE = 10000
     DEFAULT_SQL_GEN_KWARGS: t.Dict[str, str | bool | int] = {}
     ESCAPE_JSON = False
+    QUALIFY_TARGET_COLUMN_MERGE = True
     SUPPORTS_INDEXES = False
     SCHEMA_DIFFER = SchemaDiffer()
 
@@ -660,7 +661,10 @@ class EngineAdapter:
             then=exp.Update(
                 expressions=[
                     exp.EQ(
-                        this=exp.column(col, TARGET_ALIAS), expression=exp.column(col, SOURCE_ALIAS)
+                        this=exp.column(
+                            col, TARGET_ALIAS if self.QUALIFY_TARGET_COLUMN_MERGE else None
+                        ),
+                        expression=exp.column(col, SOURCE_ALIAS),
                     )
                     for col in column_names
                 ],

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 class PostgresEngineAdapter(BasePostgresEngineAdapter):
     DIALECT = "postgres"
+    QUALIFY_TARGET_COLUMN_MERGE = False
     SUPPORTS_INDEXES = True
 
     @property

--- a/tests/core/engine_adapter/test_postgres.py
+++ b/tests/core/engine_adapter/test_postgres.py
@@ -46,3 +46,22 @@ def test_replace_query_does_not_exist(mocker: MockerFixture):
     cursor_mock.execute.assert_called_once_with(
         """CREATE TABLE db.table AS SELECT col FROM db.other_table"""
     )
+
+
+def test_merge_does_not_qualify_target_table(mocker: MockerFixture):
+    connection_mock = mocker.NonCallableMock()
+    cursor_mock = mocker.Mock()
+    connection_mock.cursor.return_value = cursor_mock
+
+    adapter = PostgresEngineAdapter(lambda: connection_mock, "")  # type: ignore
+    adapter.merge(
+        target_table="target",
+        source_table="SELECT id, ts, val FROM source",
+        column_names=["id", "ts", "val"],
+        unique_key=["id", "ts"],
+    )
+    cursor_mock.execute.assert_called_once_with(
+        "MERGE INTO target AS __MERGE_TARGET__ USING (SELECT id, ts, val FROM source) AS __MERGE_SOURCE__ ON __MERGE_TARGET__.id = __MERGE_SOURCE__.id AND __MERGE_TARGET__.ts = __MERGE_SOURCE__.ts "
+        "WHEN MATCHED THEN UPDATE SET id = __MERGE_SOURCE__.id, ts = __MERGE_SOURCE__.ts, val = __MERGE_SOURCE__.val "
+        "WHEN NOT MATCHED THEN INSERT (id, ts, val) VALUES (__MERGE_SOURCE__.id, __MERGE_SOURCE__.ts, __MERGE_SOURCE__.val)"
+    )


### PR DESCRIPTION
Currently the `merge` method of `EngineAdapter` always qualifies the target column to be updated with the alias of the target table. However, this will fail on Postgres 15 (e.g. when we try `INCREMENTAL_BY_UNIQUE_KEY` for a `dim` table) as their docs request it not to be specified.

https://www.postgresql.org/docs/current/sql-merge.html

> The name of a column in the target_table_name. The column name can be qualified with a subfield name or array subscript, if needed. (Inserting into only some fields of a composite column leaves the other fields null.) Do not include the table's name in the specification of a target column.

This PR aims to correct this. Not sure if there is a preferred alternative approach.