### PR TITLE
Fix: Allow forward-only on added external models

### DIFF
--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -185,6 +185,11 @@ class ContextDiff(PydanticModel):
     def has_snapshot_changes(self) -> bool:
         return bool(self.added or self.removed or self.modified_snapshots)
 
+    @property
+    def added_internal_models(self) -> t.Set[str]:
+        """Returns the set of added internal models."""
+        return {name for name in self.added if not self.snapshots[name].model_kind_name.is_external}
+
     def directly_modified(self, model_name: str) -> bool:
         """Returns whether or not a model was directly modified in this context.
 

--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -186,9 +186,9 @@ class ContextDiff(PydanticModel):
         return bool(self.added or self.removed or self.modified_snapshots)
 
     @property
-    def added_internal_models(self) -> t.Set[str]:
+    def added_materialized_models(self) -> t.Set[str]:
         """Returns the set of added internal models."""
-        return {name for name in self.added if not self.snapshots[name].model_kind_name.is_external}
+        return {name for name in self.added if self.snapshots[name].model_kind_name.is_materialized}
 
     def directly_modified(self, model_name: str) -> bool:
         """Returns whether or not a model was directly modified in this context.

--- a/sqlmesh/core/model/__init__.py
+++ b/sqlmesh/core/model/__init__.py
@@ -1,5 +1,4 @@
 from sqlmesh.core.model.cache import ModelCache, OptimizedQueryCache
