### PR TITLE
Fix: Introduce environment finalization

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -892,7 +892,7 @@ class Context(BaseContext):
 
     def _context_diff(
         self,
-        environment: str | Environment,
+        environment: str,
         snapshots: t.Optional[t.Dict[str, Snapshot]] = None,
         create_from: t.Optional[str] = None,
     ) -> ContextDiff:

--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -37,7 +37,7 @@ class ContextDiff(PydanticModel):
     """The environment to diff."""
     is_new_environment: bool
     """Whether the target environment is new."""
-    is_unfinilized_environment: bool
+    is_unfinalized_environment: bool
     """Whether the currently stored environment record is in unfinalized state."""
     create_from: str
     """The name of the environment the target environment will be created from if new."""
@@ -148,7 +148,7 @@ class ContextDiff(PydanticModel):
         return ContextDiff(
             environment=environment,
             is_new_environment=is_new_environment,
-            is_unfinilized_environment=bool(env and not env.finalized_at_ts),
+            is_unfinalized_environment=bool(env and not env.finalized_ts),
             create_from=create_from,
             added=added,
             removed=removed,
@@ -161,7 +161,7 @@ class ContextDiff(PydanticModel):
     @property
     def has_changes(self) -> bool:
         return (
-            self.has_snapshot_changes or self.is_new_environment or self.is_unfinilized_environment
+            self.has_snapshot_changes or self.is_new_environment or self.is_unfinalized_environment
         )
 
     @property

--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -24,7 +24,7 @@ class Environment(PydanticModel):
     plan_id: str
     previous_plan_id: t.Optional[str]
     expiration_ts: t.Optional[int]
-    finalized_at_ts: t.Optional[int]
+    finalized_ts: t.Optional[int]
 
     @validator("snapshots", pre=True)
     @classmethod

--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -24,6 +24,7 @@ class Environment(PydanticModel):
     plan_id: str
     previous_plan_id: t.Optional[str]
     expiration_ts: t.Optional[int]
+    finalized_at_ts: t.Optional[int]
 
     @validator("snapshots", pre=True)
     @classmethod

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -137,6 +137,7 @@ class BuiltInPlanEvaluator(PlanEvaluator):
                 environment=environment.name,
                 on_complete=on_complete,
             )
+            self.state_sync.finalize(environment)
             completed = True
         finally:
             self.console.stop_promotion_progress(success=completed)

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -338,6 +338,15 @@ class StateSync(StateReader, abc.ABC):
         """
 
     @abc.abstractmethod
+    def finalize(self, environment: Environment) -> None:
+        """Finalize the target environment, indicating that this environment has been
+        fully promoted and is ready for use.
+
+        Args:
+            environment: The target environment to finalize.
+        """
+
+    @abc.abstractmethod
     def delete_expired_environments(self) -> t.List[Environment]:
         """Removes expired environments.
 

--- a/sqlmesh/core/state_sync/common.py
+++ b/sqlmesh/core/state_sync/common.py
@@ -146,7 +146,7 @@ class CommonStateSyncMixin(StateSync):
                 f"Stored plan ID: '{stored_environment.plan_id}'. Please recreate the plan and try again"
             )
 
-        environment.finalized_at_ts = now_timestamp()
+        environment.finalized_ts = now_timestamp()
         self._update_environment(environment)
 
     @transactional()

--- a/sqlmesh/core/state_sync/common.py
+++ b/sqlmesh/core/state_sync/common.py
@@ -17,7 +17,7 @@ from sqlmesh.core.snapshot import (
     SnapshotTableInfo,
 )
 from sqlmesh.core.state_sync.base import StateSync
-from sqlmesh.utils.date import TimeLike, now, to_datetime
+from sqlmesh.utils.date import TimeLike, now, now_timestamp, to_datetime
 from sqlmesh.utils.errors import SQLMeshError
 
 logger = logging.getLogger(__name__)
@@ -128,6 +128,26 @@ class CommonStateSyncMixin(StateSync):
         table_infos = [s.table_info for s in snapshots]
         self._update_environment(environment)
         return table_infos, [existing_table_infos[name] for name in missing_models]
