### PR TITLE
Fix!: normalize identifiers and model names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "requests",
         "rich",
         "ruamel.yaml",
-        "sqlglot~=14.1.0",
+        "sqlglot~=15.0.0",
         "fsspec",
     ],
     extras_require={

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -109,13 +109,8 @@ def render(
     dialect: t.Optional[str] = None,
 ) -> None:
     """Renders a model's query, optionally expanding referenced models."""
-    snapshot = ctx.obj.snapshots.get(model)
-
-    if not snapshot:
-        raise click.ClickException(f"Model `{model}` not found.")
-
     rendered = ctx.obj.render(
-        snapshot,
+        model,
         start=start,
         end=end,
         latest=latest,

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -51,7 +51,7 @@ from sqlmesh.core.console import Console, get_console
 from sqlmesh.core.context_diff import ContextDiff
 from sqlmesh.core.dialect import (
     format_model_expressions,
-    normalize_table,
+    normalize_model_name,
     pandas_to_sql,
     parse,
 )
@@ -282,7 +282,7 @@ class Context(BaseContext):
         Returns:
             A new instance of the updated or inserted model.
         """
-        model = self.get_model(model)
+        model = self.get_model(model, raise_if_missing=True)
         path = model._path
 
         # model.copy() can't be used here due to a cached state that can be a part of a model instance.
@@ -414,7 +414,7 @@ class Context(BaseContext):
             The expected model.
         """
         if isinstance(model_or_snapshot, str):
-            normalized_name = normalize_table(model_or_snapshot, dialect=self.config.dialect)
+            normalized_name = normalize_model_name(model_or_snapshot, dialect=self.config.dialect)
             model = self._models.get(normalized_name)
         elif isinstance(model_or_snapshot, Snapshot):
             model = model_or_snapshot.model
@@ -451,7 +451,7 @@ class Context(BaseContext):
             The expected snapshot.
         """
         if isinstance(model_or_snapshot, str):
-            normalized_name = normalize_table(model_or_snapshot, dialect=self.config.dialect)
+            normalized_name = normalize_model_name(model_or_snapshot, dialect=self.config.dialect)
             snapshot = self.snapshots.get(normalized_name)
         elif isinstance(model_or_snapshot, Snapshot):
             snapshot = model_or_snapshot

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -49,7 +49,12 @@ from sqlmesh.core.audit import Audit
 from sqlmesh.core.config import Config, load_config_from_paths
 from sqlmesh.core.console import Console, get_console
 from sqlmesh.core.context_diff import ContextDiff
-from sqlmesh.core.dialect import format_model_expressions, pandas_to_sql, parse
+from sqlmesh.core.dialect import (
+    format_model_expressions,
+    normalize_table,
+    pandas_to_sql,
+    parse,
+)
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.loader import Loader, SqlMeshLoader, update_model_schemas
@@ -409,7 +414,8 @@ class Context(BaseContext):
             The expected model.
         """
         if isinstance(model_or_snapshot, str):
-            model = self._models.get(model_or_snapshot)
+            normalized_name = normalize_table(model_or_snapshot, dialect=self.config.dialect)
+            model = self._models.get(normalized_name)
         elif isinstance(model_or_snapshot, Snapshot):
             model = model_or_snapshot.model
         else:
@@ -444,7 +450,8 @@ class Context(BaseContext):
             The expected snapshot.
         """
         if isinstance(model_or_snapshot, str):
-            snapshot = self.snapshots.get(model_or_snapshot)
+            normalized_name = normalize_table(model_or_snapshot, dialect=self.config.dialect)
+            snapshot = self.snapshots.get(normalized_name)
         elif isinstance(model_or_snapshot, Snapshot):
             snapshot = model_or_snapshot
         else:

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -548,7 +548,7 @@ def pandas_to_sql(
     )
 
 
-def normalize_table(table: str | exp.Table, dialect: DialectType = None) -> str:
+def normalize_model_name(table: str | exp.Table, dialect: DialectType = None) -> str:
     return exp.table_name(
         normalize_identifiers(exp.to_table(table, dialect=dialect), dialect=dialect)
     )

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -8,6 +8,8 @@ from difflib import unified_diff
 import pandas as pd
 from jinja2.meta import find_undeclared_variables
 from sqlglot import Dialect, Generator, Parser, TokenType, exp
+from sqlglot.dialects.dialect import DialectType
+from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
 from sqlmesh.core.constants import MAX_MODEL_DEFINITION_SIZE
 from sqlmesh.utils.jinja import ENVIRONMENT
@@ -543,4 +545,10 @@ def pandas_to_sql(
         columns_to_types=columns_to_types or columns_to_types_from_df(df),
         batch_size=batch_size,
         alias=alias,
+    )
+
+
+def normalize_table(table: str | exp.Table, dialect: DialectType = None) -> str:
+    return exp.table_name(
+        normalize_identifiers(exp.to_table(table, dialect=dialect), dialect=dialect)
     )

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -53,7 +53,7 @@ def update_model_schemas(dag: DAG[str], models: UniqueKeyDict[str, Model]) -> No
 
         for dep in model.depends_on:
             external = external or dep not in models
-            table = exp.maybe_parse(dep, into=exp.Table, dialect=model.dialect)
+            table = exp.to_table(dep, dialect=model.dialect)
             mapping_schema = schema.find(table)
 
             if mapping_schema:

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ruamel.yaml import YAML
+from sqlglot import exp
 from sqlglot.errors import SqlglotError
 from sqlglot.optimizer.qualify_columns import validate_qualify_columns
 from sqlglot.schema import MappingSchema, nested_set
@@ -39,7 +40,7 @@ if t.TYPE_CHECKING:
 
 
 def update_model_schemas(dag: DAG[str], models: UniqueKeyDict[str, Model]) -> None:
-    schema = MappingSchema()
+    schema = MappingSchema(normalize=False)
 
     for name in dag.sorted():
         model = models.get(name)
@@ -52,9 +53,7 @@ def update_model_schemas(dag: DAG[str], models: UniqueKeyDict[str, Model]) -> No
 
         for dep in model.depends_on:
             external = external or dep not in models
-            table = schema._normalize_table(
-                schema._ensure_table(dep, dialect=model.dialect), dialect=model.dialect
-            )
+            table = exp.maybe_parse(dep, into=exp.Table, dialect=model.dialect)
             mapping_schema = schema.find(table)
 
             if mapping_schema:

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -654,7 +654,7 @@ class SqlModel(_Model):
         if self._columns_to_types is None:
             self._columns_to_types = {
                 expression.output_name: expression.type or exp.DataType.build("unknown")
-                for expression in self._query_renderer.render().expressions
+                for expression in self._query_renderer.render().selects
             }
 
         return self._columns_to_types
@@ -667,7 +667,7 @@ class SqlModel(_Model):
         if self._column_descriptions is None:
             self._column_descriptions = {
                 select.alias: "\n".join(comment.strip() for comment in select.comments)
-                for select in self.render_query().expressions
+                for select in self.render_query().selects
                 if select.comments
             }
         return self._column_descriptions
@@ -678,9 +678,7 @@ class SqlModel(_Model):
         if not isinstance(query, exp.Subqueryable):
             raise_config_error("Missing SELECT query in the model definition", self._path)
 
-        projection_list = (
-            query.expressions if not isinstance(query, exp.Union) else query.this.expressions
-        )
+        projection_list = query.selects
         if not projection_list:
             raise_config_error("Query missing select statements", self._path)
 

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -7,7 +7,6 @@ from enum import Enum
 from croniter import croniter
 from pydantic import Field, root_validator, validator
 from sqlglot import exp
-from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
 from sqlmesh.core import dialect as d
 from sqlmesh.core.model.kind import (
@@ -68,8 +67,7 @@ class ModelMeta(PydanticModel):
 
     @validator("name", pre=True)
     def _name_validator(cls, v: t.Any, values: t.Dict[str, t.Any]) -> str:
-        table = exp.to_table(v, dialect=values.get("dialect"))
-        return exp.table_name(normalize_identifiers(table, dialect=values.get("dialect")))
+        return d.normalize_table(v, dialect=values.get("dialect"))
 
     @validator("audits", pre=True)
     def _audits_validator(cls, v: t.Any) -> t.Any:

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -148,14 +148,19 @@ class ModelMeta(PydanticModel):
         return v
 
     @validator("depends_on_", pre=True)
-    def _depends_on_validator(cls, v: t.Any) -> t.Optional[t.Set[str]]:
+    def _depends_on_validator(cls, v: t.Any, values: t.Dict[str, t.Any]) -> t.Optional[t.Set[str]]:
+        dialect = values.get("dialect")
+
         if isinstance(v, (exp.Array, exp.Tuple)):
             return {
-                exp.table_name(table.name if table.is_string else table.sql())
+                d.normalize_table(
+                    table.name if table.is_string else table.sql(dialect=dialect), dialect=dialect
+                )
                 for table in v.expressions
             }
         if isinstance(v, exp.Expression):
-            return {exp.table_name(v.sql())}
+            return {d.normalize_table(v.sql(dialect=dialect), dialect=dialect)}
+
         return v
 
     @validator("start", pre=True)

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -67,7 +67,7 @@ class ModelMeta(PydanticModel):
 
     @validator("name", pre=True)
     def _name_validator(cls, v: t.Any, values: t.Dict[str, t.Any]) -> str:
-        return d.normalize_table(v, dialect=values.get("dialect"))
+        return d.normalize_model_name(v, dialect=values.get("dialect"))
 
     @validator("audits", pre=True)
     def _audits_validator(cls, v: t.Any) -> t.Any:
@@ -153,13 +153,13 @@ class ModelMeta(PydanticModel):
 
         if isinstance(v, (exp.Array, exp.Tuple)):
             return {
-                d.normalize_table(
+                d.normalize_model_name(
                     table.name if table.is_string else table.sql(dialect=dialect), dialect=dialect
                 )
                 for table in v.expressions
             }
         if isinstance(v, exp.Expression):
-            return {d.normalize_table(v.sql(dialect=dialect), dialect=dialect)}
+            return {d.normalize_model_name(v.sql(dialect=dialect), dialect=dialect)}
 
         return v
 

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -292,7 +292,7 @@ class QueryRenderer(ExpressionRenderer):
                     if not isinstance(select, exp.Alias) and select.output_name not in ("*", ""):
                         select.replace(exp.alias_(select, select.output_name))
 
-            # Ensure that any alias added in the above loop are properly quoted
+            # Ensure that any aliases added in the above loop are properly quoted
             quote_identifiers(query, dialect=self._dialect)
         except SqlglotError as ex:
             raise_config_error(

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -274,11 +274,11 @@ class QueryRenderer(ExpressionRenderer):
     def _optimize_query(self, query: exp.Expression) -> exp.Expression:
         # We don't want to normalize names in the schema because that's handled by the optimizer
         schema = ensure_schema(self.schema, dialect=self._dialect, normalize=False)
-        query_ = t.cast(exp.Subqueryable, query.copy())
+        query = t.cast(exp.Subqueryable, query.copy())
 
         try:
             qualify(
-                query_,
+                query,
                 dialect=self._dialect,
                 schema=schema,
                 infer_schema=False,
@@ -288,19 +288,19 @@ class QueryRenderer(ExpressionRenderer):
             )
 
             if schema.empty:
-                for select in query_.selects:
+                for select in query.selects:
                     if not isinstance(select, exp.Alias) and select.output_name not in ("*", ""):
                         select.replace(exp.alias_(select, select.output_name))
 
             # Ensure that any alias added in the above loop are properly quoted
-            quote_identifiers(query_, dialect=self._dialect)
+            quote_identifiers(query, dialect=self._dialect)
         except SqlglotError as ex:
             raise_config_error(
                 f"Error qualifying columns, the column may not exist or is ambiguous. {ex}",
                 self._path,
             )
 
-        return annotate_types(simplify(query_), schema=schema)
+        return annotate_types(simplify(query), schema=schema)
 
 
 def _resolve_tables(

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -258,7 +258,7 @@ class QueryRenderer(ExpressionRenderer):
         if not isinstance(query, exp.Subqueryable):
             raise_config_error(f"Query needs to be a SELECT or a UNION {query}.", self._path)
 
-        return t.cast(exp.Subqueryable, query)
+        return t.cast(exp.Subqueryable, quote_identifiers(query, dialect=self._dialect))
 
     def time_column_filter(self, start: TimeLike, end: TimeLike) -> exp.Between:
         """Returns a between statement with the properly formatted time column."""
@@ -291,9 +291,6 @@ class QueryRenderer(ExpressionRenderer):
                 for select in query.selects:
                     if not isinstance(select, exp.Alias) and select.output_name not in ("*", ""):
                         select.replace(exp.alias_(select, select.output_name))
-
-            # Ensure that any aliases added in the above loop are properly quoted
-            quote_identifiers(query, dialect=self._dialect)
         except SqlglotError as ex:
             raise_config_error(
                 f"Error qualifying columns, the column may not exist or is ambiguous. {ex}",

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -144,7 +144,7 @@ def test_no_query():
 
 
 def test_macro(model: Model):
-    expected_query = "SELECT * FROM (SELECT * FROM db.test_model AS test_model WHERE ds <= '1970-01-01' AND ds >= '1970-01-01') AS _q_0 WHERE a IS NULL"
+    expected_query = """SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" <= '1970-01-01' AND "ds" >= '1970-01-01') AS "_q_0" WHERE "a" IS NULL"""
 
     audit = Audit(
         name="test_audit",
@@ -167,7 +167,7 @@ def test_not_null_audit(model: Model):
     )
     assert (
         rendered_query_a.sql()
-        == "SELECT * FROM (SELECT * FROM db.test_model AS test_model WHERE ds <= '1970-01-01' AND ds >= '1970-01-01') AS _q_0 WHERE a IS NULL"
+        == """SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" <= '1970-01-01' AND "ds" >= '1970-01-01') AS "_q_0" WHERE "a" IS NULL"""
     )
 
     rendered_query_a_and_b = builtin.not_null_audit.render_query(
@@ -176,7 +176,7 @@ def test_not_null_audit(model: Model):
     )
     assert (
         rendered_query_a_and_b.sql()
-        == "SELECT * FROM (SELECT * FROM db.test_model AS test_model WHERE ds <= '1970-01-01' AND ds >= '1970-01-01') AS _q_0 WHERE a IS NULL OR b IS NULL"
+        == """SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" <= '1970-01-01' AND "ds" >= '1970-01-01') AS "_q_0" WHERE "a" IS NULL OR "b" IS NULL"""
     )
 
 
@@ -184,7 +184,7 @@ def test_unique_values_audit(model: Model):
     rendered_query_a = builtin.unique_values_audit.render_query(model, columns=[exp.to_column("a")])
     assert (
         rendered_query_a.sql()
-        == "SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY a ORDER BY 1) AS a_rank FROM (SELECT * FROM db.test_model AS test_model WHERE ds <= '1970-01-01' AND ds >= '1970-01-01') AS _q_0) AS _q_1 WHERE a_rank > 1"
+        == """SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY "a" ORDER BY 1) AS "a_rank" FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" <= '1970-01-01' AND "ds" >= '1970-01-01') AS "_q_0") AS "_q_1" WHERE "a_rank" > 1"""
     )
 
     rendered_query_a_and_b = builtin.unique_values_audit.render_query(
@@ -192,7 +192,7 @@ def test_unique_values_audit(model: Model):
     )
     assert (
         rendered_query_a_and_b.sql()
-        == "SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY a ORDER BY 1) AS a_rank, ROW_NUMBER() OVER (PARTITION BY b ORDER BY 1) AS b_rank FROM (SELECT * FROM db.test_model AS test_model WHERE ds <= '1970-01-01' AND ds >= '1970-01-01') AS _q_0) AS _q_1 WHERE a_rank > 1 OR b_rank > 1"
+        == """SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY "a" ORDER BY 1) AS "a_rank", ROW_NUMBER() OVER (PARTITION BY "b" ORDER BY 1) AS "b_rank" FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" <= '1970-01-01' AND "ds" >= '1970-01-01') AS "_q_0") AS "_q_1" WHERE "a_rank" > 1 OR "b_rank" > 1"""
     )
 
 
@@ -204,7 +204,7 @@ def test_accepted_values_audit(model: Model):
     )
     assert (
         rendered_query.sql()
-        == "SELECT * FROM (SELECT * FROM db.test_model AS test_model WHERE ds <= '1970-01-01' AND ds >= '1970-01-01') AS _q_0 WHERE NOT a IN ('value_a', 'value_b')"
+        == """SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" <= '1970-01-01' AND "ds" >= '1970-01-01') AS "_q_0" WHERE NOT "a" IN ('value_a', 'value_b')"""
     )
 
 
@@ -215,7 +215,7 @@ def test_number_of_rows_audit(model: Model):
     )
     assert (
         rendered_query.sql()
-        == """SELECT 1 AS "1" FROM (SELECT * FROM db.test_model AS test_model WHERE ds <= '1970-01-01' AND ds >= '1970-01-01') AS _q_0 HAVING COUNT(*) <= 0 LIMIT 1"""
+        == """SELECT 1 AS "1" FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" <= '1970-01-01' AND "ds" >= '1970-01-01') AS "_q_0" HAVING COUNT(*) <= 0 LIMIT 1"""
     )
 
 
