### PR TITLE
Feat!: Add depends_on_past through self-reference check support (Built-in only)

### DIFF
--- a/examples/sushi/models/customer_revenue_lifetime.sql
+++ b/examples/sushi/models/customer_revenue_lifetime.sql
@@ -5,8 +5,9 @@
 */
 MODEL (
   name sushi.customer_revenue_lifetime,
-  kind full_with_history (
-    time_column (ds, 'YYYY-MM-dd')
+  kind incremental_by_time_range (
+    time_column (ds, 'YYYY-MM-dd'),
+    batch_size 1
   ),
   owner jen,
   cron '@daily',

--- a/examples/sushi/models/customer_revenue_lifetime.sql
+++ b/examples/sushi/models/customer_revenue_lifetime.sql
@@ -1,0 +1,59 @@
+/*
+    Table of lifetime customer revenue.
+    Date is available to get lifetime value up to a certain date.
+    Use latest date to get current lifetime value.
+*/
+MODEL (
+  name sushi.customer_revenue_lifetime,
+  kind full_with_history (
+    time_column (ds, 'YYYY-MM-dd'),
+  ),
+  owner jen,
+  cron '@daily',
+  dialect hive,
+  columns (
+    customer_id INT,
+    revenue DOUBLE,
+    ds TEXT,
+  ),
+);
+
+WITH order_total AS (
+  SELECT
+    oi.order_id AS order_id,
+    SUM(oi.quantity * i.price) AS total,
+  FROM sushi.order_items AS oi
+  LEFT JOIN sushi.items AS i
+    ON oi.item_id = i.id AND oi.ds = i.ds
+  WHERE
+    oi.ds = @end_ds
+  GROUP BY
+    oi.order_id,
+),
+incremental_total AS (
+SELECT
+  o.customer_id::INT AS customer_id,
+  SUM(ot.total)::DOUBLE AS revenue,
+FROM sushi.orders AS o
+LEFT JOIN order_total AS ot
+  ON o.id = ot.order_id
+WHERE
+  o.ds = @end_ds
+GROUP BY
+  o.customer_id,
+),
+prev_total AS (
+SELECT
+  crl.customer_id,
+  crl.revenue,
+FROM sushi.customer_revenue_lifetime AS crl
+WHERE
+  crl.ds = DATE_FORMAT(@end_date - INTERVAL 1 DAY, 'YYYY-MM-dd')
+)
+SELECT
+  coalesce(it.customer_id, prev_total.customer_id) AS customer_id /* Customer id */,
+  coalesce(it.revenue, 0) + coalesce(prev_total.revenue, 0) AS revenue, /* Lifetime revenue from this customer */
+  @end_ds AS ds, /* End date of the lifetime calculation */
+FROM incremental_total AS it
+FULL OUTER JOIN prev_total AS prev_total
+ON it.customer_id = prev_total.customer_id

--- a/examples/sushi/models/customer_revenue_lifetime.sql
+++ b/examples/sushi/models/customer_revenue_lifetime.sql
@@ -6,7 +6,7 @@
 MODEL (
   name sushi.customer_revenue_lifetime,
   kind full_with_history (
-    time_column (ds, 'YYYY-MM-dd'),
+    time_column (ds, 'YYYY-MM-dd')
   ),
   owner jen,
   cron '@daily',
@@ -14,46 +14,44 @@ MODEL (
   columns (
     customer_id INT,
     revenue DOUBLE,
-    ds TEXT,
-  ),
+    ds STRING
+  )
 );
 
 WITH order_total AS (
   SELECT
     oi.order_id AS order_id,
-    SUM(oi.quantity * i.price) AS total,
+    SUM(oi.quantity * i.price) AS total
   FROM sushi.order_items AS oi
   LEFT JOIN sushi.items AS i
     ON oi.item_id = i.id AND oi.ds = i.ds
   WHERE
     oi.ds = @end_ds
   GROUP BY
-    oi.order_id,
-),
-incremental_total AS (
-SELECT
-  o.customer_id::INT AS customer_id,
-  SUM(ot.total)::DOUBLE AS revenue,
-FROM sushi.orders AS o
-LEFT JOIN order_total AS ot
-  ON o.id = ot.order_id
-WHERE
-  o.ds = @end_ds
-GROUP BY
-  o.customer_id,
-),
-prev_total AS (
-SELECT
-  crl.customer_id,
-  crl.revenue,
-FROM sushi.customer_revenue_lifetime AS crl
-WHERE
-  crl.ds = DATE_FORMAT(@end_date - INTERVAL 1 DAY, 'YYYY-MM-dd')
+    oi.order_id
+), incremental_total AS (
+  SELECT
+    o.customer_id::INT AS customer_id,
+    SUM(ot.total)::DOUBLE AS revenue,
+  FROM sushi.orders AS o
+  LEFT JOIN order_total AS ot
+    ON o.id = ot.order_id
+  WHERE
+    o.ds = @end_ds
+  GROUP BY
+    o.customer_id
+), prev_total AS (
+  SELECT
+    crl.customer_id,
+    crl.revenue
+  FROM sushi.customer_revenue_lifetime AS crl
+  WHERE
+    crl.ds = DATE_FORMAT(@end_date - INTERVAL 1 DAY, 'YYYY-MM-dd')
 )
 SELECT
-  coalesce(it.customer_id, prev_total.customer_id) AS customer_id /* Customer id */,
-  coalesce(it.revenue, 0) + coalesce(prev_total.revenue, 0) AS revenue, /* Lifetime revenue from this customer */
-  @end_ds AS ds, /* End date of the lifetime calculation */
+  COALESCE(it.customer_id, prev_total.customer_id) AS customer_id, /* Customer id */
+  COALESCE(it.revenue, 0) + COALESCE(prev_total.revenue, 0) AS revenue, /* Lifetime revenue from this customer */
+  @end_ds AS ds /* End date of the lifetime calculation */
 FROM incremental_total AS it
 FULL OUTER JOIN prev_total AS prev_total
-ON it.customer_id = prev_total.customer_id
+  ON it.customer_id = prev_total.customer_id

--- a/sqlmesh/core/config/model.py
+++ b/sqlmesh/core/config/model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 
 from sqlmesh.core.config.base import BaseConfig
-from sqlmesh.core.model.kind import ModelKind, model_kind_validator
+from sqlmesh.core.model.kind import ModelKind
 from sqlmesh.utils.date import TimeLike
 
 
@@ -34,4 +34,4 @@ class ModelDefaultsConfig(BaseConfig):
     batch_size: t.Optional[int]
     storage_format: t.Optional[str]
 
-    _model_kind_validator = model_kind_validator
+    _model_kind_validator = ModelKind.field_validator()

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -250,7 +250,6 @@ def _create_parser(parser_type: t.Type[exp.Expression], table_keys: t.List[str])
                         ModelKindName.INCREMENTAL_BY_TIME_RANGE,
                         ModelKindName.INCREMENTAL_BY_UNIQUE_KEY,
                         ModelKindName.SEED,
-                        ModelKindName.FULL_WITH_HISTORY,
                     ) and self._match(TokenType.L_PAREN):
                         self._retreat(index)
                         props = self._parse_wrapped_csv(functools.partial(_parse_props, self))

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -250,6 +250,7 @@ def _create_parser(parser_type: t.Type[exp.Expression], table_keys: t.List[str])
                         ModelKindName.INCREMENTAL_BY_TIME_RANGE,
                         ModelKindName.INCREMENTAL_BY_UNIQUE_KEY,
                         ModelKindName.SEED,
+                        ModelKindName.FULL_WITH_HISTORY,
                     ) and self._match(TokenType.L_PAREN):
                         self._retreat(index)
                         props = self._parse_wrapped_csv(functools.partial(_parse_props, self))

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -454,8 +454,8 @@ class _Model(ModelMeta, frozen=True):
     def has_self_reference_query(self) -> bool:
         if self._has_self_reference_query is None:
             self._has_self_reference_query = (
-                self.name in _find_tables([self.render_query()])
-                or self.kind.is_incremental_by_unique_key
+                self.kind.is_incremental_by_unique_key
+                or self.name in _find_tables([self.render_query()])
             )
         return self._has_self_reference_query
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -406,7 +406,7 @@ class _Model(ModelMeta, frozen=True):
             return self.depends_on_ - {self.name}
 
         if self._depends_on is None:
