### PR TITLE
Fix: ensure dict lookup won't fail during validation

### DIFF
--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -201,7 +201,7 @@ class ModelMeta(PydanticModel):
             return {column.name: column.args["kind"] for column in v.expressions}
         if isinstance(v, dict):
             return {
-                k: exp.DataType.build(data_type, dialect=values["dialect"])
+                k: exp.DataType.build(data_type, dialect=values.get("dialect"))
                 for k, data_type in v.items()
             }
         return v


### PR DESCRIPTION
Seems like I missed this section from Pydantic's documentation:

<img width="682" alt="Screenshot 2023-05-29 at 11 52 49 PM" src="https://github.com/TobikoData/sqlmesh/assets/46752250/bde05a57-ea40-4a85-9594-c5f2d6f81ddf">

cc: @crericha