### PR TITLE
refactor: print rendered dag location in terminal

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -268,7 +268,7 @@ def dag(ctx: click.Context, file: str) -> None:
     """
     rendered_dag_path = ctx.obj.render_dag(file)
     if rendered_dag_path:
-        print(f"Generated the dag to {rendered_dag_path}")
+        ctx.obj.console.log_success(f"Generated the dag to {rendered_dag_path}")
 
 
 @cli.command("test")

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -266,7 +266,9 @@ def dag(ctx: click.Context, file: str) -> None:
 
     This command requires a manual install of both the python and system graphviz package.
     """
-    ctx.obj.render_dag(file)
+    rendered_dag_path = ctx.obj.render_dag(file)
+    if rendered_dag_path:
+        print(f"Generated the dag to {rendered_dag_path}")
 
 
 @cli.command("test")


### PR DESCRIPTION
Added a print statement to print the rendered dag filename in the terminal when `sqlmesh dag` is ran

[#306](https://github.com/TobikoData/sqlmesh/issues/306)