### PR TITLE
[Docs] Add Postgres to engine configuration list

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -39,6 +39,7 @@ connections:
 * [BigQuery](../integrations/engines.md#bigquery---localbuilt-in-scheduler)
 * [Databricks](../integrations/engines.md#databricks---localbuilt-in-scheduler)
 * [DuckDB](../integrations/engines.md#duckdb---localbuilt-in-scheduler)
+* [Postgres](../integrations/engines.md#postgres---localbuilt-in-scheduler)
 * [Redshift](../integrations/engines.md#redshift---localbuilt-in-scheduler)
 * [Snowflake](../integrations/engines.md#snowflake---localbuilt-in-scheduler)
 * [Spark](../integrations/engines.md#spark---localbuilt-in-scheduler)


### PR DESCRIPTION
- Added Postgres to the links for engine configurations

**Suggestion**
- In doing this I have noticed that the links to the specific engine headings work fine in a code editor but when you click them from a web browser they all lead to BigQuery which is at the top of the list. Users then need to scroll down to the configuration they actually wanted to view.
- I believe this is to do with the format of `#postgres---localbuilt-in-scheduler` and if this is changed to a simpler heading without punctuation then it would fix it. 
- Happy to make this change as part of this PR if you have preferences for a better heading.