### PR TITLE
Feat: Remove restriction on Databricks concurrent tasks

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -185,9 +185,7 @@ class DatabricksConnectionConfig(_ConnectionConfig):
     force_databricks_connect: bool = False
     disable_databricks_connect: bool = False
 
-    # Concurrent tasks can cause an issue due to simultaneous updates to intervals.
-    # Bump this back up when the separate table for intervals is implemented.
-    concurrent_tasks: Literal[1] = 1
+    concurrent_tasks: int = 1
 
     type_: Literal["databricks"] = Field(alias="type", default="databricks")
 


### PR DESCRIPTION
With intervals now in a separate table the number of updates is significantly reduced and therefore it should be possible to enable concurrent tasks for Delta tables. Still defaulting to one until we can do some testing to verify this isn't an issue.