### PR TITLE
Fix: Validate model definition only after the schema for it is set

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -294,6 +294,8 @@ class Context(BaseContext):
         self.dag.add(model.name, model.depends_on)
         update_model_schemas(self.dag, self._models, self.path)
 
+        model.validate_definition()
+
         return model
 
     def scheduler(self, environment: t.Optional[str] = None) -> Scheduler:

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -125,6 +125,10 @@ class Loader(abc.ABC):
         if update_schemas:
             update_model_schemas(self._dag, models, self._context.path)
 
+        for model in models.values():
+            # The model definition can be validated correctly only after the schema is set.
+            model.validate_definition()
+
         audits = self._load_audits()
 
         project = LoadedProject(

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1489,7 +1489,6 @@ def _create_model(
 
     model._path = path
     model.set_time_format(time_column_format)
-    model.validate_definition()
 
     return t.cast(Model, model)
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -553,9 +553,6 @@ class _Model(ModelMeta, frozen=True):
     def validate_definition(self) -> None:
         """Validates the model's definition.
 
-        Model's are not allowed to have duplicate column names, non-explicitly casted columns,
-        or non infererrable column names.
-
         Raises:
             ConfigError
         """
@@ -808,7 +805,7 @@ class SqlModel(_SqlBasedModel):
         self._query_renderer._optimized_cache = {}
 
     def validate_definition(self) -> None:
-        query = self._query_renderer.render(optimize=False)
+        query = self._query_renderer.render()
 
         if query is None:
             if self.depends_on_ is None:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -156,8 +156,9 @@ def test_model_validation(query, error):
         """
     )
 
+    model = load_model(expressions)
     with pytest.raises(ConfigError) as ex:
-        load_model(expressions)
+        model.validate_definition()
     assert error in str(ex.value)
 
 
@@ -188,8 +189,9 @@ def test_model_validation_union_query():
         """
     )
 
+    model = load_model(expressions)
     with pytest.raises(ConfigError, match=r"Found duplicate outer select name 'a'"):
-        load_model(expressions)
+        model.validate_definition()
 
 
 def test_partitioned_by():
@@ -280,8 +282,9 @@ def test_partition_key_is_missing_in_query():
     """
     )
 
+    model = load_model(expressions)
     with pytest.raises(ConfigError) as ex:
-        load_model(expressions)
+        model.validate_definition()
     assert "['c', 'd'] are missing" in str(ex.value)
 
 
@@ -1411,11 +1414,12 @@ def test_no_depends_on_runtime_jinja_query():
         """
     )
 
+    model = load_model(expressions)
     with pytest.raises(
         ConfigError,
         match=r"Dependencies must be provided explicitly for models that can be rendered only at runtime at.*",
     ):
-        load_model(expressions)
+        model.validate_definition()
 
 
 def test_update_schema():


### PR DESCRIPTION
Validating definition requires the columns-to-types mapping which in turn relies on the rendered optimized query. The latter cannot be produced correctly without setting the schema first.