### PR TITLE
Feat: Display external table on lineage

### DIFF
--- a/web/client/.eslintrc.js
+++ b/web/client/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     'react/jsx-uses-react': OFF,
     'react/react-in-jsx-scope': OFF,
     'no-use-before-define': OFF,
+    '@typescript-eslint/no-non-null-assertion': OFF,
     '@typescript-eslint/no-use-before-define': [
       ERROR,
       {

--- a/web/client/src/context/editor.ts
+++ b/web/client/src/context/editor.ts
@@ -1,3 +1,4 @@
+import { type LineageColumn } from '@api/client'
 import { uid } from '@utils/index'
 import { create } from 'zustand'
 import useLocalStorage from '~/hooks/useLocalStorage'
@@ -11,13 +12,7 @@ export interface Dialect {
 
 export interface Lineage {
   models: string[]
-  columns?: Record<
-    string,
-    {
-      source?: string
-      models?: Record<string, string[]>
-    }
-  >
+  columns?: Record<string, LineageColumn>
 }
 
 interface EditorStore {

--- a/web/client/src/library/components/graph/ModelLineage.tsx
+++ b/web/client/src/library/components/graph/ModelLineage.tsx
@@ -4,8 +4,7 @@ import { memo, useCallback, useEffect } from 'react'
 import { ModelColumnLineage } from './Graph'
 import { type ModelSQLMeshModel } from '@models/sqlmesh-model'
 import { useLineageFlow } from './context'
-import { type Lineage } from '@context/editor'
-import { mergeLineage } from './help'
+import { mergeLineageWithModels } from './help'
 
 const ModelLineage = memo(function ModelLineage({
   model,
@@ -18,7 +17,7 @@ const ModelLineage = memo(function ModelLineage({
   highlightedNodes?: Record<string, string[]>
   className?: string
 }): JSX.Element {
-  const { clearActiveEdges, models, lineage, setLineage } = useLineageFlow()
+  const { clearActiveEdges, setLineage } = useLineageFlow()
 
   const { data: dataLineage, refetch: getModelLineage } = useApiModelLineage(
     model.name,
@@ -37,21 +36,9 @@ const ModelLineage = memo(function ModelLineage({
     if (dataLineage == null) {
       setLineage(undefined)
     } else {
-      const lineageModels = Object.keys(dataLineage).reduce(
-        (acc: Record<string, Lineage>, key) => {
-          if (models.has(key)) {
-            acc[key] = {
-              models: (dataLineage[key] ?? []).filter(name => models.has(name)),
-              columns: lineage?.[key]?.columns ?? undefined,
-            }
-          }
-
-          return acc
-        },
-        {},
+      setLineage(lineage =>
+        mergeLineageWithModels(structuredClone(lineage), dataLineage),
       )
-
-      setLineage(mergeLineage(models, lineageModels))
     }
   }, [dataLineage])
 

--- a/web/client/src/main.tsx
+++ b/web/client/src/main.tsx
@@ -27,7 +27,9 @@ ReactDOM.createRoot(getRootNode()).render(
       <ThemeProvider>
         <Header />
         <Divider />
-        <RouterProvider router={router} />
+        <div className="h-full">
+          <RouterProvider router={router} />
+        </div>
         <Divider />
         <Footer />
       </ThemeProvider>


### PR DESCRIPTION
Displays node on lineage for external tables. In Addition to PR [856](https://github.com/TobikoData/sqlmesh/pull/856)
To be more specific it displays any node that not a `model` but still present in API response when asking for columns lineage

![Screenshot 2023-05-17 at 9 35 37 AM](https://github.com/TobikoData/sqlmesh/assets/5644753/f85c563f-ae2a-49bf-a8d3-7799536d52f3)