@@ -226,7 +226,7 @@ def test_forall_audit(model: Model):
     )
     assert (
         rendered_query_a.sql()
-        == "SELECT * FROM (SELECT * FROM db.test_model AS test_model WHERE ds <= '1970-01-01' AND ds >= '1970-01-01') AS _q_0 WHERE NOT a >= b"
+        == '''SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" <= '1970-01-01' AND "ds" >= '1970-01-01') AS "_q_0" WHERE NOT "a" >= "b"'''
     )
 
     rendered_query_a = builtin.forall_audit.render_query(
@@ -235,5 +235,5 @@ def test_forall_audit(model: Model):
     )
     assert (
         rendered_query_a.sql()
-        == "SELECT * FROM (SELECT * FROM db.test_model AS test_model WHERE ds <= '1970-01-01' AND ds >= '1970-01-01') AS _q_0 WHERE NOT a >= b OR NOT c + d - e < 1.0"
+        == """SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" <= '1970-01-01' AND "ds" >= '1970-01-01') AS "_q_0" WHERE NOT "a" >= "b" OR NOT "c" + "d" - "e" < 1.0"""
     )

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -6,6 +6,7 @@ from sqlglot import exp, parse, parse_one
 
 import sqlmesh.core.dialect as d
 from sqlmesh.core.config import Config
