### PR TITLE
Fix: Enforce dynamic INSERT/OVERWRITE and make Databricks INSERT/OVERWRITE

### DIFF
--- a/docs/integrations/engines.md
+++ b/docs/integrations/engines.md
@@ -71,14 +71,15 @@ sqlmesh_airflow = SQLMeshAirflow(
 ## Databricks - Local/Built-in Scheduler
 **Engine Adapter Type**: `databricks`
 
-SQLMesh's Databricks implementation uses the [Databricks SQL Connector](https://docs.databricks.com/dev-tools/python-sql-connector.html) to connect to Databricks by default.
+If you are always running SQLMesh commands directly on a Databricks Cluster (like in a Databricks Notebook) then the only relevant configuration is `catalog` and it is optional.
+The SparkSession provided by Databricks will be used to execute all SQLMesh commands.
+
+Otherwise SQLMesh's Databricks implementation uses the [Databricks SQL Connector](https://docs.databricks.com/dev-tools/python-sql-connector.html) to connect to Databricks by default.
 If your project contains PySpark DataFrames in Python models then it will use [Databricks Connect](https://docs.databricks.com/dev-tools/databricks-connect.html) to connect to Databricks.
 SQLMesh's Databricks Connect implementation supports Databricks Runtime 13.0 or higher. If SQLMesh detects you have Databricks Connect installed then it will use it for all Python models (so both Pandas and PySpark DataFrames).
 
 Databricks connect execution can be routed to a different cluster than the SQL Connector by setting the `databricks_connect_*` properties.
 For example this allows SQLMesh to be configured to run SQL on a [Databricks SQL Warehouse](https://docs.databricks.com/sql/admin/create-sql-warehouse.html) while still routing DataFrame operations to a normal Databricks Cluster. 
-
-If you are always running SQLMesh commands directly on a Databricks Cluster (like in a Databricks Notebook) then the only relevant configuration is `catalog` and it is optional.
 
 Note: If using Databricks Connect please note the [requirements](https://docs.databricks.com/dev-tools/databricks-connect.html#requirements) and [limitations](https://docs.databricks.com/dev-tools/databricks-connect.html#limitations)
 
@@ -87,8 +88,9 @@ Note: If using Databricks Connect please note the [requirements](https://docs.da
 | `server_hostname`                    | Databricks instance host name                                                                                                                                                            | string |    N     |
 | `http_path`                          | HTTP path, either to a DBSQL endpoint (such as `/sql/1.0/endpoints/1234567890abcdef`) or to a DBR interactive cluster (such as `/sql/protocolv1/o/1234567890123456/1234-123456-slid123`) | string |    N     |
 | `access_token`                       | HTTP Bearer access token, such as Databricks Personal Access Token                                                                                                                       | string |    N     |
-| `catalog`                            | Spark 3.4+ Only. The name of the catalog to use for the connection. Defaults to use Databricks cluster default (most likely `hive_metastore`).                                           | string |    N     |
+| `catalog`                            | Spark 3.4+ Only if not using SQL Connector. The name of the catalog to use for the connection. Defaults to use Databricks cluster default (most likely `hive_metastore`).                | string |    N     |
 | `http_headers`                       | SQL Connector Only: An optional dictionary of HTTP headers that will be set on every request                                                                                             |  dict  |    N     |
+| `session_configuration`              | SQL Connector Only: An optional dictionary of Spark session parameters. Execute the SQL command `SET -v` to get a full list of available commands.                                       |  dict  |    N     |
 | `databricks_connect_server_hostname` | Databricks Connect Only: Databricks Connect server hostname. Uses `server_hostname` if not set.                                                                                          | string |    N     |
 | `databricks_connect_access_token`    | Databricks Connect Only: Databricks Connect access token. Uses `access_token` if not set.                                                                                                | string |    N     |
 | `databricks_connect_cluster_id`      | Databricks Connect Only: Databricks Connect cluster ID. Uses `http_path` if not set. Cannot be a Databricks SQL Warehouse.                                                               | string |    N     |

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -159,17 +159,19 @@ class DatabricksConnectionConfig(_ConnectionConfig):
     Args:
         server_hostname: Databricks instance host name.
         http_path: Http path either to a DBSQL endpoint (e.g. /sql/1.0/endpoints/1234567890abcdef)
-                   or to a DBR interactive cluster (e.g. /sql/protocolv1/o/1234567890123456/1234-123456-slid123)
+            or to a DBR interactive cluster (e.g. /sql/protocolv1/o/1234567890123456/1234-123456-slid123)
         access_token: Http Bearer access token, e.g. Databricks Personal Access Token.
         catalog: Default catalog to use for SQL models. Defaults to None which means it will use the default set in
-                 the Databricks cluster (most likely `hive_metastore`).
+            the Databricks cluster (most likely `hive_metastore`).
         http_headers: An optional list of (k, v) pairs that will be set as Http headers on every request
+        session_configuration: An optional dictionary of Spark session parameters.
+            Execute the SQL command `SET -v` to get a full list of available commands.
         databricks_connect_server_hostname: The hostname to use when establishing a connecting using Databricks Connect.
-                   Defaults to the `server_hostname` value.
+            Defaults to the `server_hostname` value.
         databricks_connect_access_token: The access token to use when establishing a connecting using Databricks Connect.
-                   Defaults to the `access_token` value.
+            Defaults to the `access_token` value.
         databricks_connect_cluster_id: The cluster id to use when establishing a connecting using Databricks Connect.
-                   Defaults to deriving the cluster id from the `http_path` value.
+            Defaults to deriving the cluster id from the `http_path` value.
         force_databricks_connect: Force all queries to run using Databricks Connect instead of the SQL connector.
         disable_databricks_connect: Even if databricks connect is installed, do not use it.
     """
@@ -179,6 +181,7 @@ class DatabricksConnectionConfig(_ConnectionConfig):
     access_token: t.Optional[str]
     catalog: t.Optional[str]
     http_headers: t.Optional[t.List[t.Tuple[str, str]]]
+    session_configuration: t.Dict[str, t.Any] = {}
     databricks_connect_server_hostname: t.Optional[str]
     databricks_connect_access_token: t.Optional[str]
     databricks_connect_cluster_id: t.Optional[str]
@@ -215,6 +218,7 @@ class DatabricksConnectionConfig(_ConnectionConfig):
                 values["databricks_connect_access_token"] = access_token
             if not values.get("databricks_connect_cluster_id"):
                 values["databricks_connect_cluster_id"] = http_path.split("/")[-1]
+        values["session_configuration"]["spark.sql.sources.partitionOverwriteMode"] = "dynamic"
         return values
 
     @property

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -20,8 +20,7 @@ logger = logging.getLogger(__name__)
 
 class DatabricksEngineAdapter(SparkEngineAdapter):
     DIALECT = "databricks"
-    # Change to REPLACE WHERE once column bug is fixed
-    INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.DELETE_INSERT
+    INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
     SCHEMA_DIFFER = SchemaDiffer(
         support_positional_add=True,
         support_nested_operations=True,
@@ -104,6 +103,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
             if catalog:
                 # Note: Spark 3.4+ Only API
                 self._spark.catalog.setCurrentCatalog(catalog)
+            self._spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
         return self._spark
 
     def _fetch_native_df(self, query: t.Union[exp.Expression, str]) -> DF:

--- a/sqlmesh/engines/spark/db_api/spark_session.py
+++ b/sqlmesh/engines/spark/db_api/spark_session.py
@@ -74,6 +74,7 @@ class SparkSessionConnection:
         if self.catalog:
             # Note: Spark 3.4+ Only API
             self.spark.catalog.setCurrentCatalog(self.catalog)
+        self.spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
         return SparkSessionCursor(self.spark)
 
     def commit(self) -> None:


### PR DESCRIPTION
Two key changes:
* With this change all spark connections (either through the SparkSession DBAPI, Databricks Connect Session, or Databricks SQL Connection) will set their partitioning to be dynamic since we assume dynamic partition insert/overwrite in SQLMesh.
* This is still ongoing, but based on what Databricks support is saying is that Unity actually does support dynamic insert/overwrite so we are switching back to that.

I'm leaving the `REPLACE WHERE` stuff because still not sure what the best long term solution is going to be on Databricks. 