-            self._depends_on = _find_tables(self._render_all_sql()) - {self.name}
+            self._depends_on = self._all_model_references - {self.name}
         return self._depends_on
 
     @property
@@ -448,6 +448,14 @@ class _Model(ModelMeta, frozen=True):
     @property
     def is_seed(self) -> bool:
         return False
+
+    @property
+    def has_self_reference(self) -> bool:
+        return self.name in self._all_model_references
+
+    @property
+    def _all_model_references(self) -> t.Set[str]:
+        return _find_tables(self._render_all_sql())
 
     def validate_definition(self) -> None:
         """Validates the model's definition.
@@ -816,6 +824,10 @@ class SeedModel(_Model):
         if not seed_path.is_absolute():
             return self._path.parent / seed_path
         return seed_path
+
+    @property
+    def has_self_reference(self) -> bool:
+        return False
 
     def to_dehydrated(self) -> SeedModel:
         """Creates a dehydrated copy of this model.

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -104,7 +104,7 @@ class _Model(ModelMeta, frozen=True):
 
     _path: Path = Path()
     _depends_on: t.Optional[t.Set[str]] = None
-    _has_self_reference_query: t.Optional[bool] = None
+    _depends_on_past: t.Optional[bool] = None
     _column_descriptions: t.Optional[t.Dict[str, str]] = None
 
     _expressions_validator = expression_validator
