### PR TITLE
Fix: Make all BigQuery db calls retryable

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,9 @@ ignore_missing_imports = True
 [mypy-dbt.adapters.*]
 ignore_missing_imports = True
 
+[mypy-slack_sdk.*]
+ignore_missing_imports = True
+
 [autoflake]
 in-place = True
 expand-star-imports = True

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -193,6 +193,7 @@ class BigQueryEngineAdapter(EngineAdapter):
         if replace:
             job_config.write_disposition = bigquery.WriteDisposition.WRITE_TRUNCATE
         logger.debug(f"Loading dataframe to BigQuery. Table: {table.full_table_id}")
+        # This client call does not support retry so we don't use the `_db_call` method.
         job = self.client.load_table_from_dataframe(
             dataframe=df, destination=table, job_config=job_config
         )

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -205,8 +205,7 @@ class BigQueryEngineAdapter(EngineAdapter):
         job = self.client.load_table_from_dataframe(
             dataframe=df, destination=table, job_config=job_config
         )
-        result = self._db_call(job.result)
-        return result
+        return self._db_call(job.result)
 
     def __get_bq_schema(
         self, columns_to_types: t.Dict[str, exp.DataType]

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -320,6 +320,15 @@ class BigQueryEngineAdapter(EngineAdapter):
             assert temp_table is not None
             self.drop_table(temp_table)
 
+    def table_exists(self, table_name: TableName) -> bool:
+        from google.cloud.exceptions import NotFound
+
+        try:
+            self._get_table(table_name)
+            return True
+        except NotFound:
+            return False
+
     def _get_table(self, table_name: TableName) -> BigQueryTable:
         """
         Returns a BigQueryTable object for the given table name.

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import logging
 import typing as t
 
@@ -194,10 +193,8 @@ class BigQueryEngineAdapter(EngineAdapter):
         logger.debug(f"Loading dataframe to BigQuery. Table: {table.full_table_id}")
         # This client call does not support retry so we don't use the `_db_call` method.
         result = self.__retry(
-            functools.partial(
-                self.__db_load_table_from_dataframe, df=df, table=table, job_config=job_config
-            )
-        )()
+            self.__db_load_table_from_dataframe,
+        )(df=df, table=table, job_config=job_config)
         if result.errors:
             raise SQLMeshError(result.errors)
         return result

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -190,7 +190,7 @@ class BigQueryEngineAdapter(EngineAdapter):
         job_config = bigquery.job.LoadJobConfig(schema=self.__get_bq_schema(columns_to_types))
         if replace:
             job_config.write_disposition = bigquery.WriteDisposition.WRITE_TRUNCATE
-        logger.debug(f"Loading dataframe to BigQuery. Table: {table.full_table_id}")
+        logger.debug(f"Loading dataframe to BigQuery. Table Path: {table.path}")
         # This client call does not support retry so we don't use the `_db_call` method.
         result = self.__retry(
             self.__db_load_table_from_dataframe,

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -197,7 +197,7 @@ class BigQueryEngineAdapter(EngineAdapter):
             functools.partial(
                 self.__db_load_table_from_dataframe, df=df, table=table, job_config=job_config
             )
-        )
+        )()
         if result.errors:
             raise SQLMeshError(result.errors)
         return result

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -111,7 +111,7 @@ def test_insert_overwrite_by_time_partition_pandas(mocker: MockerFixture):
     assert load_temp_table.kwargs["job_config"].write_disposition == None
     assert (
         merge_sql.sql(dialect="bigquery")
-        == "MERGE INTO test_table AS __MERGE_TARGET__ USING (SELECT a, ds FROM project.dataset.temp_table) AS __MERGE_SOURCE__ ON FALSE WHEN NOT MATCHED BY SOURCE AND ds BETWEEN '2022-01-01' AND '2022-01-05' THEN DELETE WHEN NOT MATCHED THEN INSERT (a, ds) VALUES (a, ds)"
+        == "MERGE INTO test_table AS __MERGE_TARGET__ USING (SELECT * FROM (SELECT a, ds FROM project.dataset.temp_table) AS _subquery WHERE ds BETWEEN '2022-01-01' AND '2022-01-05') AS __MERGE_SOURCE__ ON FALSE WHEN NOT MATCHED BY SOURCE AND ds BETWEEN '2022-01-01' AND '2022-01-05' THEN DELETE WHEN NOT MATCHED THEN INSERT (a, ds) VALUES (a, ds)"
     )
     assert (
         drop_temp_table_sql.sql(dialect="bigquery")

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -91,14 +91,12 @@ def test_insert_overwrite_by_time_partition_pandas(mocker: MockerFixture):
     create_temp_table = db_call_mock.call_args_list[0]
     load_temp_table = retry_resp.call_args_list[0]
     merge, drop_temp_table = execute_mock.call_args_list
-    merge_sql = merge[0]
-    drop_temp_table_sql = drop_temp_table[0]
+    merge_sql = merge[0][0]
+    drop_temp_table_sql = drop_temp_table[0][0]
     if sys.version_info < (3, 8):
         create_temp_table.kwargs = create_temp_table[1]
         load_temp_table.kwargs = load_temp_table[1]
         drop_temp_table.kwargs = drop_temp_table[1]
-        merge_sql = merge_sql[0]
-        drop_temp_table_sql = drop_temp_table_sql[0]
     assert create_temp_table.kwargs == {
         "exists_ok": False,
         "table": get_temp_bq_table.return_value,

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -1,4 +1,6 @@
 # type: ignore
+import sys
+
 import pandas as pd
 import pytest
 from google.cloud import bigquery
@@ -79,6 +81,11 @@ def test_insert_overwrite_by_time_partition_pandas(mocker: MockerFixture):
     )
     assert db_call_mock.call_count == 4
     create_temp_table, load_temp_table, merge, drop_temp_table = db_call_mock.call_args_list
+    if sys.version_info < (3, 8):
+        create_temp_table.kwargs = create_temp_table[1]
+        load_temp_table.kwargs = load_temp_table[1]
+        merge.kwargs = merge[1]
+        drop_temp_table.kwargs = drop_temp_table[1]
     assert create_temp_table.kwargs == {
         "exists_ok": False,
         "table": get_temp_bq_table.return_value,
@@ -139,6 +146,9 @@ def test_replace_query_pandas(mocker: MockerFixture):
 
     assert db_call_mock.call_count == 2
     create_table, load_table = db_call_mock.call_args_list
+    if sys.version_info < (3, 8):
+        create_table.kwargs = create_table[1]
+        load_table.kwargs = load_table[1]
     assert create_table.kwargs == {
         "table": get_bq_table.return_value,
         "exists_ok": True,

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -15,7 +15,7 @@ def test_replace_query(mocker: MockerFixture):
     adapter.replace_query("test_table", parse_one("SELECT a FROM tbl"), {"a": "int"})
 
     cursor_mock.execute.assert_called_once_with(
-        "INSERT OVERWRITE TABLE test_table (a) SELECT a FROM tbl"
+        "INSERT OVERWRITE TABLE test_table (a) SELECT * FROM (SELECT a FROM tbl) AS _subquery WHERE 1 = 1"
     )
 
 
@@ -29,5 +29,5 @@ def test_replace_query_pandas(mocker: MockerFixture):
     adapter.replace_query("test_table", df, {"a": "int", "b": "int"})
 
     cursor_mock.execute.assert_called_once_with(
-        "INSERT OVERWRITE TABLE test_table (a, b) SELECT CAST(a AS INT) AS a, CAST(b AS INT) AS b FROM VALUES (1, 4), (2, 5), (3, 6) AS test_table(a, b)"
+        "INSERT OVERWRITE TABLE test_table (a, b) SELECT * FROM (SELECT CAST(a AS INT) AS a, CAST(b AS INT) AS b FROM VALUES (1, 4), (2, 5), (3, 6) AS test_table(a, b)) AS _subquery WHERE 1 = 1"
     )


### PR DESCRIPTION
Prior to this change whenever we did client direct calls (which is fairly common in BQ engine adapter) they were not retried and only the SQL execution calls were retried. This retries all db calls. 