### PR TITLE
Feat: Greatly simplify table diff CLI invocation

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -391,7 +391,7 @@ def create_external_models(obj: Context) -> None:
 @click.argument(
     "from_to",
     required=True,
-    help="The source and target environment to diff. Format: source:target",
+    metavar="ENV:ENV",
 )
 @click.argument("model_name", required=True)
 @click.option(

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -387,12 +387,14 @@ def create_external_models(obj: Context) -> None:
 
 
 @cli.command("table_diff")
-@click.argument("from_to", required=True, metavar="FROM:TO",)
-@click.argument("model_name", required=False)
+@click.argument("source_to_target", required=True, metavar="SOURCE:TARGET")
+@click.argument("model", required=False)
 @click.option(
+    "-O",
     "--on",
     type=str,
-    help='The SQL join condition or list of columns to use as keys. Table aliases must be "s" and "t" for source and target.',
+    multiple=True,
+    help="The column to join on. Can be specified multiple times. The model grain will be used if not specified.",
 )
 @click.option(
     "--where",
@@ -408,14 +410,14 @@ def create_external_models(obj: Context) -> None:
 @click.pass_obj
 @error_handler
 def table_diff(
-    obj: Context, from_to: str, model_name: t.Optional[str], **kwargs: t.Any
+    obj: Context, source_to_target: str, model: t.Optional[str], **kwargs: t.Any
 ) -> None:
     """Show the diff between two tables."""
-    source, target = from_to.split(":")
+    source, target = source_to_target.split(":")
     obj.table_diff(
         source=source,
         target=target,
-        model_or_snapshot=model_name,
+        model_or_snapshot=model,
         **kwargs,
     )
 

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -6,7 +6,6 @@ import sys
 import typing as t
 
 import click
-from sqlglot import exp
 
 from sqlmesh import debug_mode_enabled, enable_logging
 from sqlmesh.cli import error_handler

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -387,12 +387,8 @@ def create_external_models(obj: Context) -> None:
 
 
 @cli.command("table_diff")
-@click.argument(
-    "from_to",
-    required=True,
-    metavar="ENV:ENV",
-)
-@click.argument("model_name", required=True)
+@click.argument("from_to", required=True, metavar="FROM:TO",)
+@click.argument("model_name")
 @click.option(
     "--on",
     type=str,
@@ -412,16 +408,14 @@ def create_external_models(obj: Context) -> None:
 @click.pass_obj
 @error_handler
 def table_diff(
-    obj: Context, from_to: str, model_name: str, on: t.Optional[str], **kwargs: t.Any
+    obj: Context, from_to: str, model_name: t.Optional[str], **kwargs: t.Any
 ) -> None:
     """Show the diff between two tables."""
-    model = obj.get_model(model_name, raise_if_missing=True)
     source, target = from_to.split(":")
     obj.table_diff(
         source=source,
         target=target,
-        model_or_snapshot=model,
-        on=exp.condition(on or " and ".join([f"s.{col} = t.{col}" for col in model.grain])),
+        model_or_snapshot=model_name,
         **kwargs,
     )
 

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -388,7 +388,7 @@ def create_external_models(obj: Context) -> None:
 
 @cli.command("table_diff")
 @click.argument("from_to", required=True, metavar="FROM:TO",)
-@click.argument("model_name")
+@click.argument("model_name", required=False)
 @click.option(
     "--on",
     type=str,

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -7,7 +7,6 @@ import typing as t
 
 import click
 from sqlglot import exp
-from sqlglot.helper import ensure_list
 
 from sqlmesh import debug_mode_enabled, enable_logging
 from sqlmesh.cli import error_handler
@@ -407,6 +406,7 @@ def create_external_models(obj: Context) -> None:
 @click.option(
     "--limit",
     type=int,
+    default=20,
     help="The limit of the sample dataframe.",
 )
 @click.pass_obj

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -389,7 +389,7 @@ def create_external_models(obj: Context) -> None:
 @click.argument("source_to_target", required=True, metavar="SOURCE:TARGET")
 @click.argument("model", required=False)
 @click.option(
-    "-O",
+    "-o",
     "--on",
     type=str,
     multiple=True,

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -491,7 +491,7 @@ class TerminalConsole(Console):
         self.console.print(
             f" [green]{row_diff.target_env.upper()}[/green]: {row_diff.target_count} rows"
         )
-        self.console.print(f"\n[b]Rows Added/Removed[b]: {row_diff.count_pct_change:.1f}%")
+        self.console.print(f"\n[b]Row Diff[b]: {row_diff.count_pct_change:.1f}%")
         self.console.print("\n[b]Sample Rows:[/b]")
         self.console.print(row_diff.sample.to_string(index=False) + "\n")
 

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -484,13 +484,16 @@ class TerminalConsole(Console):
         self.console.print(tree)
 
     def show_row_diff(self, row_diff: RowDiff) -> None:
+        source_name = row_diff.source
+        if row_diff.source_alias:
+            source_name = row_diff.source_alias.upper()
+        target_name = row_diff.target
+        if row_diff.target_alias:
+            target_name = row_diff.target_alias.upper()
+
         self.console.print("\n[b]Row Count:[/b]")
-        self.console.print(
-            f" [yellow]{row_diff.source_env.upper()}[/yellow]: {row_diff.source_count} rows"
-        )
-        self.console.print(
-            f" [green]{row_diff.target_env.upper()}[/green]: {row_diff.target_count} rows"
-        )
+        self.console.print(f" [yellow]{source_name}[/yellow]: {row_diff.source_count} rows")
+        self.console.print(f" [green]{target_name}[/green]: {row_diff.target_count} rows")
         self.console.print(f"\n[b]Row Diff[b]: {row_diff.count_pct_change:.1f}%")
         self.console.print("\n[b]Sample Rows:[/b]")
         self.console.print(row_diff.sample.to_string(index=False), end="\n\n")

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -459,7 +459,9 @@ class TerminalConsole(Console):
         del self.loading_status[id]
 
     def show_schema_diff(self, schema_diff: SchemaDiff) -> None:
-        tree = Tree(f"[bold]Schema Diff Between '{schema_diff.source}' and '{schema_diff.target}':")
+        tree = Tree(
+            f"\n[b]Schema Diff Between '[yellow]{schema_diff.source}[/yellow]' and '[green]{schema_diff.target}[/green]':"
+        )
 
         if schema_diff.added:
             added = Tree("[green]Added Columns:")
@@ -482,10 +484,16 @@ class TerminalConsole(Console):
         self.console.print(tree)
 
     def show_row_diff(self, row_diff: RowDiff) -> None:
+        self.console.print("\n[b]Row Count:[/b]")
         self.console.print(
-            f"[bold]Row Count:[/bold] {row_diff.source}: {row_diff.source_count}, {row_diff.target}: {row_diff.target_count} -- {row_diff.count_pct_change}%"
+            f" [yellow]{row_diff.source_env.upper()}[/yellow]: {row_diff.source_count} rows"
         )
-        self.console.print(row_diff.sample.to_string(index=False))
+        self.console.print(
+            f" [green]{row_diff.target_env.upper()}[/green]: {row_diff.target_count} rows"
+        )
+        self.console.print(f"\n[b]Rows Added/Removed[b]: {row_diff.count_pct_change:.1f}%")
+        self.console.print("\n[b]Sample Rows:[/b]")
+        self.console.print(row_diff.sample.to_string(index=False) + "\n")
 
     def _get_snapshot_change_category(
         self, snapshot: Snapshot, plan: Plan, auto_apply: bool

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -493,7 +493,7 @@ class TerminalConsole(Console):
         )
         self.console.print(f"\n[b]Row Diff[b]: {row_diff.count_pct_change:.1f}%")
         self.console.print("\n[b]Sample Rows:[/b]")
-        self.console.print(row_diff.sample.to_string(index=False) + "\n")
+        self.console.print(row_diff.sample.to_string(index=False), end="\n\n")
 
     def _get_snapshot_change_category(
         self, snapshot: Snapshot, plan: Plan, auto_apply: bool

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -777,7 +777,7 @@ class Context(BaseContext):
         Returns:
             The TableDiff object containing schema and summary differences.
         """
-        source_env_name, target_env_name = "SOURCE", "TARGET"
+        source_alias, target_alias = source, target
         if model_or_snapshot:
             model = self.get_model(model_or_snapshot, raise_if_missing=True)
             source_env = self.state_reader.get_environment(source)
@@ -794,8 +794,8 @@ class Context(BaseContext):
             target = next(
                 snapshot for snapshot in target_env.snapshots if snapshot.name == model.name
             ).table_name()
-            source_env_name = source_env.name
-            target_env_name = target_env.name
+            source_alias = source_env.name
+            target_alias = target_env.name
 
             if not on and model.grain:
                 on = model.grain
@@ -809,8 +809,8 @@ class Context(BaseContext):
             target=target,
             on=on,
             where=where,
-            source_env=source_env_name,
-            target_env=target_env_name,
+            source_alias=source_alias,
+            target_alias=target_alias,
             limit=limit,
         )
         if show:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -756,8 +756,8 @@ class Context(BaseContext):
         self,
         source: str,
         target: str,
-        model_or_snapshot: ModelOrSnapshot,
         on: t.List[str] | exp.Condition | None = None,
+        model_or_snapshot: t.Optional[ModelOrSnapshot] = None,
         where: t.Optional[str | exp.Condition] = None,
         limit: int = 20,
         show: bool = True,
@@ -765,11 +765,11 @@ class Context(BaseContext):
         """Show a diff between two tables.
 
         Args:
-            source: The source environment.
-            target: The target environment.
+            source: The source environment or table.
+            target: The target environment or table.
             on: The join condition, table aliases must be "s" and "t" for source and target.
                 If omitted, the table's grain will be used.
-            model_or_snapshot: The model or snapshot to use.
+            model_or_snapshot: The model or snapshot to use when environments are passed in.
             where: An optional where statement to filter results.
             limit: The limit of the sample dataframe.
             show: Show the table diff in the console.
@@ -777,24 +777,28 @@ class Context(BaseContext):
         Returns:
             The TableDiff object containing schema and summary differences.
         """
-        model = self.get_model(model_or_snapshot, raise_if_missing=True)
-        source_env = self.state_reader.get_environment(source)
-        target_env = self.state_reader.get_environment(target)
+        source_env_name, target_env_name = "SOURCE", "TARGET"
+        if model_or_snapshot:
+            model = self.get_model(model_or_snapshot, raise_if_missing=True)
+            source_env = self.state_reader.get_environment(source)
+            target_env = self.state_reader.get_environment(target)
 
-        if not source_env:
-            raise SQLMeshError(f"Could not find environment '{source}'")
-        if not target_env:
-            raise SQLMeshError(f"Could not find environment '{target}')")
+            if not source_env:
+                raise SQLMeshError(f"Could not find environment '{source}'")
+            if not target_env:
+                raise SQLMeshError(f"Could not find environment '{target}')")
 
-        source = next(
-            snapshot for snapshot in source_env.snapshots if snapshot.name == model.name
-        ).table_name()
-        target = next(
-            snapshot for snapshot in target_env.snapshots if snapshot.name == model.name
-        ).table_name()
+            source = next(
+                snapshot for snapshot in source_env.snapshots if snapshot.name == model.name
+            ).table_name()
+            target = next(
+                snapshot for snapshot in target_env.snapshots if snapshot.name == model.name
+            ).table_name()
+            source_env_name = source_env.name
+            target_env_name = target_env.name
 
-        if not on and model.grain:
-            on = model.grain
+            if not on and model.grain:
+                on = model.grain
 
         if not on:
             raise SQLMeshError("Missing join condition 'on'")
@@ -805,8 +809,8 @@ class Context(BaseContext):
             target=target,
             on=on,
             where=where,
-            source_env=source_env.name,
-            target_env=target_env.name,
+            source_env=source_env_name,
+            target_env=target_env_name,
             limit=limit,
         )
         if show:

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -52,8 +52,8 @@ class RowDiff(PydanticModel, frozen=True):
     target: str
     stats: t.Dict[str, float]
     sample: pd.DataFrame
-    source_env: str = "source"
-    target_env: str = "target"
+    source_alias: t.Optional[str] = None
+    target_alias: t.Optional[str] = None
 
     @property
     def source_count(self) -> int:
@@ -85,16 +85,17 @@ class TableDiff:
         where: t.Optional[str | exp.Condition] = None,
         dialect: DialectType = None,
         limit: int = 20,
-        source_env: str = "source",
-        target_env: str = "target",
+        source_alias: t.Optional[str] = None,
+        target_alias: t.Optional[str] = None,
     ):
         self.adapter = adapter
         self.source = source
         self.target = target
         self.where = exp.condition(where, dialect=dialect) if where else None
         self.limit = limit
-        self.source_env = source_env
-        self.target_env = target_env
+        # Support environment aliases for diff output improvement in certain cases
+        self.source_alias = source_alias
+        self.target_alias = target_alias
 
         if isinstance(on, (list, tuple)):
             self.on: exp.Condition = exp.and_(
@@ -200,7 +201,7 @@ class TableDiff:
                     target=self.target,
                     stats=self.adapter.fetchdf(summary_query).iloc[0].to_dict(),
                     sample=self.adapter.fetchdf(sample_query),
-                    source_env=self.source_env,
-                    target_env=self.target_env,
+                    source_alias=self.source_alias,
+                    target_alias=self.target_alias,
                 )
         return self._row_diff

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -96,7 +96,7 @@ class TableDiff:
         self.source_env = source_env
         self.target_env = target_env
 
-        if isinstance(on, list):
+        if isinstance(on, (list, tuple)):
             self.on: exp.Condition = exp.and_(
                 *(
                     exp.column(c, "s").eq(exp.column(c, "t"))

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -52,6 +52,8 @@ class RowDiff(PydanticModel, frozen=True):
     target: str
     stats: t.Dict[str, float]
     sample: pd.DataFrame
+    source_env: str = "source"
+    target_env: str = "target"
 
     @property
     def source_count(self) -> int:
@@ -83,12 +85,16 @@ class TableDiff:
         where: t.Optional[str | exp.Condition] = None,
         dialect: DialectType = None,
         limit: int = 20,
+        source_env: str = "source",
+        target_env: str = "target",
     ):
         self.adapter = adapter
         self.source = source
         self.target = target
         self.where = exp.condition(where, dialect=dialect) if where else None
         self.limit = limit
+        self.source_env = source_env
+        self.target_env = target_env
 
         if isinstance(on, list):
             self.on: exp.Condition = exp.and_(
@@ -194,5 +200,7 @@ class TableDiff:
                     target=self.target,
                     stats=self.adapter.fetchdf(summary_query).iloc[0].to_dict(),
                     sample=self.adapter.fetchdf(sample_query),
+                    source_env=self.source_env,
+                    target_env=self.target_env,
                 )
         return self._row_diff


### PR DESCRIPTION
We need dead-simple diffs. Certain parameters are required so they should be positional arguments, not options. We should leverage the new `grain` metadata (it already leverages it). The invocation should be as concise and self evident as possible without having to remember flags and help text. Please see the examples below to get a feel for the utility and practical approach.

**Notes:**

1. Use pos args, reduce flags
2. Use a new easy-to-grasp syntax for cross env comparison, `<from-env>:<to-env>` as pos arg 1
3. We are diffing a model against itself in another env, so just take the name as pos arg 2
4. We use the `grain` metadata if supplied reducing invocation to just 2 args, total, for full functionality
5. Keep `--on` flag so user has escape hatch to override grain if they want
6. `--where` and `--limit` left as is

🥇 Please see improved ergonomics below.

```sh
sqlmesh table_diff dev:prod sushi.top_waiters

sqlmesh table_diff pr_123:prod sushi.top_waiters

sqlmesh table_diff prod:alex sushi.top_waiters

sqlmesh table_diff alex:toby sushi.top_waiters
```


Now we should also take quick look at the CLI output and improve that in this pass too. `show_row_diff` needs some love. The row count/percentage change numbers are part of the highlight alongside the more obvious schema changes. Let's make sure there are line breaks and negative space to emphasize these.