@@ -451,13 +451,13 @@ class _Model(ModelMeta, frozen=True):
         return False
 
     @property
-    def has_self_reference_query(self) -> bool:
-        if self._has_self_reference_query is None:
-            self._has_self_reference_query = (
+    def depends_on_past(self) -> bool:
+        if self._depends_on_past is None:
+            self._depends_on_past = (
                 self.kind.is_incremental_by_unique_key
                 or self.name in _find_tables([self.render_query()])
             )
-        return self._has_self_reference_query
+        return self._depends_on_past
 
     def validate_definition(self) -> None:
         """Validates the model's definition.
@@ -828,7 +828,7 @@ class SeedModel(_Model):
         return seed_path
 
     @property
-    def has_self_reference_query(self) -> bool:
+    def depends_on_past(self) -> bool:
         return False
 
     def to_dehydrated(self) -> SeedModel:

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -448,7 +448,7 @@ class _Model(ModelMeta, frozen=True):
         return False
 
     @property
-    def has_self_reference(self) -> bool:
+    def has_self_reference_query(self) -> bool:
         return (
             self.name in self._query_only_model_references or self.kind.is_incremental_by_unique_key
         )
@@ -834,7 +834,7 @@ class SeedModel(_Model):
         return seed_path
 
     @property
-    def has_self_reference(self) -> bool:
+    def has_self_reference_query(self) -> bool:
         return False
 
     def to_dehydrated(self) -> SeedModel:

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -405,6 +405,7 @@ class _Model(ModelMeta, frozen=True):
         """
         if self.depends_on_ is not None:
             return self.depends_on_ - {self.name}
+
         if self._depends_on is None:
             self._depends_on = _find_tables(self._render_all_sql()) - {self.name}
         return self._depends_on

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import typing as t
 from enum import Enum
 
@@ -11,6 +12,11 @@ from sqlglot.time import format_time
 from sqlmesh.core import dialect as d
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.pydantic import PydanticModel
+
+if sys.version_info >= (3, 9):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class ModelKindMixin:
@@ -30,6 +36,10 @@ class ModelKindMixin:
     @property
     def is_full(self) -> bool:
         return self.model_kind_name == ModelKindName.FULL
+
+    @property
+    def is_full_with_history(self) -> bool:
+        return self.model_kind_name == ModelKindName.FULL_WITH_HISTORY
 
     @property
     def is_view(self) -> bool:
@@ -59,7 +69,17 @@ class ModelKindMixin:
     @property
     def only_latest(self) -> bool:
         """Whether or not this model only cares about latest date to render."""
-        return self.model_kind_name in (ModelKindName.VIEW, ModelKindName.FULL)
+        return self.is_view or self.is_full
+
+    @property
+    def depends_on_past(self) -> bool:
+        """Whether or not this models depends on past intervals to be accurate before loading following intervals."""
+        return self.is_incremental_by_unique_key or self.is_full_with_history
+
+    @property
+    def is_time_based_load(self) -> bool:
+        """Whether or not this model has a time column which influences the load pattern used."""
+        return self.is_incremental_by_time_range or self.is_full_with_history
 
 
 class ModelKindName(str, ModelKindMixin, Enum):
@@ -68,6 +88,7 @@ class ModelKindName(str, ModelKindMixin, Enum):
     INCREMENTAL_BY_TIME_RANGE = "INCREMENTAL_BY_TIME_RANGE"
     INCREMENTAL_BY_UNIQUE_KEY = "INCREMENTAL_BY_UNIQUE_KEY"
     FULL = "FULL"
+    FULL_WITH_HISTORY = "FULL_WITH_HISTORY"
     VIEW = "VIEW"
     EMBEDDED = "EMBEDDED"
     SEED = "SEED"
@@ -81,17 +102,83 @@ class ModelKindName(str, ModelKindMixin, Enum):
 class ModelKind(PydanticModel, ModelKindMixin):
     name: ModelKindName
 
-    def to_expression(self, **kwargs: t.Any) -> d.ModelKind:
-        return d.ModelKind(this=self.name.value.upper(), **kwargs)
+    @classmethod
+    def field_validator(cls) -> classmethod:
+        def _model_kind_validator(v: t.Any) -> ModelKind:
+            if isinstance(v, ModelKind):
+                return v
+
+            if isinstance(v, d.ModelKind):
+                name = v.this
+                props = {prop.name: prop.args.get("value") for prop in v.expressions}
+                klass: t.Type[ModelKind] = ModelKind
+                if name == ModelKindName.INCREMENTAL_BY_TIME_RANGE:
+                    klass = IncrementalByTimeRangeKind
+                elif name == ModelKindName.INCREMENTAL_BY_UNIQUE_KEY:
+                    klass = IncrementalByUniqueKeyKind
+                elif name == ModelKindName.SEED:
+                    klass = SeedKind
+                elif name == ModelKindName.FULL_WITH_HISTORY:
+                    klass = FullWithHistory
+                else:
+                    props["name"] = ModelKindName(name)
+                return klass(**props)
+
+            if isinstance(v, dict):
+                if v.get("name") == ModelKindName.INCREMENTAL_BY_TIME_RANGE:
+                    klass = IncrementalByTimeRangeKind
+                elif v.get("name") == ModelKindName.INCREMENTAL_BY_UNIQUE_KEY:
+                    klass = IncrementalByUniqueKeyKind
+                elif v.get("name") == ModelKindName.SEED:
+                    klass = SeedKind
+                elif v.get("name") == ModelKindName.FULL_WITH_HISTORY:
+                    klass = FullWithHistory
+                else:
+                    klass = ModelKind
+                return klass(**v)
+
+            name = (v.name if isinstance(v, exp.Expression) else str(v)).upper()
+
+            try:
+                return ModelKind(name=ModelKindName(name))
+            except ValueError:
+                raise ConfigError(f"Invalid model kind '{name}'")
+
+        return validator("kind", pre=True, allow_reuse=True)(_model_kind_validator)
 
     @property
     def model_kind_name(self) -> ModelKindName:
         return self.name
 
+    def to_expression(self, **kwargs: t.Any) -> d.ModelKind:
+        return d.ModelKind(this=self.name.value.upper(), **kwargs)
+
 
 class TimeColumn(PydanticModel):
     column: str
     format: t.Optional[str] = None
+
+    @classmethod
+    def field_validator(cls) -> classmethod:
+        def _time_column_validator(v: t.Any) -> TimeColumn:
+            if isinstance(v, exp.Tuple):
+                kwargs = {
+                    key: v.expressions[i].name
+                    for i, key in enumerate(("column", "format")[: len(v.expressions)])
+                }
+                return TimeColumn(**kwargs)
+
+            if isinstance(v, exp.Identifier):
+                return TimeColumn(column=v.name)
+
+            if isinstance(v, exp.Expression):
+                return TimeColumn(column=v.name)
+
+            if isinstance(v, str):
+                return TimeColumn(column=v)
+            return v
+
+        return validator("time_column", pre=True, allow_reuse=True)(_time_column_validator)
 
     @validator("column", pre=True)
     def _column_validator(cls, v: str) -> str:
@@ -126,6 +213,9 @@ class TimeColumn(PydanticModel):
             ]
         )
 
