### PR TITLE
Chore: Refactor the snapshot evaluator

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -768,7 +768,7 @@ class ViewStrategy(PromotableStrategy):
         )
 
     def migrate(self, target_table_name: str, source_table_name: str) -> None:
-        pass
+        raise ConfigError(f"Cannot migrate a view '{target_table_name}'.")
 
     def delete(self, name: str) -> None:
         self.adapter.drop_view(name)


### PR DESCRIPTION
Refactored the flag-driven implementation of the Snapshot Evaluator so that it relies on polymorphism instead.

This should help make subsequent iterations on this module a lot less error-prone. 

While refactoring I noticed a bug which impacted `INCREMENTAL_BY_UNIQUE_KEY` models in case when more than one DataFrame is returned. The first DataFrame was inserted using `merge` strategy while all subsequent inserts where appended. The new implementation made it very clear.