### PR TITLE
Feat: Log exception stack traces from executor tasks to API console

### DIFF
--- a/web/server/console.py
+++ b/web/server/console.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import traceback
 import typing as t
 import unittest
 
@@ -101,8 +102,13 @@ class ApiConsole(TerminalConsole):
         self.queue.put_nowait(self._make_event(msg))
         self.stop_snapshot_progress()
 
-    def log_exception(self, tb: str) -> None:
-        self.queue.put_nowait(self._make_event(tb, event="errors", ok=False))
+    def log_exception(self, exc: Exception) -> None:
+        """Log an exception."""
+        self.queue.put_nowait(
+            self._make_event(
+                {"details": str(exc), "traceback": traceback.format_exc()}, event="errors", ok=False
+            )
+        )
 
 
 api_console = ApiConsole()

--- a/web/server/console.py
+++ b/web/server/console.py
@@ -100,3 +100,9 @@ class ApiConsole(TerminalConsole):
     def log_success(self, msg: str) -> None:
         self.queue.put_nowait(self._make_event(msg))
         self.stop_snapshot_progress()
+
+    def log_exception(self, tb: str) -> None:
+        self.queue.put_nowait(self._make_event(tb, event="errors", ok=False))
+
+
+api_console = ApiConsole()

--- a/web/server/main.py
+++ b/web/server/main.py
@@ -6,11 +6,10 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from web.server.api.endpoints import api_router
-from web.server.console import ApiConsole
+from web.server.console import api_console
 from web.server.watcher import watch_project
 
 app = FastAPI()
-api_console = ApiConsole()
 
 app.include_router(api_router, prefix="/api")
 WEB_DIRECTORY = pathlib.Path(__file__).parent.parent

--- a/web/server/utils.py
+++ b/web/server/utils.py
@@ -34,7 +34,7 @@ async def run_in_executor(func: t.Callable[..., R], *args: t.Any) -> R:
         try:
             return func(*args)
         except Exception as e:
-            api_console.log_exception(traceback.format_exc())
+            api_console.log_exception(e)
             raise e
 
     loop = asyncio.get_running_loop()


### PR DESCRIPTION
This PR has the API send stack traces in SSEs so exceptions from executor tasks, e.g. plan/apply, don't get lost and the app can react to the errors.