+    def to_property(self, dialect: str = "") -> exp.Property:
+        return exp.Property(this="time_column", value=self.to_expression(dialect))
+
 
 class _Incremental(ModelKind):
     batch_size: t.Optional[int]
@@ -156,31 +246,10 @@ class IncrementalByTimeRangeKind(_Incremental):
     name: ModelKindName = Field(ModelKindName.INCREMENTAL_BY_TIME_RANGE, const=True)
     time_column: TimeColumn
 
-    @validator("time_column", pre=True)
-    def _parse_time_column(cls, v: t.Any) -> TimeColumn:
-        if isinstance(v, exp.Tuple):
-            kwargs = {
-                key: v.expressions[i].name
-                for i, key in enumerate(("column", "format")[: len(v.expressions)])
-            }
-            return TimeColumn(**kwargs)
-
-        if isinstance(v, exp.Identifier):
-            return TimeColumn(column=v.name)
-
-        if isinstance(v, exp.Expression):
-            return TimeColumn(column=v.name)
-
-        if isinstance(v, str):
-            return TimeColumn(column=v)
-        return v
+    _time_column_validator = TimeColumn.field_validator()
 
     def to_expression(self, dialect: str = "", **kwargs: t.Any) -> d.ModelKind:
-        return super().to_expression(
-            expressions=[
-                exp.Property(this="time_column", value=self.time_column.to_expression(dialect))
-            ],
-        )
+        return super().to_expression(expressions=[self.time_column.to_property(dialect)])
 
 
 class IncrementalByUniqueKeyKind(_Incremental):
