### PR TITLE
Fix: Various Databricks related fixes

### DIFF
--- a/docs/integrations/engines.md
+++ b/docs/integrations/engines.md
@@ -87,7 +87,7 @@ Note: If using Databricks Connect please note the [requirements](https://docs.da
 | `server_hostname`                    | Databricks instance host name                                                                                                                                                            | string |    N     |
 | `http_path`                          | HTTP path, either to a DBSQL endpoint (such as `/sql/1.0/endpoints/1234567890abcdef`) or to a DBR interactive cluster (such as `/sql/protocolv1/o/1234567890123456/1234-123456-slid123`) | string |    N     |
 | `access_token`                       | HTTP Bearer access token, such as Databricks Personal Access Token                                                                                                                       | string |    N     |
-| `catalog`                            | The name of the catalog to use for the connection. Defaults to use Databricks cluster default (most likely `hive_metastore`).                                                            | string |    N     |
+| `catalog`                            | Spark 3.4+ Only. The name of the catalog to use for the connection. Defaults to use Databricks cluster default (most likely `hive_metastore`).                                           | string |    N     |
 | `http_headers`                       | SQL Connector Only: An optional dictionary of HTTP headers that will be set on every request                                                                                             |  dict  |    N     |
 | `databricks_connect_server_hostname` | Databricks Connect Only: Databricks Connect server hostname. Uses `server_hostname` if not set.                                                                                          | string |    N     |
 | `databricks_connect_access_token`    | Databricks Connect Only: Databricks Connect access token. Uses `access_token` if not set.                                                                                                | string |    N     |
@@ -297,11 +297,11 @@ sqlmesh_airflow = SQLMeshAirflow(
 ## Spark - Local/Built-in Scheduler
 **Engine Adapter Type**: `spark`
 
-| Option          | Description                                          |  Type  | Required |
-|-----------------|------------------------------------------------------|:------:|:--------:|
-| `config_dir`    | Value to set for `SPARK_CONFIG_DIR`                  | string |    N     |
-| `catalog`       | The catalog to use when issuing commands             | string |    N     |
-| `config`        | Key/value pairs to set for the Spark Configuration.  |  dict  |    N     |
+| Option          | Description                                               |  Type  | Required |
+|-----------------|-----------------------------------------------------------|:------:|:--------:|
+| `config_dir`    | Value to set for `SPARK_CONFIG_DIR`                       | string |    N     |
+| `catalog`       | Spark 3.4+ Only. The catalog to use when issuing commands | string |    N     |
+| `config`        | Key/value pairs to set for the Spark Configuration.       |  dict  |    N     |
 
 ## Spark - Airflow Scheduler
 **Engine Name:** `spark`

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -632,9 +632,10 @@ class EngineAdapter:
     ) -> None:
         table = exp.to_table(table_name)
         if (
-            self.INSERT_OVERWRITE_STRATEGY.is_delete_insert
-            or self.INSERT_OVERWRITE_STRATEGY.is_replace_where
-        ) and not where:
+            self.INSERT_OVERWRITE_STRATEGY
+            in (InsertOverwriteStrategy.DELETE_INSERT, InsertOverwriteStrategy.REPLACE_WHERE)
+            and not where
+        ):
             raise SQLMeshError(
                 "Where condition is required when doing a delete/insert or replace/where for insert/overwrite"
             )

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -102,6 +102,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
             ).getOrCreate()
             catalog = self._extra_config.get("catalog")
             if catalog:
+                # Note: Spark 3.4+ Only API
                 self._spark.catalog.setCurrentCatalog(catalog)
         return self._spark
 

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 class DatabricksEngineAdapter(SparkEngineAdapter):
     DIALECT = "databricks"
+    SUPPORTS_INSERT_OVERWRITE = False
     SCHEMA_DIFFER = SchemaDiffer(
         support_positional_add=True,
         support_nested_operations=True,

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -100,7 +100,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
             ).getOrCreate()
             catalog = self._extra_config.get("catalog")
             if catalog:
-                self._spark.sql(f"USE CATALOG {catalog}")
+                self._spark.catalog.setCurrentCatalog(catalog)
         return self._spark
 
     def _fetch_native_df(self, query: t.Union[exp.Expression, str]) -> DF:

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -6,6 +6,7 @@ import typing as t
 import pandas as pd
 from sqlglot import Dialect, exp
 
