### PR TITLE
Fix: Properly support DataFrames when doing INCREMENTAL_BY_UNIQUE_KEY

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -718,6 +718,15 @@ class EngineAdapter:
         if columns_to_types is None:
             columns_to_types = self.columns(target_table)
 
+        df = self.try_get_pandas_df(source_table)
+        if df is not None:
+            source_table = next(
+                pandas_to_sql(
+                    df,
+                    columns_to_types=columns_to_types,
+                )
+            )
+
         column_names = list(columns_to_types or [])
         on = exp.and_(
             *(

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -271,3 +271,96 @@ def test_create_table_time_partition(
     assert sql_calls == [
         f"CREATE TABLE IF NOT EXISTS `test_table` (`a` int, `b` int) PARTITION BY {partition_by_statement}"
     ]
+
+
+def test_merge(mocker: MockerFixture):
+    connection_mock = mocker.NonCallableMock()
+    cursor_mock = mocker.Mock()
+    connection_mock.cursor.return_value = cursor_mock
+
+    adapter = BigQueryEngineAdapter(lambda: connection_mock)
+    execute_mock = mocker.patch(
+        "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.execute"
+    )
+    adapter.merge(
+        target_table="target",
+        source_table="SELECT id, ts, val FROM source",
+        columns_to_types={
+            "id": exp.DataType.Type.INT,
+            "ts": exp.DataType.Type.TIMESTAMP,
+            "val": exp.DataType.Type.INT,
+        },
+        unique_key=["id"],
+    )
+    sql_calls = [
+        # Python 3.7 support
+        call[0][0].sql(dialect="bigquery")
+        if isinstance(call[0], tuple)
+        else call[0].sql(dialect="bigquery")
+        for call in execute_mock.call_args_list
+    ]
+    assert sql_calls == [
+        "MERGE INTO target AS __MERGE_TARGET__ USING (SELECT id, ts, val FROM source) AS __MERGE_SOURCE__ ON __MERGE_TARGET__.id = __MERGE_SOURCE__.id "
+        "WHEN MATCHED THEN UPDATE SET __MERGE_TARGET__.id = __MERGE_SOURCE__.id, __MERGE_TARGET__.ts = __MERGE_SOURCE__.ts, __MERGE_TARGET__.val = __MERGE_SOURCE__.val "
+        "WHEN NOT MATCHED THEN INSERT (id, ts, val) VALUES (__MERGE_SOURCE__.id, __MERGE_SOURCE__.ts, __MERGE_SOURCE__.val)"
+    ]
+
+    execute_mock.reset_mock()
+    get_temp_bq_table = mocker.Mock()
+    get_temp_bq_table.return_value = AttributeDict(
+        {"project": "project", "dataset_id": "dataset", "table_id": "temp_table"}
+    )
+    adapter._BigQueryEngineAdapter__get_temp_bq_table = get_temp_bq_table
+    db_call_mock = mocker.patch(
+        "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter._db_call"
+    )
+    retry_mock = mocker.patch(
+        "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter._BigQueryEngineAdapter__retry"
+    )
+    retry_resp = mocker.MagicMock()
+    retry_resp_call = mocker.MagicMock()
+    retry_resp.return_value = retry_resp_call
+    retry_resp_call.errors = None
+    retry_mock.return_value = retry_resp
+    db_call_mock.return_value = AttributeDict({"errors": None})
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    adapter.merge(
+        target_table="target",
+        source_table=df,
+        columns_to_types={
+            "id": exp.DataType.build("INT"),
+            "ts": exp.DataType.build("TIMESTAMP"),
+            "val": exp.DataType.build("INT"),
+        },
+        unique_key=["id"],
+    )
+
+    sql_calls = [
+        # Python 3.7 support
+        call[0][0].sql(dialect="bigquery")
+        if isinstance(call[0], tuple)
+        else call[0].sql(dialect="bigquery")
+        for call in execute_mock.call_args_list
+    ]
+    assert sql_calls == [
+        "MERGE INTO target AS __MERGE_TARGET__ USING (SELECT id, ts, val FROM project.dataset.temp_table) AS __MERGE_SOURCE__ ON __MERGE_TARGET__.id = __MERGE_SOURCE__.id "
+        "WHEN MATCHED THEN UPDATE SET __MERGE_TARGET__.id = __MERGE_SOURCE__.id, __MERGE_TARGET__.ts = __MERGE_SOURCE__.ts, __MERGE_TARGET__.val = __MERGE_SOURCE__.val "
+        "WHEN NOT MATCHED THEN INSERT (id, ts, val) VALUES (__MERGE_SOURCE__.id, __MERGE_SOURCE__.ts, __MERGE_SOURCE__.val)",
+        "DROP TABLE IF EXISTS project.dataset.temp_table",
+    ]
+    assert retry_resp.call_count == 1
+    assert db_call_mock.call_count == 1
+    create_temp_table = db_call_mock.call_args_list[0]
+    load_temp_table = retry_resp.call_args_list[0]
+    if sys.version_info < (3, 8):
+        create_temp_table.kwargs = create_temp_table[1]
+        load_temp_table.kwargs = load_temp_table[1]
+    assert create_temp_table.kwargs == {
+        "exists_ok": False,
+        "table": get_temp_bq_table.return_value,
+    }
+    assert sorted(load_temp_table.kwargs) == [
+        "df",
+        "job_config",
+        "table",
+    ]


### PR DESCRIPTION
I noticed when answering a Slack question that we didn't properly handle if a DataFrame was passed into the `merge` method.  I made sure to update BigQuery implementation too since it does special handling of Dataframes. 