### PR TITLE
Chore: bump sqlglot to v17.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "requests",
         "rich",
         "ruamel.yaml",
-        "sqlglot~=17.2.0",
+        "sqlglot~=17.3.0",
         "fsspec",
     ],
     extras_require={

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -91,7 +91,7 @@ def test_alter_table(mocker: MockerFixture):
         [
             call("""ALTER TABLE test_table DROP COLUMN b"""),
             call("""ALTER TABLE test_table DROP COLUMN id"""),
-            call("""ALTER TABLE test_table ADD COLUMN id LONG"""),
+            call("""ALTER TABLE test_table ADD COLUMN id BIGINT"""),
             call("""ALTER TABLE test_table DROP COLUMN a"""),
             call("""ALTER TABLE test_table ADD COLUMN a STRING"""),
             call("""ALTER TABLE test_table DROP COLUMN complex"""),


### PR DESCRIPTION
This fixes a regression that will be caused due to https://github.com/tobymao/sqlglot/commit/bdac905b85330e7c44d2ddcd3a84a6f0babcb08c.

TODO
- [x] Release SQLGlot v17.3.0 and bump version in setup.py