### PR TITLE
Feat!: Extend SQL parser with designated blocks for jinja code

### DIFF
--- a/examples/sushi/models/waiter_as_customer_by_day.sql
+++ b/examples/sushi/models/waiter_as_customer_by_day.sql
@@ -12,6 +12,8 @@ MODEL (
   )
 );
 
+JINJA_QUERY_BEGIN;
+
 {% set x = 1 %}
 
 SELECT
@@ -21,4 +23,6 @@ SELECT
   {{ alias(identity(x), 'flag') }}
 FROM sushi.waiters AS w
 JOIN sushi.customers as c ON w.waiter_id = c.customer_id
-JOIN sushi.waiter_names as wn ON w.waiter_id = wn.id
+JOIN sushi.waiter_names as wn ON w.waiter_id = wn.id;
+
+JINJA_END;

--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -53,7 +53,7 @@ class Audit(AuditMeta, frozen=True):
     An audit is a SQL query that returns bad records.
     """
 
-    query: t.Union[exp.Subqueryable, d.Jinja]
+    query: t.Union[exp.Subqueryable, d.JinjaQuery]
     expressions_: t.Optional[t.List[exp.Expression]] = Field(default=None, alias="expressions")
     jinja_macros: JinjaMacroRegistry = JinjaMacroRegistry()
 

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -4,12 +4,14 @@ import functools
 import re
 import typing as t
 from difflib import unified_diff
+from enum import Enum, auto
 
 import pandas as pd
 from jinja2.meta import find_undeclared_variables
 from sqlglot import Dialect, Generator, Parser, TokenType, exp
 from sqlglot.dialects.dialect import DialectType
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
+from sqlglot.tokens import Token
 
 from sqlmesh.core.constants import MAX_MODEL_DEFINITION_SIZE
 from sqlmesh.utils.jinja import ENVIRONMENT
@@ -27,6 +29,14 @@ class Audit(exp.Expression):
 class Jinja(exp.Func):
     arg_types = {"this": True, "expressions": False}
     is_var_len_args = True
+
+
+class JinjaQuery(Jinja):
+    pass
+
+
+class JinjaStatement(Jinja):
+    pass
 
 
 class ModelKind(exp.Expression):
@@ -387,6 +397,47 @@ DIALECT_PATTERN = re.compile(
 )
 
 
+def _is_command_statement(command: str, tokens: t.List[Token], pos: int) -> bool:
+    try:
+        return (
+            tokens[pos].text.upper() == command.upper()
+            and tokens[pos + 1].token_type == TokenType.SEMICOLON
+        )
+    except IndexError:
+        return False
+
+
+JINJA_QUERY_BEGIN = "JINJA_QUERY_BEGIN"
+JINJA_STATEMENT_BEGIN = "JINJA_STATEMENT_BEGIN"
+JINJA_END = "JINJA_END"
+
+
+def _is_jinja_statement_begin(tokens: t.List[Token], pos: int) -> bool:
+    return _is_command_statement(JINJA_STATEMENT_BEGIN, tokens, pos)
+
+
+def _is_jinja_query_begin(tokens: t.List[Token], pos: int) -> bool:
+    return _is_command_statement(JINJA_QUERY_BEGIN, tokens, pos)
+
+
+def _is_jinja_end(tokens: t.List[Token], pos: int) -> bool:
+    return _is_command_statement(JINJA_END, tokens, pos)
+
+
+def jinja_query(query: str) -> JinjaQuery:
+    return JinjaQuery(this=exp.Literal.string(query))
+
+
+def jinja_statement(statement: str) -> JinjaStatement:
+    return JinjaStatement(this=exp.Literal.string(statement))
+
+
+class ChunkType(Enum):
+    JINJA_QUERY = auto()
+    JINJA_STATEMENT = auto()
+    SQL = auto()
+
+
 def parse(sql: str, default_dialect: t.Optional[str] = None) -> t.List[exp.Expression]:
     """Parse a sql string.
 
