### PR TITLE
Fix: Populate unittest inputs before rendering query, which may access the input tables

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -207,6 +207,7 @@ class _Model(ModelMeta, frozen=True):
         end: t.Optional[TimeLike] = None,
         latest: t.Optional[TimeLike] = None,
         snapshots: t.Optional[t.Dict[str, Snapshot]] = None,
+        table_mapping: t.Optional[t.Dict[str, str]] = None,
         expand: t.Iterable[str] = tuple(),
         is_dev: bool = False,
         engine_adapter: t.Optional[EngineAdapter] = None,
@@ -219,6 +220,7 @@ class _Model(ModelMeta, frozen=True):
             end: The end datetime to render. Defaults to epoch start.
             latest: The latest datetime to use for non-incremental queries. Defaults to epoch start.
             snapshots: All upstream snapshots (by model name) to use for expansion and mapping of physical locations.
+            table_mapping: Table mapping of physical locations. Takes precedence over snapshot mappings.
             expand: Expand referenced models as subqueries. This is used to bypass backfills when running queries
                 that depend on materialized tables.  Model definitions are inlined and can thus be run end to
                 end on the fly.
@@ -244,6 +246,7 @@ class _Model(ModelMeta, frozen=True):
         end: t.Optional[TimeLike] = None,
         latest: t.Optional[TimeLike] = None,
         snapshots: t.Optional[t.Dict[str, Snapshot]] = None,
+        table_mapping: t.Optional[t.Dict[str, str]] = None,
         expand: t.Iterable[str] = tuple(),
         is_dev: bool = False,
         engine_adapter: t.Optional[EngineAdapter] = None,
@@ -256,6 +259,7 @@ class _Model(ModelMeta, frozen=True):
             end: The end datetime to render. Defaults to epoch start.
             latest: The latest datetime to use for non-incremental queries. Defaults to epoch start.
             snapshots: All upstream snapshots (by model name) to use for expansion and mapping of physical locations.
+            table_mapping: Table mapping of physical locations. Takes precedence over snapshot mappings.
             expand: Expand referenced models as subqueries. This is used to bypass backfills when running queries
                 that depend on materialized tables.  Model definitions are inlined and can thus be run end to
                 end on the fly.
@@ -271,6 +275,7 @@ class _Model(ModelMeta, frozen=True):
             end=end,
             latest=latest,
             snapshots=snapshots,
+            table_mapping=table_mapping,
             expand=expand,
             is_dev=is_dev,
             engine_adapter=engine_adapter,
@@ -738,6 +743,7 @@ class SqlModel(_SqlBasedModel):
         end: t.Optional[TimeLike] = None,
         latest: t.Optional[TimeLike] = None,
         snapshots: t.Optional[t.Dict[str, Snapshot]] = None,
+        table_mapping: t.Optional[t.Dict[str, str]] = None,
         expand: t.Iterable[str] = tuple(),
         is_dev: bool = False,
         engine_adapter: t.Optional[EngineAdapter] = None,
@@ -748,6 +754,7 @@ class SqlModel(_SqlBasedModel):
             end=end,
             latest=latest,
             snapshots=snapshots,
+            table_mapping=table_mapping,
             expand=expand,
             is_dev=is_dev,
             engine_adapter=engine_adapter,

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -437,7 +437,7 @@ def _resolve_tables(
 
     snapshots = snapshots or {}
     table_mapping = table_mapping or {}
-    mapping = table_mapping | to_table_mapping(snapshots.values(), is_dev)
+    mapping = {**to_table_mapping(snapshots.values(), is_dev), **table_mapping}
     # if a snapshot is provided but not mapped, we need to expand it or the query
     # won't be valid
     expand = set(expand) | {name for name in snapshots if name not in mapping}

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -76,6 +76,7 @@ class BaseExpressionRenderer:
         end: t.Optional[TimeLike] = None,
         latest: t.Optional[TimeLike] = None,
         snapshots: t.Optional[t.Dict[str, Snapshot]] = None,
+        table_mapping: t.Optional[t.Dict[str, str]] = None,
         is_dev: bool = False,
         **kwargs: t.Any,
     ) -> t.List[exp.Expression]:
@@ -87,6 +88,7 @@ class BaseExpressionRenderer:
             latest: The latest datetime to use for non-incremental models. Defaults to epoch start.
             kwargs: Additional kwargs to pass to the renderer.
             snapshots: All upstream snapshots (by model name) to use for expansion and mapping of physical locations.
+            table_mapping: Table mapping of physical locations. Takes precedence over snapshot mappings.
             is_dev: Indicates whether the rendering happens in the development mode and temporary
                 tables / table clones should be used where applicable.
 
