### PR TITLE
Feat: Add support for materialzied views

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -127,7 +127,7 @@ class SnowflakeConnectionConfig(_ConnectionConfig):
     def _validate_authenticator(
         cls, values: t.Dict[str, t.Optional[str]]
     ) -> t.Dict[str, t.Optional[str]]:
-        if values["type"] != "snowflake":
+        if "type" in values and values["type"] != "snowflake":
             return values
         auth = values.get("authenticator")
         user = values.get("user")

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -252,6 +252,7 @@ def _create_parser(parser_type: t.Type[exp.Expression], table_keys: t.List[str])
                         ModelKindName.INCREMENTAL_BY_TIME_RANGE,
                         ModelKindName.INCREMENTAL_BY_UNIQUE_KEY,
                         ModelKindName.SEED,
+                        ModelKindName.VIEW,
                     ) and self._match(TokenType.L_PAREN):
                         self._retreat(index)
                         props = self._parse_wrapped_csv(functools.partial(_parse_props, self))

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -19,6 +19,7 @@ if t.TYPE_CHECKING:
 
 class BasePostgresEngineAdapter(EngineAdapter):
     COLUMNS_TABLE = "information_schema.columns"
+    SUPPORTS_MATERIALIZED_VIEWS = True
 
     def columns(self, table_name: TableName) -> t.Dict[str, exp.DataType]:
         """Fetches column names and types for the target table."""
@@ -71,6 +72,7 @@ class BasePostgresEngineAdapter(EngineAdapter):
         query_or_df: QueryOrDF,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         replace: bool = True,
+        materialized: bool = False,
         **create_kwargs: t.Any,
     ) -> None:
         """
@@ -87,7 +89,8 @@ class BasePostgresEngineAdapter(EngineAdapter):
                 view_name,
                 query_or_df,
                 columns_to_types=columns_to_types,
-                replace=replace,
+                replace=False,
+                materialized=materialized,
                 **create_kwargs,
             )
 

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -47,6 +47,7 @@ class BigQueryEngineAdapter(EngineAdapter):
     DIALECT = "bigquery"
     DEFAULT_BATCH_SIZE = 1000
     ESCAPE_JSON = True
+    SUPPORTS_MATERIALIZED_VIEWS = True
     # SQL is not supported for adding columns to structs: https://cloud.google.com/bigquery/docs/managing-table-schemas#api_1
     # Can explore doing this with the API in the future
     SCHEMA_DIFFER = SchemaDiffer(

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -35,6 +35,7 @@ class RedshiftEngineAdapter(BasePostgresEngineAdapter):
         query_or_df: QueryOrDF,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         replace: bool = True,
+        materialized: bool = False,
         **create_kwargs: t.Any,
     ) -> None:
         """
@@ -52,7 +53,13 @@ class RedshiftEngineAdapter(BasePostgresEngineAdapter):
                 "support using `VALUES` in a `CREATE VIEW` statement."
             )
         return super().create_view(
-            view_name, query_or_df, columns_to_types, replace, no_schema_binding=True
+            view_name,
+            query_or_df,
+            columns_to_types,
+            replace,
+            materialized,
+            no_schema_binding=True,
+            **create_kwargs,
         )
 
     def _fetch_native_df(self, query: t.Union[exp.Expression, str]) -> pd.DataFrame:

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -18,6 +18,7 @@ class SnowflakeEngineAdapter(EngineAdapter):
     DEFAULT_SQL_GEN_KWARGS = {"identify": False}
     DIALECT = "snowflake"
     ESCAPE_JSON = True
+    SUPPORTS_MATERIALIZED_VIEWS = True
 
     def _fetch_native_df(self, query: t.Union[exp.Expression, str]) -> DF:
         from snowflake.connector.errors import NotSupportedError

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -200,6 +200,7 @@ class SparkEngineAdapter(EngineAdapter):
         query_or_df: QueryOrDF,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         replace: bool = True,
