### PR TITLE
Fix: Allow SELECT * in models that reference external tables

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -652,7 +652,8 @@ def find_tables(expression: exp.Expression, dialect: DialectType = None) -> t.Se
     """Find all tables referenced in a query.
 
     Args:
-        expressions: The list of expressions to find tables for.
+        expressions: The query to find the tables in.
+        dialect: The dialect to use for normalization of table names.
 
     Returns:
         A Set of all the table names.

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -10,6 +10,7 @@ import pandas as pd
 from sqlglot import Dialect, Generator, Parser, Tokenizer, TokenType, exp
 from sqlglot.dialects.dialect import DialectType
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
+from sqlglot.optimizer.scope import traverse_scope
 from sqlglot.tokens import Token
 
 from sqlmesh.core.constants import MAX_MODEL_DEFINITION_SIZE
@@ -644,4 +645,21 @@ def extract_columns_to_types(query: exp.Subqueryable) -> t.Dict[str, exp.DataTyp
     return {
         expression.output_name: expression.type or exp.DataType.build("unknown")
         for expression in query.selects
+    }
+
+
+def find_tables(expression: exp.Expression, dialect: DialectType = None) -> t.Set[str]:
+    """Find all tables referenced in a query.
+
+    Args:
+        expressions: The list of expressions to find tables for.
+
+    Returns:
+        A Set of all the table names.
+    """
+    return {
+        normalize_model_name(table, dialect=dialect)
+        for scope in traverse_scope(expression)
+        for table in scope.tables
+        if isinstance(table.this, exp.Identifier) and exp.table_name(table) not in scope.cte_sources
     }

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -54,8 +54,12 @@ def update_model_schemas(
             continue
 
         model.update_schema(schema)
+
         cache_hit = optimized_query_cache.with_optimized_query(model)
-        schema.add_table(name, model.columns_to_types, dialect=model.dialect)
+
+        columns_to_types = model.columns_to_types
+        if columns_to_types is not None:
+            schema.add_table(name, columns_to_types, dialect=model.dialect)
 
         if isinstance(model, SqlModel) and model.mapping_schema and not cache_hit:
             query = model.render_query()

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -57,15 +57,7 @@ def update_model_schemas(
         cache_hit = optimized_query_cache.with_optimized_query(model)
         schema.add_table(name, model.columns_to_types, dialect=model.dialect)
 
-        if any(dep not in models for dep in model.depends_on):
-            if "*" in model.columns_to_types:
-                raise ConfigError(
-                    f"Can't expand SELECT * expression for model '{name}' at '{model._path}'."
-                    " Either specify external source projections expliticly or"
-                    ' add source tables as "external models" using the command'
-                    " 'sqlmesh create_external_models'."
-                )
-        elif isinstance(model, SqlModel) and model.mapping_schema and not cache_hit:
+        if isinstance(model, SqlModel) and model.mapping_schema and not cache_hit:
             query = model.render_query()
             if query is not None:
                 try:

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -559,7 +559,7 @@ class _Model(ModelMeta, frozen=True):
                 )
 
             columns_to_types = self.columns_to_types
-            if columns_to_types is not None and "*" not in columns_to_types:
+            if columns_to_types is not None:
                 column_names = {c.lower() for c in columns_to_types}
                 missing_keys = unique_partition_keys - column_names
                 if missing_keys:
@@ -752,6 +752,9 @@ class SqlModel(_SqlBasedModel):
             if query is None:
                 return None
             self._columns_to_types = d.extract_columns_to_types(query)
+
+        if "*" in self._columns_to_types:
+            return None
 
         return self._columns_to_types
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -463,6 +463,13 @@ class _Model(ModelMeta, frozen=True):
             else:
                 # Reset the entire mapping if at least one upstream dependency is missing from the mapping
                 # to prevent partial mappings from being used.
+                logger.warning(
+                    "Missing schema for model '%s' referenced in model '%s'. Run `sqlmesh create_external_models` "
+                    "and / or make sure that model '%s' can be rendered at parse time",
+                    dep,
+                    self.name,
+                    dep,
+                )
                 self.mapping_schema.clear()
                 return
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -460,6 +460,11 @@ class _Model(ModelMeta, frozen=True):
                     tuple(str(part) for part in table.parts),
                     {k: str(v) for k, v in mapping_schema.items()},
                 )
+            else:
+                # Reset the entire mapping if at least one upstream dependency is missing from the mapping
+                # to prevent partial mappings from being used.
+                self.mapping_schema.clear()
+                return
 
     @property
     def depends_on(self) -> t.Set[str]:

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -263,7 +263,6 @@ class QueryRenderer(ExpressionRenderer):
                     ),
                 )
             except ParsetimeAdapterCallError:
-                logger.debug("Failed to render query at parse time:\n%s", self._expression)
                 return None
 
             if not query:

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -14,7 +14,7 @@ from sqlglot.optimizer.qualify import qualify
 from sqlglot.optimizer.qualify_columns import quote_identifiers
 from sqlglot.optimizer.qualify_tables import qualify_tables
 from sqlglot.optimizer.simplify import simplify
-from sqlglot.schema import ensure_schema
+from sqlglot.schema import MappingSchema
 
 from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
@@ -324,9 +324,20 @@ class QueryRenderer(ExpressionRenderer):
 
     def _optimize_query(self, query: exp.Subqueryable) -> exp.Subqueryable:
         # We don't want to normalize names in the schema because that's handled by the optimizer
-        schema = ensure_schema(self.schema, dialect=self._dialect, normalize=False)
+        schema = MappingSchema(self.schema, dialect=self._dialect, normalize=False)
         original = query
         failure = False
+
+        if not schema.empty:
+            for dependency in d.find_tables(query, dialect=self._dialect):
+                if schema.find(exp.to_table(dependency, dialect=self._dialect)) is None:
+                    logger.warning(
+                        "Query cannot be optimized due to missing schema for model '%s'. "
+                        "Make sure that the model query can be rendered at parse time",
+                        dependency,
+                    )
+                    schema = MappingSchema(None, dialect=self._dialect, normalize=False)
+                    break
 
         try:
             if not schema.empty:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1,5 +1,6 @@
 from datetime import date
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from pytest_mock.plugin import MockerFixture
@@ -1228,7 +1229,7 @@ def test_case_sensitivity(assert_exp_eq):
             """
             MODEL (name example.source, kind EMBEDDED);
 
