### PR TITLE
Feat!: Add Github Action Bot Deploy Command

### DIFF
--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -82,7 +82,7 @@ users:
 Commands can be issued to the bot to have it run specific actions. Below are the currently supported commands:
 * `/deploy` - Deploys the changes in the PR to Production. It will run all the same checks as if you just pushed a commit except for the required approvals check since we assume we can to skip that check if you are manually deploying.
 
-See [Run All Configuration](#run-all-configuration) if you want SQLMesh's commands to have a different prefix to avoid them from clashing with other bots. 
+See [Run All Configuration](#run-all-configuration) for the `--command_namespace` option if you want SQLMesh's commands to have a different prefix to avoid them from clashing with other bots. 
 
 ## Configuration
 ### SQLMesh Configuration
@@ -102,7 +102,7 @@ It has two boolean flags that can be passed in to enable additional functionalit
 * `--delete` - This will delete the PR environment after deploying to production. 
     * Note: If using `--delete` then the runner will need a connection to the engine even if you are using Airflow. This is because the delete is done outside of Airflow.
     * Eventually want the SQLMesh Janitor to automatically do this cleanup which would remove the need for this flag.
-* `--command_namespace` - Namespace to use for SQLMesh commands. For example if you provide `SQLMesh` as a value then commands will be expected in the format of `#SQLMesh/<command>`. The `#` prefix is automatically added.
+* `--command_namespace` - Namespace to use for SQLMesh commands. For example if you provide `#SQLMesh` as a value then commands will be expected in the format of `#SQLMesh/<command>`. 
 
 ### Custom Workflow Configuration
 You can configure each individual action to run as a separate step. This can allow for more complex workflows or integrating specific steps with other actions you want to trigger. Run `sqlmesh_cicd github` to see a list of commands that can be supplied and their potential options.

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -29,11 +29,16 @@ on:
     types:
     - synchronize
     - opened
+  # Required if using required approvers to automate deployments
   pull_request_review:
     types:
     - edited
     - submitted
     - dismissed
+  # Required if using comments to issue commands to the bot
+  issue_comment:
+    types: 
+    - created
 # The latest commit is the one that will be used to create the PR environment and deploy to production
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
@@ -73,6 +78,12 @@ users:
 ```
 4. You're done! SQLMesh will now automatically create PR environments, check for required approvers (if configured), and do data gapless deployments to production.
 
+## Bot Commands
+Commands can be issued to the bot to have it run specific actions. Below are the currently supported commands:
+* `/deploy` - Deploys the changes in the PR to Production. It will run all the same checks as if you just pushed a commit except for the required approvals check since we assume we can to skip that check if you are manually deploying.
+
+See [Run All Configuration](#run-all-configuration) if you want SQLMesh's commands to have a different prefix to avoid them from clashing with other bots. 
+
 ## Configuration
 ### SQLMesh Configuration
 `sqlmesh_cicd` accepts the following config:
@@ -91,6 +102,7 @@ It has two boolean flags that can be passed in to enable additional functionalit
 * `--delete` - This will delete the PR environment after deploying to production. 
     * Note: If using `--delete` then the runner will need a connection to the engine even if you are using Airflow. This is because the delete is done outside of Airflow.
     * Eventually want the SQLMesh Janitor to automatically do this cleanup which would remove the need for this flag.
+* `--command_namespace` - Namespace to use for SQLMesh commands. For example if you provide `SQLMesh` as a value then commands will be expected in the format of `#SQLMesh/<command>`. The `#` prefix is automatically added.
 
 ### Custom Workflow Configuration
 You can configure each individual action to run as a separate step. This can allow for more complex workflows or integrating specific steps with other actions you want to trigger. Run `sqlmesh_cicd github` to see a list of commands that can be supplied and their potential options.
@@ -121,11 +133,16 @@ on:
     types:
     - synchronize
     - opened
+  # Required if using required approvers to automate deployments
   pull_request_review:
     types:
     - edited
     - submitted
     - dismissed
+  # Required if using comments to issue commands to the bot
+  issue_comment:
+    types: 
+    - created
 # The latest commit is the one that will be used to create the PR environment and deploy to production
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
@@ -174,5 +191,5 @@ the job keeps running. Ideally we would then cancel the Airflow job as well.
 * The Airflow job could take a while and we don't need to be running the Github Action for the entire time. Ideally
 we would have Airflow tag the PR when the job is done which would trigger a follow up action to check status and 
 move to the next step if successful.
-* When using `run_all` ideally we would parallelize the tasks that can be run in parallel. One can work around this 
+* When using `run_all` ideally we could parallelize the tasks that can be run in parallel. One can work around this 
 though by using the individual commands and running them in parallel from within the workflow.

--- a/sqlmesh/integrations/github/cicd/command.py
+++ b/sqlmesh/integrations/github/cicd/command.py
@@ -190,7 +190,7 @@ def _run_all(
 @click.option(
     "--command_namespace",
     type=str,
-    help="Namespace to use for SQLMesh commands. For example if you provide `SQLMesh` as a value then commands will be expected in the format of `#SQLMesh/<command>`. The `#` prefix is automatically added.",
+    help="Namespace to use for SQLMesh commands. For example if you provide `#SQLMesh` as a value then commands will be expected in the format of `#SQLMesh/<command>`.",
 )
 @click.pass_context
 def run_all(

--- a/sqlmesh/integrations/github/cicd/command.py
+++ b/sqlmesh/integrations/github/cicd/command.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import typing as t
 
 import click
 
@@ -9,7 +10,7 @@ from sqlmesh.integrations.github.cicd.controller import (
     GithubCheckStatus,
     GithubController,
 )
-from sqlmesh.utils.errors import PlanError
+from sqlmesh.utils.errors import CICDBotError, PlanError
 
 logger = logging.getLogger(__name__)
 
@@ -145,16 +146,33 @@ def deploy_production(ctx: click.Context, merge: bool, delete: bool) -> None:
     )
 
 
-def _run_all(controller: GithubController, merge: bool, delete: bool) -> None:
+def _run_all(
+    controller: GithubController,
+    merge: bool,
+    delete: bool,
+    command_namespace: t.Optional[str] = None,
+) -> None:
+    has_required_approval = False
+    if controller.is_comment_triggered:
+        command = controller.get_command_from_comment(command_namespace)
+        if command.is_invalid:
+            # Probably a comment unrelated to SQLMesh so we do nothing
+            return
+        elif command.is_deploy_prod:
+            has_required_approval = True
+        else:
+            raise CICDBotError(f"Unsupported command: {command}")
     controller.update_pr_environment_check(status=GithubCheckStatus.QUEUED)
     controller.update_prod_environment_check(status=GithubCheckStatus.QUEUED)
     controller.update_test_check(status=GithubCheckStatus.QUEUED)
     tests_passed = _run_tests(controller)
-    if controller.do_required_approval_check:
+    if not has_required_approval and controller.do_required_approval_check:
         controller.update_required_approval_check(status=GithubCheckStatus.QUEUED)
         has_required_approval = _check_required_approvers(controller)
     else:
-        has_required_approval = True
+        controller.update_required_approval_check(
+            status=GithubCheckStatus.COMPLETED, conclusion=GithubCheckConclusion.SKIPPED
+        )
     pr_environment_updated = _update_pr_environment(controller)
     if tests_passed and has_required_approval and pr_environment_updated:
         _deploy_production(
@@ -169,7 +187,14 @@ def _run_all(controller: GithubController, merge: bool, delete: bool) -> None:
 @github.command()
 @merge_option
 @delete_option
+@click.option(
+    "--command_namespace",
+    type=str,
+    help="Namespace to use for SQLMesh commands. For example if you provide `SQLMesh` as a value then commands will be expected in the format of `#SQLMesh/<command>`. The `#` prefix is automatically added.",
+)
 @click.pass_context
-def run_all(ctx: click.Context, merge: bool, delete: bool) -> None:
+def run_all(
+    ctx: click.Context, merge: bool, delete: bool, command_namespace: t.Optional[str]
+) -> None:
     """Runs all the commands in the correct order."""
-    return _run_all(ctx.obj["github"], merge, delete)
+    return _run_all(ctx.obj["github"], merge, delete, command_namespace)

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -122,18 +122,11 @@ class BotCommand(Enum):
     @classmethod
     def from_comment_body(cls, body: str, namespace: t.Optional[str] = None) -> BotCommand:
         body = body.strip()
-        command_aliases = {
-            cls.DEPLOY_PROD: {"/deploy_prod", "/deploy-prod", "/deployprod", "/deploy"},
+        namespace = namespace.strip() if namespace else ""
+        input_to_command = {
+            namespace + "/deploy": cls.DEPLOY_PROD,
         }
-        if namespace:
-            command_aliases = {
-                command: {namespace + alias for alias in alias_values}
-                for command, alias_values in command_aliases.items()
-            }
-        for command, aliases in command_aliases.items():
-            if body in aliases:
-                return command
-        return cls.INVALID
+        return input_to_command.get(body, cls.INVALID)
 
     @property
     def is_invalid(self) -> bool:

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -127,7 +127,7 @@ class BotCommand(Enum):
         }
         if namespace:
             command_aliases = {
-                command: {f"#{namespace}{alias}" for alias in alias_values}
+                command: {namespace + alias for alias in alias_values}
                 for command, alias_values in command_aliases.items()
             }
         for command, aliases in command_aliases.items():

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -168,8 +168,7 @@ class GithubEvent:
         comment = self.payload.get("comment")
         if not comment:
             return False
-        body = comment.get("body")
-        if not body:
+        if not comment.get("body"):
             return False
         return self.payload.get("action") != "deleted"
 

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -214,8 +214,6 @@ class GithubEvent:
 
 
 class GithubController:
-    DEFAULT_COMMAND_NAMESPACE = "SQLMesh"
-
     def __init__(
         self,
         paths: t.Union[str, t.Iterable[str]],

--- a/tests/fixtures/github/pull_request_command_deploy.json
+++ b/tests/fixtures/github/pull_request_command_deploy.json
@@ -1,7 +1,7 @@
 {
   "action": "created",
   "comment": {
-    "body": "example_comment"
+    "body": "/deploy"
   },
   "issue": {
     "pull_request": {

--- a/tests/integrations/github/cicd/helper.py
+++ b/tests/integrations/github/cicd/helper.py
@@ -1,0 +1,23 @@
+import os
+import typing as t
+from unittest import mock
+
+from pytest_mock.plugin import MockerFixture
+
+from sqlmesh.integrations.github.cicd.controller import GithubController, GithubEvent
+
+
+def get_mocked_controller(
+    event: GithubEvent, mocker: MockerFixture, config: t.Optional[str] = None
+) -> GithubController:
+    mocker.patch("github.Github", mocker.MagicMock())
+    mocker.patch("sqlmesh.core.context.Context._run_plan_tests", mocker.MagicMock())
+    mocker.patch("sqlmesh.core.context.Context._run_tests", mocker.MagicMock())
+    with mock.patch.dict(
+        os.environ, {"GITHUB_API_URL": "https://api.github.com/repos/Codertocat/Hello-World"}
+    ):
+        controller = GithubController(
+            paths=["examples/sushi"], token="abc", event=event, config=config
+        )
+        controller._console = mocker.MagicMock()
+        return controller

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -147,17 +147,11 @@ def test_bot_command_parsing(
     comment_raw["comment"]["body"] = "/deploy"
     controller = get_mocked_controller(GithubEvent.from_obj(comment_raw), mocker)
     assert controller.get_command_from_comment() == BotCommand.DEPLOY_PROD
-    assert (
-        controller.get_command_from_comment(GithubController.DEFAULT_COMMAND_NAMESPACE)
-        == BotCommand.INVALID
-    )
+    assert controller.get_command_from_comment("SQLMesh") == BotCommand.INVALID
     comment_raw["comment"]["body"] = "#SQLMesh/deploy"
     controller = get_mocked_controller(GithubEvent.from_obj(comment_raw), mocker)
     assert controller.get_command_from_comment() == BotCommand.INVALID
-    assert (
-        controller.get_command_from_comment(GithubController.DEFAULT_COMMAND_NAMESPACE)
-        == BotCommand.DEPLOY_PROD
-    )
+    assert controller.get_command_from_comment("SQLMesh") == BotCommand.DEPLOY_PROD
     comment_raw["comment"]["body"] = "Something Something /deploy"
     controller = get_mocked_controller(GithubEvent.from_obj(comment_raw), mocker)
     assert controller.get_command_from_comment() == BotCommand.INVALID

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -147,11 +147,11 @@ def test_bot_command_parsing(
     comment_raw["comment"]["body"] = "/deploy"
     controller = get_mocked_controller(GithubEvent.from_obj(comment_raw), mocker)
     assert controller.get_command_from_comment() == BotCommand.DEPLOY_PROD
-    assert controller.get_command_from_comment("SQLMesh") == BotCommand.INVALID
+    assert controller.get_command_from_comment("#SQLMesh") == BotCommand.INVALID
     comment_raw["comment"]["body"] = "#SQLMesh/deploy"
     controller = get_mocked_controller(GithubEvent.from_obj(comment_raw), mocker)
     assert controller.get_command_from_comment() == BotCommand.INVALID
-    assert controller.get_command_from_comment("SQLMesh") == BotCommand.DEPLOY_PROD
+    assert controller.get_command_from_comment("#SQLMesh") == BotCommand.DEPLOY_PROD
     comment_raw["comment"]["body"] = "Something Something /deploy"
     controller = get_mocked_controller(GithubEvent.from_obj(comment_raw), mocker)
     assert controller.get_command_from_comment() == BotCommand.INVALID

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -1,13 +1,19 @@
 # type: ignore
+import typing as t
 from unittest.mock import Mock, call
 
 import pytest
 from pytest_mock.plugin import MockerFixture
 
 from sqlmesh.core import constants as c
-from sqlmesh.integrations.github.cicd.controller import GithubController
+from sqlmesh.integrations.github.cicd.controller import (
+    BotCommand,
+    GithubController,
+    GithubEvent,
+)
 from sqlmesh.utils import AttributeDict
 from sqlmesh.utils.errors import CICDBotError
+from tests.integrations.github.cicd.helper import get_mocked_controller
 
 pytest_plugins = ["tests.integrations.github.cicd.fixtures"]
 
@@ -129,3 +135,37 @@ def test_merge_pr(
     controller._pull_request = mocker.MagicMock()
     controller.merge_pr()
     controller._pull_request.method_calls == [call.merge()]
+
+
+def test_bot_command_parsing(
+    github_pull_request_comment_raw: t.Dict[str, t.Any], mocker: MockerFixture
+):
+    comment_raw = github_pull_request_comment_raw
+    controller = get_mocked_controller(GithubEvent.from_obj(comment_raw), mocker)
+    assert controller.is_comment_triggered
+    assert controller.get_command_from_comment() == BotCommand.INVALID
+    comment_raw["comment"]["body"] = "/deploy"
+    controller = get_mocked_controller(GithubEvent.from_obj(comment_raw), mocker)
+    assert controller.get_command_from_comment() == BotCommand.DEPLOY_PROD
+    assert (
+        controller.get_command_from_comment(GithubController.DEFAULT_COMMAND_NAMESPACE)
+        == BotCommand.INVALID
+    )
+    comment_raw["comment"]["body"] = "#SQLMesh/deploy"
+    controller = get_mocked_controller(GithubEvent.from_obj(comment_raw), mocker)
+    assert controller.get_command_from_comment() == BotCommand.INVALID
+    assert (
+        controller.get_command_from_comment(GithubController.DEFAULT_COMMAND_NAMESPACE)
+        == BotCommand.DEPLOY_PROD
+    )
+    comment_raw["comment"]["body"] = "Something Something /deploy"
+    controller = get_mocked_controller(GithubEvent.from_obj(comment_raw), mocker)
+    assert controller.get_command_from_comment() == BotCommand.INVALID
+    assert controller.get_command_from_comment() == BotCommand.INVALID
+    comment_raw["comment"][
+        "body"
+    ] = """
+    /deploy_prod
+    """
+    controller = get_mocked_controller(GithubEvent.from_obj(comment_raw), mocker)
+    assert controller.get_command_from_comment() == BotCommand.DEPLOY_PROD

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -159,7 +159,7 @@ def test_bot_command_parsing(
     comment_raw["comment"][
         "body"
     ] = """
-    /deploy_prod
+    /deploy
     """
     controller = get_mocked_controller(GithubEvent.from_obj(comment_raw), mocker)
     assert controller.get_command_from_comment() == BotCommand.DEPLOY_PROD

--- a/tests/integrations/github/cicd/test_github_event.py
+++ b/tests/integrations/github/cicd/test_github_event.py
@@ -26,6 +26,7 @@ def test_github_pull_request_comment(github_pull_request_comment_event: GithubEv
         github_pull_request_comment_event.pull_request_url
         == "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
     )
+    assert github_pull_request_comment_event.pull_request_comment_body == "example_comment"
 
 
 def test_pull_request_synchronized_info(github_pull_request_synchronized_info: PullRequestInfo):


### PR DESCRIPTION
Breaking Change: The bot now has a behavior change where before if you had a SQLMesh project where no required approvers were defined in your config then a PR would automatically be deployed to prod if tests passed and PR environment was updated. Now the bot skips the prod deploy in this case. To do the deploy you need to issue the `/deploy` command. 