+        materialized: bool = False,
         **create_kwargs: t.Any,
     ) -> None:
         """Create a view with a query or dataframe.
@@ -217,7 +218,9 @@ class SparkEngineAdapter(EngineAdapter):
         pyspark_df = self.try_get_pyspark_df(query_or_df)
         if pyspark_df:
             query_or_df = pyspark_df.toPandas()
-        super().create_view(view_name, query_or_df, columns_to_types, replace, **create_kwargs)
+        super().create_view(
+            view_name, query_or_df, columns_to_types, replace, materialized, **create_kwargs
+        )
 
     def _create_table_properties(
         self,

--- a/sqlmesh/core/model/__init__.py
+++ b/sqlmesh/core/model/__init__.py
@@ -20,6 +20,7 @@ from sqlmesh.core.model.kind import (
     ModelKindName,
     SeedKind,
     TimeColumn,
+    ViewKind,
 )
 from sqlmesh.core.model.meta import ModelMeta
 from sqlmesh.core.model.seed import Seed

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -97,6 +97,8 @@ class ModelKind(PydanticModel, ModelKindMixin):
                     klass = IncrementalByUniqueKeyKind
                 elif name == ModelKindName.SEED:
                     klass = SeedKind
+                elif name == ModelKindName.VIEW:
+                    klass = ViewKind
                 else:
                     props["name"] = ModelKindName(name)
                 return klass(**props)
@@ -108,6 +110,8 @@ class ModelKind(PydanticModel, ModelKindMixin):
                     klass = IncrementalByUniqueKeyKind
                 elif v.get("name") == ModelKindName.SEED:
                     klass = SeedKind
+                elif v.get("name") == ModelKindName.VIEW:
+                    klass = ViewKind
                 else:
                     klass = ModelKind
                 return klass(**v)
@@ -238,6 +242,17 @@ class IncrementalByUniqueKeyKind(_Incremental):
         if isinstance(v, exp.Tuple):
             return [e.this for e in v.expressions]
         return [i.this if isinstance(i, exp.Identifier) else str(i) for i in v]
+
+
+class ViewKind(ModelKind):
+    name: ModelKindName = Field(ModelKindName.VIEW, const=True)
+    materialized: bool = False
+
+    @validator("materialized", pre=True)
+    def _parse_materialized(cls, v: t.Any) -> bool:
+        if isinstance(v, exp.Expression):
+            return bool(v.this)
+        return bool(v)
 
 
 class SeedKind(ModelKind):

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -12,8 +12,8 @@ from sqlmesh.core import dialect as d
 from sqlmesh.core.model.kind import (
     IncrementalByUniqueKeyKind,
     ModelKind,
-    ModelKindName,
     TimeColumn,
+    ViewKind,
     _Incremental,
 )
 from sqlmesh.utils import unique
@@ -43,7 +43,7 @@ class ModelMeta(PydanticModel):
 
     dialect: str = ""
     name: str
-    kind: ModelKind = ModelKind(name=ModelKindName.VIEW)
+    kind: ModelKind = ViewKind()
     cron: str = "@daily"
     owner: t.Optional[str]
     description: t.Optional[str]

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -19,6 +19,7 @@ from sqlmesh.core.model import (
     PythonModel,
     SeedModel,
     SqlModel,
+    ViewKind,
     kind,
     parse_model_name,
 )
@@ -792,6 +793,11 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
             intervals=self.intervals.copy(),
             dev_intervals=self.dev_intervals.copy(),
         )
+
+    @property
+    def is_materialized_view(self) -> bool:
+        """Returns whether or not this snapshot's model represents a materialized view."""
+        return isinstance(self.model.kind, ViewKind) and self.model.kind.materialized
 
     @property
     def is_new_version(self) -> bool:

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -13,6 +13,7 @@ from sqlmesh.core.model import (
     Model,
     ModelKind,
     ModelKindName,
+    ViewKind,
     create_sql_model,
 )
 from sqlmesh.dbt.basemodel import BaseModelConfig, Materialization
@@ -123,7 +124,7 @@ class ModelConfig(BaseModelConfig):
         if materialization == Materialization.TABLE:
             return ModelKind(name=ModelKindName.FULL)
         if materialization == Materialization.VIEW:
-            return ModelKind(name=ModelKindName.VIEW)
+            return ViewKind()
         if materialization == Materialization.INCREMENTAL:
             incremental_kwargs = {}
             for field in ("batch_size", "lookback"):

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -29,6 +29,26 @@ def test_create_view(mocker: MockerFixture):
     )
 
 