@@ -106,7 +108,10 @@ class BaseExpressionRenderer:
 
             env = prepare_env(self._python_env)
             jinja_env = self._jinja_macro_registry.build_environment(
-                **{**render_kwargs, **env}, snapshots=(snapshots or {}), is_dev=is_dev
+                **{**render_kwargs, **env},
+                snapshots=(snapshots or {}),
+                table_mapping=table_mapping,
+                is_dev=is_dev,
             )
 
             if isinstance(self._expression, d.Jinja):
@@ -175,11 +180,12 @@ class BaseExpressionRenderer:
         end: t.Optional[TimeLike] = None,
         latest: t.Optional[TimeLike] = None,
         snapshots: t.Optional[t.Dict[str, Snapshot]] = None,
+        table_mapping: t.Optional[t.Dict[str, str]] = None,
         expand: t.Iterable[str] = tuple(),
         is_dev: bool = False,
         **kwargs: t.Any,
     ) -> E:
-        if not snapshots and not expand:
+        if not snapshots and not table_mapping and not expand:
             return expression
 
         expression = expression.copy()
@@ -187,6 +193,7 @@ class BaseExpressionRenderer:
             return _resolve_tables(
                 expression,
                 snapshots=snapshots,
+                table_mapping=table_mapping,
                 expand=expand,
                 is_dev=is_dev,
                 start=start,
@@ -203,6 +210,7 @@ class ExpressionRenderer(BaseExpressionRenderer):
         end: t.Optional[TimeLike] = None,
         latest: t.Optional[TimeLike] = None,
         snapshots: t.Optional[t.Dict[str, Snapshot]] = None,
+        table_mapping: t.Optional[t.Dict[str, str]] = None,
         is_dev: bool = False,
         expand: t.Iterable[str] = tuple(),
         **kwargs: t.Any,
@@ -220,6 +228,7 @@ class ExpressionRenderer(BaseExpressionRenderer):
             self._resolve_tables(
                 e,
                 snapshots=snapshots,
+                table_mapping=table_mapping,
                 expand=expand,
                 is_dev=is_dev,
                 start=start,
@@ -266,6 +275,7 @@ class QueryRenderer(BaseExpressionRenderer):
         end: t.Optional[TimeLike] = None,
         latest: t.Optional[TimeLike] = None,
         snapshots: t.Optional[t.Dict[str, Snapshot]] = None,
+        table_mapping: t.Optional[t.Dict[str, str]] = None,
         is_dev: bool = False,
         expand: t.Iterable[str] = tuple(),
         optimize: bool = True,
@@ -279,6 +289,7 @@ class QueryRenderer(BaseExpressionRenderer):
             end: The end datetime to render. Defaults to epoch start.
             latest: The latest datetime to use for non-incremental queries. Defaults to epoch start.
             snapshots: All upstream snapshots (by model name) to use for expansion and mapping of physical locations.
+            table_mapping: Table mapping of physical locations. Takes precedence over snapshot mappings.
             is_dev: Indicates whether the rendering happens in the development mode and temporary
                 tables / table clones should be used where applicable.
             expand: Expand referenced models as subqueries. This is used to bypass backfills when running queries
@@ -291,7 +302,7 @@ class QueryRenderer(BaseExpressionRenderer):
             The rendered expression.
         """
         cache_key = _dates(start, end, latest)
-        skip_cache = bool(snapshots or expand)
+        skip_cache = bool(snapshots or table_mapping or expand)
 
         if skip_cache or not optimize or cache_key not in self._optimized_cache:
             try:
@@ -300,6 +311,7 @@ class QueryRenderer(BaseExpressionRenderer):
                     end=end,
                     latest=latest,
                     snapshots=snapshots,
+                    table_mapping=table_mapping,
                     is_dev=is_dev,
                     **kwargs,
                 )
@@ -325,6 +337,7 @@ class QueryRenderer(BaseExpressionRenderer):
         query = self._resolve_tables(
             query,
             snapshots=snapshots,
+            table_mapping=table_mapping,
             expand=expand,
             is_dev=is_dev,
             start=start,
@@ -415,6 +428,7 @@ def _resolve_tables(
     expression: E,
     *,
     snapshots: t.Optional[t.Dict[str, Snapshot]] = None,
+    table_mapping: t.Optional[t.Dict[str, str]] = None,
     expand: t.Iterable[str] = tuple(),
     is_dev: bool = False,
     **render_kwargs: t.Any,
@@ -422,7 +436,8 @@ def _resolve_tables(
     from sqlmesh.core.snapshot import to_table_mapping
 
     snapshots = snapshots or {}
-    mapping = to_table_mapping(snapshots.values(), is_dev)
+    table_mapping = table_mapping or {}
+    mapping = table_mapping | to_table_mapping(snapshots.values(), is_dev)
     # if a snapshot is provided but not mapped, we need to expand it or the query
     # won't be valid
     expand = set(expand) | {name for name in snapshots if name not in mapping}

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -302,9 +302,8 @@ class QueryRenderer(BaseExpressionRenderer):
             The rendered expression.
         """
         cache_key = _dates(start, end, latest)
-        skip_cache = bool(snapshots or table_mapping or expand)
 
-        if skip_cache or not optimize or cache_key not in self._optimized_cache:
+        if not optimize or cache_key not in self._optimized_cache:
             try:
                 expressions = super()._render(
                     start=start,
@@ -328,8 +327,7 @@ class QueryRenderer(BaseExpressionRenderer):
 
             if optimize:
                 query = self._optimize_query(query)
-                if not skip_cache:
-                    self._optimized_cache[cache_key] = query
+                self._optimized_cache[cache_key] = query
         else:
             query = t.cast(exp.Subqueryable, self._optimized_cache[cache_key])
 

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -179,7 +179,6 @@ class SqlModelTest(ModelTest):
             for name in self.models.keys() | self.body.get("inputs", {}).keys()
         }
         query = self.model.render_query_or_raise(
-            add_incremental_filter=True,
             **self.body.get("vars", {}),
             engine_adapter=self.engine_adapter,
             table_mapping=mapping,

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -173,18 +173,17 @@ class SqlModelTest(ModelTest):
                 self.assert_equal(expected_df, actual_df)
 
     def runTest(self) -> None:
-        query = self.model.render_query_or_raise(
-            add_incremental_filter=True,
-            **self.body.get("vars", {}),
-            engine_adapter=self.engine_adapter,
-        )
         # For tests we just use the model name for the table reference and we don't want to expand
         mapping = {
             name: _test_fixture_name(name)
             for name in self.models.keys() | self.body.get("inputs", {}).keys()
         }
-        if mapping:
-            query = exp.replace_tables(query, mapping)
+        query = self.model.render_query_or_raise(
+            add_incremental_filter=True,
+            **self.body.get("vars", {}),
+            engine_adapter=self.engine_adapter,
+            table_mapping=mapping,
+        )
 
         self.test_ctes({cte.alias: cte for cte in query.ctes})
 

--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -165,7 +165,10 @@ class RuntimeAdapter(BaseAdapter):
         self.engine_adapter = engine_adapter
         self.relation_type = relation_type or BaseRelation
         self.quote_policy = quote_policy or Policy()
-        self.table_mapping = table_mapping | to_table_mapping((snapshots or {}).values(), is_dev)
+        self.table_mapping = {
+            **to_table_mapping((snapshots or {}).values(), is_dev),
+            **table_mapping,
+        }
 
     def get_relation(
         self, database: t.Optional[str], schema: str, identifier: str

--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -152,6 +152,7 @@ class RuntimeAdapter(BaseAdapter):
         relation_type: t.Optional[t.Type[BaseRelation]] = None,
         quote_policy: t.Optional[Policy] = None,
         snapshots: t.Optional[t.Dict[str, Snapshot]] = None,
+        table_mapping: t.Optional[t.Dict[str, str]] = None,
         is_dev: bool = False,
     ):
         from dbt.adapters.base import BaseRelation
@@ -159,10 +160,12 @@ class RuntimeAdapter(BaseAdapter):
 
         super().__init__(jinja_macros, jinja_globals=jinja_globals, dialect=engine_adapter.dialect)
 
+        table_mapping = table_mapping or {}
+
         self.engine_adapter = engine_adapter
         self.relation_type = relation_type or BaseRelation
         self.quote_policy = quote_policy or Policy()
-        self.table_mapping = to_table_mapping((snapshots or {}).values(), is_dev)
+        self.table_mapping = table_mapping | to_table_mapping((snapshots or {}).values(), is_dev)
 
     def get_relation(
         self, database: t.Optional[str], schema: str, identifier: str

--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -335,6 +335,7 @@ def create_builtin_globals(
             relation_type=api.Relation,
             quote_policy=api.quote_policy,
             snapshots=jinja_globals.get("snapshots", {}),
+            table_mapping=jinja_globals.get("table_mapping", {}),
             is_dev=jinja_globals.get("is_dev", False),
         )
         builtin_globals.update({"log": log, "print": log})

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -908,6 +908,17 @@ def test_render_query(assert_exp_eq):
           AND "y" BETWEEN '2020-10-28' AND '2020-10-28'
         """,
     )
+    assert_exp_eq(
+        model.render_query(start="2020-10-28", end="2020-10-28", table_mapping={"x": "x_mapped"}),
+        """
+        SELECT
+          "y" AS "y"
+        FROM "x_mapped" AS "x"
+        WHERE
+          "y" BETWEEN DATE_STR_TO_DATE('2020-10-28') AND DATE_STR_TO_DATE('2020-10-28')
+          AND "y" BETWEEN '2020-10-28' AND '2020-10-28'
+        """,
+    )
 
 
 def test_time_column():


### PR DESCRIPTION
- dbt models may try to hit the db during rendering, so make sure the db tables are populated before rendering the model.
- Allow unit tests to override table mappings when rendering.