@@ -230,41 +299,12 @@ class SeedKind(ModelKind):
         )
 
 
-def _model_kind_validator(v: t.Any) -> ModelKind:
-    if isinstance(v, ModelKind):
-        return v
+class FullWithHistory(ModelKind):
+    name: ModelKindName = Field(ModelKindName.FULL_WITH_HISTORY, const=True)
+    batch_size: Literal[1] = 1
+    time_column: TimeColumn
 
-    if isinstance(v, d.ModelKind):
-        name = v.this
-        props = {prop.name: prop.args.get("value") for prop in v.expressions}
-        klass: t.Type[ModelKind] = ModelKind
-        if name == ModelKindName.INCREMENTAL_BY_TIME_RANGE:
-            klass = IncrementalByTimeRangeKind
-        elif name == ModelKindName.INCREMENTAL_BY_UNIQUE_KEY:
-            klass = IncrementalByUniqueKeyKind
-        elif name == ModelKindName.SEED:
-            klass = SeedKind
-        else:
-            props["name"] = ModelKindName(name)
-        return klass(**props)
+    _time_column_validator = TimeColumn.field_validator()
 
-    if isinstance(v, dict):
-        if v.get("name") == ModelKindName.INCREMENTAL_BY_TIME_RANGE:
-            klass = IncrementalByTimeRangeKind
-        elif v.get("name") == ModelKindName.INCREMENTAL_BY_UNIQUE_KEY:
-            klass = IncrementalByUniqueKeyKind
-        elif v.get("name") == ModelKindName.SEED:
-            klass = SeedKind
-        else:
-            klass = ModelKind
-        return klass(**v)
-
-    name = (v.name if isinstance(v, exp.Expression) else str(v)).upper()
-
-    try:
-        return ModelKind(name=ModelKindName(name))
-    except ValueError:
-        raise ConfigError(f"Invalid model kind '{name}'")
-
-
-model_kind_validator = validator("kind", pre=True, allow_reuse=True)(_model_kind_validator)
+    def to_expression(self, dialect: str = "", **kwargs: t.Any) -> d.ModelKind:
+        return super().to_expression(expressions=[self.time_column.to_property(dialect)])

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 from enum import Enum
 