+def test_create_materialized_view(mocker: MockerFixture):
+    connection_mock = mocker.NonCallableMock()
+    cursor_mock = mocker.Mock()
+    connection_mock.cursor.return_value = cursor_mock
+
+    adapter = EngineAdapter(lambda: connection_mock, "")  # type: ignore
+    adapter.SUPPORTS_MATERIALIZED_VIEWS = True
+    adapter.create_view("test_view", parse_one("SELECT a FROM tbl"), materialized=True)
+    adapter.create_view(
+        "test_view", parse_one("SELECT a FROM tbl"), replace=False, materialized=True
+    )
+
+    cursor_mock.execute.assert_has_calls(
+        [
+            call("CREATE OR REPLACE MATERIALIZED VIEW test_view AS SELECT a FROM tbl"),
+            call("CREATE MATERIALIZED VIEW test_view AS SELECT a FROM tbl"),
+        ]
+    )
+
+
 def test_create_schema(mocker: MockerFixture):
     connection_mock = mocker.NonCallableMock()
     cursor_mock = mocker.Mock()

--- a/tests/core/engine_adapter/test_base_postgres.py
+++ b/tests/core/engine_adapter/test_base_postgres.py
@@ -54,7 +54,7 @@ def test_create_view(mocker: MockerFixture):
         [
             # 1st call
             call("DROP VIEW IF EXISTS db.view"),
-            call("CREATE OR REPLACE VIEW db.view AS SELECT 1"),
+            call("CREATE VIEW db.view AS SELECT 1"),
             # 2nd call
             call("CREATE VIEW db.view AS SELECT 1"),
         ]

--- a/tests/core/test_plan_evaluator.py
+++ b/tests/core/test_plan_evaluator.py
@@ -3,7 +3,7 @@ from pytest_mock.plugin import MockerFixture
 from sqlglot import parse_one
 
 from sqlmesh.core.context import Context
-from sqlmesh.core.model import ModelKind, ModelKindName, SqlModel
+from sqlmesh.core.model import ModelKind, ModelKindName, SqlModel, ViewKind
 from sqlmesh.core.plan import AirflowPlanEvaluator, BuiltInPlanEvaluator, Plan
 from sqlmesh.core.snapshot import SnapshotChangeCategory
 from sqlmesh.utils.errors import SQLMeshError
@@ -33,7 +33,7 @@ def test_builtin_evaluator_push(sushi_context: Context, make_snapshot):
     )
     new_view_model = SqlModel(
         name="sushi.new_test_view_model",
-        kind=ModelKind(name=ModelKindName.VIEW),
+        kind=ViewKind(),
         owner="jen",
         start="2020-01-01",
         query=parse_one("SELECT 1::INT AS one FROM sushi.new_test_model, sushi.waiters"),

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -11,6 +11,7 @@ from sqlmesh.core.model import (
     IncrementalByUniqueKeyKind,
     ModelKind,
     ModelKindName,
+    ViewKind,
 )
 from sqlmesh.dbt.column import (
     ColumnConfig,
@@ -36,9 +37,7 @@ def test_model_kind():
     assert ModelConfig(materialized=Materialization.TABLE).model_kind(target) == ModelKind(
         name=ModelKindName.FULL
     )
-    assert ModelConfig(materialized=Materialization.VIEW).model_kind(target) == ModelKind(
-        name=ModelKindName.VIEW
-    )
+    assert ModelConfig(materialized=Materialization.VIEW).model_kind(target) == ViewKind()
     assert ModelConfig(materialized=Materialization.EPHEMERAL).model_kind(target) == ModelKind(
         name=ModelKindName.EMBEDDED
     )


### PR DESCRIPTION
This PR introduces support for materialized views. 

The `VIEW` kind has been extended to accommodate the new `materialized` flag. The model definition looks as follows:
```sql
MODEL (
    name test_schema.test_model,
    kind VIEW (
        materialized true
    )
);
```

The support for materialized views has been enabled for the following engines:
* Snowflake
* BigQuery
* Redshift
* Postgres

The `materialized` flag is ignored when applied to engines that don't support it. 

During evaluation of a model of this kind, the view will be replaced (or recreated) only if the model's query rendered during evaluation doesn't match the query used during the previous view creation for this model, or if the target view doesn't exist. Thus, views are recreated only when needed in order to realize all the benefits provided by materialized views.

Closes #904 