### PR TITLE
Feat: Gateway configuration BREAKING CHANGE

### DIFF
--- a/docs/guides/connections.md
+++ b/docs/guides/connections.md
@@ -4,36 +4,75 @@
 
 **Note:** The following guide only applies when using the built-in scheduler. Connections are configured differently when using an external scheduler such as Airflow. See the [Scheduling guide](scheduling.md) for more details.
 
-In order to deploy models and to apply changes to them, you must configure a connection to the Data Warehouse. This can be done in either the `config.yaml` file in your project folder, or the one in `~/.sqlmesh`.
+In order to deploy models and to apply changes to them, you must configure a connection to your Data Warehouse and, optionally, connection to the database where the SQLMesh state is stored. This can be done in either the `config.yaml` file in your project folder, or the one in `~/.sqlmesh`.
 
-Each configured connection has a unique name associated with it, which can be used to select a specific connection when using the CLI. For example:
+Each connection is configured as part of a gateway which has a unique name associated with it. The gateway name can be used to select a specific combination of connection settings  when using the CLI. For example:
+
 ```yaml linenums="1"
-connections:
+gateways:
     local_db:
-        type: duckdb
+        connection:
+            type: duckdb
 ```
 
-Now the defined connection can be specified in the `sqlmesh plan` CLI command as follows:
+Now the defined connection can be selected in the `sqlmesh plan` CLI command as follows:
+
 ```bash
-sqlmesh --connection local_db plan
+sqlmesh --gateway local_db plan
+```
+
+## State connection
+
+By default, the data warehouse connection is also used to store the SQLMesh state. This behavior can be changed by providing different connection settings in the `state_connection` key of the gateway configuration:
+
+```yaml linenums="1"
+gateways:
+    local_db:
+        state_connection:
+            type: duckdb
+            database: state.db
 ```
 
 ## Default connection
-If no connection name is provided, then the first connection in the `config.yaml` connections specification will be used.
 
-Additionally, you can set a default connection by specifying the connection name in the `default_connection` key:
+Additionally, you can set a default connection by defining its configuration in the `default_connection` key:
+
 ```yaml linenums="1"
-default_connection: local_db
+default_connection:
+    type: duckdb
+    database: local.db
 ```
+
+This connection configuration will be used if one is not provided in the target gateway.
 
 ## Test connection
-By default, when running [tests](../concepts/tests.md), SQLMesh uses an in-memory DuckDB database connection. You can override this behavior by specifying a connection name in the `test_connection` key:
+
+By default, when running [tests](../concepts/tests.md), SQLMesh uses an in-memory DuckDB database connection. You can override this behavior by providing connection settings in the `test_connection` key of the gateway configuration:
+
 ```yaml linenums="1"
-test_connection: local_db
+gateways:
+    local_db:
+        test_connection:
+            type: duckdb
+            database: test.db
 ```