-            SELECT "id", "name", "payload" FROM db.schema."table"
+            SELECT 'id' AS "id", 'name' AS "name", 'payload' AS "payload"
             """
         ),
         dialect="snowflake",
@@ -1259,10 +1260,9 @@ def test_case_sensitivity(assert_exp_eq):
           "SOURCE"."payload" AS "payload"
         FROM (
           SELECT
-            "id" AS "id",
-            "name" AS "name",
-            "payload" AS "payload"
-          FROM "DB"."SCHEMA"."table" AS "table"
+            'id' AS "id",
+            'name' AS "name",
+            'payload' AS "payload"
         ) AS "SOURCE"
         """,
     )
@@ -1414,3 +1414,45 @@ def test_update_schema():
         "table_a": {"a": "INT"},
         "table_b": {"b": "INT"},
     }
+
+
+def test_user_provided_depends_on():
+    expressions = d.parse(
+        """
+        MODEL (name db.table, depends_on [table_b]);
+
+        SELECT a FROM table_a
+        """
+    )
+
+    model = load_model(expressions)
+
+    assert model.depends_on == {"table_a", "table_b"}
+
+
+def test_check_schema_mapping_when_rendering_at_runtime(assert_exp_eq):
+    expressions = d.parse(
+        """
+        MODEL (name db.table, depends_on [table_b]);
+
+        SELECT * FROM table_a JOIN table_b
+        """
+    )
+
+    model = load_model(expressions)
+
+    # Simulate a query that cannot be rendered at parse time.
+    with patch.object(SqlModel, "render_query", return_value=None) as render_query_mock:
+        schema = MappingSchema(normalize=False)
+        schema.add_table("table_b", {"b": exp.DataType.build("int")})
+        model.update_schema(schema)
+
+    assert "table_b" in model.mapping_schema
+    assert model.depends_on == {"table_b"}
+
+    render_query_mock.assert_called_once()
+
+    # Simulate rendering at runtime.
+    assert_exp_eq(
+        model.render_query(), """SELECT * FROM "table_a" AS "table_a", "table_b" AS "table_b" """
+    )


### PR DESCRIPTION
Since the column-to-types mapping is now optional there doesn't seem to be much reason to prohibit `SELECT *` queries in models that reference external tables.

With this update we assume that we don't have a mapping available if we identify a `*` projection in the rendered / optimized query.