### PR TITLE
Refactor: use sqlglot's exp.insert to simplify Insert building

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "requests",
         "rich",
         "ruamel.yaml",
-        "sqlglot~=13.0.0",
+        "sqlglot~=13.0.1",
         "fsspec",
     ],
     extras_require={

--- a/sqlmesh/core/engine_adapter/base_spark.py
+++ b/sqlmesh/core/engine_adapter/base_spark.py
@@ -6,6 +6,7 @@ import pandas as pd
 from sqlglot import exp
 
 from sqlmesh.core.dialect import pandas_to_sql
+from sqlmesh.core.engine_adapter._typing import Query
 from sqlmesh.core.engine_adapter.base import EngineAdapter
 from sqlmesh.core.engine_adapter.shared import (
     DataObject,
@@ -54,12 +55,10 @@ class BaseSparkEngineAdapter(EngineAdapter):
                     columns_to_types=columns_to_types,
                 )
             )
+
+        column_names = list(columns_to_types or [])
         self.execute(
-            exp.Insert(
-                this=self._insert_into_expression(table_name, columns_to_types),
-                expression=query_or_df,
-                overwrite=True,
-            )
+            exp.insert(t.cast(Query, query_or_df), table, columns=column_names, overwrite=True)
         )
 
     def create_state_table(

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -23,13 +23,8 @@ class DuckDBEngineAdapter(LogicalMergeAdapter):
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         contains_json: bool = False,
     ) -> None:
-        self.execute(
-            exp.Insert(
-                this=self._insert_into_expression(table_name, columns_to_types),
-                expression="SELECT * FROM df",
-                overwrite=False,
-            )
-        )
+        column_names = list(columns_to_types or [])
+        self.execute(exp.insert("SELECT * FROM df", table_name, columns=column_names))
 
     def _get_data_objects(
         self, schema_name: str, catalog_name: t.Optional[str] = None


### PR DESCRIPTION
Cleaned up some sections where we do `exp.Insert(this=..., expression=..., overwrite=...)`, by using the builder introduced in https://github.com/tobymao/sqlglot/commit/c01edb014b5101eac9913b04404753b324581214.