### PR TITLE
Fix: Avoid duplicate subscription on component reuse

### DIFF
--- a/web/client/src/library/components/report/ReportErrors.tsx
+++ b/web/client/src/library/components/report/ReportErrors.tsx
@@ -1,110 +1,88 @@
-import { useChannelEvents } from '@api/channels'
 import { Disclosure, Popover, Transition } from '@headlessui/react'
 import pluralize from 'pluralize'
 import clsx from 'clsx'
-import { useState, useEffect, Fragment } from 'react'
-import {
-  useIDE,
-  EnumErrorKey,
-  type ErrorIDE,
-  type ErrorKey,
-} from '../../pages/ide/context'
+import { useState, Fragment } from 'react'
+import { useIDE, type ErrorIDE, type ErrorKey } from '../../pages/ide/context'
 import { toDate, toDateFormat } from '@utils/index'
 import { MinusCircleIcon, PlusCircleIcon } from '@heroicons/react/24/solid'
 import { Divider } from '@components/divider/Divider'
 
 export default function ReportErrors(): JSX.Element {
-  const subscribe = useChannelEvents()
-
-  const { errors, addError } = useIDE()
+  const { errors } = useIDE()
 
   const [isShow, setIsShow] = useState(false)
-
-  useEffect(() => {
-    const unsubscribeErrors = subscribe<ErrorIDE>('errors', displayErrors)
-
-    return () => {
-      unsubscribeErrors?.()
-    }
-  }, [])
-
-  function displayErrors(data: ErrorIDE): void {
-    addError(EnumErrorKey.General, data)
-  }
 
   const hasError = errors.size > 0
 
   return (
-    <>
-      <Popover
-        onMouseEnter={() => {
-          setIsShow(true)
-        }}
-        onMouseLeave={() => {
-          setIsShow(false)
-        }}
-        className="flex"
-      >
-        {() => (
-          <>
-            <span
+    <Popover
+      onMouseEnter={() => {
+        setIsShow(true)
+      }}
+      onMouseLeave={() => {
+        setIsShow(false)
+      }}
+      className="flex"
+    >
+      {() => (
+        <>
+          <span
+            className={clsx(
+              'block ml-1 px-2 first-child:ml-0 rounded-full border whitespace-nowrap dark:text-neutral-100 text-xs text-center',
+              hasError
+                ? 'border-danger-500 text-danger-100 bg-danger-500 cursor-pointer'
+                : 'border-neutral-500 cursor-default text-neutral-700',
+            )}
+          >
+            {hasError ? (
+              <span>
+                {errors.size} {pluralize('Error', errors.size)}
+              </span>
+            ) : (
+              <span>No Errors</span>
+            )}
+          </span>
+          <Transition
+            show={isShow && hasError}
+            as={Fragment}
+            enter="transition ease-out duration-200"
+            enterFrom="opacity-0 translate-y-1"
+            enterTo="opacity-100 translate-y-0"
+            leave="transition ease-in duration-150"
+            leaveFrom="opacity-100 translate-y-0"
+            leaveTo="opacity-0 translate-y-1"
+          >
+            <Popover.Panel
               className={clsx(
-                'block ml-1 px-2 first-child:ml-0 rounded-full border whitespace-nowrap dark:text-neutral-100 text-xs text-center',
-                hasError
-                  ? 'border-danger-500 text-danger-100 bg-danger-500 cursor-pointer'
-                  : 'border-neutral-500 cursor-default text-neutral-700',
+                'absolute rounded-md top-20 right-2 z-[1000] bg-light p-2 transform overflow-hidden text-danger-700 shadow-2xl',
+                'w-[90vw] max-h-[80vh]',
               )}
             >
-              {hasError ? (
-                <span>
-                  {errors.size} {pluralize('Error', errors.size)}
-                </span>
-              ) : (
-                <span>No Errors</span>
-              )}
-            </span>
-            <Transition
-              show={isShow && hasError}
-              as={Fragment}
-              enter="transition ease-out duration-200"
-              enterFrom="opacity-0 translate-y-1"
-              enterTo="opacity-100 translate-y-0"
-              leave="transition ease-in duration-150"
-              leaveFrom="opacity-100 translate-y-0"
-              leaveTo="opacity-0 translate-y-1"
-            >
-              <Popover.Panel
+              <ul
                 className={clsx(
-                  'absolute rounded-md top-20 right-2 z-[1000] bg-light p-2 transform overflow-hidden text-danger-700 shadow-2xl',
-                  'w-[90vw] max-h-[80vh]',
+                  'w-full bg-danger-10 py-4 pl-3 pr-1 rounded-md overflow-auto scrollbar scrollbar--vertical scrollbar--horizontal',
+                  'max-w-[90vw] max-h-[80vh]',
                 )}
               >
-                <ul
-                  className={clsx(
-                    'w-full bg-danger-10 py-4 pl-3 pr-1 rounded-md overflow-auto scrollbar scrollbar--vertical scrollbar--horizontal',
-                    'max-w-[90vw] max-h-[80vh]',
-                  )}
-                >
-                  {Array.from(errors.entries())
-                    .reverse()
-                    .map(([scope, error]) => (
-                      <li
-                        key={`${scope}-${error.message}`}
-                        className="mb-10"
-                      >
-                        <DisplayError
-                          scope={scope}
-                          error={error}
-                        />
-                      </li>
-                    ))}
-                </ul>
-              </Popover.Panel>
-            </Transition>
-          </>
-        )}
-      </Popover>
-    </>
+                {Array.from(errors.entries())
+                  .reverse()
+                  .map(([scope, error]) => (
+                    <li
+                      key={`${scope}-${error.message}`}
+                      className="mb-10"
+                    >
+                      <DisplayError
+                        scope={scope}
+                        error={error}
+                      />
+                    </li>
+                  ))}
+              </ul>
+            </Popover.Panel>
+          </Transition>
+        </>
+      )}
+    </Popover>
   )
 }
 

