### PR TITLE
Chore: Don't use bugged typing-extensions release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,8 @@ setup(
             "tenacity==8.1.0",
             "types-croniter",
             "types-dateparser",
+            # Remove once fix is ready for 4.6.0
+            "typing-extensions==4.5.0",
             "types-pytz",
             "types-requests==2.28.8",
         ],


### PR DESCRIPTION
4.6.0 is causing issues for us on Python 3.8 and 3.9. So forcing the last known good release for now. 