### PR TITLE
Chore!: fix mypy issues, use _parse_table_parts instead of _parse_table

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "requests",
         "rich",
         "ruamel.yaml",
-        "sqlglot~=14.0.0",
+        "sqlglot~=14.1.0",
         "fsspec",
     ],
     extras_require={

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -236,7 +236,7 @@ def _create_parser(parser_type: t.Type[exp.Expression], table_keys: t.List[str])
             value: t.Optional[exp.Expression | str]
 
             if key in table_keys:
-                value = exp.table_name(self._parse_table())
+                value = exp.table_name(self._parse_table_parts())
             elif key == "columns":
                 value = self._parse_schema()
             elif key == "kind":

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -168,13 +168,12 @@ class EngineAdapter:
         """
         if not self.SUPPORTS_INDEXES:
             return
+
         expression = exp.Create(
             this=exp.Index(
                 this=exp.to_identifier(index_name),
                 table=exp.to_table(table_name),
-                columns=exp.Tuple(
-                    expressions=[exp.to_column(c) for c in columns],
-                ),
+                columns=[exp.to_column(c) for c in columns],
             ),
             kind="INDEX",
             exists=exists,

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -250,7 +250,7 @@ class QueryRenderer(ExpressionRenderer):
                 query.set("with", with_)
 
         if mapping:
-            return exp.replace_tables(query, mapping)
+            return exp.replace_tables(t.cast(exp.Subqueryable, query), mapping)
 
         if not isinstance(query, exp.Subqueryable):
             raise_config_error(f"Query needs to be a SELECT or a UNION {query}.", self._path)

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import pytest
 from sqlglot import exp, parse_one
 
@@ -9,7 +11,7 @@ from sqlmesh.utils.metaprogramming import Executable
 def filter_country(
     evaluator: MacroEvaluator, expression: exp.Condition, country: str
 ) -> exp.Condition:
-    return exp.and_(expression, exp.column("country").eq(country))
+    return t.cast(exp.Condition, exp.and_(expression, exp.column("country").eq(country)))
 
 
 @macro("UPPER")


### PR DESCRIPTION
This will resolve mypy issues created due to the latest sqlglot [changes](https://github.com/tobymao/sqlglot/pull/1689/).

When we bump sqlglot to v14.1.0, I'll bump its version here too and the CI will be fixed.