### PR TITLE
Fix: JSON encoding for models

### DIFF
--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 
+from fastapi.encoders import jsonable_encoder
 from watchfiles import DefaultFilter, awatch
 
 from sqlmesh.core import constants as c
@@ -28,7 +29,5 @@ async def watch_project(queue: asyncio.Queue) -> None:
             logger.exception("Error loading context")
         else:
             queue.put_nowait(
-                Event(
-                    event="models", data=json.dumps([model.dict() for model in get_models(context)])
-                )
+                Event(event="models", data=json.dumps(jsonable_encoder(get_models(context))))
             )


### PR DESCRIPTION
An API model used to be simpler so `json.dumps()` was good enough. However, a model now has datetime fields and other fields the standard Python `json` library can't encode out of the box.