### PR TITLE
Feat: Optional rendered query and columns-to-types mapping

### DIFF
--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -12,7 +12,7 @@ from sqlmesh.core import dialect as d
 from sqlmesh.core.model.definition import Model, _Model, expression_validator
 from sqlmesh.core.renderer import QueryRenderer
 from sqlmesh.utils.date import TimeLike
-from sqlmesh.utils.errors import AuditConfigError, raise_config_error
+from sqlmesh.utils.errors import AuditConfigError, SQLMeshError, raise_config_error
 from sqlmesh.utils.jinja import JinjaMacroRegistry
 from sqlmesh.utils.pydantic import PydanticModel
 
@@ -197,7 +197,7 @@ class Audit(AuditMeta, frozen=True):
             .subquery()
         )
 
-        return query_renderer.render(
+        rendered_query = query_renderer.render(
             start=start,
             end=end,
             latest=latest,
@@ -206,6 +206,13 @@ class Audit(AuditMeta, frozen=True):
             this_model=query,
             **kwargs,
         )
+
+        if rendered_query is None:
+            raise SQLMeshError(
+                f"Failed to render query for audit '{self.name}', model '{model.name}'."
+            )
+
+        return rendered_query
 
     @property
     def expressions(self) -> t.List[exp.Expression]:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -580,12 +580,13 @@ class Context(BaseContext):
             )
             return next(pandas_to_sql(t.cast(pd.DataFrame, df), model.columns_to_types))
 
-        return model.render_query(
+        return model.render_query_or_raise(
             start=start,
             end=end,
             latest=latest,
             snapshots=self.snapshots,
             expand=expand,
+            engine_adapter=self.engine_adapter,
             **kwargs,
         )
 

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -604,3 +604,11 @@ def normalize_model_name(table: str | exp.Table, dialect: DialectType = None) ->
     return exp.table_name(
         normalize_identifiers(exp.to_table(table, dialect=dialect), dialect=dialect)
     )
+
+
+def extract_columns_to_types(query: exp.Subqueryable) -> t.Dict[str, exp.DataType]:
+    """Extract the column names and types from a query."""
+    return {
+        expression.output_name: expression.type or exp.DataType.build("unknown")
+        for expression in query.selects
+    }

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -671,9 +671,12 @@ class EngineAdapter:
         self,
         target_table: TableName,
         source_table: QueryOrDF,
-        columns_to_types: t.Dict[str, exp.DataType],
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[str],
     ) -> None:
+        if columns_to_types is None:
+            columns_to_types = self.columns(target_table)
+
         column_names = list(columns_to_types or [])
         on = exp.and_(
             *(

--- a/sqlmesh/core/engine_adapter/logical_merge.py
+++ b/sqlmesh/core/engine_adapter/logical_merge.py
@@ -16,7 +16,7 @@ class LogicalMergeAdapter(EngineAdapter):
         self,
         target_table: TableName,
         source_table: QueryOrDF,
-        columns_to_types: t.Dict[str, exp.DataType],
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[str],
     ) -> None:
         """
@@ -29,6 +29,9 @@ class LogicalMergeAdapter(EngineAdapter):
            within the temporary table are ommitted.
         4. Drop the temporary table.
         """
+        if columns_to_types is None:
+            columns_to_types = self.columns(target_table)
+
         temp_table = self._get_temp_table(target_table)
         unique_exp = exp.func("CONCAT_WS", "'__SQLMESH_DELIM__'", *unique_key)
         column_names = list(columns_to_types or [])

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -83,9 +83,12 @@ class SparkEngineAdapter(EngineAdapter):
         self,
         target_table: TableName,
         source_table: QueryOrDF,
-        columns_to_types: t.Dict[str, exp.DataType],
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[str],
     ) -> None:
+        if columns_to_types is None:
+            columns_to_types = self.columns(target_table)
+
         column_names = columns_to_types.keys()
         df = self.try_get_df(source_table)
         if self._use_spark_session and df is not None:

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -24,6 +24,7 @@ from sqlmesh.core.model import (
     ModelCache,
     OptimizedQueryCache,
     SeedModel,
+    SqlModel,
     create_external_model,
     load_model,
 )
@@ -64,13 +65,15 @@ def update_model_schemas(
                     ' add source tables as "external models" using the command'
                     " 'sqlmesh create_external_models'."
                 )
