### PR TITLE
Fix: cli failure due to missing package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "ipywidgets",
         "jinja2",
         "pandas",
-        "pydantic>=1.10.7,<2.0.0",
+        "pydantic[email]>=1.10.7,<2.0.0",
         "requests",
         "rich",
         "ruamel.yaml",


### PR DESCRIPTION
A dependency is missing. `sqlmesh` invocation fails.

```
Traceback (most recent call last):
  File "pydantic/networks.py", line 578, in pydantic.networks.import_email_validator
ModuleNotFoundError: No module named 'email_validator'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/alexanderbutler/Documents/harness/analytics-platform/.venv/bin/cdf", line 5, in <module>
    from continuous_data_flow.cli import app
  File "/Users/alexanderbutler/Documents/harness/analytics-platform/src/continuous_data_flow/cli.py", line 7, in <module>
    import sqlmesh.cli.main as sqlmesh
  File "/Users/alexanderbutler/Documents/harness/analytics-platform/.venv/lib/python3.10/site-packages/sqlmesh/__init__.py", line 16, in <module>
    from sqlmesh.core.config import Config
  File "/Users/alexanderbutler/Documents/harness/analytics-platform/.venv/lib/python3.10/site-packages/sqlmesh/core/config/__init__.py", line 12, in <module>
    from sqlmesh.core.config.gateway import GatewayConfig
  File "/Users/alexanderbutler/Documents/harness/analytics-platform/.venv/lib/python3.10/site-packages/sqlmesh/core/config/gateway.py", line 7, in <module>
    from sqlmesh.core.config.scheduler import SchedulerConfig
  File "/Users/alexanderbutler/Documents/harness/analytics-platform/.venv/lib/python3.10/site-packages/sqlmesh/core/config/scheduler.py", line 13, in <module>
    from sqlmesh.core.plan import AirflowPlanEvaluator, BuiltInPlanEvaluator, PlanEvaluator
  File "/Users/alexanderbutler/Documents/harness/analytics-platform/.venv/lib/python3.10/site-packages/sqlmesh/core/plan/__init__.py", line 1, in <module>
    from sqlmesh.core.plan.definition import (
  File "/Users/alexanderbutler/Documents/harness/analytics-platform/.venv/lib/python3.10/site-packages/sqlmesh/core/plan/definition.py", line 7, in <module>
    from sqlmesh.core import scheduler
  File "/Users/alexanderbutler/Documents/harness/analytics-platform/.venv/lib/python3.10/site-packages/sqlmesh/core/scheduler.py", line 10, in <module>
    from sqlmesh.core.notification_target import (
  File "/Users/alexanderbutler/Documents/harness/analytics-platform/.venv/lib/python3.10/site-packages/sqlmesh/core/notification_target.py", line 265, in <module>
    class BasicSMTPNotificationTarget(BaseNotificationTarget):
  File "pydantic/main.py", line 197, in pydantic.main.ModelMetaclass.__new__
  File "pydantic/fields.py", line 506, in pydantic.fields.ModelField.infer
  File "pydantic/fields.py", line 436, in pydantic.fields.ModelField.__init__
  File "pydantic/fields.py", line 557, in pydantic.fields.ModelField.prepare
  File "pydantic/fields.py", line 831, in pydantic.fields.ModelField.populate_validators
  File "pydantic/networks.py", line 591, in __get_validators__
  File "pydantic/networks.py", line 580, in pydantic.networks.import_email_validator
ImportError: email-validator is not installed, run `pip install pydantic[email]`
```

ImportError: email-validator is not installed, run `pip install pydantic[email]`

