### PR TITLE
Improve BigQuery Pandas Implementation

### DIFF
--- a/examples/wursthall/config.yaml
+++ b/examples/wursthall/config.yaml
@@ -1,4 +1,5 @@
-default_connection: duckdb
-connection:
+default_gateway: duckdb
+gateways:
   duckdb:
-    type: duckdb
+    connection:
+      type: duckdb

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ setup(
         "dev": [
             f"apache-airflow=={os.environ.get('AIRFLOW_VERSION', '2.3.3')}",
             "autoflake==1.7.7",
+            "google-cloud-bigquery",
+            "google-cloud-bigquery-storage",
             "black==22.6.0",
             "dbt-core",
             "Faker",

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -804,7 +804,7 @@ class EngineAdapter:
         """
         Returns the name of the temp table that should be used for the given table name.
         """
-        table = exp.to_table(table)
+        table = t.cast(exp.Table, exp.to_table(table).copy())
         table.set("this", f"__temp_{table.name}_{uuid.uuid4().hex}")
         if table_only:
             table.set("db", None)

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -22,6 +22,7 @@ from sqlmesh.utils.date import to_datetime
 from sqlmesh.utils.errors import SQLMeshError
 
 if t.TYPE_CHECKING:
+    from google.cloud import bigquery
     from google.cloud.bigquery.client import Client as BigQueryClient
     from google.cloud.bigquery.client import Connection as BigQueryConnection
     from google.cloud.bigquery.job.base import _AsyncJob as BigQueryQueryResult
@@ -131,37 +132,71 @@ class BigQueryEngineAdapter(EngineAdapter):
         self.execute(query, ignore_unsupported_errors=ignore_unsupported_errors)
         return list(self.cursor._query_data)
 
-    def __load_pandas_to_temp_table(
+    def _create_table_from_df(
         self,
-        table: TableName,
-        df: pd.DataFrame,
+        table_name: TableName,
+        df: DF,
         columns_to_types: t.Dict[str, exp.DataType],
-    ) -> t.Tuple[BigQueryQueryResult, str]:
+        exists: bool = True,
+        replace: bool = False,
+        **kwargs: t.Any,
+    ) -> None:
+        assert isinstance(df, pd.DataFrame)
+        table = self.__get_bq_table(table_name, columns_to_types)
+        self.__load_pandas_to_table(table, df, exists=exists, replace=replace)
+
+    def __load_pandas_to_table(
+        self,
+        table: bigquery.Table,
+        df: pd.DataFrame,
+        exists: bool = True,
+        replace: bool = False,
+    ) -> BigQueryQueryResult:
         """
-        Loads a pandas dataframe into a temporary table in BigQuery. Returns the result of the load and the name of the
-        temporary table. The temporary table will be deleted after 3 hours.
+        Loads a pandas dataframe into a table in BigQuery. Will do an overwrite if replace is True. Note that
+        the replace will replace the entire table, not just the rows that are in the dataframe.
         """
+        from google.cloud import bigquery
+
+        self.client.create_table(table, exists_ok=exists)
+        job_config = bigquery.job.LoadJobConfig()
+        if replace:
+            job_config.write_disposition = bigquery.WriteDisposition.WRITE_TRUNCATE
+        result = self.client.load_table_from_dataframe(df, table, job_config=job_config).result()
+        if result.errors:
+            raise SQLMeshError(result.errors)
+        return result
+
+    def __get_bq_schema(
+        self, columns_to_types: t.Dict[str, exp.DataType]
+    ) -> t.List[bigquery.SchemaField]:
         from google.cloud import bigquery
 
         precisionless_col_to_types = {
             col_name: remove_precision_parameterized_types(col_type)
             for col_name, col_type in columns_to_types.items()
         }
-
-        temp_table_name = ".".join(
-            [self.client.project, self._get_temp_table(table).sql(dialect=self.dialect)]
-        )
-        schema = [
+        return [
             bigquery.SchemaField(col_name, col_type.sql(dialect=self.dialect))
             for col_name, col_type in precisionless_col_to_types.items()
         ]
-        bq_table = bigquery.Table(table_ref=temp_table_name, schema=schema)
+
+    def __get_temp_bq_table(
+        self, table: TableName, columns_to_type: t.Dict[str, exp.DataType]
+    ) -> bigquery.Table:
+        bq_table = self.__get_bq_table(self._get_temp_table(table), columns_to_type)
         bq_table.expires = to_datetime("in 3 hours")
-        self.client.create_table(bq_table)
-        result = self.client.load_table_from_dataframe(df, bq_table).result()
-        if result.errors:
-            raise SQLMeshError(result.errors)
-        return result, temp_table_name
+        return bq_table
+
+    def __get_bq_table(
+        self, table: TableName, columns_to_type: t.Dict[str, exp.DataType]
+    ) -> bigquery.Table:
+        table_name = ".".join([self.client.project, exp.to_table(table).sql(dialect=self.dialect)])
+        return bigquery.Table(table_ref=table_name, schema=self.__get_bq_schema(columns_to_type))
+
+    @classmethod
+    def __convert_bq_table_to_table(cls, bq_table: bigquery.Table) -> exp.Table:
+        return exp.to_table(".".join([bq_table.project, bq_table.dataset_id, bq_table.table_id]))
 
     def _insert_overwrite_by_condition(
         self,
@@ -182,7 +217,7 @@ class BigQueryEngineAdapter(EngineAdapter):
         table = exp.to_table(table_name)
         query: t.Union[Query, exp.Select]
         is_pandas = isinstance(query_or_df, pd.DataFrame)
-        temp_table_name: t.Optional[str] = None
+        temp_table: t.Optional[exp.Table] = None
         if isinstance(query_or_df, DF_TYPES):
             if not is_pandas:
                 raise SQLMeshError("BigQuery only supports pandas DataFrames")
@@ -190,13 +225,13 @@ class BigQueryEngineAdapter(EngineAdapter):
                 raise SQLMeshError("columns_to_types must be provided when using Pandas DataFrames")
             if table.db is None:
                 raise SQLMeshError("table_name must be qualified when using Pandas DataFrames")
-            query_or_df = t.cast(pd.DataFrame, query_or_df)
-            result, temp_table_name = self.__load_pandas_to_temp_table(
-                table, query_or_df, columns_to_types
-            )
+            df = t.cast(pd.DataFrame, query_or_df)
+            temp_bq_table = self.__get_temp_bq_table(table, columns_to_types)
+            temp_table = self.__convert_bq_table_to_table(temp_bq_table)
+            result = self.__load_pandas_to_table(temp_bq_table, df, replace=False, exists=False)
             if result.errors:
                 raise SQLMeshError(result.errors)
-            query = exp.select(*columns_to_types).from_(exp.to_table(temp_table_name))
+            query = exp.select(*columns_to_types).from_(temp_table)
         else:
             query = t.cast(Query, query_or_df)
         columns = [
@@ -224,8 +259,8 @@ class BigQueryEngineAdapter(EngineAdapter):
             match_expressions=[when_not_matched_by_source, when_not_matched_by_target],
         )
         if is_pandas:
-            assert temp_table_name is not None
-            self.drop_table(temp_table_name)
+            assert temp_table is not None
+            self.drop_table(temp_table)
 
     def table_exists(self, table_name: TableName) -> bool:
         from google.cloud.exceptions import NotFound

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -141,6 +141,10 @@ class BigQueryEngineAdapter(EngineAdapter):
         replace: bool = False,
         **kwargs: t.Any,
     ) -> None:
+        """
+        Creates a table from a pandas dataframe. Will create the table if it doesn't exist. Will replace the contents
+        of the table if `replace` is true.
+        """
         assert isinstance(df, pd.DataFrame)
         table = self.__get_bq_table(table_name, columns_to_types)
         self.__load_pandas_to_table(table, df, exists=exists, replace=replace)
@@ -170,6 +174,9 @@ class BigQueryEngineAdapter(EngineAdapter):
     def __get_bq_schema(
         self, columns_to_types: t.Dict[str, exp.DataType]
     ) -> t.List[bigquery.SchemaField]:
+        """
+        Returns a bigquery schema object from a dictionary of column names to types.
+        """
         from google.cloud import bigquery
 
         precisionless_col_to_types = {
@@ -184,6 +191,9 @@ class BigQueryEngineAdapter(EngineAdapter):
     def __get_temp_bq_table(
         self, table: TableName, columns_to_type: t.Dict[str, exp.DataType]
     ) -> bigquery.Table:
+        """
+        Returns a bigquery table object that is temporary and will expire in 3 hours.
+        """
         bq_table = self.__get_bq_table(self._get_temp_table(table), columns_to_type)
         bq_table.expires = to_datetime("in 3 hours")
         return bq_table
@@ -191,6 +201,11 @@ class BigQueryEngineAdapter(EngineAdapter):
     def __get_bq_table(
         self, table: TableName, columns_to_type: t.Dict[str, exp.DataType]
     ) -> bigquery.Table:
+        """
+        Returns a bigquery table object with a schema defines that matches the columns_to_type dictionary.
+        """
+        from google.cloud import bigquery
+
         table_name = ".".join([self.client.project, exp.to_table(table).sql(dialect=self.dialect)])
         return bigquery.Table(table_ref=table_name, schema=self.__get_bq_schema(columns_to_type))
 

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -1,5 +1,6 @@
 # type: ignore
 import pandas as pd
+from google.cloud import bigquery
 from pytest_mock.plugin import MockerFixture
 from sqlglot import expressions as exp
 from sqlglot import parse_one
@@ -47,9 +48,14 @@ def test_insert_overwrite_by_time_partition_pandas(mocker: MockerFixture):
     cursor_mock = mocker.Mock()
     connection_mock.cursor.return_value = cursor_mock
     adapter = BigQueryEngineAdapter(lambda: connection_mock)
-    load_pandas_to_temp_table_mock = mocker.Mock()
-    load_pandas_to_temp_table_mock.return_value = (AttributeDict({"errors": None}), "temp_table")
-    adapter._BigQueryEngineAdapter__load_pandas_to_temp_table = load_pandas_to_temp_table_mock
+    get_temp_bq_table = mocker.Mock()
+    get_temp_bq_table.return_value = AttributeDict(
+        {"project": "project", "dataset_id": "dataset", "table_id": "temp_table"}
+    )
+    adapter._BigQueryEngineAdapter__get_temp_bq_table = get_temp_bq_table
+    load_pandas_to_table_mock = mocker.Mock()
+    load_pandas_to_table_mock.return_value = AttributeDict({"errors": None})
+    adapter._BigQueryEngineAdapter__load_pandas_to_table = load_pandas_to_table_mock
     execute_mock = mocker.patch(
         "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.execute"
     )
@@ -77,9 +83,9 @@ def test_insert_overwrite_by_time_partition_pandas(mocker: MockerFixture):
         for call in execute_mock.call_args_list
     ]
     assert sql_calls == [
-        "MERGE INTO `test_table` AS `__MERGE_TARGET__` USING (SELECT `a`, `ds` FROM `temp_table`) AS __MERGE_SOURCE__ ON FALSE WHEN NOT MATCHED BY SOURCE AND `ds` BETWEEN '2022-01-01' AND '2022-01-05' THEN DELETE WHEN NOT MATCHED THEN INSERT (`a`, `ds`) VALUES (`a`, `ds`)",
+        "MERGE INTO `test_table` AS `__MERGE_TARGET__` USING (SELECT `a`, `ds` FROM `project`.`dataset`.`temp_table`) AS __MERGE_SOURCE__ ON FALSE WHEN NOT MATCHED BY SOURCE AND `ds` BETWEEN '2022-01-01' AND '2022-01-05' THEN DELETE WHEN NOT MATCHED THEN INSERT (`a`, `ds`) VALUES (`a`, `ds`)",
     ]
-    drop_table_mock.assert_called_once_with("temp_table")
+    drop_table_mock.assert_called_once_with(exp.to_table("project.dataset.temp_table"))
 
 
 def test_replace_query(mocker: MockerFixture):
@@ -107,24 +113,33 @@ def test_replace_query_pandas(mocker: MockerFixture):
     connection_mock = mocker.NonCallableMock()
     cursor_mock = mocker.Mock()
     connection_mock.cursor.return_value = cursor_mock
-
     adapter = BigQueryEngineAdapter(lambda: connection_mock)
+    get_bq_table = mocker.Mock()
+    get_bq_table.return_value = AttributeDict(
+        {"project": "project", "dataset_id": "dataset", "table_id": "test_table"}
+    )
+    adapter._BigQueryEngineAdapter__get_bq_table = get_bq_table
     execute_mock = mocker.patch(
         "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.execute"
     )
+    client_mock = mocker.patch("sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.client")
+    load_result = mocker.Mock()
+    load_result.result.return_value = AttributeDict({"errors": None})
+    client_mock.load_table_from_dataframe.return_value = load_result
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.replace_query("test_table", df, {"a": "int", "b": "int"})
 
-    sql_calls = [
-        # Python 3.7 support
-        call[0][0].sql(dialect="bigquery", identify=True)
-        if isinstance(call[0], tuple)
-        else call[0].sql(dialect="bigquery", identify=True)
-        for call in execute_mock.call_args_list
+    assert execute_mock.call_args_list == []
+    assert client_mock.method_calls[0] == [
+        "create_table",
+        (get_bq_table.return_value,),
+        {"exists_ok": True},
     ]
-    assert sql_calls == [
-        "CREATE OR REPLACE TABLE `test_table` AS SELECT CAST(`a` AS INT64) AS `a`, CAST(`b` AS INT64) AS `b` FROM UNNEST([STRUCT(CAST(1 AS INT64) AS `a`, CAST(4 AS INT64) AS `b`), STRUCT(2 AS `a`, 5 AS `b`), STRUCT(3 AS `a`, 6 AS `b`)])"
-    ]
+    assert client_mock.method_calls[1][0] == "load_table_from_dataframe"
+    assert (
+        client_mock.method_calls[1][2]["job_config"].write_disposition
+        == bigquery.WriteDisposition.WRITE_TRUNCATE
+    )
 
 
 def test_create_table_date_partition(mocker: MockerFixture):


### PR DESCRIPTION
Previously we only loaded Pandas DataFrames using the native loader when loading for insert overwrite models. Now we also use it when creating a table from a DataFrame. 

Also fixed a bug with the new temp table logic that would modify the table object passed in to also have the new table table name. 