-Or, you can specify the test connection in the `sqlmesh plan` CLI command:
-```bash
-sqlmesh --test-connection local_db plan
+
+### Default test connection
+
+To configure a default test connection for all gateways use the `default_test_connection` key:
+
+```yaml linenums="1"
+default_test_connection:
+    type: duckdb
+    database: test.db
+```
+
+## Default gateway
+
+To change the default gateway used by the CLI when no gateway name is provided, set the desired name in the `default_gateway` key:
+
+```yaml linenums="1"
+default_gateway: local_db
 ```
 
 ## Supported engines

--- a/docs/guides/scheduling.md
+++ b/docs/guides/scheduling.md
@@ -68,7 +68,7 @@ After setup is completed, the `sqlmesh_janitor_dag` DAG should become available 
 
 On the client side, you must configure the connection to your Airflow cluster in the `config.yaml` file as follows:
 
-        scheduler:
+        default_scheduler:
             type: airflow
             airflow_url: http://localhost:8080/
             username: airflow
@@ -81,7 +81,7 @@ sqlmesh init -t airflow
 
 For Airflow configuration types specific to Google Cloud Composer, configure the file as follows:
 
-        scheduler:
+        default_scheduler:
             type: cloud_composer
             airflow_url: https:/XXXXXXXX.composer.googleusercontent.com/
 

--- a/examples/multi/repo_1/config.yaml
+++ b/examples/multi/repo_1/config.yaml
@@ -1,11 +1,13 @@
 project: repo_1
 
-connections:
+gateways:
     local:
-        type: duckdb
-        database: db.db
+        connection:
+            type: duckdb
+            database: db.db
 
     memory:
-        type: duckdb
+        connection:
+            type: duckdb
 
-default_connection: local
+default_gateway: local

--- a/examples/multi/repo_2/config.yaml
+++ b/examples/multi/repo_2/config.yaml
@@ -1,11 +1,13 @@
 project: repo_2
 
-connections:
+gateways:
     local:
-        type: duckdb
-        database: db.db
+        connection:
+            type: duckdb
+            database: db.db
 
     memory:
-        type: duckdb
+        connection:
+            type: duckdb
 
-default_connection: local
+default_gateway: local

--- a/examples/sushi/config.py
+++ b/examples/sushi/config.py
@@ -12,24 +12,24 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
 
 # An in memory DuckDB config.
-config = Config(connections=DuckDBConnectionConfig())
+config = Config(default_connection=DuckDBConnectionConfig())
 
 
 # A configuration used for SQLMesh tests.
 test_config = Config(
-    connections=DuckDBConnectionConfig(),
+    default_connection=DuckDBConnectionConfig(),
     auto_categorize_changes=CategorizerConfig(sql=AutoCategorizationMode.SEMI),
 )
 
 # A stateful DuckDB config.
 local_config = Config(
-    connections=DuckDBConnectionConfig(database=f"{DATA_DIR}/local.duckdb"),
+    default_connection=DuckDBConnectionConfig(database=f"{DATA_DIR}/local.duckdb"),
 )
 
 
-airflow_config = Config(**{"scheduler": AirflowSchedulerConfig()})
+airflow_config = Config(default_scheduler=AirflowSchedulerConfig())
 
 
 airflow_config_docker = Config(
-    **{"scheduler": AirflowSchedulerConfig(airflow_url="http://airflow-webserver:8080/")},
+    default_scheduler=AirflowSchedulerConfig(airflow_url="http://airflow-webserver:8080/"),
 )

--- a/examples/sushi_dbt/config.py
+++ b/examples/sushi_dbt/config.py
@@ -9,4 +9,4 @@ config = sqlmesh_config(Path(__file__).parent)
 test_config = config
 
 
-airflow_config = sqlmesh_config(Path(__file__).parent, scheduler=AirflowSchedulerConfig())
+airflow_config = sqlmesh_config(Path(__file__).parent, default_scheduler=AirflowSchedulerConfig())

--- a/sqlmesh/cli/example_project.py
+++ b/sqlmesh/cli/example_project.py
@@ -4,16 +4,17 @@ from pathlib import Path
 
 import click
 
-DEFAULT_CONFIG = """connections:
+DEFAULT_CONFIG = """gateways:
     local:
-        type: duckdb
-        database: db.db
+        connection:
+            type: duckdb
+            database: db.db
 
-default_connection: local
+default_gateway: local
 """
 
 
-DEFAULT_AIRFLOW_CONFIG = """scheduler:
+DEFAULT_AIRFLOW_CONFIG = """default_scheduler:
     type: airflow
     airflow_url: http://localhost:8080/
     username: airflow
@@ -74,7 +75,7 @@ EXAMPLE_SEED_MODEL_DEF = f"""MODEL (
     columns (
         id INTEGER,
         item_id INTEGER,
-        ds DATE
+        ds VARCHAR
     )
 );
 """

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -20,14 +20,9 @@ from sqlmesh.utils.errors import MissingDependencyError
 @opt.paths
 @opt.config
 @click.option(
-    "--connection",
+    "--gateway",
     type=str,
-    help="The name of the connection.",
-)
-@click.option(
-    "--test-connection",
-    type=str,
-    help="The name of the connection to use for tests.",
+    help="The name of the gateway.",
 )
 @click.pass_context
 @error_handler
@@ -35,8 +30,7 @@ def cli(
     ctx: click.Context,
     paths: t.List[str],
     config: t.Optional[str] = None,
-    connection: t.Optional[str] = None,
-    test_connection: t.Optional[str] = None,
+    gateway: t.Optional[str] = None,
 ) -> None:
     """SQLMesh command line tool."""
     if ctx.invoked_subcommand == "version":
@@ -58,8 +52,7 @@ def cli(
     context = Context(
         paths=paths,
         config=config,
-        connection=connection,
-        test_connection=test_connection,
+        gateway=gateway,
     )
 
     if not context.models:

--- a/sqlmesh/core/config/__init__.py
+++ b/sqlmesh/core/config/__init__.py
@@ -10,6 +10,7 @@ from sqlmesh.core.config.connection import (
     RedshiftConnectionConfig,
     SnowflakeConnectionConfig,
 )
+from sqlmesh.core.config.gateway import GatewayConfig
 from sqlmesh.core.config.loader import load_config_from_paths
 from sqlmesh.core.config.model import ModelDefaultsConfig
 from sqlmesh.core.config.root import Config

--- a/sqlmesh/core/config/gateway.py
+++ b/sqlmesh/core/config/gateway.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import typing as t
+
+from sqlmesh.core.config.base import BaseConfig
+from sqlmesh.core.config.connection import ConnectionConfig
+from sqlmesh.core.config.scheduler import SchedulerConfig
+
+
+class GatewayConfig(BaseConfig):
+    """Gateway configuration defines how SQLMesh should connect to the data warehouse,
+    the state backend and the scheduler.
+
+    Args:
+        connection: Connection configuration for the data warehouse.
+        state_connection: Connection configuration for the state backend. If not provided,
+            the same connection as the data warehouse will be used.
+        test_connection: Connection configuration for running unit tests.
+        scheduler: The scheduler configuration.
+    """
+
+    connection: t.Optional[ConnectionConfig] = None
+    state_connection: t.Optional[ConnectionConfig] = None
+    test_connection: t.Optional[ConnectionConfig] = None
+    scheduler: t.Optional[SchedulerConfig] = None

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -68,7 +68,11 @@ class BuiltInSchedulerConfig(_SchedulerConfig, BaseConfig):
     type_: Literal["builtin"] = Field(alias="type", default="builtin")
 
     def create_state_sync(self, context: Context) -> t.Optional[StateSync]:
-        return EngineAdapterStateSync(context.engine_adapter)
+        state_connection = context.config.get_state_connection(context.gateway)
+        engine_adapter = (
+            state_connection.create_engine_adapter() if state_connection else context.engine_adapter
+        )
+        return EngineAdapterStateSync(engine_adapter)
 
     def create_plan_evaluator(self, context: Context) -> PlanEvaluator:
         return BuiltInPlanEvaluator(

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from sqlmesh.core import constants as c
 from sqlmesh.core.audit import Audit
-from sqlmesh.core.config import Config
+from sqlmesh.core.config import Config, GatewayConfig
 from sqlmesh.core.hooks import HookRegistry
 from sqlmesh.core.loader import Loader
 from sqlmesh.core.macros import MacroRegistry
@@ -27,8 +27,8 @@ def sqlmesh_config(project_root: t.Optional[Path] = None, **kwargs: t.Any) -> Co
     profile = Profile.load(context)
 
     return Config(
-        default_connection=profile.target_name,
-        connections={profile.target_name: profile.target.to_sqlmesh()},
+        default_gateway=profile.target_name,
+        gateways={profile.target_name: GatewayConfig(connection=profile.target.to_sqlmesh())},
         loader=DbtLoader,
         **kwargs,
     )
@@ -53,7 +53,7 @@ class DbtLoader(Loader):
         models: UniqueKeyDict = UniqueKeyDict("models")
 
         project = Project.load(
-            DbtContext(project_root=self._context.path, target_name=self._context.connection)
+            DbtContext(project_root=self._context.path, target_name=self._context.gateway)
         )
         for path in project.project_files:
             self._track_file(path)

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -24,7 +24,7 @@ def test_global_config():
 
 def test_named_config():
     context = Context(paths="examples/sushi", config="local_config")
-    assert len(context.config.connections) == 1
+    assert len(context.config.gateways) == 1
 
 
 def test_invalid_named_config():

--- a/tests/fixtures/dbt/sushi_test/config.py
+++ b/tests/fixtures/dbt/sushi_test/config.py
@@ -9,4 +9,4 @@ config = sqlmesh_config(Path(__file__).parent)
 test_config = config
 
 
-airflow_config = sqlmesh_config(Path(__file__).parent, scheduler=AirflowSchedulerConfig())
+airflow_config = sqlmesh_config(Path(__file__).parent, default_scheduler=AirflowSchedulerConfig())

--- a/web/server/api/endpoints/context.py
+++ b/web/server/api/endpoints/context.py
@@ -23,7 +23,7 @@ def get_api_context(
     return models.Context(
         concurrent_tasks=context.concurrent_tasks,
         engine_adapter=context.engine_adapter.dialect,
-        scheduler=context.config.scheduler.type_,
+        scheduler=context.config.get_scheduler(context.gateway).type_,
         time_column_format=context.config.time_column_format,
         models=list(context.models),
         config=settings.config,


### PR DESCRIPTION
This PR introduces a new configuration entity: "gateway". Thanks to this new entity users are now able to configure different combinations of connection and scheduler configurations and easily switch between them in the CLI.

Additionally, this change decouples the connection used for model evaluation from the connection used to write and read the SQLMesh state. This means that users can now configure external databases to store SQLMesh state instead of using their data warehouse for this purpose.

**Note:** Support for external state connections for Airflow is out of this update's scope. It will be added in a follow-up PR.