+from sqlmesh.core.config.model import ModelDefaultsConfig
 from sqlmesh.core.context import Context
 from sqlmesh.core.macros import macro
 from sqlmesh.core.model import (
@@ -1048,26 +1049,29 @@ def test_star_expansion(assert_exp_eq) -> None:
 
 
 def test_case_sensitivity(assert_exp_eq):
-    context = Context(config=Config())
+    config = Config(model_defaults=ModelDefaultsConfig(dialect="snowflake"))
+    context = Context(config=config)
 
     source = load_model(
         d.parse(
             """
-            MODEL (name example.source, kind EMBEDDED, dialect snowflake);
+            MODEL (name example.source, kind EMBEDDED);
 
             SELECT "id", "name", "payload" FROM db.schema."table"
             """
         ),
+        dialect="snowflake",
     )
 
     downstream = load_model(
         d.parse(
             """
-            MODEL (name example.model, kind FULL, dialect snowflake);
+            MODEL (name example.model, kind FULL);
 
             SELECT JSON_EXTRACT_PATH_TEXT("payload", 'field') AS "new_field", * FROM example.source
             """
-        )
+        ),
+        dialect="snowflake",
     )
 
     context.upsert_model(source)

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1063,10 +1063,11 @@ def test_case_sensitivity(assert_exp_eq):
         dialect="snowflake",
     )
 