-from sqlmesh.core.model.common import parse_model_name
 from sqlmesh.core.model.decorator import model
 from sqlmesh.core.model.definition import (
     Model,

--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -4,7 +4,7 @@ import typing as t
 
 from pydantic import validator
 from sqlglot import exp
-from sqlglot.helper import seq_get, split_num_words
+from sqlglot.helper import seq_get
 
 from sqlmesh.core.dialect import parse
 from sqlmesh.utils.errors import ConfigError
@@ -19,7 +19,8 @@ def parse_model_name(name: str) -> t.Tuple[t.Optional[str], t.Optional[str], str
     Returns:
         A tuple consisting of catalog, schema, table name.
     """
-    return split_num_words(name, ".", 3)  # type: ignore
+    table = exp.to_table(name)
+    return table.catalog or None, table.db or None, table.name
 
 
 def parse_expression(

--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -10,19 +10,6 @@ from sqlmesh.core.dialect import parse
 from sqlmesh.utils.errors import ConfigError
 
 
-def parse_model_name(name: str) -> t.Tuple[t.Optional[str], t.Optional[str], str]:
-    """Convert a model name into table parts.
-
-    Args:
-        name: model name.
-
-    Returns:
-        A tuple consisting of catalog, schema, table name.
-    """
-    table = exp.to_table(name)
-    return table.catalog or None, table.db or None, table.name
-
-
 def parse_expression(
     v: t.Union[t.List[str], t.List[exp.Expression], str, exp.Expression, t.Callable, None],
     values: t.Dict[str, t.Any],

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -22,7 +22,7 @@ from sqlglot.time import format_time
 from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
 from sqlmesh.core.macros import MacroRegistry, macro
-from sqlmesh.core.model.common import expression_validator, parse_model_name
+from sqlmesh.core.model.common import expression_validator
 from sqlmesh.core.model.kind import ModelKindName, SeedKind
 from sqlmesh.core.model.meta import ModelMeta
 from sqlmesh.core.model.seed import Seed, create_seed
@@ -533,7 +533,7 @@ class _Model(ModelMeta, frozen=True):
 
     @property
     def view_name(self) -> str:
-        return parse_model_name(self.name)[2]
+        return exp.to_table(self.name).name
 
     @property
     def python_env(self) -> t.Dict[str, Executable]:

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -536,7 +536,7 @@ class Plan:
                 )
 
     def _ensure_no_forward_only_new_models(self) -> None:
-        if self.forward_only and self.context_diff.added:
+        if self.forward_only and self.context_diff.added_internal_models:
             raise PlanError("New models can't be added as part of the forward-only plan.")
 
     def _ensure_no_broken_references(self) -> None:

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -536,8 +536,10 @@ class Plan:
                 )
 
     def _ensure_no_forward_only_new_models(self) -> None:
-        if self.forward_only and self.context_diff.added_internal_models:
-            raise PlanError("New models can't be added as part of the forward-only plan.")
+        if self.forward_only and self.context_diff.added_materialized_models:
+            raise PlanError(
+                "New models that require materialization can't be added as part of the forward-only plan."
+            )
 
     def _ensure_no_broken_references(self) -> None:
         for snapshot in self.context_diff.snapshots.values():

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -756,7 +756,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
     def physical_schema(self) -> str:
         if self.physical_schema_ is not None:
             return self.physical_schema_
-        _, schema, _ = parse_model_name(self.name)
+        schema = parse_model_name(self.name)[1]
         if schema is None:
             schema = c.DEFAULT_SCHEMA
         return f"{c.SQLMESH}__{schema}"

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from enum import IntEnum
 
 from pydantic import Field, validator
+from sqlglot import exp
 from sqlglot.helper import seq_get
 
 from sqlmesh.core import constants as c
@@ -20,7 +21,6 @@ from sqlmesh.core.model import (
     SqlModel,
     ViewKind,
     kind,
-    parse_model_name,
 )
 from sqlmesh.core.model.definition import _SqlBasedModel
 from sqlmesh.core.model.meta import IntervalUnit
@@ -194,8 +194,12 @@ class SnapshotInfoMixin(ModelKindMixin):
 
     @property
     def qualified_view_name(self) -> QualifiedViewName:
-        catalog, schema, table = parse_model_name(self.name)
-        return QualifiedViewName(catalog=catalog, schema_name=schema, table=table)
+        view_name = exp.to_table(self.name)
+        return QualifiedViewName(
+            catalog=view_name.catalog or None,
+            schema_name=view_name.db or None,
+            table=view_name.name,
+        )
 
     @property
     def previous_version(self) -> t.Optional[SnapshotDataVersion]:
@@ -756,8 +760,8 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
     def physical_schema(self) -> str:
         if self.physical_schema_ is not None:
             return self.physical_schema_
-        schema = parse_model_name(self.name)[1]
-        if schema is None:
+        schema = exp.to_table(self.name).db
+        if not schema:
             schema = c.DEFAULT_SCHEMA
         return f"{c.SQLMESH}__{schema}"
 

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -40,7 +40,7 @@ def test_forward_only_plan_sets_version(make_snapshot, mocker: MockerFixture):
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {"b": (snapshot_b, snapshot_b)}
     context_diff_mock.new_snapshots = {snapshot_b.snapshot_id: snapshot_b}
-    context_diff_mock.added_internal_models = set()
+    context_diff_mock.added_materialized_models = set()
 
     state_reader_mock = mocker.Mock()
 
@@ -71,7 +71,7 @@ def test_forward_only_dev(make_snapshot, mocker: MockerFixture):
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {}
     context_diff_mock.new_snapshots = {snapshot_a.snapshot_id: snapshot_a}
-    context_diff_mock.added_internal_models = set()
+    context_diff_mock.added_materialized_models = set()
 
     state_reader_mock = mocker.Mock()
 
@@ -102,16 +102,17 @@ def test_forward_only_plan_new_models_not_allowed(make_snapshot, mocker: MockerF
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {}
     context_diff_mock.new_snapshots = {}
-    context_diff_mock.added_internal_models = {"a"}
+    context_diff_mock.added_materialized_models = {"a"}
 
     state_reader_mock = mocker.Mock()
 
     with pytest.raises(
-        PlanError, match="New models can't be added as part of the forward-only plan."
+        PlanError,
+        match="New models that require materialization can't be added as part of the forward-only plan.",
     ):
         Plan(context_diff_mock, state_reader_mock, forward_only=True)
 
-    context_diff_mock.added_internal_models = set()
+    context_diff_mock.added_materialized_models = set()
     Plan(context_diff_mock, state_reader_mock, forward_only=True)
 
 
@@ -138,7 +139,7 @@ def test_paused_forward_only_parent(make_snapshot, mocker: MockerFixture):
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {"b": (snapshot_b, snapshot_b)}
     context_diff_mock.new_snapshots = {snapshot_b.snapshot_id: snapshot_b}
-    context_diff_mock.added_internal_models = set()
+    context_diff_mock.added_materialized_models = set()
 
     state_reader_mock = mocker.Mock()
 
@@ -175,7 +176,7 @@ def test_restate_model_with_merge_strategy(make_snapshot, mocker: MockerFixture)
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {}
     context_diff_mock.new_snapshots = {}
-    context_diff_mock.added_internal_models = set()
+    context_diff_mock.added_materialized_models = set()
 
     state_reader_mock = mocker.Mock()
 
@@ -274,7 +275,7 @@ def test_forward_only_revert_not_allowed(make_snapshot, mocker: MockerFixture):
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {"a": (snapshot, forward_only_snapshot)}
     context_diff_mock.new_snapshots = {}
-    context_diff_mock.added_internal_models = set()
+    context_diff_mock.added_materialized_models = set()
 
     state_reader_mock = mocker.Mock()
 
@@ -324,7 +325,7 @@ def test_forward_only_plan_seed_models(make_snapshot, mocker: MockerFixture):
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {"a": (snapshot_a_updated, snapshot_a)}
     context_diff_mock.new_snapshots = {snapshot_a_updated.snapshot_id: snapshot_a_updated}
-    context_diff_mock.added_internal_models = set()
+    context_diff_mock.added_materialized_models = set()
 
     state_reader_mock = mocker.Mock()
 
@@ -447,7 +448,7 @@ def test_effective_from(make_snapshot, mocker: MockerFixture):
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {}
     context_diff_mock.new_snapshots = {snapshot.snapshot_id: snapshot}
-    context_diff_mock.added_internal_models = set()
+    context_diff_mock.added_materialized_models = set()
 
     state_reader_mock = mocker.Mock()
 

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -40,6 +40,7 @@ def test_forward_only_plan_sets_version(make_snapshot, mocker: MockerFixture):
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {"b": (snapshot_b, snapshot_b)}
     context_diff_mock.new_snapshots = {snapshot_b.snapshot_id: snapshot_b}
+    context_diff_mock.added_internal_models = set()
 
     state_reader_mock = mocker.Mock()
 
@@ -70,6 +71,7 @@ def test_forward_only_dev(make_snapshot, mocker: MockerFixture):
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {}
     context_diff_mock.new_snapshots = {snapshot_a.snapshot_id: snapshot_a}
+    context_diff_mock.added_internal_models = set()
 
     state_reader_mock = mocker.Mock()
 
@@ -100,6 +102,7 @@ def test_forward_only_plan_new_models_not_allowed(make_snapshot, mocker: MockerF
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {}
     context_diff_mock.new_snapshots = {}
+    context_diff_mock.added_internal_models = {"a"}
 
     state_reader_mock = mocker.Mock()
 
@@ -107,6 +110,9 @@ def test_forward_only_plan_new_models_not_allowed(make_snapshot, mocker: MockerF
         PlanError, match="New models can't be added as part of the forward-only plan."
     ):
         Plan(context_diff_mock, state_reader_mock, forward_only=True)
+
+    context_diff_mock.added_internal_models = set()
+    Plan(context_diff_mock, state_reader_mock, forward_only=True)
 
 
 def test_paused_forward_only_parent(make_snapshot, mocker: MockerFixture):
@@ -132,6 +138,7 @@ def test_paused_forward_only_parent(make_snapshot, mocker: MockerFixture):
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {"b": (snapshot_b, snapshot_b)}
     context_diff_mock.new_snapshots = {snapshot_b.snapshot_id: snapshot_b}
+    context_diff_mock.added_internal_models = set()
 
     state_reader_mock = mocker.Mock()
 
@@ -168,6 +175,7 @@ def test_restate_model_with_merge_strategy(make_snapshot, mocker: MockerFixture)
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {}
     context_diff_mock.new_snapshots = {}
+    context_diff_mock.added_internal_models = set()
 
     state_reader_mock = mocker.Mock()
 
@@ -266,6 +274,7 @@ def test_forward_only_revert_not_allowed(make_snapshot, mocker: MockerFixture):
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {"a": (snapshot, forward_only_snapshot)}
     context_diff_mock.new_snapshots = {}
+    context_diff_mock.added_internal_models = set()
 
     state_reader_mock = mocker.Mock()
 
@@ -315,6 +324,7 @@ def test_forward_only_plan_seed_models(make_snapshot, mocker: MockerFixture):
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {"a": (snapshot_a_updated, snapshot_a)}
     context_diff_mock.new_snapshots = {snapshot_a_updated.snapshot_id: snapshot_a_updated}
+    context_diff_mock.added_internal_models = set()
 
     state_reader_mock = mocker.Mock()
 
@@ -437,6 +447,7 @@ def test_effective_from(make_snapshot, mocker: MockerFixture):
     context_diff_mock.removed = set()
     context_diff_mock.modified_snapshots = {}
     context_diff_mock.new_snapshots = {snapshot.snapshot_id: snapshot}
+    context_diff_mock.added_internal_models = set()
 
     state_reader_mock = mocker.Mock()
 


### PR DESCRIPTION
Prior to this change if you added an external model then it would block being able to apply that change as forward-only. Now we only block if the model is an internal model. 