### PR TITLE
Fix: Map relations to snapshot physical tables in the dbt adapter

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -94,9 +94,8 @@ class BigQueryEngineAdapter(EngineAdapter):
         try:
             super().create_schema(schema_name, ignore_if_exists=ignore_if_exists)
         except Conflict as e:
-            for arg in e.args:
-                if ignore_if_exists and "Already Exists: " in arg.message:
-                    return
+            if "Already Exists:" in str(e):
+                return
             raise e
 
     def columns(

--- a/tests/dbt/conftest.py
+++ b/tests/dbt/conftest.py
@@ -22,9 +22,9 @@ def sushi_test_project() -> Project:
 
 @pytest.fixture()
 def runtime_renderer() -> t.Callable:
-    def create_renderer(context: DbtContext) -> t.Callable:
+    def create_renderer(context: DbtContext, **kwargs: t.Any) -> t.Callable:
         environment = context.jinja_macros.build_environment(
-            **context.jinja_globals, engine_adapter=context.engine_adapter
+            **context.jinja_globals, **kwargs, engine_adapter=context.engine_adapter
         )
 
         def render(value: str) -> str:


### PR DESCRIPTION
Sometimes `ref` are passed into the dbt adapter while constructing a model query. This means that the production table name will be used since jinja rendering happens before we get a chance to resolve table references. 

This update ensures that dbt's `ref` returns resolved table references when using adapter.