### PR TITLE
Fix!: Update redshift connection id to be consistent

### DIFF
--- a/docs/integrations/engines.md
+++ b/docs/integrations/engines.md
@@ -231,7 +231,7 @@ By default, the connection ID is set to `sqlmesh_redshift_default`, but it can b
 sqlmesh_airflow = SQLMeshAirflow(
     "redshift",
     engine_operator_args={
-        "conn_id": "<Connection ID>"
+        "redshift_conn_id": "<Connection ID>"
     },
 )
 ```

--- a/sqlmesh/schedulers/airflow/operators/redshift.py
+++ b/sqlmesh/schedulers/airflow/operators/redshift.py
@@ -14,15 +14,16 @@ class SQLMeshRedshiftOperator(BaseSQLOperator):
 
     Args:
         target: The target that will be executed by this operator instance.
-        conn_id: The Airflow connection id for the Redshift target.
+        redshift_conn_id: The Airflow connection id for the Redshift target.
     """
 
     def __init__(
         self,
         target: BaseTarget,
+        redshift_conn_id: str = SQLMeshRedshiftHook.default_conn_name,
         **kwargs: t.Any,
     ) -> None:
-        super().__init__(conn_id=SQLMeshRedshiftHook.default_conn_name, **kwargs)
+        super().__init__(conn_id=redshift_conn_id, **kwargs)
         self._target = target
 
     def get_db_hook(self) -> SQLMeshRedshiftHook:


### PR DESCRIPTION
Breaking Change: When passing in a override for the default connection ID for Redshift in Airflow you will need to use `redshift_conn_id` instead of `conn_id`. 