### PR TITLE
Fix: replace exp.StructKwarg with exp.ColumnDef in schema diff

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "requests",
         "rich",
         "ruamel.yaml",
-        "sqlglot~=12.1.0",
+        "sqlglot~=12.2.0",
         "fsspec",
     ],
     extras_require={


### PR DESCRIPTION
This PR resolves the regression that would be caused due to `StructKwarg` being removed in https://github.com/tobymao/sqlglot/commit/7b09bffd7820748df5e9f1ce21f74883a7041ca8 once we bump SQLGlot.

This depends on releasing a new SQLGlot version because it's still in v12.1.0; once that's done I'll bump its version here too.