@@ -12,11 +11,6 @@ from sqlglot.time import format_time
 from sqlmesh.core import dialect as d
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.pydantic import PydanticModel
-
-if sys.version_info >= (3, 9):
-    pass
-else:
-    pass
 
 
 class ModelKindMixin:
@@ -66,11 +60,6 @@ class ModelKindMixin:
     def only_latest(self) -> bool:
         """Whether or not this model only cares about latest date to render."""
         return self.is_view or self.is_full
-
-    @property
-    def is_time_based_load(self) -> bool:
-        """Whether or not this model has a time column which influences the load pattern used."""
-        return self.is_incremental_by_time_range
 
 
 class ModelKindName(str, ModelKindMixin, Enum):

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -173,9 +173,7 @@ class ModelMeta(PydanticModel):
     @property
     def time_column(self) -> t.Optional[TimeColumn]:
         """The time column for incremental models."""
-        if hasattr(self.kind, "time_column"):
-            return self.kind.time_column
-        return None
+        return getattr(self.kind, "time_column", None)
 
     @property
     def unique_key(self) -> t.List[str]:
@@ -214,7 +212,7 @@ class ModelMeta(PydanticModel):
     @property
     def batch_size(self) -> t.Optional[int]:
         """The maximal number of units in a single task for a backfill."""
-        return self.kind.batch_size if hasattr(self.kind, "batch_size") else None
+        return getattr(self.kind, "batch_size", None)
 
     def interval_unit(self, sample_size: int = 10) -> IntervalUnit:
         """Returns the IntervalUnit of the model

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -10,13 +10,11 @@ from sqlglot import exp
 
 from sqlmesh.core import dialect as d
 from sqlmesh.core.model.kind import (
-    IncrementalByTimeRangeKind,
     IncrementalByUniqueKeyKind,
     ModelKind,
     ModelKindName,
     TimeColumn,
     _Incremental,
-    model_kind_validator,
 )
 from sqlmesh.utils import unique
 from sqlmesh.utils.date import TimeLike, preserve_time_like_kind, to_datetime
@@ -64,7 +62,7 @@ class ModelMeta(PydanticModel):
     _croniter: t.Optional[croniter] = None
     _interval_unit: t.Optional[IntervalUnit] = None
 
-    _model_kind_validator = model_kind_validator
+    _model_kind_validator = ModelKind.field_validator()
 
     @validator("audits", pre=True)
     def _audits_validator(cls, v: t.Any) -> t.Any:
@@ -174,7 +172,8 @@ class ModelMeta(PydanticModel):
 
     @property
     def time_column(self) -> t.Optional[TimeColumn]:
-        if isinstance(self.kind, IncrementalByTimeRangeKind):
+        """The time column for incremental models."""
+        if hasattr(self.kind, "time_column"):
             return self.kind.time_column
         return None
 
@@ -215,7 +214,7 @@ class ModelMeta(PydanticModel):
     @property
     def batch_size(self) -> t.Optional[int]:
         """The maximal number of units in a single task for a backfill."""
-        return self.kind.batch_size if isinstance(self.kind, _Incremental) else None
+        return self.kind.batch_size if hasattr(self.kind, "batch_size") else None
 
     def interval_unit(self, sample_size: int = 10) -> IntervalUnit:
         """Returns the IntervalUnit of the model

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -272,12 +272,11 @@ class Scheduler:
             ]
             for i, interval in enumerate(intervals):
                 dag.add((snapshot, interval), upstream_dependencies)
