### PR TITLE
Docs: Update engines.md

### DIFF
--- a/docs/integrations/engines.md
+++ b/docs/integrations/engines.md
@@ -42,7 +42,7 @@ By default, the connection ID is set to `sqlmesh_google_cloud_bigquery_default`,
 sqlmesh_airflow = SQLMeshAirflow(
     "bigquery",
     engine_operator_args={
-        "sqlmesh_gcp_conn_id": "<Connection ID>"
+        "bigquery_conn_id": "<Connection ID>"
     },
 )
 ```

--- a/docs/integrations/engines.md
+++ b/docs/integrations/engines.md
@@ -41,7 +41,7 @@ By default, the connection ID is set to `sqlmesh_google_cloud_bigquery_default`,
 ```python linenums="1"
 sqlmesh_airflow = SQLMeshAirflow(
     "bigquery",
-    default_engine_operator_args={
+    engine_operator_args={
         "sqlmesh_gcp_conn_id": "<Connection ID>"
     },
 )


### PR DESCRIPTION
`default_engine_operator_args` is actually: `engine_operator_args`
Also the key `sqlmesh_gcp_conn_id` should be: `bigquery_conn_id`