@@ -404,37 +455,51 @@ def parse(sql: str, default_dialect: t.Optional[str] = None) -> t.List[exp.Expre
     dialect = Dialect.get_or_raise(match.group(2) if match else default_dialect)()
 
     tokens = dialect.tokenizer.tokenize(sql)
-    chunks: t.List[t.Tuple[t.List, bool]] = [([], False)]
+    chunks: t.List[t.Tuple[t.List[Token], ChunkType]] = [([], ChunkType.SQL)]
     total = len(tokens)
 
-    for i, token in enumerate(tokens):
-        if token.token_type == TokenType.SEMICOLON:
-            if i < total - 1:
-                chunks.append(([], False))
+    pos = 0
+    while pos < total:
+        token = tokens[pos]
+        if _is_jinja_end(tokens, pos) or (
+            chunks[-1][1] == ChunkType.SQL
+            and token.token_type == TokenType.SEMICOLON
+            and pos < total - 1
+        ):
+            chunks.append(([], ChunkType.SQL))
+            if token.token_type == TokenType.SEMICOLON:
+                pos += 1
+            else:
+                # Jinja end statement
+                pos += 2
+        elif _is_jinja_query_begin(tokens, pos):
+            chunks.append(([], ChunkType.JINJA_QUERY))
+            pos += 2
+        elif _is_jinja_statement_begin(tokens, pos):
+            chunks.append(([], ChunkType.JINJA_STATEMENT))
+            pos += 2
         else:
-            if token.token_type == TokenType.BLOCK_START or (
-                i < total - 1
-                and token.token_type == TokenType.L_BRACE
-                and tokens[i + 1].token_type == TokenType.L_BRACE
-            ):
-                chunks[-1] = (chunks[-1][0], True)
             chunks[-1][0].append(token)
+            pos += 1
 
     expressions: t.List[exp.Expression] = []
 
-    for chunk, is_jinja in chunks:
-        if is_jinja:
+    for chunk, chunk_type in chunks:
+        if chunk_type == ChunkType.SQL:
+            for expression in dialect.parser().parse(chunk, sql):
+                if expression:
+                    expressions.append(expression)
+        else:
             start, *_, end = chunk
             segment = sql[start.start : end.end + 2]
             variables = [
                 exp.Literal.string(var)
                 for var in find_undeclared_variables(ENVIRONMENT.parse(segment))
             ]
-            expressions.append(Jinja(this=exp.Literal.string(segment), expressions=variables))
-        else:
-            for expression in dialect.parser().parse(chunk, sql):
-                if expression:
-                    expressions.append(expression)
+            klass = JinjaQuery if chunk_type == ChunkType.JINJA_QUERY else JinjaStatement
+            expressions.append(
+                klass(this=exp.Literal.string(segment.strip()), expressions=variables)
+            )
 
     return expressions
 
@@ -462,6 +527,8 @@ def extend_sqlglot() -> None:
                     MacroVar: lambda self, e: f"@{e.name}",
                     Model: _model_sql,
                     Jinja: lambda self, e: e.name,
+                    JinjaQuery: lambda self, e: f"{JINJA_QUERY_BEGIN};\n{e.name}\n{JINJA_END};",
+                    JinjaStatement: lambda self, e: f"{JINJA_STATEMENT_BEGIN};\n{e.name.strip()}\n{JINJA_END};",
                     ModelKind: _model_kind_sql,
                     PythonCode: lambda self, e: self.expressions(e, sep="\n", indent=False),
                 }

--- a/sqlmesh/dbt/basemodel.py
+++ b/sqlmesh/dbt/basemodel.py
@@ -241,16 +241,8 @@ class BaseModelConfig(GeneralConfig):
             "jinja_macros": jinja_macros,
             "path": self.path,
             "hash_raw_query": True,