-                if snapshot.is_incremental_by_unique_key:
+                if snapshot.depends_on_past:
                     dag.add(
                         (snapshot, interval),
                         [(snapshot, _interval) for _interval in intervals[:i]],
                     )
-
         return dag
 
 

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -806,7 +806,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
     @property
     def depends_on_past(self) -> bool:
         """Whether or not this models depends on past intervals to be accurate before loading following intervals."""
-        return self.model.has_self_reference
+        return self.model.has_self_reference_query
 
     def _ensure_categorized(self) -> None:
         if not self.change_category:

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -806,7 +806,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
     @property
     def depends_on_past(self) -> bool:
         """Whether or not this models depends on past intervals to be accurate before loading following intervals."""
-        return self.model.has_self_reference_query
+        return self.model.depends_on_past
 
     def _ensure_categorized(self) -> None:
         if not self.change_category:

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -806,7 +806,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
     @property
     def depends_on_past(self) -> bool:
         """Whether or not this models depends on past intervals to be accurate before loading following intervals."""
-        return self.is_incremental_by_unique_key or self.model.has_self_reference
+        return self.model.has_self_reference
 
     def _ensure_categorized(self) -> None:
         if not self.change_category:

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -803,6 +803,11 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
     def model_kind_name(self) -> ModelKindName:
         return self.model.kind.name
 
+    @property
+    def depends_on_past(self) -> bool:
+        """Whether or not this models depends on past intervals to be accurate before loading following intervals."""
+        return self.is_incremental_by_unique_key or self.model.has_self_reference
+
     def _ensure_categorized(self) -> None:
         if not self.change_category:
             raise SQLMeshError(f"Snapshot {self.snapshot_id} has not been categorized yet.")

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -115,7 +115,7 @@ class SnapshotEvaluator:
                 self.adapter.replace_query(table_name, query_or_df, columns_to_types)
             else:
                 logger.info("Inserting batch (%s, %s) into %s'", start, end, table_name)
-                if snapshot.is_time_based_load:
+                if snapshot.is_incremental_by_time_range:
                     # A model's time_column could be None but
                     # it shouldn't be for time based loads
                     assert model.time_column

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -115,9 +115,9 @@ class SnapshotEvaluator:
                 self.adapter.replace_query(table_name, query_or_df, columns_to_types)
             else:
                 logger.info("Inserting batch (%s, %s) into %s'", start, end, table_name)
-                if snapshot.is_incremental_by_time_range:
+                if snapshot.is_time_based_load:
                     # A model's time_column could be None but
-                    # it shouldn't be for an incremental by time range model
+                    # it shouldn't be for time based loads
                     assert model.time_column
                     self.adapter.insert_overwrite_by_time_partition(
                         table_name,

--- a/sqlmesh/migrations/v0010_seed_hash_batch_size.py
+++ b/sqlmesh/migrations/v0010_seed_hash_batch_size.py
@@ -1,0 +1,5 @@
+"""Seed metadata hashes now correctly include the batch_size."""
+
+
+def migrate(state_sync):  # type: ignore
+    pass

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -149,6 +149,7 @@ def validate_query_change(
         "sushi.order_items",
         "sushi.waiter_revenue_by_day",
         "sushi.customer_revenue_by_day",
+        "sushi.customer_revenue_lifetime",
         "sushi.top_waiters",
     ]
     not_modified = [
@@ -243,6 +244,7 @@ def validate_model_kind_change(
         "sushi.order_items",
         "sushi.waiter_revenue_by_day",
         "sushi.customer_revenue_by_day",
+        "sushi.customer_revenue_lifetime",
         "sushi.top_waiters",
     ]
     if kind_name == ModelKindName.INCREMENTAL_BY_TIME_RANGE:
@@ -288,6 +290,7 @@ def test_environment_isolation(sushi_context: Context):
         "sushi.order_items",
         "sushi.waiter_revenue_by_day",
         "sushi.customer_revenue_by_day",
+        "sushi.customer_revenue_lifetime",
         "sushi.top_waiters",
     ]
 
@@ -483,6 +486,7 @@ def setup_rebase(
             "sushi.waiter_revenue_by_day",
             "sushi.top_waiters",
             "sushi.customer_revenue_by_day",
+            "sushi.customer_revenue_lifetime",
         }
     }
     context.apply(plan)

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -1,3 +1,4 @@
+import datetime
 import typing as t
 
 import pytest
