### PR TITLE
Chore: fix mypy type hints in test_duckdb

### DIFF
--- a/tests/core/engine_adapter/test_duckdb.py
+++ b/tests/core/engine_adapter/test_duckdb.py
@@ -1,3 +1,4 @@
+import typing as t
 from unittest.mock import call
 
 import pytest
@@ -84,7 +85,7 @@ def test_merge(mocker: MockerFixture):
     adapter = DuckDBEngineAdapter(lambda: connection_mock)  # type: ignore
     adapter.merge(
         target_table="target",
-        source_table=parse_one("SELECT id, ts, val FROM source"),
+        source_table=t.cast(exp.Select, parse_one("SELECT id, ts, val FROM source")),
         columns_to_types={
             "id": exp.DataType(this=exp.DataType.Type.INT),
             "ts": exp.DataType(this=exp.DataType.Type.TIMESTAMP),
@@ -109,7 +110,7 @@ def test_merge(mocker: MockerFixture):
     cursor_mock.reset_mock()
     adapter.merge(
         target_table="target",
-        source_table=parse_one("SELECT id, ts, val FROM source"),
+        source_table=t.cast(exp.Select, parse_one("SELECT id, ts, val FROM source")),
         columns_to_types={
             "id": exp.DataType(this=exp.DataType.Type.INT),
             "ts": exp.DataType(this=exp.DataType.Type.TIMESTAMP),


### PR DESCRIPTION
The `merge` method expects a `QueryOrDf` but `parse_one` without an `into` arg returns `Expression` which is incompatible. Dunno why this wasn't caught, but we'll get a mypy failure if https://github.com/tobymao/sqlglot/pull/1797 is merged (tested locally).