### PR TITLE
Feat: Add type discriminator to notification targets

### DIFF
--- a/sqlmesh/core/_typing.py
+++ b/sqlmesh/core/_typing.py
@@ -4,9 +4,5 @@ import typing as t
 
 from sqlglot import exp
 
-from sqlmesh.core.notification_target import BaseNotificationTarget
-
-NotificationTarget = BaseNotificationTarget
-
 if t.TYPE_CHECKING:
     TableName = t.Union[str, exp.Table]

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -5,7 +5,6 @@ import typing as t
 from pydantic import root_validator, validator
 
 from sqlmesh.core import constants as c
-from sqlmesh.core._typing import NotificationTarget
 from sqlmesh.core.config.base import BaseConfig, UpdateStrategy
 from sqlmesh.core.config.categorizer import CategorizerConfig
 from sqlmesh.core.config.connection import ConnectionConfig, DuckDBConnectionConfig
@@ -13,6 +12,7 @@ from sqlmesh.core.config.gateway import GatewayConfig
 from sqlmesh.core.config.model import ModelDefaultsConfig
 from sqlmesh.core.config.scheduler import BuiltInSchedulerConfig, SchedulerConfig
 from sqlmesh.core.loader import Loader, SqlMeshLoader
+from sqlmesh.core.notification_target import NotificationTarget
 from sqlmesh.core.user import User
 from sqlmesh.utils.errors import ConfigError
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -47,7 +47,6 @@ import pandas as pd
 from sqlglot import exp
 
 from sqlmesh.core import constants as c
-from sqlmesh.core._typing import NotificationTarget
 from sqlmesh.core.audit import Audit
 from sqlmesh.core.config import Config, load_config_from_paths, load_config_from_yaml
 from sqlmesh.core.console import Console, get_console
@@ -66,6 +65,7 @@ from sqlmesh.core.model import Model
 from sqlmesh.core.model.definition import _Model
 from sqlmesh.core.notification_target import (
     NotificationEvent,
+    NotificationTarget,
     NotificationTargetManager,
 )
 from sqlmesh.core.plan import Plan

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -16,9 +16,11 @@ Refer to `sqlmesh.core.plan`.
 import abc
 import typing as t
 
-from sqlmesh.core._typing import NotificationTarget
 from sqlmesh.core.console import Console, get_console
-from sqlmesh.core.notification_target import NotificationTargetManager
+from sqlmesh.core.notification_target import (
+    NotificationTarget,
+    NotificationTargetManager,
+)
 from sqlmesh.core.plan.definition import Plan
 from sqlmesh.core.scheduler import Scheduler
 from sqlmesh.core.snapshot import (

--- a/sqlmesh/core/user.py
+++ b/sqlmesh/core/user.py
@@ -3,8 +3,10 @@ from enum import Enum
 
 from pydantic import validator
 
-from sqlmesh.core._typing import NotificationTarget
-from sqlmesh.core.notification_target import BasicSMTPNotificationTarget
+from sqlmesh.core.notification_target import (
+    BasicSMTPNotificationTarget,
+    NotificationTarget,
+)
 from sqlmesh.utils.pydantic import PydanticModel
 
 

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -7,9 +7,9 @@ from urllib.parse import urlencode, urljoin
 import requests
 from requests.models import Response
 
-from sqlmesh.core._typing import NotificationTarget
 from sqlmesh.core.console import Console
 from sqlmesh.core.environment import Environment
+from sqlmesh.core.notification_target import NotificationTarget
 from sqlmesh.core.snapshot import (
     Snapshot,
     SnapshotId,

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import typing as t
 
 from sqlmesh.core import constants as c
-from sqlmesh.core._typing import NotificationTarget
 from sqlmesh.core.environment import Environment
+from sqlmesh.core.notification_target import NotificationTarget
 from sqlmesh.core.scheduler import Interval
 from sqlmesh.core.snapshot import (
     Snapshot,

--- a/sqlmesh/schedulers/airflow/dag_generator.py
+++ b/sqlmesh/schedulers/airflow/dag_generator.py
@@ -9,8 +9,8 @@ from airflow.models import BaseOperator, baseoperator
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 
-from sqlmesh.core._typing import NotificationTarget
 from sqlmesh.core.environment import Environment
+from sqlmesh.core.notification_target import NotificationTarget
 from sqlmesh.core.plan import PlanStatus
 from sqlmesh.core.snapshot import (
     Snapshot,
@@ -326,7 +326,7 @@ class SnapshotDagGenerator:
             sid = intervals_per_snapshot.snapshot_id
 
             if not intervals_per_snapshot.intervals:
-                logger.info(f"Skipping backfill for snapshot %s", sid)
+                logger.info("Skipping backfill for snapshot %s", sid)
                 continue
 
             snapshot = snapshots[sid]


### PR DESCRIPTION
This allows us to properly create target notifications from YAML configs. For example
```yaml
default_gateway: duckdb
gateways:
  duckdb:
    connection:
      type: duckdb
users:
  - username: admin
    roles:
      - required_approver
    notification_targets:
      - type: slack_api # <-- type
        notify_on:
          - apply_start
          - apply_failure
          - apply_end
          - audit_failure
        token: "{{ env_var('ADMIN_SLACK_API_TOKEN') }}"
        channel: UXXXXXXXXX
notification_targets:
  - type: slack_webhook # <-- type
    notify_on:
      - apply_start
      - apply_failure
      - run_start
    url: "{{ env_var('SLACK_WEBHOOK_URL') }}"
  - type: smtp # <-- type
    notify_on:
      - run_failure
    host: "{{ env_var('SMTP_HOST') }}"
    user: "{{ env_var('SMTP_USER') }}"
    password: "{{ env_var('SMTP_PASSWORD') }}"
    sender: sushi@example.com
    recipients:
      - team@example.com
```