+    # Ensure that when manually specifying dependencies, they're normalized correctly
     downstream = load_model(
         d.parse(
             """
-            MODEL (name example.model, kind FULL);
+            MODEL (name example.model, kind FULL, depends_on [ExAmPlE.SoUrCe]);
 
             SELECT JSON_EXTRACT_PATH_TEXT("payload", 'field') AS "new_field", * FROM example.source
             """

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -511,11 +511,11 @@ def test_render_definition():
     expressions = parse(
         """
         MODEL (
+            dialect spark,
             name db.table,
             kind INCREMENTAL_BY_TIME_RANGE (
                 time_column (a, 'yyyymmdd')
             ),
-            dialect spark,
             owner owner_name,
             storage_format iceberg,
             partitioned_by a,
@@ -1151,7 +1151,7 @@ def test_model_ctas_query():
         read="bigquery",
     )
 
-    assert load_model(expressions, dialect="bigquery").ctas_query({}).sql() == "SELECT 1 AS a"
+    assert load_model(expressions, dialect="bigquery").ctas_query({}).sql() == 'SELECT 1 AS "a"'
 
     expressions = parse(
         """
@@ -1160,7 +1160,10 @@ def test_model_ctas_query():
         """
     )
 
-    assert load_model(expressions).ctas_query({}).sql() == "SELECT 1 AS a FROM b AS b WHERE FALSE"
+    assert (
+        load_model(expressions).ctas_query({}).sql()
+        == 'SELECT 1 AS "a" FROM "b" AS "b" WHERE FALSE'
+    )
 
 
 def test_is_breaking_change():

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -383,7 +383,7 @@ def test_fingerprint(model: Model, parent_model: Model):
     fingerprint = fingerprint_from_model(model, models={})
 
     original_fingerprint = SnapshotFingerprint(
-        data_hash="1204843539",
+        data_hash="1634812886",
         metadata_hash="382750147",
     )
 
@@ -473,7 +473,7 @@ def test_fingerprint_jinja_macros(model: Model):
     fingerprint = fingerprint_from_model(model, models={})
 
     original_fingerprint = SnapshotFingerprint(
-        data_hash="3334558345",
+        data_hash="524645336",
         metadata_hash="382750147",
     )
 

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -28,6 +28,6 @@ def test_data_diff(sushi_context):
     assert schema_diff.removed == []
 
     row_diff = diff.row_diff()
-    assert row_diff.source_count == 2346
-    assert row_diff.target_count == 2759
+    assert row_diff.source_count == 2163
+    assert row_diff.target_count == 2586
     assert row_diff.sample.shape == (20, 7)

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -104,6 +104,7 @@ def test_model_kind():
 
 def test_model_columns():
     model = ModelConfig(
+        alias="test",
         target_schema="foo",
         table_name="bar",
         sql="SELECT * FROM baz",


### PR DESCRIPTION
This PR (WIP) aims to improve how we handle case-sensitive identifiers across different dialects, especially in Snowflake. The problem is that Snowflake [resolves identifiers](https://docs.snowflake.com/en/sql-reference/identifiers-syntax) as uppercase, which [used to be](https://github.com/tobymao/sqlglot/commit/dcfe67f5aff6a1f8739c704dfc4f71ad2f2b293e) inconsistent with SQLGlot's optimizer, hence causing problems when expanding star projections (case-sensitivity was not preserved).

There are several outstanding items:

- [x] Make a new SQLGlot release and bump its version here.
- [x] Ensure that model names are consistently normalized, e.g. when received from a CLI / Notebook command.
- [x] Same goes for `depends_on`: if a user specifies this as part of the model's meta, every name in it needs to be normalized as well, according to the given dialect. When it's missing from the model's meta, `depends_on` returns normalized names because `_optimize_query` is called under the hood.
- [x] Make sure to normalize & quote as needed in places where we create new identifiers. One such example is when we're expanding model names into subqueries: the aliases attached to these subqueries aren't currently quoted, because they're created post-optimization. EDIT: this is now handled towards the very end of `render_query`.