### PR TITLE
Fix: ensure AST is correct in meta field converter

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1459,17 +1459,12 @@ def _is_udtf(expr: exp.Expression) -> bool:
     )
 
 
-def _single_value_or_tuple(
-    converter: t.Callable,
-) -> t.Callable[[t.Sequence], exp.Identifier | exp.Tuple]:
-    def _convert(values: t.Sequence) -> exp.Identifier | exp.Tuple:
-        return (
-            converter(values[0])
-            if len(values) == 1
-            else exp.Tuple(expressions=[converter(v) for v in values])
-        )
-
-    return _convert
+def _single_value_or_tuple(values: t.Sequence) -> exp.Identifier | exp.Tuple:
+    return (
+        exp.to_identifier(values[0])
+        if len(values) == 1
+        else exp.Tuple(expressions=[exp.to_identifier(v) for v in values])
+    )
 
 
 META_FIELD_CONVERTER: t.Dict[str, t.Callable] = {
@@ -1477,7 +1472,7 @@ META_FIELD_CONVERTER: t.Dict[str, t.Callable] = {
     "start": lambda value: exp.Literal.string(value),
     "cron": lambda value: exp.Literal.string(value),
     "batch_size": lambda value: exp.Literal.number(value),
-    "partitioned_by_": _single_value_or_tuple(exp.to_identifier),
+    "partitioned_by_": _single_value_or_tuple,
     "depends_on_": lambda value: exp.Tuple(expressions=value),
     "pre": _list_of_calls_to_exp,
     "post": _list_of_calls_to_exp,
@@ -1485,6 +1480,6 @@ META_FIELD_CONVERTER: t.Dict[str, t.Callable] = {
     "columns_to_types_": lambda value: exp.Schema(
         expressions=[exp.ColumnDef(this=exp.to_column(c), kind=t) for c, t in value.items()]
     ),
-    "tags": _single_value_or_tuple(exp.to_identifier),
-    "grain": _single_value_or_tuple(exp.to_column),
+    "tags": _single_value_or_tuple,
+    "grain": _single_value_or_tuple,
 }


### PR DESCRIPTION
If we don't mind converting the grains to `Identifier`s, the implementation can be simplified (fwiw it can also be simplified if I just do it all inline like it used to be).