+
+    @transactional()
+    def finalize(self, environment: Environment) -> None:
+        """Finalize the target environment, indicating that this environment has been
+        fully promoted and is ready for use.
+
+        Args:
+            environment: The target environment to finalize.
+        """
+        logger.info("Finalizing environment '%s'", environment)
+
+        stored_environment = self._get_environment(environment.name, lock_for_update=True)
+        if stored_environment and stored_environment.plan_id != environment.plan_id:
+            raise SQLMeshError(
+                f"Plan '{environment.plan_id}' is no longer valid for the target environment '{environment.name}'. "
+                f"Stored plan ID: '{stored_environment.plan_id}'. Please recreate the plan and try again"
+            )
+
+        environment.finalized_at_ts = now_timestamp()
+        self._update_environment(environment)
 
     @transactional()
     def delete_expired_snapshots(self) -> t.List[Snapshot]:

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -90,7 +90,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
             "plan_id": exp.DataType.build("text"),
             "previous_plan_id": exp.DataType.build("text"),
             "expiration_ts": exp.DataType.build("bigint"),
-            "finalized_at_ts": exp.DataType.build("bigint"),
+            "finalized_ts": exp.DataType.build("bigint"),
         }
 
     @property
@@ -237,7 +237,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
                             environment.plan_id,
                             environment.previous_plan_id,
                             environment.expiration_ts,
-                            environment.finalized_at_ts,
+                            environment.finalized_ts,
                         )
                     ],
                     columns_to_types=self.environment_columns_to_types,

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -90,6 +90,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
             "plan_id": exp.DataType.build("text"),
             "previous_plan_id": exp.DataType.build("text"),
             "expiration_ts": exp.DataType.build("bigint"),
+            "finalized_at_ts": exp.DataType.build("bigint"),
         }
 
     @property
@@ -236,6 +237,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
                             environment.plan_id,
                             environment.previous_plan_id,
                             environment.expiration_ts,
+                            environment.finalized_at_ts,
                         )
                     ],
                     columns_to_types=self.environment_columns_to_types,

--- a/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
+++ b/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
@@ -1,0 +1,19 @@
+"""Add support for environment finalization."""
+from sqlglot import exp
+
+
+def migrate(state_sync):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    environments_table = state_sync.environments_table
+
+    alter_table_exp = exp.AlterTable(
+        this=exp.to_table(environments_table),
+        actions=[
+            exp.ColumnDef(
+                this=exp.to_column("finalized_at_ts"),
+                kind=exp.DataType.build("bigint"),
+            )
+        ],
+    )
+
+    engine_adapter.execute(alter_table_exp)

--- a/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
+++ b/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
@@ -10,7 +10,7 @@ def migrate(state_sync):  # type: ignore
         this=exp.to_table(environments_table),
         actions=[
             exp.ColumnDef(
-                this=exp.to_column("finalized_at_ts"),
+                this=exp.to_column("finalized_ts"),
                 kind=exp.DataType.build("bigint"),
             )
         ],

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -452,8 +452,8 @@ def test_finalize(state_sync: EngineAdapterStateSync, make_snapshot: t.Callable)
             name="a",
             query=parse_one("select 1, ds"),
         ),
-        version="a",
     )
+    snapshot_a.categorize_as(SnapshotChangeCategory.BREAKING)
 
     state_sync.push_snapshots([snapshot_a])
     promote_snapshots(state_sync, [snapshot_a], "prod")

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -464,7 +464,7 @@ def test_finalize(state_sync: EngineAdapterStateSync, make_snapshot: t.Callable)
 
     env = state_sync.get_environment("prod")
     assert env
-    assert env.finalized_at_ts is not None
+    assert env.finalized_ts is not None
 
     env.plan_id = "different_plan_id"
     with pytest.raises(

--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -488,6 +488,7 @@ def test_get_environments(project_context: Context) -> None:
             "plan_id": "",
             "previous_plan_id": None,
             "expiration_ts": None,
+            "finalized_at_ts": None,
         }
     }
 

--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -488,7 +488,7 @@ def test_get_environments(project_context: Context) -> None:
             "plan_id": "",
             "previous_plan_id": None,
             "expiration_ts": None,
-            "finalized_at_ts": None,
+            "finalized_ts": None,
         }
     }
 


### PR DESCRIPTION
The environment record in the state is updated before virtual layer operations are applied to the data warehouse. This leads to scenarios in which SQLMesh ends up in an incorrect state due to the partially applied transition without any ability to repair it.

This PR introduces a new state operation called `finalize` which is applied to the target environment *at the very end* of the plan application process. Thanks to this finalization, SQLMesh can now determine whether the previous environment update was successful and then reapply the plan if it wasn't, even if there's no meaningful difference between the local state and the remote environment otherwise.