### PR TITLE
Fix!: Allow partials when loading configs + Personal Config Overrides Project

### DIFF
--- a/sqlmesh/core/config/loader.py
+++ b/sqlmesh/core/config/loader.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from sqlmesh.core import constants as c
 from sqlmesh.core.config.root import Config
-from sqlmesh.utils import merge_list_of_dicts, sys_path
+from sqlmesh.utils import merge_dicts, sys_path
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.metaprogramming import import_python_file
 from sqlmesh.utils.yaml import load as yaml_load
@@ -57,7 +57,7 @@ def load_config_from_paths(
             "SQLMesh config could not be found. Point the cli to the right path with `sqlmesh -p`. If you haven't set up SQLMesh, run `sqlmesh init`."
         )
 
-    non_python_config = Config.parse_obj(merge_list_of_dicts(non_python_configs))
+    non_python_config = Config.parse_obj(merge_dicts(*non_python_configs))
     if python_config:
         return python_config.update_with(non_python_config)
     return non_python_config

--- a/sqlmesh/core/config/loader.py
+++ b/sqlmesh/core/config/loader.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from sqlmesh.core import constants as c
 from sqlmesh.core.config.root import Config
-from sqlmesh.utils import sys_path
+from sqlmesh.utils import merge_list_of_dicts, sys_path
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.metaprogramming import import_python_file
 from sqlmesh.utils.yaml import load as yaml_load
@@ -16,11 +16,11 @@ def load_config_from_paths(
     *paths: Path,
     config_name: str = "config",
     load_from_env: bool = True,
-    config_defaults: Config | None = None,
 ) -> Config:
-    config: t.Optional[Config] = None
 
     visited_folders: t.Set[Path] = set()
+    python_config: t.Optional[Config] = None
+    non_python_configs = []
     for path in paths:
         if not path.exists():
             continue
@@ -39,33 +39,32 @@ def load_config_from_paths(
                 raise ConfigError(
                     "YAML configs do not support multiple configs. Use Python instead."
                 )
-            next_config = load_config_from_yaml(path)
+            non_python_configs.append(load_config_from_yaml(path))
         elif extension == "py":
-            next_config = load_config_from_python_module(path, config_name=config_name)
+            python_config = load_config_from_python_module(path, config_name=config_name)
         else:
             raise ConfigError(
                 f"Unsupported config file extension '{extension}' in config file '{path}'."
             )
 
-        config = config.update_with(next_config) if config is not None else next_config
+    if load_from_env:
+        env_config = load_config_from_env()
+        if env_config:
+            non_python_configs.append(load_config_from_env())
 
-    if config is None:
+    if not non_python_configs and not python_config:
         raise ConfigError(
             "SQLMesh config could not be found. Point the cli to the right path with `sqlmesh -p`. If you haven't set up SQLMesh, run `sqlmesh init`."
         )
 
-    if load_from_env:
-        config = config.update_with(load_config_from_env())
-
-    if config_defaults:
-        config = config_defaults.update_with(config)
-
-    return config
+    non_python_config = Config.parse_obj(merge_list_of_dicts(non_python_configs))
+    if python_config:
+        return python_config.update_with(non_python_config)
+    return non_python_config
 
 
-def load_config_from_yaml(path: Path) -> Config:
-    config_dict = yaml_load(path)
-    return Config.parse_obj(config_dict)
+def load_config_from_yaml(path: Path) -> t.Dict[str, t.Any]:
+    return yaml_load(path)
 
 
 def load_config_from_python_module(module_path: Path, config_name: str = "config") -> Config:
@@ -88,7 +87,7 @@ def load_config_from_python_module(module_path: Path, config_name: str = "config
     return config_obj
 
 
-def load_config_from_env() -> Config:
+def load_config_from_env() -> t.Dict[str, t.Any]:
     config_dict: t.Dict[str, t.Any] = {}
 
     for key, value in os.environ.items():
@@ -105,4 +104,4 @@ def load_config_from_env() -> Config:
                 target_dict = target_dict[config_key]
             target_dict[segments[-1]] = value
 
-    return Config.parse_obj(config_dict)
+    return config_dict

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1134,20 +1134,25 @@ class Context(BaseContext):
         if isinstance(config, Config):
             return {path: config for path in paths}
 
-        config_defaults = None
-        for path in (self.sqlmesh_path / "config.yml", self.sqlmesh_path / "config.yaml"):
+        config_env_vars = None
+        personal_paths = [
+            self.sqlmesh_path / "config.yml",
+            self.sqlmesh_path / "config.yaml",
+        ]
+        for path in personal_paths:
             if path.exists():
-                config_defaults = load_config_from_yaml(path)
-                break
+                config_env_vars = load_config_from_yaml(path).get("env_vars")
+                if config_env_vars:
+                    break
 
-        with env_vars(config_defaults.env_vars if config_defaults else {}):
+        with env_vars(config_env_vars if config_env_vars else {}):
             return {
                 path: load_config_from_paths(
                     path / "config.py",
                     path / "config.yml",
                     path / "config.yaml",
+                    *personal_paths,
                     config_name=config,
-                    config_defaults=config_defaults,
                 )
                 for path in paths
             }

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -239,9 +239,9 @@ def env_vars(environ: dict[str, str]) -> t.Iterator[None]:
         os.environ.update(old_environ)
 
 
-def merge_list_of_dicts(list_of_dicts: t.List[t.Dict]) -> t.Dict:
+def merge_dicts(*args: t.Dict) -> t.Dict:
     """
-    Merges a list of dicts. Just does key collision replacement
+    Merges dicts. Just does key collision replacement
     """
 
     def merge(a: t.Dict, b: t.Dict) -> t.Dict:
@@ -255,4 +255,4 @@ def merge_list_of_dicts(list_of_dicts: t.List[t.Dict]) -> t.Dict:
                 a[b_key] = b_value
         return a
 
-    return reduce(merge, list_of_dicts, {})
+    return reduce(merge, args, {})

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -247,7 +247,7 @@ def merge_dicts(*args: t.Dict) -> t.Dict:
     def merge(a: t.Dict, b: t.Dict) -> t.Dict:
         for b_key, b_value in b.items():
             a_value = a.get(b_key)
-            if b_key in a and isinstance(a_value, dict) and isinstance(b_value, dict):
+            if isinstance(a_value, dict) and isinstance(b_value, dict):
                 merge(a_value, b_value)
             elif isinstance(b_value, dict):
                 a[b_key] = copy.deepcopy(b_value)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -183,7 +183,7 @@ def test_load_config_from_env():
             "SQLMESH__GATEWAY__CONNECTION__DATABASE": "test_db",
         },
     ):