--- a/web/client/src/library/components/report/ReportTestsErrors.tsx
+++ b/web/client/src/library/components/report/ReportTestsErrors.tsx
@@ -21,7 +21,7 @@ export default function ReportTestsErrors({
             className="flex mb-1"
           >
             <span className="inline-block mr-4">&mdash;</span>
-            <div className="mr-4">
+            <div className="overflow-hidden">
               <span className="inline-block mb-2">{item.message}</span>
               <code className="inline-block max-h-[50vh] bg-theme py-2 px-4 rounded-lg w-full overflow-auto scrollbar scrollbar--vertical scrollbar--horizontal">
                 <pre>{item.details}</pre>

--- a/web/client/src/library/pages/ide/IDE.tsx
+++ b/web/client/src/library/pages/ide/IDE.tsx
@@ -24,7 +24,7 @@ import { EnumSize, EnumVariant } from '~/types/enum'
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { EnumRoutes } from '~/routes'
 import { useStoreFileTree } from '@context/fileTree'
-import { EnumErrorKey, useIDE } from './context'
+import { EnumErrorKey, ErrorIDE, useIDE } from './context'
 import { type Model } from '@api/client'
 import { Button } from '@components/button/Button'
 import { Divider } from '@components/divider/Divider'
@@ -43,7 +43,7 @@ export default function PageIDE(): JSX.Element {
 
   const client = useQueryClient()
 
-  const { removeError } = useIDE()
+  const { removeError, addError } = useIDE()
 
   const models = useStoreContext(s => s.models)
   const environment = useStoreContext(s => s.environment)
@@ -98,6 +98,7 @@ export default function PageIDE(): JSX.Element {
   useEffect(() => {
     const unsubscribeTasks = subscribe<PlanProgress>('tasks', updateTasks)
     const unsubscribeModels = subscribe<Model[]>('models', updateModels)
+    const unsubscribeErrors = subscribe<ErrorIDE>('errors', displayErrors)
     const unsubscribePromote = subscribe<any>(
       'promote-environment',
       handlePromote,
@@ -125,6 +126,7 @@ export default function PageIDE(): JSX.Element {
       unsubscribeTasks?.()
       unsubscribeModels?.()
       unsubscribePromote?.()
+      unsubscribeErrors?.()
     }
   }, [])
 
@@ -190,6 +192,10 @@ export default function PageIDE(): JSX.Element {
     } else {
       setState(EnumPlanState.Applying)
     }
+  }
+
+  function displayErrors(data: ErrorIDE): void {
+    addError(EnumErrorKey.General, data)
   }
 
   function handlePromote(): void {


### PR DESCRIPTION
When re-using `ReportErrors` component it subscribing to `errors` SSE multiple times which causing issue with displaying errors