### PR TITLE
Feat: Add ability to invalidate the environment

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -259,6 +259,16 @@ def run(ctx: click.Context, environment: t.Optional[str] = None, **kwargs: t.Any
     context.run(environment, **kwargs)
 
 
+@cli.command("invalidate")
+@click.argument("environment", required=True)
+@click.pass_context
+@error_handler
+def invalidate(ctx: click.Context, environment: str) -> None:
+    """Invalidates the target environment, forcing its removal during the next run of the janitor process."""
+    context = ctx.obj
+    context.invalidate_environment(environment)
+
+
 @cli.command("dag")
 @opt.file
 @click.pass_context

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -207,10 +207,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         if name == c.PROD:
             raise SQLMeshError("Cannot invalidate the production environment.")
 
-        filter_expr = exp.EQ(
-            this=exp.to_column("name"),
-            expression=exp.Literal.string(name),
-        )
+        filter_expr = exp.to_column("name").eq(name)
 
         self.engine_adapter.update_table(
             self.environments_table,

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -18,7 +18,6 @@ from sqlmesh.core import constants as c
 from sqlmesh.core.console import MarkdownConsole
 from sqlmesh.core.context import Context
 from sqlmesh.core.environment import Environment
-from sqlmesh.core.model import parse_model_name
 from sqlmesh.core.plan import LoadedSnapshotIntervals, Plan
 from sqlmesh.core.user import User
 from sqlmesh.utils.date import now
@@ -407,15 +406,7 @@ class GithubController:
         """
         Deletes all the schemas for a given environment by checking all the schemas used by models.
         """
-        schemas = {parse_model_name(model.name)[1] for model in self._context.models.values()}
-        for schema in schemas:
-            assert schema
-            self._context.engine_adapter.drop_schema(
-                schema_name="__".join([schema, self.pr_environment_name]),
-                ignore_if_not_exists=True,
-                cascade=True,
-            )
-        return
+        self._context.invalidate_environment(self.pr_environment_name)
 
     def get_loaded_snapshot_intervals(self) -> t.List[LoadedSnapshotIntervals]:
         return self.prod_plan_with_gaps.loaded_snapshot_intervals

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -404,7 +404,7 @@ class GithubController:
 
     def delete_pr_environment(self) -> None:
         """
-        Deletes all the schemas for a given environment by checking all the schemas used by models.
+        Marks the PR environment for garbage collection.
         """
         self._context.invalidate_environment(self.pr_environment_name)
 

--- a/sqlmesh/schedulers/airflow/api.py
+++ b/sqlmesh/schedulers/airflow/api.py
@@ -67,6 +67,20 @@ def get_environments() -> Response:
     return _success(common.EnvironmentsResponse(environments=environments))
 
 
+@sqlmesh_api_v1.delete("/environments/<name>")
+@csrf.exempt
+@check_authentication
+def invalidate_environment(name: str) -> Response:
+    name = name.lower()
+    if name == c.PROD:
+        return _error("Cannot invalidate production environment", 400)
+
+    with util.scoped_state_sync() as state_sync:
+        state_sync.invalidate_environment(name)
+
+    return _success(common.InvalidateEnvironmentResponse(name=name))
+
+
 @sqlmesh_api_v1.get("/snapshots")
 @csrf.exempt
 @check_authentication

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -132,6 +132,12 @@ class AirflowClient:
         response = self._get(ENVIRONMENTS_PATH)
         return common.EnvironmentsResponse.parse_obj(response).environments
 
+    def invalidate_environment(self, environment: str) -> None:
+        response = self._session.delete(
+            urljoin(self._airflow_url, f"{ENVIRONMENTS_PATH}/{environment}")
+        )
+        self._raise_for_status(response)
+
     def get_versions(self) -> Versions:
         return Versions.parse_obj(self._get(VERSIONS_PATH))
 

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -100,6 +100,10 @@ class ExistingModelsResponse(PydanticModel):
     names: t.List[str]
 
 
+class InvalidateEnvironmentResponse(PydanticModel):
+    name: str
+
+
 def snapshot_key(snapshot: SnapshotIdLike) -> str:
     return snapshot_key_from_name_identifier(snapshot.name, snapshot.identifier)
 

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -9,17 +9,22 @@ from sqlmesh.core.snapshot import (
     Snapshot,
     SnapshotId,
     SnapshotIdLike,
+    SnapshotInfoLike,
     SnapshotIntervals,
     SnapshotNameVersion,
     SnapshotNameVersionLike,
+    SnapshotTableInfo,
 )
-from sqlmesh.core.state_sync import StateReader, Versions
+from sqlmesh.core.state_sync import StateSync, Versions
 from sqlmesh.schedulers.airflow.client import AirflowClient
+
+if t.TYPE_CHECKING:
+    from sqlmesh.utils.date import TimeLike
 
 logger = logging.getLogger(__name__)
 
 
-class HttpStateReader(StateReader):
+class HttpStateSync(StateSync):
     """Reads state of models and snapshot through the Airflow REST API.
 
     Args:
@@ -133,3 +138,162 @@ class HttpStateReader(StateReader):
             The versions object.
         """
         return self._client.get_versions()
+
+    def push_snapshots(self, snapshots: t.Iterable[Snapshot]) -> None:
+        """Push snapshots into the state sync.
+
+        This method only allows for pushing new snapshots. If existing snapshots are found,
+        this method should raise an error.
+
+        Raises:
+            SQLMeshError when existing snapshots are pushed.
+
+        Args:
+            snapshots: A list of snapshots to save in the state sync.
+        """
+        raise NotImplementedError("Pushing snapshots is not supported by the Airflow state sync.")
+
+    def delete_snapshots(self, snapshot_ids: t.Iterable[SnapshotIdLike]) -> None:
+        """Delete snapshots from the state sync.
+
+        Args:
+            snapshot_ids: A list of snapshot like objects to delete.
+        """
+        raise NotImplementedError("Deleting snapshots is not supported by the Airflow state sync.")
+
+    def delete_expired_snapshots(self) -> t.List[Snapshot]:
+        """Removes expired snapshots.
+
+        Expired snapshots are snapshots that have exceeded their time-to-live
+        and are no longer in use within an environment.
+
+        Returns:
+            The list of removed snapshots.
+        """
+        raise NotImplementedError(
+            "Deleting expired snapshots is not supported by the Airflow state sync."
+        )
+
+    def invalidate_environment(self, name: str) -> None:
+        """Invalidates the target environment by setting its expiration timestamp to now.
+
+        Args:
+            name: The name of the environment to invalidate.
+        """
+        self._client.invalidate_environment(name)
+
+    def add_interval(
+        self,
+        snapshot: Snapshot,
+        start: TimeLike,
+        end: TimeLike,
+        is_dev: bool = False,
+    ) -> None:
+        """Add an interval to a snapshot and sync it to the store.
+
+        Snapshots must be pushed before adding intervals to them.
+
+        Args:
+            snapshot: The snapshot like object to add an interval to.
+            start: The start of the interval to add.
+            end: The end of the interval to add.
+            is_dev: Indicates whether the given interval is being added while in
+                development mode.
+        """
+        raise NotImplementedError("Adding intervals is not supported by the Airflow state sync.")
+
+    def remove_interval(
+        self,
+        snapshots: t.Iterable[SnapshotInfoLike],
+        start: TimeLike,
+        end: TimeLike,
+        all_snapshots: t.Optional[t.Iterable[Snapshot]] = None,
+    ) -> None:
+        """Remove an interval from a list of snapshots and sync it to the store.
+
+        Because multiple snapshots can be pointing to the same version or physical table, this method
+        can also grab all snapshots tied to the passed in version.
+
+        Args:
+            snapshots: The snapshot info like object to remove intervals from.
+            start: The start of the interval to add.
+            end: The end of the interval to add.
+            all_snapshots: All snapshots can be passed in to skip fetching matching snapshot versions.
+        """
+        raise NotImplementedError("Removing intervals is not supported by the Airflow state sync.")
+
+    def promote(
+        self, environment: Environment, no_gaps: bool = False
+    ) -> t.Tuple[t.List[SnapshotTableInfo], t.List[SnapshotTableInfo]]:
+        """Update the environment to reflect the current state.
+
+        This method verifies that snapshots have been pushed.
+
+        Args:
+            environment: The environment to promote.
+            no_gaps:  Whether to ensure that new snapshots for models that are already a
+                part of the target environment have no data gaps when compared against previous
+                snapshots for same models.
+
+        Returns:
+           A tuple of (added snapshot table infos, removed snapshot table infos)
+        """
+        raise NotImplementedError(
+            "Promoting environments is not supported by the Airflow state sync."
+        )
+
+    def finalize(self, environment: Environment) -> None:
+        """Finalize the target environment, indicating that this environment has been
+        fully promoted and is ready for use.
+
+        Args:
+            environment: The target environment to finalize.
+        """
+        raise NotImplementedError(
+            "Finalizing environments is not supported by the Airflow state sync."
+        )
+
+    def delete_expired_environments(self) -> t.List[Environment]:
+        """Removes expired environments.
+
+        Expired environments are environments that have exceeded their time-to-live value.
+
+        Returns:
+            The list of removed environments.
+        """
+        raise NotImplementedError(
+            "Deleting expired environments is not supported by the Airflow state sync."
+        )
+
+    def unpause_snapshots(
+        self, snapshots: t.Iterable[SnapshotInfoLike], unpaused_dt: TimeLike
+    ) -> None:
+        """Unpauses target snapshots.
+
+        Unpaused snapshots are scheduled for evaluation on a recurring basis.
+        Once unpaused a snapshot can't be paused again.
+
+        Args:
+            snapshots: Target snapshots.
+            unpaused_dt: The datetime object which indicates when target snapshots
+                were unpaused.
+        """
+        raise NotImplementedError("Unpausing snapshots is not supported by the Airflow state sync.")
+
+    def compact_intervals(self) -> None:
+        """Compacts intervals for all snapshots.
+
+        Compaction process involves merging of existing interval records into new records and
+        then deleting the old ones.
+        """
+        raise NotImplementedError(
+            "Compacting intervals is not supported by the Airflow state sync."
+        )
+
+    def migrate(self, skip_backup: bool = False) -> None:
+        """Migrate the state sync to the latest SQLMesh / SQLGlot version."""
+        raise NotImplementedError("Migration is not supported by the Airflow state sync.")
+
+    def rollback(self) -> None:
+        """Rollback to previous backed up state."""
+        raise NotImplementedError("Rollback is not supported by the Airflow state sync.")

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -119,14 +119,9 @@ def test_delete_pr_environment(
     github_pr_synchronized_approvers_controller: GithubController, mocker: MockerFixture
 ):
     controller = github_pr_synchronized_approvers_controller
-    controller._context._engine_adapter = mock_engine_adapter = mocker.MagicMock()
+    controller._context._state_sync = mock_state_sync = mocker.MagicMock()
     controller.delete_pr_environment()
-    assert sorted(mock_engine_adapter.method_calls, key=str) == [
-        call.drop_schema(schema_name="raw__hello_world_2", ignore_if_not_exists=True, cascade=True),
-        call.drop_schema(
-            schema_name="sushi__hello_world_2", ignore_if_not_exists=True, cascade=True
-        ),
-    ]
+    mock_state_sync.invalidate_environment.assert_called_once_with("hello_world_2")
 
 
 def test_merge_pr(

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -287,3 +287,18 @@ def test_get_dag_run_state(mocker: MockerFixture):
     get_snapshot_mock.assert_called_once_with(
         "http://localhost:8080/api/v1/dags/test_dag_id/dagRuns/test_dag_run_id"
     )
+
+
+def test_invalidat_environment(mocker: MockerFixture):
+    delete_environment_response_mock = mocker.Mock()
+    delete_environment_response_mock.status_code = 200
+    delete_environment_response_mock.json.return_value = {"name": "test_environment"}
+    delete_environment_mock = mocker.patch("requests.Session.delete")
+    delete_environment_mock.return_value = delete_environment_response_mock
+
+    client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
+    client.invalidate_environment("test_environment")
+
+    delete_environment_mock.assert_called_once_with(
+        "http://localhost:8080/sqlmesh/api/v1/environments/test_environment"
+    )


### PR DESCRIPTION
This update allows user to invalidate the target environment by setting its expiration timestamp to now, forcing it to be garbage collected during a subsequent run of the janitor process.

CC: @z3z1ma 