### PR TITLE
Fix: Concat Dataframes if insert overwrite

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -64,6 +64,7 @@ class EngineAdapter:
     DEFAULT_SQL_GEN_KWARGS: t.Dict[str, str | bool | int] = {}
     ESCAPE_JSON = False
     SUPPORTS_INDEXES = False
+    SUPPORTS_INSERT_OVERWRITE = False
     SCHEMA_DIFFER = SchemaDiffer()
 
     def __init__(

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -30,6 +30,7 @@ if t.TYPE_CHECKING:
 class SparkEngineAdapter(EngineAdapter):
     DIALECT = "spark"
     ESCAPE_JSON = True
+    SUPPORTS_INSERT_OVERWRITE = True
 
     @property
     def spark(self) -> PySparkSession:


### PR DESCRIPTION
A follow up PR will make use of the `SUPPORTS_INSERT_OVERWRITE` property within the engine adapter to cleanup implementation. This PR is just focused on resolving yielding dataframes into an insert/overwrite. 