### PR TITLE
Feat: Enhance notification target functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: docs
 
 install-dev:
-	pip3 install -e ".[dev,web]"
+	pip3 install -e ".[dev,web,slack]"
 
 install-pre-commit:
 	pre-commit install

--- a/examples/sushi/config.py
+++ b/examples/sushi/config.py
@@ -11,7 +11,6 @@ from sqlmesh.core.config import (
 )
 from sqlmesh.core.notification_target import (
     BasicSMTPNotificationTarget,
-    NotificationStatus,
     SlackApiNotificationTarget,
     SlackWebhookNotificationTarget,
 )
@@ -19,14 +18,6 @@ from sqlmesh.core.user import User, UserRole
 
 CURRENT_FILE_PATH = os.path.abspath(__file__)
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
-
-
-class CustomSMTPNotificationTarget(BasicSMTPNotificationTarget):
-    def notify_run_failure(self, exc: Exception) -> None:
-        with open("/home/sqlmesh/sqlmesh.log", "r", encoding="utf-8") as f:
-            msg = f"{exc}\n\n{f.read()}"
-        subject = "SQLMesh Run Failed!"
-        self.send(notification_status=NotificationStatus.FAILURE, msg=msg, subject=subject)
 
 
 # An in memory DuckDB config.
@@ -85,7 +76,7 @@ required_approvers_config = Config(
             notify_on=["apply_start", "run_start"],
             url=os.getenv("SLACK_WEBHOOK_URL"),
         ),