-        elif model.mapping_schema and not cache_hit:
-            try:
-                validate_qualify_columns(model.render_query())
-            except SqlglotError as e:
-                raise ConfigError(
-                    f"Column references could not be resolved for model '{name}' at '{model._path}'. {e}"
-                )
+        elif isinstance(model, SqlModel) and model.mapping_schema and not cache_hit:
+            query = model.render_query()
+            if query is not None:
+                try:
+                    validate_qualify_columns(query)
+                except SqlglotError as e:
+                    raise ConfigError(
+                        f"Column references could not be resolved for model '{name}' at '{model._path}'. {e}"
+                    )
 
 
 @dataclass

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -173,7 +173,7 @@ class _Model(ModelMeta, frozen=True):
                             value=field_value.to_expression(dialect=self.dialect),
                         )
                     )
-                else:
+                elif field.name != "column_descriptions_":
                     expressions.append(
                         exp.Property(
                             this=field.alias or field.name,
@@ -781,6 +781,11 @@ class SqlModel(_SqlBasedModel):
         query = self._query_renderer.render(optimize=False)
 
         if query is None:
+            if self.depends_on_ is None:
+                raise_config_error(
+                    "Dependencies must be provided explicitly for models that can be rendered only at runtime",
+                    self._path,
+                )
             return
 
         if not isinstance(query, exp.Subqueryable):

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -932,7 +932,7 @@ def _model_data_hash(model: Model) -> str:
         macro_defs = []
 
     if isinstance(model, SqlModel):
-        query = model.query if model.hash_raw_query else model.render_query()
+        query = model.query if model.hash_raw_query else model.render_query() or model.query
 
         for e in (query, *pre_statements, *post_statements, *macro_defs):
             data.append(e.sql(comments=False))
@@ -995,6 +995,7 @@ def _model_metadata_hash(model: Model, audits: t.Dict[str, Audit]) -> str:
                 audit.query
                 if model.hash_raw_query
                 else audit.render_query(model, **t.cast(t.Dict[str, t.Any], audit_args))
+                or audit.query
             )
             metadata.extend(
                 [
@@ -1009,9 +1010,11 @@ def _model_metadata_hash(model: Model, audits: t.Dict[str, Audit]) -> str:
 
     # Add comments from the model query.
     if model.is_sql:
-        for e, _, _ in model.render_query().walk():
-            if e.comments:
-                metadata.extend(e.comments)
+        rendered_query = model.render_query()
+        if rendered_query:
+            for e, _, _ in rendered_query.walk():
+                if e.comments:
+                    metadata.extend(e.comments)
 
     return _hash(metadata)
 

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -365,7 +365,7 @@ class SnapshotEvaluator:
 
         render_kwargs: t.Dict[str, t.Any] = dict(
             engine_adapter=self.adapter,
-            snapshots=snapshots,
+            snapshots=parent_snapshots_by_name,
             is_dev=is_dev,
         )
 
@@ -373,7 +373,7 @@ class SnapshotEvaluator:
             self.adapter.execute(snapshot.model.render_pre_statements(**render_kwargs))
 
             _evaluation_strategy(snapshot, self.adapter).create(
-                snapshot.model, table_name, parent_snapshots_by_name, is_dev
+                snapshot.model, table_name, **render_kwargs
             )
 
             self.adapter.execute(snapshot.model.render_post_statements(**render_kwargs))
@@ -508,15 +508,17 @@ class EvaluationStrategy(abc.ABC):
 
     @abc.abstractmethod
     def create(
-        self, model: Model, name: str, snapshots: t.Dict[str, Snapshot], is_dev: bool
+        self,
+        model: Model,
+        name: str,
+        **render_kwargs: t.Any,
     ) -> None:
         """Creates the target table or view.
 
         Args:
             model: The target model.
             name: The name of a table or a view.
-            snapshots: Parent snapshots.
-            is_dev: Whether the table is for the dev table.
+            render_kwargs: Additional kwargs for model rendering.
         """
 
     @abc.abstractmethod
@@ -578,7 +580,10 @@ class SymbolicStrategy(EvaluationStrategy):
         pass
 
     def create(
-        self, model: Model, name: str, snapshots: t.Dict[str, Snapshot], is_dev: bool
+        self,
+        model: Model,
+        name: str,
+        **render_kwargs: t.Any,
     ) -> None:
         pass
 
@@ -624,12 +629,15 @@ class MaterializableStrategy(PromotableStrategy):
         self.adapter.insert_append(table_name, query_or_df, columns_to_types=model.columns_to_types)
 
     def create(
-        self, model: Model, table_name: str, snapshots: t.Dict[str, Snapshot], is_dev: bool
+        self,
+        model: Model,
+        name: str,
+        **render_kwargs: t.Any,
     ) -> None:
-        logger.info("Creating table '%s'", table_name)
+        logger.info("Creating table '%s'", name)
         if model.annotated:
             self.adapter.create_table(
-                table_name,
+                name,
                 columns_to_types=model.columns_to_types_or_raise,
                 storage_format=model.storage_format,
                 partitioned_by=model.partitioned_by,
@@ -637,8 +645,8 @@ class MaterializableStrategy(PromotableStrategy):
             )
         else:
             self.adapter.ctas(
-                table_name,
-                model.ctas_query(snapshots, is_dev=is_dev),
+                name,
+                model.ctas_query(**render_kwargs),
                 model.columns_to_types,
                 storage_format=model.storage_format,
                 partitioned_by=model.partitioned_by,
@@ -767,12 +775,15 @@ class ViewStrategy(PromotableStrategy):
         raise ConfigError(f"Cannot append to a view '{table_name}'.")
 
     def create(
-        self, model: Model, name: str, snapshots: t.Dict[str, Snapshot], is_dev: bool
+        self,
+        model: Model,
+        name: str,
+        **render_kwargs: t.Any,
     ) -> None:
         logger.info("Creating view '%s'", name)
         self.adapter.create_view(
             name,
-            model.render_query(snapshots=snapshots, is_dev=is_dev),
+            model.render_query_or_raise(**render_kwargs),
             materialized=self._is_materialized_view(model),
         )
 

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -678,7 +678,7 @@ class IncrementalByTimeRangeStrategy(MaterializableStrategy):
             query_or_df,
             time_formatter=model.convert_to_time_column,
             time_column=model.time_column,
-            columns_to_types=model.columns_to_types,
+            columns_to_types=_columns_to_types(model, query_or_df),
             **kwargs,
         )
 
@@ -696,7 +696,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
         self.adapter.merge(
             name,
             query_or_df,
-            columns_to_types=self._columns_to_types(model, query_or_df),
+            columns_to_types=_columns_to_types(model, query_or_df),
             unique_key=model.unique_key,
         )
 
@@ -712,16 +712,8 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
         self.adapter.merge(
             table_name,
             query_or_df,
-            columns_to_types=self._columns_to_types(model, query_or_df),
+            columns_to_types=_columns_to_types(model, query_or_df),
             unique_key=model.unique_key,
-        )
-
-    @staticmethod
-    def _columns_to_types(model: Model, query_or_df: QueryOrDF) -> t.Dict[str, exp.DataType]:
-        return (
-            d.extract_columns_to_types(query_or_df)
-            if isinstance(query_or_df, exp.Subqueryable)
-            else model.columns_to_types_or_raise
         )
 
 
@@ -796,3 +788,11 @@ class ViewStrategy(PromotableStrategy):
 
     def _is_materialized_view(self, model: Model) -> bool:
         return isinstance(model.kind, ViewKind) and model.kind.materialized
+
+
+def _columns_to_types(model: Model, query_or_df: QueryOrDF) -> t.Dict[str, exp.DataType]:
+    return (
+        d.extract_columns_to_types(query_or_df)
+        if isinstance(query_or_df, exp.Subqueryable)
+        else model.columns_to_types_or_raise
+    )

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -31,7 +31,6 @@ import pandas as pd
 from sqlglot import exp, select
 from sqlglot.executor import execute
 
-from sqlmesh.core import dialect as d
 from sqlmesh.core.audit import BUILT_IN_AUDITS, AuditResult
 from sqlmesh.core.engine_adapter import EngineAdapter, TransactionType
 from sqlmesh.core.model import Model, ViewKind
@@ -678,7 +677,7 @@ class IncrementalByTimeRangeStrategy(MaterializableStrategy):
             query_or_df,
             time_formatter=model.convert_to_time_column,
             time_column=model.time_column,
-            columns_to_types=_columns_to_types(model, query_or_df),
+            columns_to_types=model.columns_to_types,
             **kwargs,
         )
 
@@ -696,7 +695,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
         self.adapter.merge(
             name,
             query_or_df,
-            columns_to_types=_columns_to_types(model, query_or_df),
+            columns_to_types=model.columns_to_types,
             unique_key=model.unique_key,
         )
 
@@ -712,7 +711,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
         self.adapter.merge(
             table_name,
             query_or_df,
-            columns_to_types=_columns_to_types(model, query_or_df),
+            columns_to_types=model.columns_to_types,
             unique_key=model.unique_key,
         )
 
@@ -788,11 +787,3 @@ class ViewStrategy(PromotableStrategy):
 
     def _is_materialized_view(self, model: Model) -> bool:
         return isinstance(model.kind, ViewKind) and model.kind.materialized
-
-
-def _columns_to_types(model: Model, query_or_df: QueryOrDF) -> t.Dict[str, exp.DataType]:
-    return (
-        d.extract_columns_to_types(query_or_df)
-        if isinstance(query_or_df, exp.Subqueryable)
-        else model.columns_to_types_or_raise
-    )

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -167,7 +167,7 @@ class SqlModelTest(ModelTest):
         """
         super().__init__(body, test_name, model, models, engine_adapter, path)
 
-        self.query = model.render_query(
+        self.query = model.render_query_or_raise(
             add_incremental_filter=True,
             **self.body.get("vars", {}),
             engine_adapter=engine_adapter,

--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -8,7 +8,7 @@ from sqlglot import exp
 from sqlglot.helper import seq_get
 
 from sqlmesh.core.engine_adapter import EngineAdapter, TransactionType
-from sqlmesh.utils.errors import ConfigError
+from sqlmesh.utils.errors import ConfigError, ParsetimeAdapterCallError
 from sqlmesh.utils.jinja import JinjaMacroRegistry, MacroReference
 
 if t.TYPE_CHECKING:
@@ -70,7 +70,7 @@ class BaseAdapter(abc.ABC):
     @abc.abstractmethod
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False
-    ) -> t.Optional[t.Tuple[AdapterResponse, agate.Table]]:
+    ) -> t.Tuple[AdapterResponse, agate.Table]:
         """Executes the given SQL statement and returns the results as an agate table."""
 
     def quote(self, identifier: str) -> str:
@@ -96,35 +96,45 @@ class BaseAdapter(abc.ABC):
 
 class ParsetimeAdapter(BaseAdapter):
     def get_relation(self, database: str, schema: str, identifier: str) -> t.Optional[BaseRelation]:
-        return None
+        self._raise_parstime_adapter_call_error("get relation")
+        raise
 
     def list_relations(self, database: t.Optional[str], schema: str) -> t.List[BaseRelation]:
-        return []
+        self._raise_parstime_adapter_call_error("list relation")
+        raise
 
     def list_relations_without_caching(self, schema_relation: BaseRelation) -> t.List[BaseRelation]:
-        return []
+        self._raise_parstime_adapter_call_error("list relation")
+        raise
 
     def get_columns_in_relation(self, relation: BaseRelation) -> t.List[Column]:
-        return []
+        self._raise_parstime_adapter_call_error("get columns")
+        raise
 
     def get_missing_columns(
         self, from_relation: BaseRelation, to_relation: BaseRelation
     ) -> t.List[Column]:
-        return []
+        self._raise_parstime_adapter_call_error("get missing columns")
+        raise
 
     def create_schema(self, relation: BaseRelation) -> None:
-        pass
+        self._raise_parstime_adapter_call_error("create schema")
 
     def drop_schema(self, relation: BaseRelation) -> None:
-        pass
+        self._raise_parstime_adapter_call_error("drop schema")
 
     def drop_relation(self, relation: BaseRelation) -> None:
-        pass
+        self._raise_parstime_adapter_call_error("drop relation")
 
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False
-    ) -> t.Optional[t.Tuple[AdapterResponse, agate.Table]]:
-        return None
+    ) -> t.Tuple[AdapterResponse, agate.Table]:
+        self._raise_parstime_adapter_call_error("execute SQL")
+        raise
+
+    @staticmethod
+    def _raise_parstime_adapter_call_error(action: str) -> None:
+        raise ParsetimeAdapterCallError(f"Can't {action} at parse time.")
 
 
 class RuntimeAdapter(BaseAdapter):

--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -96,44 +96,44 @@ class BaseAdapter(abc.ABC):
 
 class ParsetimeAdapter(BaseAdapter):
     def get_relation(self, database: str, schema: str, identifier: str) -> t.Optional[BaseRelation]:
-        self._raise_parstime_adapter_call_error("get relation")
+        self._raise_parsetime_adapter_call_error("get relation")
         raise
 
     def list_relations(self, database: t.Optional[str], schema: str) -> t.List[BaseRelation]:
-        self._raise_parstime_adapter_call_error("list relation")
+        self._raise_parsetime_adapter_call_error("list relation")
         raise
 
     def list_relations_without_caching(self, schema_relation: BaseRelation) -> t.List[BaseRelation]:
-        self._raise_parstime_adapter_call_error("list relation")
+        self._raise_parsetime_adapter_call_error("list relation")
         raise
 
     def get_columns_in_relation(self, relation: BaseRelation) -> t.List[Column]:
-        self._raise_parstime_adapter_call_error("get columns")
+        self._raise_parsetime_adapter_call_error("get columns")
         raise
 
     def get_missing_columns(
         self, from_relation: BaseRelation, to_relation: BaseRelation
     ) -> t.List[Column]:
-        self._raise_parstime_adapter_call_error("get missing columns")
+        self._raise_parsetime_adapter_call_error("get missing columns")
         raise
 
     def create_schema(self, relation: BaseRelation) -> None:
-        self._raise_parstime_adapter_call_error("create schema")
+        self._raise_parsetime_adapter_call_error("create schema")
 
     def drop_schema(self, relation: BaseRelation) -> None:
-        self._raise_parstime_adapter_call_error("drop schema")
+        self._raise_parsetime_adapter_call_error("drop schema")
 
     def drop_relation(self, relation: BaseRelation) -> None:
-        self._raise_parstime_adapter_call_error("drop relation")
+        self._raise_parsetime_adapter_call_error("drop relation")
 
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False
     ) -> t.Tuple[AdapterResponse, agate.Table]:
-        self._raise_parstime_adapter_call_error("execute SQL")
+        self._raise_parsetime_adapter_call_error("execute SQL")
         raise
 
     @staticmethod
-    def _raise_parstime_adapter_call_error(action: str) -> None:
+    def _raise_parsetime_adapter_call_error(action: str) -> None:
         raise ParsetimeAdapterCallError(f"Can't {action} at parse time.")
 
 

--- a/sqlmesh/dbt/basemodel.py
+++ b/sqlmesh/dbt/basemodel.py
@@ -235,6 +235,9 @@ class BaseModelConfig(GeneralConfig):
             "audits": [(test.name, {}) for test in self.tests],
             "columns": column_types_to_sqlmesh(self.columns) or None,
             "column_descriptions_": column_descriptions_to_sqlmesh(self.columns) or None,
+            "depends_on": {model.sql_name for model in model_context.refs.values()}.union(
+                {source.sql_name for source in model_context.sources.values()}
+            ),
             "jinja_macros": jinja_macros,
             "path": self.path,
             "hash_raw_query": True,

--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -305,9 +305,8 @@ def create_builtin_globals(
         {k: builtin_globals.get(k) for k in ("ref", "source", "config")}
     )
 
-    adapter: BaseAdapter
     if engine_adapter is not None:
-        adapter = RuntimeAdapter(
+        adapter: BaseAdapter = RuntimeAdapter(
             engine_adapter,
             jinja_macros,
             jinja_globals={**builtin_globals, **jinja_globals},

--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -305,8 +305,6 @@ def create_builtin_globals(
         {k: builtin_globals.get(k) for k in ("ref", "source", "config")}
     )
 
-    builtin_globals["execute"] = True
-
     adapter: BaseAdapter
     if engine_adapter is not None:
         adapter = RuntimeAdapter(

--- a/sqlmesh/integrations/llm.py
+++ b/sqlmesh/integrations/llm.py
@@ -47,7 +47,7 @@ def _to_table_info(models: t.Iterable[Model]) -> str:
         if not model.kind.is_materialized:
             continue
 
-        columns_csv = ", ".join(model.columns_to_types)
+        columns_csv = ", ".join(model.columns_to_types_or_raise)
         infos.append(f"Table: {model.name}\nColumns: {columns_csv}\n")
 
     return "\n".join(infos)

--- a/sqlmesh/utils/errors.py
+++ b/sqlmesh/utils/errors.py
@@ -77,6 +77,10 @@ class CICDBotError(SQLMeshError):
     pass
 
 
+class ParsetimeAdapterCallError(SQLMeshError):
+    pass
+
+
 def raise_config_error(
     msg: str,
     location: t.Optional[str | Path] = None,

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1306,7 +1306,7 @@ def test_model_ctas_query():
         read="bigquery",
     )
 
-    assert load_model(expressions, dialect="bigquery").ctas_query({}).sql() == 'SELECT 1 AS "a"'
+    assert load_model(expressions, dialect="bigquery").ctas_query().sql() == 'SELECT 1 AS "a"'
 
     expressions = parse(
         """
@@ -1316,8 +1316,7 @@ def test_model_ctas_query():
     )
 
     assert (
-        load_model(expressions).ctas_query({}).sql()
-        == 'SELECT 1 AS "a" FROM "b" AS "b" WHERE FALSE'
+        load_model(expressions).ctas_query().sql() == 'SELECT 1 AS "a" FROM "b" AS "b" WHERE FALSE'
     )
 
 

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -88,7 +88,7 @@ def test_model_to_sqlmesh_fields(sushi_test_project: Project):
     assert isinstance(model, SqlModel)
     assert model.name == "database.custom.model"
     assert model.description == "test model"
-    assert model.render_query().sql() == 'SELECT 1 AS "a" FROM "foo" AS "foo"'
+    assert model.render_query_or_raise().sql() == 'SELECT 1 AS "a" FROM "foo" AS "foo"'
     assert model.start == "Jan 1 2023"
     assert model.partitioned_by == ["a"]
     assert model.cron == "@hourly"

--- a/tests/dbt/test_manifest.py
+++ b/tests/dbt/test_manifest.py
@@ -36,6 +36,7 @@ def test_manifest_helper():
         macros={
             MacroReference(name="log_value"),
             MacroReference(package="customers", name="duckdb__current_engine"),
+            MacroReference(package="dbt", name="run_query"),
             MacroReference(package="dbt", name="is_incremental"),
         },
         sources={"streaming.items", "streaming.orders", "streaming.order_items"},

--- a/tests/fixtures/dbt/sushi_test/models/waiter_revenue_by_day.sql
+++ b/tests/fixtures/dbt/sushi_test/models/waiter_revenue_by_day.sql
@@ -10,10 +10,15 @@
 {{ log_value(5) }}
 {{ log(adapter.dispatch('current_engine', 'customers')()) }}
 
+{% set results = run_query('select 1 as constant') %}
+
 SELECT
   o.waiter_id::INT AS waiter_id, /* Waiter id */
   SUM(oi.quantity * i.price)::DOUBLE AS revenue, /* Revenue from orders taken by this waiter */
-  o.ds::TEXT AS ds /* Date */
+  o.ds::TEXT AS ds, /* Date */
+  {% if execute %}
+    {{ results.columns[0].values()[0] }}::INT AS constant /* Constant */
+  {% endif %}
 FROM {{ source('streaming', 'orders') }} AS o
 LEFT JOIN {{ source('streaming', 'order_items') }} AS oi
   ON o.id = oi.order_id AND o.ds = oi.ds

--- a/web/server/api/endpoints/lineage.py
+++ b/web/server/api/endpoints/lineage.py
@@ -52,9 +52,9 @@ async def column_lineage(
     try:
         node = lineage(
             column=column_name,
-            sql=context.models[model_name].render_query(),
+            sql=context.models[model_name].render_query_or_raise(),
             sources={
-                model: context.models[model].render_query()
+                model: context.models[model].render_query_or_raise()
                 for model in context.dag.upstream(model_name)
                 if model in context.models
             },

--- a/web/server/api/endpoints/models.py
+++ b/web/server/api/endpoints/models.py
@@ -63,7 +63,7 @@ def get_all_models(context: Context) -> t.List[models.Model]:
             models.Column(
                 name=name, type=str(data_type), description=model.column_descriptions.get(name)
             )
-            for name, data_type in model.columns_to_types.items()
+            for name, data_type in model.columns_to_types_or_raise.items()
         ]
         details = models.ModelDetails(
             owner=model.owner,

--- a/web/server/api/endpoints/models.py
+++ b/web/server/api/endpoints/models.py
@@ -93,7 +93,7 @@ def get_all_models(context: Context) -> t.List[models.Model]:
                 columns=columns,
                 details=details,
                 description=model.description,
-                sql=model.render_query().sql(pretty=True, dialect=model.dialect),
+                sql=model.render_query_or_raise().sql(pretty=True, dialect=model.dialect),
                 type=type,
             )
         )


### PR DESCRIPTION
To support model queries with jinja expressions that can only be rendered at runtime (as opposed to parse time) I refactored the model definition and made the rendered query and the columns-to-types mapping optional for sql models.

For context, the jinja expression can't be rendered at parse time if it requires connection to the data warehouse.