-            "pre_statements": [
-                exp
-                for hook in pre_hooks
-                for exp in d.parse(hook.sql, default_dialect=self.model_dialect or context.dialect)
-            ],
-            "post_statements": [
-                exp
-                for hook in self.post_hook
-                for exp in d.parse(hook.sql, default_dialect=self.model_dialect or context.dialect)
-            ],
+            "pre_statements": [d.jinja_statement(hook.sql) for hook in pre_hooks],
+            "post_statements": [d.jinja_statement(hook.sql) for hook in self.post_hook],
             **optional_kwargs,
         }
 

--- a/sqlmesh/dbt/test.py
+++ b/sqlmesh/dbt/test.py
@@ -99,7 +99,7 @@ class TestConfig(GeneralConfig):
 
         sql_no_config, _sql_config_only = extract_jinja_config(self.sql)
         sql_no_config = sql_no_config.replace("**_dbt_generic_test_kwargs", self._kwargs())
-        expressions = d.parse(sql_no_config, default_dialect=self.dialect or context.dialect)
+        query = d.jinja_query(sql_no_config)
 
         skip = not self.enabled
         blocking = self.severity == Severity.ERROR
@@ -109,8 +109,7 @@ class TestConfig(GeneralConfig):
             dialect=self.dialect,
             skip=skip,
             blocking=blocking,
-            query=expressions[-1],
-            expressions=expressions[0:-1],
+            query=query,
             jinja_macros=jinja_macros,
         )
 

--- a/sqlmesh/migrations/v0012_update_jinja_expressions.py
+++ b/sqlmesh/migrations/v0012_update_jinja_expressions.py
@@ -1,0 +1,85 @@
+"""Fix expressions that contain jinja."""
+import json
+import re
+import typing as t
+
+import pandas as pd
+from sqlglot import exp
+
+
+def migrate(state_sync):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = f"{schema}._snapshots"
+
+    new_snapshots = []
+
+    for name, identifier, version, snapshot, kind_name in engine_adapter.fetchall(
+        exp.select("name", "identifier", "version", "snapshot", "kind_name").from_(snapshots_table)
+    ):
+        parsed_snapshot = json.loads(snapshot)
+        audits = parsed_snapshot.get("audits", [])
+        model = parsed_snapshot["model"]
+
+        if "query" in model and _has_jinja(model["query"]):
+            model["query"] = _wrap_query(model["query"])
+
+        _wrap_statements(model, "pre_statements")
+        _wrap_statements(model, "post_statements")
+
+        for audit in audits:
+            if _has_jinja(audit["query"]):
+                audit["query"] = _wrap_query(audit["query"])
+            _wrap_statements(audit, "expressions")
+
+        new_snapshots.append(
+            {
+                "name": name,
+                "identifier": identifier,
+                "version": version,
+                "snapshot": json.dumps(parsed_snapshot),
+                "kind_name": kind_name,
+            }
+        )
+
+    if new_snapshots:
+        engine_adapter.delete_from(snapshots_table, "TRUE")
+
+        engine_adapter.insert_append(
+            snapshots_table,
+            pd.DataFrame(new_snapshots),
+            columns_to_types={
+                "name": exp.DataType.build("text"),
+                "identifier": exp.DataType.build("text"),
+                "version": exp.DataType.build("text"),
+                "snapshot": exp.DataType.build("text"),
+                "kind_name": exp.DataType.build("text"),
+            },
+            contains_json=True,
+        )
+
+
+def _wrap_statements(obj: t.Dict, key: str) -> None:
+    updated_statements = []
+    for statement in obj.get(key, []):
+        if _has_jinja(statement):
+            statement = _wrap_statement(statement)
+        updated_statements.append(statement)
+
+    if updated_statements:
+        obj[key] = updated_statements
+
+
+def _wrap_query(sql: str) -> str:
+    return f"JINJA_QUERY_BEGIN;\n{sql}\nJINJA_END;"
+
+
+def _wrap_statement(sql: str) -> str:
+    return f"JINJA_STATEMENT_BEGIN;\n{sql}\nJINJA_END;"
+
+
+JINJA_REGEX = r"({{|{%)"
+
+
+def _has_jinja(value: str) -> bool:
+    return re.search(JINJA_REGEX, value) is not None