+from sqlmesh.core.engine_adapter.base import InsertOverwriteStrategy
 from sqlmesh.core.engine_adapter.spark import SparkEngineAdapter
 from sqlmesh.core.schema_diff import SchemaDiffer
 from sqlmesh.utils import classproperty
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 class DatabricksEngineAdapter(SparkEngineAdapter):
     DIALECT = "databricks"
-    SUPPORTS_INSERT_OVERWRITE = False
+    INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.REPLACE_WHERE
     SCHEMA_DIFFER = SchemaDiffer(
         support_positional_add=True,
         support_nested_operations=True,

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -20,7 +20,8 @@ logger = logging.getLogger(__name__)
 
 class DatabricksEngineAdapter(SparkEngineAdapter):
     DIALECT = "databricks"
-    INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.REPLACE_WHERE
+    # Change to REPLACE WHERE once column bug is fixed
+    INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.DELETE_INSERT
     SCHEMA_DIFFER = SchemaDiffer(
         support_positional_add=True,
         support_nested_operations=True,

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -5,7 +5,7 @@ import typing as t
 import pandas as pd
 from sqlglot import exp
 
-from sqlmesh.core.engine_adapter.base import EngineAdapter
+from sqlmesh.core.engine_adapter.base import EngineAdapter, InsertOverwriteStrategy
 from sqlmesh.core.engine_adapter.shared import (
     DataObject,
     DataObjectType,
@@ -28,7 +28,7 @@ if t.TYPE_CHECKING:
 class SparkEngineAdapter(EngineAdapter):
     DIALECT = "spark"
     ESCAPE_JSON = True
-    SUPPORTS_INSERT_OVERWRITE = True
+    INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
 
     @property
     def spark(self) -> PySparkSession:

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -191,7 +191,7 @@ class SparkEngineAdapter(EngineAdapter):
         # Note: Some storage formats (like Delta and Iceberg) support REPLACE TABLE but since we don't
         # currently check for storage formats we will just do an insert/overwrite.
         return self._insert_overwrite_by_condition(
-            table_name, query_or_df, columns_to_types=columns_to_types
+            table_name, query_or_df, columns_to_types=columns_to_types, where=exp.condition("1=1")
         )
 
     def create_state_table(

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -33,6 +33,7 @@ from sqlglot.executor import execute
 
 from sqlmesh.core.audit import BUILT_IN_AUDITS, AuditResult
 from sqlmesh.core.engine_adapter import EngineAdapter, TransactionType
+from sqlmesh.core.engine_adapter.base import InsertOverwriteStrategy
 from sqlmesh.core.model import Model, ViewKind
 from sqlmesh.core.snapshot import (
     Snapshot,
@@ -158,9 +159,10 @@ class SnapshotEvaluator:
             # Note: We assume that if multiple things are yielded from `queries_or_dfs` that they are dataframes
             # and not SQL expressions.
             elif (
-                self.adapter.INSERT_OVERWRITE_STRATEGY.is_insert_overwrite
-                or self.adapter.INSERT_OVERWRITE_STRATEGY.is_replace_where
-            ) and snapshot.is_incremental_by_time_range:
+                self.adapter.INSERT_OVERWRITE_STRATEGY
+                in (InsertOverwriteStrategy.INSERT_OVERWRITE, InsertOverwriteStrategy.REPLACE_WHERE)
+                and snapshot.is_incremental_by_time_range
+            ):
                 query_or_df = reduce(
                     lambda a, b: a.union_all(b)  # type: ignore
                     if self.adapter.is_pyspark_df(a)

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -158,9 +158,9 @@ class SnapshotEvaluator:
             # Note: We assume that if multiple things are yielded from `queries_or_dfs` that they are dataframes
             # and not SQL expressions.
             elif (
-                self.adapter.INSERT_OVERWRITE_STRATEGY.is_not_delete_insert
-                and snapshot.is_incremental_by_time_range
-            ):
+                self.adapter.INSERT_OVERWRITE_STRATEGY.is_insert_overwrite
+                or self.adapter.INSERT_OVERWRITE_STRATEGY.is_replace_where
+            ) and snapshot.is_incremental_by_time_range:
                 query_or_df = reduce(
                     lambda a, b: a.union_all(b)  # type: ignore
                     if self.adapter.is_pyspark_df(a)

--- a/sqlmesh/engines/spark/db_api/spark_session.py
+++ b/sqlmesh/engines/spark/db_api/spark_session.py
@@ -72,7 +72,7 @@ class SparkSessionConnection:
             # Databricks Connect does not support accessing the SparkContext
             pass
         if self.catalog:
-            self.spark.sql(f"USE CATALOG {self.catalog}")
+            self.spark.catalog.setCurrentCatalog(self.catalog)
         return SparkSessionCursor(self.spark)
 
     def commit(self) -> None:

--- a/sqlmesh/engines/spark/db_api/spark_session.py
+++ b/sqlmesh/engines/spark/db_api/spark_session.py
@@ -72,6 +72,7 @@ class SparkSessionConnection:
             # Databricks Connect does not support accessing the SparkContext
             pass
         if self.catalog:
+            # Note: Spark 3.4+ Only API
             self.spark.catalog.setCurrentCatalog(self.catalog)
         return SparkSessionCursor(self.spark)
 

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -1,4 +1,6 @@
 # type: ignore
+from unittest.mock import call
+
 import pandas as pd
 from pytest_mock.plugin import MockerFixture
 from sqlglot import parse_one
@@ -14,8 +16,11 @@ def test_replace_query(mocker: MockerFixture):
     adapter = DatabricksEngineAdapter(lambda: connection_mock)
     adapter.replace_query("test_table", parse_one("SELECT a FROM tbl"), {"a": "int"})
 
-    cursor_mock.execute.assert_called_once_with(
-        "INSERT OVERWRITE TABLE test_table (a) SELECT a FROM tbl"
+    cursor_mock.execute.assert_has_calls(
+        [
+            call("DELETE FROM test_table WHERE 1 = 1"),
+            call("INSERT INTO test_table (a) SELECT a FROM tbl"),
+        ]
     )
 
 
@@ -28,6 +33,11 @@ def test_replace_query_pandas(mocker: MockerFixture):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.replace_query("test_table", df, {"a": "int", "b": "int"})
 
-    cursor_mock.execute.assert_called_once_with(
-        "INSERT OVERWRITE TABLE test_table (a, b) SELECT CAST(a AS INT) AS a, CAST(b AS INT) AS b FROM VALUES (1, 4), (2, 5), (3, 6) AS test_table(a, b)"
+    cursor_mock.execute.assert_has_calls(
+        [
+            call("DELETE FROM test_table WHERE 1 = 1"),
+            call(
+                "INSERT INTO test_table (a, b) SELECT CAST(a AS INT) AS a, CAST(b AS INT) AS b FROM VALUES (1, 4), (2, 5), (3, 6) AS t(a, b)"
+            ),
+        ]
     )

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -7,6 +7,7 @@ from sqlglot import expressions as exp
 from sqlglot import parse, parse_one
 
 from sqlmesh.core.engine_adapter import EngineAdapter, create_engine_adapter
+from sqlmesh.core.engine_adapter.base import InsertOverwriteStrategy
 from sqlmesh.core.macros import macro
 from sqlmesh.core.model import (
     IncrementalByTimeRangeKind,
@@ -498,7 +499,7 @@ def test_audit_unversioned(mocker: MockerFixture, adapter_mock, make_snapshot):
 )
 def test_snapshot_evaluator_yield_pd(adapter_mock, make_snapshot, input_dfs, output_dict):
     adapter_mock.is_pyspark_df.return_value = False
-    adapter_mock.SUPPORTS_INSERT_OVERWRITE = True
+    adapter_mock.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
     adapter_mock.try_get_df = lambda x: x
     evaluator = SnapshotEvaluator(adapter_mock)
 


### PR DESCRIPTION
Note: This PR has Databricks do a non-transactional delete + insert due to issues with dynamic insert/overwrite on Unity catalog tables. Once a `REPLACE WHERE` bug is fixed we will be switching to that which will make it atomic again. 

The `USE CATALOG` approach from before only worked if SQL was being executed. So if you had a Dataframe then that catalog would not be used. The `setCurrentCatalog` works across both SQL and Dataframe API. 