@@ -23,7 +24,7 @@ from sqlmesh.core.snapshot import (
     SnapshotInfoLike,
     SnapshotTableInfo,
 )
-from sqlmesh.utils.date import TimeLike
+from sqlmesh.utils.date import TimeLike, to_ds, yesterday
 
 
 @pytest.fixture(autouse=True)
@@ -642,6 +643,24 @@ def test_multi(mocker):
     assert len(plan.missing_intervals) == 2
     context.apply(plan)
     validate_apply_basics(context, c.PROD, plan.snapshots)
+
+
+@pytest.mark.integration
+@pytest.mark.core_integration
+def test_full_with_history(sushi_context: Context):
+    df = sushi_context.engine_adapter.fetchdf("SELECT MIN(ds) FROM sushi.customer_revenue_lifetime")
+    assert df.iloc[0, 0] == to_ds("1 week ago")
+    df = sushi_context.engine_adapter.fetchdf("SELECT MAX(ds) FROM sushi.customer_revenue_lifetime")
+    assert df.iloc[0, 0] == to_ds("yesterday")
+    results = sushi_context.engine_adapter.fetchdf(
+        "SELECT ds, count(*) FROM sushi.customer_revenue_lifetime group by 1 order by 2 desc, 1 desc"
+    ).values
+    # Validate that both rows increase over time and all days are present
+    assert len(results) == 7
+    assert [x[0] for x in results] == [
+        to_ds(yesterday() - datetime.timedelta(days=x)) for x in range(7)
+    ]
+    # TODO: Add a restatement test
 
 
 def initial_add(context: Context, environment: str):

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -651,7 +651,7 @@ def test_multi(mocker):
 
 @pytest.mark.integration
 @pytest.mark.core_integration
-def test_full_with_history(sushi_context: Context):
+def test_incremental_time_self_reference(sushi_context: Context):
     df = sushi_context.engine_adapter.fetchdf("SELECT MIN(ds) FROM sushi.customer_revenue_lifetime")
     assert df.iloc[0, 0] == to_ds("1 week ago")
     df = sushi_context.engine_adapter.fetchdf("SELECT MAX(ds) FROM sushi.customer_revenue_lifetime")

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -407,7 +407,7 @@ def test_fingerprint_seed_model():
 
     expected_fingerprint = SnapshotFingerprint(
         data_hash="3834815287",
-        metadata_hash="1120323454",
+        metadata_hash="1624292983",
     )
 
     model = load_model(expressions, path=Path("./examples/sushi/models/test_model.sql"))

--- a/tests/utils/test_dag.py
+++ b/tests/utils/test_dag.py
@@ -4,6 +4,7 @@ from sqlmesh.utils.dag import DAG
 def test_downstream(sushi_context):
     assert set(sushi_context.dag.downstream("sushi.order_items")) == {
         "sushi.customer_revenue_by_day",
+        "sushi.customer_revenue_lifetime",
         "sushi.top_waiters",
         "sushi.waiter_revenue_by_day",
     }


### PR DESCRIPTION
Breaking Change: Bugfix is included in this PR that correctly includes `batch_size` in the model metadata fingerprint for seed models. 

This adds support for the built-in scheduler but without proper restatement support.

TODO:
* Add restatement support for all `depends_on_past` models (so that means incremental by unique key also)
  * PR: https://github.com/TobikoData/sqlmesh/pull/921
* Add Airflow support