### PR TITLE
Feat: Introduce config env_vars

### DIFF
--- a/sqlmesh/core/config/__init__.py
+++ b/sqlmesh/core/config/__init__.py
@@ -10,7 +10,7 @@ from sqlmesh.core.config.connection import (
     SparkConnectionConfig,
 )
 from sqlmesh.core.config.gateway import GatewayConfig
-from sqlmesh.core.config.loader import load_config_from_paths
+from sqlmesh.core.config.loader import load_config_from_paths, load_config_from_yaml
 from sqlmesh.core.config.model import ModelDefaultsConfig
 from sqlmesh.core.config.root import Config
 from sqlmesh.core.config.scheduler import AirflowSchedulerConfig, BuiltInSchedulerConfig

--- a/sqlmesh/core/config/loader.py
+++ b/sqlmesh/core/config/loader.py
@@ -13,7 +13,10 @@ from sqlmesh.utils.yaml import load as yaml_load
 
 
 def load_config_from_paths(
-    *paths: Path, config_name: str = "config", load_from_env: bool = True
+    *paths: Path,
+    config_name: str = "config",
+    load_from_env: bool = True,
+    config_defaults: Config | None = None,
 ) -> Config:
     config: t.Optional[Config] = None
 
@@ -34,7 +37,7 @@ def load_config_from_paths(
         if extension in ("yml", "yaml"):
             if config_name != "config":
                 raise ConfigError(
-                    f"YAML configs do not support multiple configs. Use Python instead."
+                    "YAML configs do not support multiple configs. Use Python instead."
                 )
             next_config = load_config_from_yaml(path)
         elif extension == "py":
@@ -53,6 +56,9 @@ def load_config_from_paths(
 
     if load_from_env:
         config = config.update_with(load_config_from_env())
+
+    if config_defaults:
+        config = config_defaults.update_with(config)
 
     return config
 

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -55,6 +55,7 @@ class Config(BaseConfig):
     users: t.List[User] = []
     model_defaults: ModelDefaultsConfig = ModelDefaultsConfig()
     loader: t.Type[Loader] = SqlMeshLoader
+    env_vars: t.Dict[str, str] = {}
 
     _FIELD_UPDATE_STRATEGY: t.ClassVar[t.Dict[str, UpdateStrategy]] = {
         "gateways": UpdateStrategy.KEY_UPDATE,

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 import re
 import sys
 import time
@@ -218,3 +219,16 @@ class classproperty(property):
 
     def __get__(self, obj: t.Any, owner: t.Any = None) -> t.Any:
         return classmethod(self.fget).__get__(None, owner)()  # type: ignore
+
+
+@contextmanager
+def env_vars(environ: dict[str, str]) -> t.Iterator[None]:
+    """A context manager to temporarily modify environment variables."""
+    old_environ = os.environ.copy()
+    os.environ.update(environ)
+
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)


### PR DESCRIPTION
This PR allows users to set environment variables for their SQLMesh project configs in their `~/.sqlmesh/` config defaults. This is useful for variables like user tokens, keys, passwords, etc.