### PR TITLE
Chore: Update uvicorn configs for a better developer experience

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,16 +31,19 @@ services:
   api:
     image: tobiko-api
     container_name: tobiko-api
-    working_dir: /sqlmesh
+    working_dir: /home
     build:
       dockerfile: Dockerfile.api
-    command: python -m uvicorn web.server.main:app --host 0.0.0.0 --port 8000 --reload
+    command: python -m uvicorn web.server.main:app --host 0.0.0.0 --port 8000 --reload --reload-dir /sqlmesh/web/server --reload-dir /sqlmesh/sqlmesh --timeout-graceful-shutdown 1
     ports:
       - 8000:8000
     volumes:
       - .:/sqlmesh
     networks:
       - tobiko-development
+    environment:
+      - PYTHONPATH=/sqlmesh
+      - PROJECT_PATH=/sqlmesh/examples/sushi
 
 networks:
   tobiko-development:

--- a/setup.py
+++ b/setup.py
@@ -102,9 +102,9 @@ setup(
         ],
         "web": [
             "fastapi==0.95.0",
-            "watchfiles==0.19.0",
+            "watchfiles>=0.19.0",
             "pyarrow==11.0.0",
-            "uvicorn==0.21.1",
+            "uvicorn[standard]==0.22.0",
         ],
     },
     classifiers=[


### PR DESCRIPTION
- Less server reloading by only watching `sqlmesh` and `web/server` directories for changes.
- Set a graceful shutdown timeout to force reloading since SSE connections were blocking the server from reloading.