### PR TITLE
Feat: Add primary key capture to model to seed future interfaces

### DIFF
--- a/examples/sushi/models/customer_revenue_by_day.sql
+++ b/examples/sushi/models/customer_revenue_by_day.sql
@@ -9,6 +9,7 @@ MODEL (
   cron '@daily',
   dialect hive,
   tags expensive,
+  grain [order_id, ds],
 );
 
 WITH order_total AS (

--- a/examples/sushi/models/customer_revenue_lifetime.sql
+++ b/examples/sushi/models/customer_revenue_lifetime.sql
@@ -16,7 +16,8 @@ MODEL (
     customer_id INT,
     revenue DOUBLE,
     ds STRING
-  )
+  ),
+  grain [customer_id, ds],
 );
 
 WITH order_total AS (

--- a/examples/sushi/models/customers.sql
+++ b/examples/sushi/models/customers.sql
@@ -3,7 +3,8 @@ MODEL (
   kind FULL,
   owner jen,
   cron '@daily',
-  tags (pii, fact)
+  tags (pii, fact),
+  grain customer_id,
 );
 
 CREATE SCHEMA IF NOT EXISTS raw;

--- a/examples/sushi/models/top_waiters.sql
+++ b/examples/sushi/models/top_waiters.sql
@@ -4,7 +4,8 @@ MODEL (
   owner jen,
   audits (
     unique_values(columns=[waiter_id])
-  )
+  ),
+  grain waiter_id
 );
 
 SELECT

--- a/examples/sushi/models/waiter_names.sql
+++ b/examples/sushi/models/waiter_names.sql
@@ -4,5 +4,6 @@ MODEL (
     path '../seeds/waiter_names.csv',
     batch_size 5
   ),
-  owner jen
+  owner jen,
+  grain id
 )

--- a/examples/sushi/models/waiter_revenue_by_day.sql
+++ b/examples/sushi/models/waiter_revenue_by_day.sql
@@ -9,7 +9,8 @@ MODEL (
   cron '@daily',
   audits (
     NUMBER_OF_ROWS(threshold=0)
-  )
+  ),
+  grain (waiter_id, ds)
 );
 
 SELECT

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1468,7 +1468,7 @@ META_FIELD_CONVERTER: t.Dict[str, t.Callable] = {
     "tags": lambda value: (
         exp.to_identifier(value[0]) if len(value) == 1 else exp.Tuple(expressions=value)
     ),
-    "primary_key": lambda value: (
+    "grain": lambda value: (
         exp.to_column(value[0]) if len(value) == 1 else exp.Tuple(expressions=exp.to_column(value))
-    )
+    ),
 }

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1469,6 +1469,6 @@ META_FIELD_CONVERTER: t.Dict[str, t.Callable] = {
         exp.to_identifier(value[0]) if len(value) == 1 else exp.Tuple(expressions=value)
     ),
     "primary_key": lambda value: (
-        exp.to_identifier(value[0]) if len(value) == 1 else exp.Tuple(expressions=value)
+        exp.to_column(value[0]) if len(value) == 1 else exp.Tuple(expressions=exp.to_column(value))
     )
 }

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1468,4 +1468,7 @@ META_FIELD_CONVERTER: t.Dict[str, t.Callable] = {
     "tags": lambda value: (
         exp.to_identifier(value[0]) if len(value) == 1 else exp.Tuple(expressions=value)
     ),
+    "primary_key": lambda value: (
+        exp.to_identifier(value[0]) if len(value) == 1 else exp.Tuple(expressions=value)
+    )
 }

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -57,6 +57,7 @@ class ModelMeta(PydanticModel):
     column_descriptions_: t.Optional[t.Dict[str, str]]
     audits: t.List[AuditReference] = []
     tags: t.List[str] = []
+    primary_key: t.List[str] = []
     hash_raw_query: bool = False
 
     _croniter: t.Optional[croniter] = None
@@ -105,7 +106,7 @@ class ModelMeta(PydanticModel):
             ]
         return v
 
-    @validator("partitioned_by_", "tags", pre=True)
+    @validator("partitioned_by_", "tags", "primary_key", pre=True)
     def _value_or_tuple_validator(cls, v: t.Any) -> t.Any:
         if isinstance(v, (exp.Tuple, exp.Array)):
             return [e.name for e in v.expressions]

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -57,7 +57,7 @@ class ModelMeta(PydanticModel):
     column_descriptions_: t.Optional[t.Dict[str, str]]
     audits: t.List[AuditReference] = []
     tags: t.List[str] = []
-    primary_key: t.List[str] = []
+    grain: t.List[str] = []
     hash_raw_query: bool = False
 
     _croniter: t.Optional[croniter] = None
@@ -106,7 +106,7 @@ class ModelMeta(PydanticModel):
             ]
         return v
 
-    @validator("partitioned_by_", "tags", "primary_key", pre=True)
+    @validator("partitioned_by_", "tags", "grain", pre=True)
     def _value_or_tuple_validator(cls, v: t.Any) -> t.Any:
         if isinstance(v, (exp.Tuple, exp.Array)):
             return [e.name for e in v.expressions]

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -941,7 +941,7 @@ def _model_metadata_hash(model: Model, audits: t.Dict[str, Audit]) -> str:
         str(model.batch_size) if model.batch_size is not None else None,
         json.dumps(model.mapping_schema, sort_keys=True),
         *model.tags,
-        *model.primary_key
+        *model.grain,
     ]
 
     for audit_name, audit_args in sorted(model.audits, key=lambda a: a[0]):

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -941,6 +941,7 @@ def _model_metadata_hash(model: Model, audits: t.Dict[str, Audit]) -> str:
         str(model.batch_size) if model.batch_size is not None else None,
         json.dumps(model.mapping_schema, sort_keys=True),
         *model.tags,