-        assert load_config_from_env() == Config(
+        assert Config.parse_obj(load_config_from_env()) == Config(
             gateways=GatewayConfig(connection=DuckDBConnectionConfig(database="test_db"))
         )
 

--- a/tests/utils/test_filesystem.py
+++ b/tests/utils/test_filesystem.py
@@ -1,16 +1,9 @@
 import pathlib
 
-import py.error
 
-
-def create_temp_file(tmpdir, filepath: pathlib.Path, contents: str) -> pathlib.Path:
-    target_dir = tmpdir
-    for directory in list(filepath.parts)[:-1]:
-        try:
-            target_dir = target_dir.mkdir(directory)  # type: ignore
-        except py.error.EEXIST:
-            target_dir = target_dir.join(directory)  # type: ignore
-    target_filepath = target_dir.join(filepath.name)  # type: ignore
-    target_filepath.write(contents)
-    assert target_filepath.read() == contents
+def create_temp_file(tmp_path: pathlib.Path, filepath: pathlib.Path, contents: str) -> pathlib.Path:
+    target_filepath = tmp_path / filepath
+    target_filepath.parent.mkdir(parents=True, exist_ok=True)
+    target_filepath.write_text(contents)
+    assert target_filepath.read_text() == contents
     return target_filepath


### PR DESCRIPTION
Breaking Change: Personal config files in your home directory now override config defined in a project. 

Prior to this change whenever a config was loaded it was validated as is and therefore it was expected any source of configs be complete and not partial. This made doing things like defining a password in a personal config not possible. This change combines all the config as dicts and then after that validates that combined representation. 

Python config cannot be partial and all the other configs override it if they are defined. I wonder though if we should just have it be that users either use Python or use YAML + Env vars. Open to feedback. 

Also included is some cleanup of tests where I didn't realize we could get `tmp_path` which is a `pathlib.Path` object instead of using `tmpdir`. 

Follow up work:
* Improve validation messages so if a config a incorrectly supplied we get a clean error instead of the current confusing error from Pydantic