--- a/sqlmesh/migrations/v0012_update_jinja_expressions.py
+++ b/sqlmesh/migrations/v0012_update_jinja_expressions.py
@@ -78,8 +78,8 @@ def _wrap_statement(sql: str) -> str:
     return f"JINJA_STATEMENT_BEGIN;\n{sql}\nJINJA_END;"
 
 
-JINJA_REGEX = r"({{|{%)"
+JINJA_REGEX = re.compile(r"({{|{%)")
 
 
 def _has_jinja(value: str) -> bool:
-    return re.search(JINJA_REGEX, value) is not None
+    return JINJA_REGEX.search(value) is not None

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -153,7 +153,7 @@ def test_macro(model: Model):
 
     audit_jinja = Audit(
         name="test_audit",
-        query="SELECT * FROM {{ this_model }} WHERE a IS NULL",
+        query="JINJA_QUERY_BEGIN; SELECT * FROM {{ this_model }} WHERE a IS NULL; JINJA_END;",
     )
 
     assert audit.render_query(model).sql() == expected_query

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -1,3 +1,4 @@
+import json
 import typing as t
 
 import duckdb
@@ -839,6 +840,13 @@ def test_migrate_rows(state_sync: EngineAdapterStateSync, mocker: MockerFixture)
     assert len(state_sync.missing_intervals("dev", start="2023-01-08", end="2023-01-10")) == 8
 
     assert all(not s.intervals for s in state_sync.get_snapshots(None).values())
+
+    customer_revenue_by_day = new_snapshots.loc[
+        new_snapshots["name"] == "sushi.customer_revenue_by_day"
+    ].iloc[0]
+    assert json.loads(customer_revenue_by_day["snapshot"])["model"]["query"].startswith(
+        "JINJA_QUERY_BEGIN"
+    )
 
 
 def test_backup_state(state_sync: EngineAdapterStateSync, mocker: MockerFixture) -> None:

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -88,7 +88,7 @@ def test_model_to_sqlmesh_fields(sushi_test_project: Project):
     assert isinstance(model, SqlModel)
     assert model.name == "database.custom.model"
     assert model.description == "test model"
-    assert model.query.sql() == "SELECT 1 AS a FROM foo"
+    assert model.render_query().sql() == 'SELECT 1 AS "a" FROM "foo" AS "foo"'
     assert model.start == "Jan 1 2023"
     assert model.partitioned_by == ["a"]
     assert model.cron == "@hourly"
@@ -119,7 +119,7 @@ def test_test_to_sqlmesh_fields():
     assert audit.dialect == "snowflake"
     assert audit.skip == False
     assert audit.blocking == True
-    assert audit.query.sql() == sql
+    assert sql in audit.query.sql()
 
     sql = "SELECT * FROM FOO WHERE NOT id IS NULL"
     test_config = TestConfig(
@@ -138,7 +138,7 @@ def test_test_to_sqlmesh_fields():
     assert audit.dialect == "duckdb"
     assert audit.skip == True
     assert audit.blocking == False
-    assert audit.query.sql() == sql
+    assert sql in audit.query.sql()
 
 
 def test_model_config_sql_no_config():


### PR DESCRIPTION
This update isolates Jinja expressions into designated blocks to simplify SQL parsing and capture user's intention more precisely. 

Model definition example:
```sql
MODEL (
  name sqlmesh_example.full_model
);

JINJA_STATEMENT_BEGIN;
{{ pre_hook() }}
JINJA_END;

JINJA_QUERY_BEGIN;
SELECT {{ 1 + 1 }};
JINJA_END;

JINJA_STATEMENT_BEGIN;
{{ post_hook() }}
JINJA_END;
```

