### PR TITLE
Modify quickstart project and add seed file

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -38,7 +38,25 @@ This will create the directories and files that you can use to organize your SQL
 
 ## 2. Plan and apply environments
 ### 2.1 Create a prod environment
-This example project structure is a three-model pipeline, where `sqlmesh_example.full_model` depends on `sqlmesh_example.incremental_model`, which in turn depends on `sqlmesh_example.seed_model`. 
+This example project structure is a three-model pipeline with a CSV acting as a source data file: 
+
+```
+┌─────────────┐
+│seed_data.csv│
+└────────────┬┘
+             │
+            ┌▼─────────────┐
+            │seed_model.sql│
+            └─────────────┬┘
+                          │
+                         ┌▼────────────────────┐
+                         │incremental_model.sql│
+                         └────────────────────┬┘
+                                              │
+                                             ┌▼─────────────┐
+                                             │full_model.sql│
+                                             └──────────────┘
+```
 
 To materialize this pipeline into DuckDB, run `sqlmesh plan` to get started with the plan/apply flow. The prompt will ask you what date to backfill; you can leave those blank for now (hit `Enter`) to backfill all of history. Finally, it will ask you whether or not you want backfill the plan. Enter `y`:
 

--- a/sqlmesh/cli/example_project.py
+++ b/sqlmesh/cli/example_project.py
@@ -198,7 +198,7 @@ def _create_seeds(seeds_path: Path) -> None:
 
 
 def _create_tests(tests_path: Path) -> None:
-    _write_file(tests_path / "test_example_full_model.yaml", EXAMPLE_TEST)
+    _write_file(tests_path / "test_full_model.yaml", EXAMPLE_TEST)
 
 
 def _write_file(path: Path, payload: str) -> None:

--- a/sqlmesh/cli/example_project.py
+++ b/sqlmesh/cli/example_project.py
@@ -181,7 +181,7 @@ def _create_macros(macros_path: Path) -> None:
 
 
 def _create_audits(audits_path: Path) -> None:
-    _write_file(audits_path / "example_full_model.sql", EXAMPLE_AUDIT)
+    _write_file(audits_path / "assert_positive_order_ids.sql", EXAMPLE_AUDIT)
 
 
 def _create_models(models_path: Path) -> None:

--- a/sqlmesh/cli/example_project.py
+++ b/sqlmesh/cli/example_project.py
@@ -192,11 +192,14 @@ def _create_models(models_path: Path) -> None:
     ]:
         _write_file(models_path / f"{model_name.split('.')[-1]}.sql", model_def)
 
+
 def _create_seeds(seeds_path: Path) -> None:
     _write_file(seeds_path / "seed_data.csv", EXAMPLE_SEED_DATA)
 
+
 def _create_tests(tests_path: Path) -> None:
     _write_file(tests_path / "test_example_full_model.yaml", EXAMPLE_TEST)
+
 
 def _write_file(path: Path, payload: str) -> None:
     with open(path, "w", encoding="utf-8") as fd:


### PR DESCRIPTION
Makes some changes to increase the accessibility & readability of the [quick start project](https://sqlmesh.readthedocs.io/en/stable/quick_start/) (what you get when you do `sqlmesh init`): 

- Removed leading `example_` from all model names 
- Added `/seeds` dir, `seed_data.csv`, and `seed_model.sql` model
- Updated `incremental_model.sql` to be downstream of `seed_model.sql` 
- Renamed audit from `example_full_model.sql` to `assert_positive_order_ids.sql` (it tends to be convention to give the audit/macro filename the same name as the audit/macro itself.  
- Updated quick start doc to reflect all of the above, fixed typo with new_columns having `1` not `z`, and added ASCII art of the DAG it builds (could be replaced by an IDE screenshot later). 

I've tested it locally by running `sqlmesh init` and going through the quick start guide and it looks good. The advantage of having a seed file & model is now it's easier for folks to mess around with changing seed data and looking at the impact on the rest of the DAG, as opposed to directly editing the `VALUES()` call within the incremental model definition. 