-        CustomSMTPNotificationTarget(
+        BasicSMTPNotificationTarget(
             notify_on=["run_failure"],
             host=os.getenv("SMTP_HOST"),
             user=os.getenv("SMTP_USER"),

--- a/examples/sushi/config.py
+++ b/examples/sushi/config.py
@@ -60,20 +60,20 @@ required_approvers_config = Config(
     default_connection=DuckDBConnectionConfig(),
     users=[
         User(
-            username="test",
+            username="admin",
             roles=[UserRole.REQUIRED_APPROVER],
             notification_targets=[
                 SlackApiNotificationTarget(
-                    notify_on=["apply_start", "audit_failure"],
-                    token=os.getenv("SLACK_API_TOKEN"),
-                    channel="UXXXXXXXXX",  # User's Slack ID
+                    notify_on=["apply_start", "apply_failure", "apply_end", "audit_failure"],
+                    token=os.getenv("ADMIN_SLACK_API_TOKEN"),
+                    channel="UXXXXXXXXX",  # User's Slack member ID
                 ),
             ],
         )
     ],
     notification_targets=[
         SlackWebhookNotificationTarget(
-            notify_on=["apply_start", "run_start"],
+            notify_on=["apply_start", "apply_failure", "run_start"],
             url=os.getenv("SLACK_WEBHOOK_URL"),
         ),
         BasicSMTPNotificationTarget(

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,9 @@ setup(
         "redshift": [
             "redshift_connector",
         ],
+        "slack": [
+            "slack_sdk",
+        ],
         "snowflake": [
             "snowflake-connector-python[pandas,secure-local-storage]",
         ],

--- a/sqlmesh/core/_typing.py
+++ b/sqlmesh/core/_typing.py
@@ -4,9 +4,9 @@ import typing as t
 
 from sqlglot import exp
 
-from sqlmesh.core.notification_target import ConsoleNotificationTarget
+from sqlmesh.core.notification_target import BaseNotificationTarget
 
-NotificationTarget = ConsoleNotificationTarget
+NotificationTarget = BaseNotificationTarget
 
 if t.TYPE_CHECKING:
     TableName = t.Union[str, exp.Table]

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -58,6 +58,7 @@ class Config(BaseConfig):
     pinned_environments: t.Set[str] = set()
     loader: t.Type[Loader] = SqlMeshLoader
     env_vars: t.Dict[str, str] = {}
+    username: str = ""
 
     _FIELD_UPDATE_STRATEGY: t.ClassVar[t.Dict[str, UpdateStrategy]] = {
         "gateways": UpdateStrategy.KEY_UPDATE,

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -66,6 +66,7 @@ class BuiltInSchedulerConfig(_SchedulerConfig, BaseConfig):
             snapshot_evaluator=context.snapshot_evaluator,
             backfill_concurrent_tasks=context.concurrent_tasks,
             console=context.console,
+            notification_target_manager=context.notification_target_manager,
         )
 
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -386,10 +386,10 @@ class Context(BaseContext):
             skip_janitor: Whether to skip the janitor task.
         """
         environment = environment or c.PROD
+        self.notification_target_manager.notify(
+            NotificationEvent.RUN_START, environment=environment
+        )
         try:
-            self.notification_target_manager.notify(
-                NotificationEvent.RUN_START, environment=environment
-            )
             self.scheduler(environment=environment).run(environment, start, end, latest)
         except Exception as e:
             self.notification_target_manager.notify(NotificationEvent.RUN_FAILURE, e)
@@ -763,10 +763,10 @@ class Context(BaseContext):
             return
         if plan.uncategorized:
             raise PlanError("Can't apply a plan with uncategorized changes.")
+        self.notification_target_manager.notify(
+            NotificationEvent.APPLY_START, environment=plan.environment.name
+        )
         try:
-            self.notification_target_manager.notify(
-                NotificationEvent.APPLY_START, environment=plan.environment.name
-            )
             self._scheduler.create_plan_evaluator(self).evaluate(plan)
         except Exception as e:
             self.notification_target_manager.notify(NotificationEvent.APPLY_FAILURE, e)

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1161,10 +1161,14 @@ class Context(BaseContext):
     def _register_notification_targets(self) -> None:
         event_notifications = collections.defaultdict(set)
         for target in self.notification_targets:
-            for event in target.notify_on:
-                event_notifications[event].add(target)
+            if target.is_configured:
+                for event in target.notify_on:
+                    event_notifications[event].add(target)
         user_notification_targets = {
-            user.username: set(user.notification_targets) for user in self.users
+            user.username: set(
+                target for target in user.notification_targets if target.is_configured
+            )
+            for user in self.users
         }
         self.notification_target_manager = NotificationTargetManager(
             event_notifications, user_notification_targets, username=self.config.username

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -36,7 +36,6 @@ import abc
 import collections
 import contextlib
 import gc
-import itertools
 import typing as t
 import unittest.result
 from io import StringIO
@@ -1161,9 +1160,12 @@ class Context(BaseContext):
 
     def _register_notification_targets(self) -> None:
         event_notifications = collections.defaultdict(set)
-        for target in itertools.chain(
-            self.notification_targets, *(user.notification_targets for user in self.users)
-        ):
+        for target in self.notification_targets:
             for event in target.notify_on:
                 event_notifications[event].add(target)
-        self.notification_target_manager = NotificationTargetManager(event_notifications)
+        user_notification_targets = {
+            user.username: set(user.notification_targets) for user in self.users
+        }
+        self.notification_target_manager = NotificationTargetManager(
+            event_notifications, user_notification_targets, username=self.config.username
+        )

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -392,7 +392,7 @@ class Context(BaseContext):
             )
             self.scheduler(environment=environment).run(environment, start, end, latest)
         except Exception as e:
-            self.notification_target_manager.notify(NotificationEvent.RUN_FAILURE)
+            self.notification_target_manager.notify(NotificationEvent.RUN_FAILURE, e)
             raise e
 
         if not skip_janitor and environment.lower() == c.PROD:
@@ -769,7 +769,7 @@ class Context(BaseContext):
             )
             self._scheduler.create_plan_evaluator(self).evaluate(plan)
         except Exception as e:
-            self.notification_target_manager.notify(NotificationEvent.APPLY_FAILURE)
+            self.notification_target_manager.notify(NotificationEvent.APPLY_FAILURE, e)
             raise e
 
     def invalidate_environment(self, name: str) -> None:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -36,6 +36,7 @@ import abc
 import collections
 import contextlib
 import gc
+import traceback
 import typing as t
 import unittest.result
 from io import StringIO
@@ -392,7 +393,9 @@ class Context(BaseContext):
         try:
             self.scheduler(environment=environment).run(environment, start, end, latest)
         except Exception as e:
-            self.notification_target_manager.notify(NotificationEvent.RUN_FAILURE, e)
+            self.notification_target_manager.notify(
+                NotificationEvent.RUN_FAILURE, traceback.format_exc()
+            )
             raise e
         self.notification_target_manager.notify(NotificationEvent.RUN_END, environment=environment)
 
@@ -770,7 +773,9 @@ class Context(BaseContext):
         try:
             self._scheduler.create_plan_evaluator(self).evaluate(plan)
         except Exception as e:
-            self.notification_target_manager.notify(NotificationEvent.APPLY_FAILURE, e)
+            self.notification_target_manager.notify(
+                NotificationEvent.APPLY_FAILURE, traceback.format_exc()
+            )
             raise e
         self.notification_target_manager.notify(
             NotificationEvent.APPLY_END, environment=plan.environment.name

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -33,8 +33,10 @@ context.test()
 from __future__ import annotations
 
 import abc
+import collections
 import contextlib
 import gc
+import itertools
 import typing as t
 import unittest.result
 from io import StringIO
@@ -62,6 +64,10 @@ from sqlmesh.core.loader import Loader, SqlMeshLoader, update_model_schemas
 from sqlmesh.core.macros import ExecutableOrMacro
 from sqlmesh.core.model import Model
 from sqlmesh.core.model.definition import _Model
+from sqlmesh.core.notification_target import (
+    NotificationEvent,
+    NotificationTargetManager,
+)
 from sqlmesh.core.plan import Plan
 from sqlmesh.core.scheduler import Scheduler
 from sqlmesh.core.schema_loader import create_schema_file
@@ -256,6 +262,7 @@ class Context(BaseContext):
         self.notification_targets = (notification_targets or []) + self.config.notification_targets
         self.users = (users or []) + self.config.users
         self.users = list({user.username: user for user in self.users}.values())
+        self._register_notification_targets()
 
         if load:
             self.load()
@@ -326,6 +333,7 @@ class Context(BaseContext):
             self.state_sync,
             max_workers=self.concurrent_tasks,
             console=self.console,
+            notification_target_manager=self.notification_target_manager,
         )
 
     @property
@@ -379,7 +387,14 @@ class Context(BaseContext):
             skip_janitor: Whether to skip the janitor task.
         """
         environment = environment or c.PROD
-        self.scheduler(environment=environment).run(environment, start, end, latest)
+        try:
+            self.notification_target_manager.notify(
+                NotificationEvent.RUN_START, environment=environment
+            )
+            self.scheduler(environment=environment).run(environment, start, end, latest)
+        except Exception as e:
+            self.notification_target_manager.notify(NotificationEvent.RUN_FAILURE)
+            raise e
 
         if not skip_janitor and environment.lower() == c.PROD:
             self._run_janitor()
@@ -749,7 +764,14 @@ class Context(BaseContext):
             return
         if plan.uncategorized:
             raise PlanError("Can't apply a plan with uncategorized changes.")
-        self._scheduler.create_plan_evaluator(self).evaluate(plan)
+        try:
+            self.notification_target_manager.notify(
+                NotificationEvent.APPLY_START, environment=plan.environment.name
+            )
+            self._scheduler.create_plan_evaluator(self).evaluate(plan)
+        except Exception as e:
+            self.notification_target_manager.notify(NotificationEvent.APPLY_FAILURE)
+            raise e
 
     def invalidate_environment(self, name: str) -> None:
         """Invalidates the target environment by setting its expiration timestamp to now.
@@ -1136,3 +1158,12 @@ class Context(BaseContext):
 
     def _new_state_sync(self) -> StateSync:
         return self._provided_state_sync or self._scheduler.create_state_sync(self)
+
+    def _register_notification_targets(self) -> None:
+        event_notifications = collections.defaultdict(set)
+        for target in itertools.chain(
+            self.notification_targets, *(user.notification_targets for user in self.users)
+        ):
+            for event in target.notify_on:
+                event_notifications[event].add(target)
+        self.notification_target_manager = NotificationTargetManager(event_notifications)

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -394,6 +394,7 @@ class Context(BaseContext):
         except Exception as e:
             self.notification_target_manager.notify(NotificationEvent.RUN_FAILURE, e)
             raise e
+        self.notification_target_manager.notify(NotificationEvent.RUN_END, environment=environment)
 
         if not skip_janitor and environment.lower() == c.PROD:
             self._run_janitor()
@@ -771,6 +772,9 @@ class Context(BaseContext):
         except Exception as e:
             self.notification_target_manager.notify(NotificationEvent.APPLY_FAILURE, e)
             raise e
+        self.notification_target_manager.notify(
+            NotificationEvent.APPLY_END, environment=plan.environment.name
+        )
 
     def invalidate_environment(self, name: str) -> None:
         """Invalidates the target environment by setting its expiration timestamp to now.

--- a/sqlmesh/core/notification_target.py
+++ b/sqlmesh/core/notification_target.py
@@ -21,7 +21,7 @@ else:
 if t.TYPE_CHECKING:
     from slack_sdk import WebClient, WebhookClient
 
-NOTIFICATION_FUNCTIONS: dict[NotificationEvent, str] = {}
+NOTIFICATION_FUNCTIONS: t.Dict[NotificationEvent, str] = {}
 
 
 class NotificationStatus(str, Enum):
@@ -128,9 +128,10 @@ class NotificationTargetManager:
 
     def __init__(
         self,
-        notification_targets: dict[NotificationEvent, set[BaseNotificationTarget]] | None = None,
-        user_notification_targets: dict[str, set[BaseNotificationTarget]] | None = None,
-        username: str = "",
+        notification_targets: t.Dict[NotificationEvent, t.Set[BaseNotificationTarget]]
+        | None = None,
+        user_notification_targets: t.Dict[str, t.Set[BaseNotificationTarget]] | None = None,
+        username: str | None = None,
     ) -> None:
         self.notification_targets = notification_targets or {}
         self.user_notification_targets = user_notification_targets or {}

--- a/sqlmesh/core/notification_target.py
+++ b/sqlmesh/core/notification_target.py
@@ -116,12 +116,12 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
         )
 
     @notify(NotificationEvent.APPLY_FAILURE)
-    def notify_apply_failure(self, exc: Exception) -> None:
+    def notify_apply_failure(self, exc: str) -> None:
         """Notify in the case of an apply failure."""
         self.send(NotificationStatus.FAILURE, f"Failed to apply plan.\n{exc}")
 
     @notify(NotificationEvent.RUN_FAILURE)
-    def notify_run_failure(self, exc: Exception) -> None:
+    def notify_run_failure(self, exc: str) -> None:
         """Notify in the case of a run failure."""
         self.send(NotificationStatus.FAILURE, "Failed to run SQLMesh.\n{exc}")
 

--- a/sqlmesh/core/notification_target.py
+++ b/sqlmesh/core/notification_target.py
@@ -54,7 +54,9 @@ class NotificationStatus(str, Enum):
 
 class NotificationEvent(str, Enum):
     APPLY_START = "apply_start"
+    APPLY_END = "apply_end"
     RUN_START = "run_start"
+    RUN_END = "run_end"
     APPLY_FAILURE = "apply_failure"
     RUN_FAILURE = "run_failure"
     AUDIT_FAILURE = "audit_failure"
@@ -94,10 +96,20 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
         """Notify when an apply starts."""
         self.send(NotificationStatus.INFO, f"Plan apply started for environment `{environment}`.")
 
+    @notify(NotificationEvent.APPLY_END)
+    def notify_apply_end(self, environment: str) -> None:
+        """Notify when an apply ends."""
+        self.send(NotificationStatus.INFO, f"Plan apply finished for environment `{environment}`.")
+
     @notify(NotificationEvent.RUN_START)
     def notify_run_start(self, environment: str) -> None:
         """Notify when an apply starts."""
         self.send(NotificationStatus.INFO, f"SQLMesh run started for environment `{environment}`.")
+
+    @notify(NotificationEvent.RUN_END)
+    def notify_run_end(self, environment: str) -> None:
+        """Notify when an apply starts."""
+        self.send(NotificationStatus.INFO, f"SQLMesh run finished for environment `{environment}`.")
 
     @notify(NotificationEvent.APPLY_FAILURE)
     def notify_apply_failure(self, exc: Exception) -> None:

--- a/sqlmesh/core/notification_target.py
+++ b/sqlmesh/core/notification_target.py
@@ -1,18 +1,27 @@
 from __future__ import annotations
 
+import functools
+import smtplib
 import sys
 import typing as t
+from email.message import EmailMessage
 from enum import Enum
 
-from pydantic import Field
+from pydantic import EmailStr, Field, SecretStr
 
 from sqlmesh.core.console import Console, get_console
+from sqlmesh.utils.errors import AuditError, MissingDependencyError
 from sqlmesh.utils.pydantic import PydanticModel
 
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
+
+if t.TYPE_CHECKING:
+    from slack_sdk import WebClient, WebhookClient
+
+NOTIFICATION_FUNCTIONS: dict[NotificationEvent, str] = {}
 
 
 class NotificationStatus(str, Enum):
@@ -43,7 +52,29 @@ class NotificationStatus(str, Enum):
         return self == NotificationStatus.PROGRESS
 
 
-class BaseNotificationTarget(PydanticModel):
+class NotificationEvent(str, Enum):
+    APPLY_START = "apply_start"
+    RUN_START = "run_start"
+    APPLY_FAILURE = "apply_failure"
+    RUN_FAILURE = "run_failure"
+    AUDIT_FAILURE = "audit_failure"
+
+
+def notify(event: NotificationEvent) -> t.Callable:
+    """Decorator used to register 'notify' methods and the events they correspond to."""
+
+    def decorator(f: t.Callable) -> t.Callable:
+        @functools.wraps(f)
+        def wrapper(*args: t.List[t.Any], **kwargs: t.Dict[str, t.Any]) -> None:
+            return f(*args, **kwargs)
+
+        NOTIFICATION_FUNCTIONS[event] = f.__name__
+        return wrapper
+
+    return decorator
+
+
+class BaseNotificationTarget(PydanticModel, frozen=True):
     """
     Base notification target model. Provides a command for sending notifications that is currently only used
     by the built-in scheduler. Other schedulers like Airflow use the configuration of the target itself
@@ -51,11 +82,57 @@ class BaseNotificationTarget(PydanticModel):
     """
 
     type_: str
+    notify_on: t.FrozenSet[NotificationEvent] = frozenset()
 
     def send(self, notification_status: NotificationStatus, msg: str, **kwargs: t.Any) -> None:
         """
-        Sends notification with the provided message. Currently only used by the built-in scheduler.
+        Sends notification with the provided message.
         """
+
+    @notify(NotificationEvent.APPLY_START)
+    def notify_apply_start(self, environment: str) -> None:
+        """Notify when an apply starts."""
+        self.send(NotificationStatus.INFO, f"Plan apply started for environment `{environment}`.")
+
+    @notify(NotificationEvent.RUN_START)
+    def notify_run_start(self, environment: str) -> None:
+        """Notify when an apply starts."""
+        self.send(NotificationStatus.INFO, f"SQLMesh run started for environment `{environment}`.")
+
+    @notify(NotificationEvent.APPLY_FAILURE)
+    def notify_apply_failure(self, exc: Exception) -> None:
+        """Notify in the case of an apply failure."""
+        self.send(NotificationStatus.FAILURE, f"Failed to apply plan.\n{exc}")
+
+    @notify(NotificationEvent.RUN_FAILURE)
+    def notify_run_failure(self, exc: Exception) -> None:
+        """Notify in the case of a run failure."""
+        self.send(NotificationStatus.FAILURE, "Failed to run SQLMesh.\n{exc}")
+
+    @notify(NotificationEvent.AUDIT_FAILURE)
+    def notify_audit_failure(self, audit_error: AuditError) -> None:
+        """Notify in the case of an audit failure."""
+        self.send(NotificationStatus.FAILURE, str(audit_error))
+
+
+class NotificationTargetManager:
+    """Wrapper around a list of notification targets.
+
+    Calling a notification target's "notify_" method on this object will call it
+    on all registered notification targets.
+    """
+
+    def __init__(
+        self, notification_targets: dict[NotificationEvent, set[BaseNotificationTarget]]
+    ) -> None:
+        self.notification_targets = notification_targets
+
+    def notify(self, event: NotificationEvent, *args: t.Any, **kwargs: t.Any) -> None:
+        """Call the 'notify_`event`' function of all notification targets that care about the event."""
+        for notification_target in self.notification_targets[event]:
+            func_name = NOTIFICATION_FUNCTIONS[event]
+            notify_func = getattr(notification_target, func_name)
+            notify_func(*args, **kwargs)
 
 
 class ConsoleNotificationTarget(BaseNotificationTarget):
@@ -79,3 +156,76 @@ class ConsoleNotificationTarget(BaseNotificationTarget):
             self.console.log_error(msg)
         else:
             self.console.log_status_update(msg)
+
+
+class SlackWebhookNotificationTarget(BaseNotificationTarget):
+    url: str
+    type_: Literal["slack_webhook"] = Field(alias="type", default="slack_webhook")
+    _client: t.Optional[WebhookClient] = None
+
+    @property
+    def client(self) -> WebhookClient:
+        if not self._client:
+            try:
+                from slack_sdk import WebhookClient
+            except ModuleNotFoundError as e:
+                raise MissingDependencyError(
+                    "Missing Slack dependencies. Run `pip install 'sqlmesh[slack]'` to install them."
+                ) from e
+
+            self._client = WebhookClient(url=self.url)
+        return self._client
+
+    def send(self, notification_status: NotificationStatus, msg: str, **kwargs: t.Any) -> None:
+        self.client.send(text=msg)
+
+
+class SlackApiNotificationTarget(BaseNotificationTarget):
+    token: str
+    channel: str
+    type_: Literal["slack_api"] = Field(alias="type", default="slack_api")
+    _client: t.Optional[WebClient] = None
+
+    @property
+    def client(self) -> WebClient:
+        if not self._client:
+            try:
+                from slack_sdk import WebClient
+            except ModuleNotFoundError as e:
+                raise MissingDependencyError(
+                    "Missing Slack dependencies. Run `pip install 'sqlmesh[slack]'` to install them."
+                ) from e
+
+            self._client = WebClient(token=self.token)
+        return self._client
+
+    def send(self, notification_status: NotificationStatus, msg: str, **kwargs: t.Any) -> None:
+        self.client.chat_postMessage(channel=self.channel, text=msg)
+
+
+class BasicSMTPNotificationTarget(BaseNotificationTarget):
+    host: str
+    port: int = 465
+    user: t.Optional[str] = None
+    password: t.Optional[SecretStr] = None
+    sender: EmailStr
+    recipients: t.FrozenSet[EmailStr]
+    subject: t.Optional[str] = "SQLMesh Notification"
+    type_: Literal["smtp"] = Field(alias="type", default="smtp")
+
+    def send(
+        self,
+        notification_status: NotificationStatus,
+        msg: str,
+        subject: t.Optional[str] = None,
+        **kwargs: t.Any,
+    ) -> None:
+        email = EmailMessage()
+        email["Subject"] = subject or self.subject
+        email["To"] = ",".join(self.recipients)
+        email["From"] = self.sender
+        email.set_content(msg)
+        with smtplib.SMTP_SSL(host=self.host, port=self.port) as smtp:
+            if self.user and self.password:
+                smtp.login(user=self.user, password=self.password.get_secret_value())
+            smtp.send_message(email)

--- a/sqlmesh/core/notification_target.py
+++ b/sqlmesh/core/notification_target.py
@@ -114,6 +114,10 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
         """Notify in the case of an audit failure."""
         self.send(NotificationStatus.FAILURE, str(audit_error))
 
+    @property
+    def is_configured(self) -> bool:
+        return True
+
 
 class NotificationTargetManager:
     """Wrapper around a list of notification targets.
@@ -206,6 +210,10 @@ class SlackWebhookNotificationTarget(BaseNotificationTarget):
     def send(self, notification_status: NotificationStatus, msg: str, **kwargs: t.Any) -> None:
         self.client.send(text=msg)
 
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.url)
+
 
 class SlackApiNotificationTarget(BaseNotificationTarget):
     token: t.Optional[str] = None
@@ -231,6 +239,10 @@ class SlackApiNotificationTarget(BaseNotificationTarget):
             raise ConfigError("Missing Slack channel for notification")
 
         self.client.chat_postMessage(channel=self.channel, text=msg)
+
+    @property
+    def is_configured(self) -> bool:
+        return all((self.token, self.channel))
 
 
 class BasicSMTPNotificationTarget(BaseNotificationTarget):
@@ -262,3 +274,7 @@ class BasicSMTPNotificationTarget(BaseNotificationTarget):
             if self.user and self.password:
                 smtp.login(user=self.user, password=self.password.get_secret_value())
             smtp.send_message(email)
+
+    @property
+    def is_configured(self) -> bool:
+        return all((self.host, self.user, self.password, self.sender))

--- a/sqlmesh/core/notification_target.py
+++ b/sqlmesh/core/notification_target.py
@@ -145,7 +145,7 @@ class NotificationTargetManager:
         self, event: NotificationEvent, username: str, *args: t.Any, **kwargs: t.Any
     ) -> None:
         """Call the 'notify_`event`' function of the user's notification targets that care about the event."""
-        notification_targets = self.user_notification_targets.get(self.username, set())
+        notification_targets = self.user_notification_targets.get(username, set())
         for notification_target in notification_targets:
             if event in notification_target.notify_on:
                 notify_func = self._get_notification_function(notification_target, event)

--- a/sqlmesh/core/notification_target.py
+++ b/sqlmesh/core/notification_target.py
@@ -99,7 +99,9 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
     @notify(NotificationEvent.APPLY_END)
     def notify_apply_end(self, environment: str) -> None:
         """Notify when an apply ends."""
-        self.send(NotificationStatus.INFO, f"Plan apply finished for environment `{environment}`.")
+        self.send(
+            NotificationStatus.SUCCESS, f"Plan apply finished for environment `{environment}`."
+        )
 
     @notify(NotificationEvent.RUN_START)
     def notify_run_start(self, environment: str) -> None:
@@ -109,7 +111,9 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
     @notify(NotificationEvent.RUN_END)
     def notify_run_end(self, environment: str) -> None:
         """Notify when an apply starts."""
-        self.send(NotificationStatus.INFO, f"SQLMesh run finished for environment `{environment}`.")
+        self.send(
+            NotificationStatus.SUCCESS, f"SQLMesh run finished for environment `{environment}`."
+        )
 
     @notify(NotificationEvent.APPLY_FAILURE)
     def notify_apply_failure(self, exc: Exception) -> None:

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -18,6 +18,7 @@ import typing as t
 
 from sqlmesh.core._typing import NotificationTarget
 from sqlmesh.core.console import Console, get_console
+from sqlmesh.core.notification_target import NotificationTargetManager
 from sqlmesh.core.plan.definition import Plan
 from sqlmesh.core.scheduler import Scheduler
 from sqlmesh.core.snapshot import (
@@ -56,11 +57,13 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         snapshot_evaluator: SnapshotEvaluator,
         backfill_concurrent_tasks: int = 1,
         console: t.Optional[Console] = None,
+        notification_target_manager: t.Optional[NotificationTargetManager] = None,
     ):
         self.state_sync = state_sync
         self.snapshot_evaluator = snapshot_evaluator
         self.backfill_concurrent_tasks = backfill_concurrent_tasks
         self.console = console or get_console()
+        self.notification_target_manager = notification_target_manager
 
     def evaluate(self, plan: Plan) -> None:
         tasks = (
@@ -91,6 +94,7 @@ class BuiltInPlanEvaluator(PlanEvaluator):
             self.state_sync,
             max_workers=self.backfill_concurrent_tasks,
             console=self.console,
+            notification_target_manager=self.notification_target_manager,
         )
         is_run_successful = scheduler.run(
             plan.environment_name, plan.start, plan.end, restatements=plan.restatements

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -69,8 +69,8 @@ class Scheduler:
         self.state_sync = state_sync
         self.max_workers = max_workers
         self.console: Console = console or get_console()
-        self.notification_target_manager = notification_target_manager or NotificationTargetManager(
-            {}
+        self.notification_target_manager = (
+            notification_target_manager or NotificationTargetManager()
         )
 
     def batches(

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -7,6 +7,10 @@ from datetime import datetime
 from sqlmesh.core import constants as c
 from sqlmesh.core.console import Console, get_console
 from sqlmesh.core.model import SeedModel
+from sqlmesh.core.notification_target import (
+    NotificationEvent,
+    NotificationTargetManager,
+)
 from sqlmesh.core.snapshot import (
     Snapshot,
     SnapshotEvaluator,
@@ -24,6 +28,7 @@ from sqlmesh.utils.date import (
     validate_date_range,
     yesterday,
 )
+from sqlmesh.utils.errors import AuditError
 
 logger = logging.getLogger(__name__)
 Interval = t.Tuple[datetime, datetime]
@@ -56,6 +61,7 @@ class Scheduler:
         state_sync: StateSync,
         max_workers: int = 1,
         console: t.Optional[Console] = None,
+        notification_target_manager: t.Optional[NotificationTargetManager] = None,
     ):
         self.snapshots = {s.snapshot_id: s for s in snapshots}
         self.snapshot_per_version = _resolve_one_snapshot_per_version(snapshots)
@@ -63,6 +69,9 @@ class Scheduler:
         self.state_sync = state_sync
         self.max_workers = max_workers
         self.console: Console = console or get_console()
+        self.notification_target_manager = notification_target_manager or NotificationTargetManager(
+            {}
+        )
 
     def batches(
         self,
@@ -135,15 +144,19 @@ class Scheduler:
             is_dev=is_dev,
             **kwargs,
         )
-        self.snapshot_evaluator.audit(
-            snapshot=snapshot,
-            start=start,
-            end=end,
-            latest=latest,
-            snapshots=snapshots,
-            is_dev=is_dev,
-            **kwargs,
-        )
+        try:
+            self.snapshot_evaluator.audit(
+                snapshot=snapshot,
+                start=start,
+                end=end,
+                latest=latest,
+                snapshots=snapshots,
+                is_dev=is_dev,
+                **kwargs,
+            )
+        except AuditError as e:
+            self.notification_target_manager.notify(NotificationEvent.AUDIT_FAILURE, e)
+            raise e
         self.state_sync.add_interval(snapshot, start, end, is_dev=is_dev)
         self.console.update_snapshot_progress(snapshot.name, 1)
 

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -156,6 +156,10 @@ class Scheduler:
             )
         except AuditError as e:
             self.notification_target_manager.notify(NotificationEvent.AUDIT_FAILURE, e)
+            if not is_dev and snapshot.model.owner:
+                self.notification_target_manager.notify_user(
+                    NotificationEvent.AUDIT_FAILURE, snapshot.model.owner, e
+                )
             raise e
         self.state_sync.add_interval(snapshot, start, end, is_dev=is_dev)
         self.console.update_snapshot_progress(snapshot.name, 1)

--- a/sqlmesh/core/user.py
+++ b/sqlmesh/core/user.py
@@ -49,5 +49,5 @@ class User(PydanticModel):
             if isinstance(target, BasicSMTPNotificationTarget) and target.recipients != {
                 values["email"]
             }:
-                raise ValueError("Receipient emails does not match user email")
+                raise ValueError("Receipient emails do not match user email")
         return v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,3 +190,10 @@ def delete_cache(project_paths: str | t.List[str]) -> None:
             rmtree(path + "/.cache")
         except FileNotFoundError:
             pass
+
+
+@pytest.fixture(autouse=True)
+def sushi_env_var(monkeypatch) -> None:
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "url")
+    monkeypatch.setenv("SLACK_API_TOKEN", "token")
+    monkeypatch.setenv("SMTP_HOST", "host")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,10 +190,3 @@ def delete_cache(project_paths: str | t.List[str]) -> None:
             rmtree(path + "/.cache")
         except FileNotFoundError:
             pass
-
-
-@pytest.fixture(autouse=True)
-def sushi_env_var(monkeypatch) -> None:
-    monkeypatch.setenv("SLACK_WEBHOOK_URL", "url")
-    monkeypatch.setenv("SLACK_API_TOKEN", "token")
-    monkeypatch.setenv("SMTP_HOST", "host")

--- a/tests/core/test_notification_target.py
+++ b/tests/core/test_notification_target.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import typing as t
+from unittest import mock
+
+import pytest
+
+from sqlmesh.core.notification_target import (
+    ConsoleNotificationTarget,
+    NotificationEvent,
+    NotificationStatus,
+    NotificationTargetManager,
+)
+
+
+@pytest.fixture
+def notification_target_manager_with_spy(mocker) -> tuple[NotificationTargetManager, t.Callable]:
+    console_notification_target_send_spy = mocker.spy(ConsoleNotificationTarget, "send")
+    console_notification_target = ConsoleNotificationTarget()
+    test_user_console_notification_target = ConsoleNotificationTarget(
+        notify_on={NotificationEvent.APPLY_START}
+    )
+    notification_target_manager = NotificationTargetManager(
+        notification_targets={
+            NotificationEvent.APPLY_START: {console_notification_target},
+            NotificationEvent.APPLY_END: {console_notification_target},
+        },
+        user_notification_targets={
+            "test_user": {test_user_console_notification_target},
+        },
+    )
+    return notification_target_manager, console_notification_target_send_spy
+
+
+def test_notify(notification_target_manager_with_spy):
+    notification_target_manager, spy = notification_target_manager_with_spy
+    notification_target_manager.notify(NotificationEvent.APPLY_START, "prod")
+    spy.assert_called_once_with(
+        mock.ANY,
+        NotificationStatus.INFO,
+        "Plan apply started for environment `prod`.",
+    )
+
+    spy.reset_mock()
+    notification_target_manager.notify(NotificationEvent.APPLY_END, "prod")
+    spy.assert_called_once_with(
+        mock.ANY,
+        NotificationStatus.SUCCESS,
+        "Plan apply finished for environment `prod`.",
+    )
+
+    # No notification target configured for APPLY_FAILURE event
+    spy.reset_mock()
+    notification_target_manager.notify(NotificationEvent.APPLY_FAILURE, ValueError())
+    spy.assert_not_called()
+
+
+def test_notify_user(notification_target_manager_with_spy):
+    notification_target_manager, spy = notification_target_manager_with_spy
+    notification_target_manager.notify_user(NotificationEvent.APPLY_START, "test_user", "prod")
+    spy.assert_called_once_with(
+        mock.ANY,
+        NotificationStatus.INFO,
+        "Plan apply started for environment `prod`.",
+    )
+
+    # No notification target configured for APPLY_END event for test_user
+    spy.reset_mock()
+    notification_target_manager.notify_user(NotificationEvent.APPLY_END, "test_user", "prod")
+    spy.assert_not_called()


### PR DESCRIPTION
This PR adds Slack and SMTP notification targets as well as the notion of events that should trigger notifications.

- Notification targets defined in a config but missing fields will be silently ignored. Most common case is probably fields that are taken from environment variables but the environment variables are not available.
- If no username is specified in a config, the config's notification targets are used. Most common use case is probably production environments.
- If a username is specified in a config, only that user gets notified. Most common use case is probably users developing locally. There is currently one exception. See below:
- Audit model owners are notified their audits failed if there is a user with a notification target configured for an `audit_failure` event and the environment is prod.