+        *model.primary_key
     ]
 
     for audit_name, audit_args in sorted(model.audits, key=lambda a: a[0]):

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -38,6 +38,7 @@ def test_load(assert_exp_eq):
                 time_column a,
             ),
             tags [tag_foo, tag_bar],
+            primary_key [a, b],
         );
 
         @DEF(x, 1);
@@ -109,6 +110,7 @@ def test_load(assert_exp_eq):
     """,
     )
     assert model.tags == ["tag_foo", "tag_bar"]
+    assert model.primary_key == ["a", "b"]
 
 
 def test_model_multiple_select_statements():

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -38,7 +38,7 @@ def test_load(assert_exp_eq):
                 time_column a,
             ),
             tags [tag_foo, tag_bar],
-            primary_key [a, b],
+            grain [a, b],
         );
 
         @DEF(x, 1);
@@ -110,7 +110,7 @@ def test_load(assert_exp_eq):
     """,
     )
     assert model.tags == ["tag_foo", "tag_bar"]
-    assert model.primary_key == ["a", "b"]
+    assert model.grain == ["a", "b"]
 
 
 def test_model_multiple_select_statements():

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -103,7 +103,7 @@ def test_json(snapshot: Snapshot):
             },
             "source_type": "sql",
             "tags": [],
-            "primary_key": [],
+            "grain": [],
             "hash_raw_query": False,
         },
         "audits": [],

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -103,6 +103,7 @@ def test_json(snapshot: Snapshot):
             },
             "source_type": "sql",
             "tags": [],
+            "primary_key": [],
             "hash_raw_query": False,
         },
         "audits": [],

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -28,6 +28,6 @@ def test_data_diff(sushi_context):
     assert schema_diff.removed == []
 
     row_diff = diff.row_diff()
-    assert row_diff.source_count == 2299
-    assert row_diff.target_count == 2675
+    assert row_diff.source_count == 2346
+    assert row_diff.target_count == 2759
     assert row_diff.sample.shape == (20, 7)

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -91,6 +91,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
                     },
                     "source_type": "sql",
                     "tags": [],
+                    "primary_key": [],
                     "hash_raw_query": False,
                 },
                 "audits": [],

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -91,7 +91,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
                     },
                     "source_type": "sql",
                     "tags": [],
-                    "primary_key": [],
+                    "grain": [],
                     "hash_raw_query": False,
                 },
                 "audits": [],

--- a/web/server/api/endpoints/models.py
+++ b/web/server/api/endpoints/models.py
@@ -56,6 +56,7 @@ def get_all_models(context: Context) -> t.List[models.Model]:
             else None
         )
         tags = ", ".join(model.tags) if model.tags else None
+        primary_key = ", ".join(model.primary_key) if model.primary_key else None
         partitioned_by = ", ".join(model.partitioned_by) if model.partitioned_by else None
         lookback = model.lookback if model.lookback > 0 else None
         columns = [
@@ -75,6 +76,7 @@ def get_all_models(context: Context) -> t.List[models.Model]:
             storage_format=model.storage_format,
             time_column=time_column,
             tags=tags,
+            primary_key=primary_key,
             partitioned_by=partitioned_by,
             lookback=lookback,
             cron_prev=to_datetime(model.cron_prev(value=now())),

--- a/web/server/api/endpoints/models.py
+++ b/web/server/api/endpoints/models.py
@@ -56,7 +56,7 @@ def get_all_models(context: Context) -> t.List[models.Model]:
             else None
         )
         tags = ", ".join(model.tags) if model.tags else None
-        primary_key = ", ".join(model.primary_key) if model.primary_key else None
+        grain = ", ".join(model.grain) if model.grain else None
         partitioned_by = ", ".join(model.partitioned_by) if model.partitioned_by else None
         lookback = model.lookback if model.lookback > 0 else None
         columns = [
@@ -76,7 +76,7 @@ def get_all_models(context: Context) -> t.List[models.Model]:
             storage_format=model.storage_format,
             time_column=time_column,
             tags=tags,
-            primary_key=primary_key,
+            grain=grain,
             partitioned_by=partitioned_by,
             lookback=lookback,
             cron_prev=to_datetime(model.cron_prev(value=now())),

--- a/web/server/models.py
+++ b/web/server/models.py
@@ -184,6 +184,7 @@ class ModelDetails(BaseModel):
     storage_format: t.Optional[str] = None
     time_column: t.Optional[str] = None
     tags: t.Optional[str] = None
+    primary_key: t.Optional[str] = None
     partitioned_by: t.Optional[str] = None
     lookback: t.Optional[int] = None
     cron_prev: t.Optional[TimeLike] = None

--- a/web/server/models.py
+++ b/web/server/models.py
@@ -184,7 +184,7 @@ class ModelDetails(BaseModel):
     storage_format: t.Optional[str] = None
     time_column: t.Optional[str] = None
     tags: t.Optional[str] = None
-    primary_key: t.Optional[str] = None
+    grain: t.Optional[str] = None
     partitioned_by: t.Optional[str] = None
     lookback: t.Optional[int] = None
     cron_prev: t.Optional[TimeLike] = None


### PR DESCRIPTION
We should start capturing primary key early as it could seed future interfaces. What is a model without a primary key anyway. 

Given this interface, we can simplify the data-diff interface, use this to do automatic non_null & unique audits, and to communicate outwards in the UI and metadata clearly the key for the model, be it a single or composite value. 