### PR TITLE
Fix: When applying a forward-only plan in dev the backfill should precede the promotion

### DIFF
--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -61,7 +61,7 @@ class BuiltInPlanEvaluator(PlanEvaluator):
     def evaluate(self, plan: Plan) -> None:
         tasks = (
             [self._push, self._restate, self._backfill, self._promote]
-            if not plan.forward_only
+            if not plan.forward_only or plan.is_dev
             else [self._push, self._restate, self._promote, self._backfill]
         )
 

--- a/sqlmesh/schedulers/airflow/dag_generator.py
+++ b/sqlmesh/schedulers/airflow/dag_generator.py
@@ -166,7 +166,7 @@ class SnapshotDagGenerator:
             ) = self._create_promotion_demotion_tasks(plan_dag_spec)
 
             start_task >> create_start_task
-            if not plan_dag_spec.forward_only:
+            if not plan_dag_spec.forward_only or plan_dag_spec.is_dev:
                 create_end_task >> backfill_start_task
                 backfill_end_task >> promote_start_task
                 latest_end_task = promote_end_task


### PR DESCRIPTION
I forgot that it's ok to backfill before promoting when applying a forward-only plan in dev, since all forward-only snapshots target temp tables and no schema migration takes place.