### PR TITLE
Fix: Use unique type for GCPPostgresConnectionConfig

### DIFF
--- a/docs/integrations/engines.md
+++ b/docs/integrations/engines.md
@@ -258,6 +258,18 @@ sqlmesh_airflow = SQLMeshAirflow(
 )
 ```
 
+## GCP Postgres
+### GCP Postgres - Local/Built-in Scheduler
+**Engine Adapter Type**: `postgres`
+
+| Option                    | Description                                                             |  Type   | Required |
+|---------------------------|-------------------------------------------------------------------------|:-------:|:--------:|
+| `instance_connection_str` | Connection name for the postgres instance                               | string  |    Y     |
+| `user`                    | The username (posgres or IAM) to use for authentication                 | string  |    Y     |
+| `password`                | The password to use for authentication when using a Postgres user       | string  |    N     |
+| `enable_iam_auth`         | Enables IAM authentication when using a IAM user                        | boolean |    N     |
+| `db`                      | The name of the database instance to connect to                         | string  |    Y     |
+
 ## Snowflake
 ### Snowflake - Local/Built-in Scheduler
 **Engine Adapter Type**: `snowflake`

--- a/docs/integrations/engines.md
+++ b/docs/integrations/engines.md
@@ -262,13 +262,13 @@ sqlmesh_airflow = SQLMeshAirflow(
 ### GCP Postgres - Local/Built-in Scheduler
 **Engine Adapter Type**: `postgres`
 
-| Option                    | Description                                                             |  Type   | Required |
-|---------------------------|-------------------------------------------------------------------------|:-------:|:--------:|
-| `instance_connection_str` | Connection name for the postgres instance                               | string  |    Y     |
-| `user`                    | The username (posgres or IAM) to use for authentication                 | string  |    Y     |
-| `password`                | The password to use for authentication when using a Postgres user       | string  |    N     |
-| `enable_iam_auth`         | Enables IAM authentication when using a IAM user                        | boolean |    N     |
-| `db`                      | The name of the database instance to connect to                         | string  |    Y     |
+| Option                    | Description                                                                         |  Type   | Required |
+|---------------------------|-------------------------------------------------------------------------------------|:-------:|:--------:|
+| `instance_connection_str` | Connection name for the postgres instance                                           | string  |    Y     |
+| `user`                    | The username (posgres or IAM) to use for authentication                             | string  |    Y     |
+| `password`                | The password to use for authentication. Required when connecting as a Postgres user | string  |    N     |
+| `enable_iam_auth`         | Enables IAM authentication. Required when connecting as an IAM user                 | boolean |    N     |
+| `db`                      | The name of the database instance to connect to                                     | string  |    Y     |
 
 ## Snowflake
 ### Snowflake - Local/Built-in Scheduler

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -447,6 +447,8 @@ class GCPPostgresConnectionConfig(_ConnectionConfig):
     def _validate_auth_method(
         cls, values: t.Dict[str, t.Optional[str]]
     ) -> t.Dict[str, t.Optional[str]]:
+        if "type" in values and values["type"] != "gcp_postgres":
+            return values
         password = values.get("password")
         enable_iam_auth = values.get("enable_iam_auth")
         if password and enable_iam_auth:


### PR DESCRIPTION
Also adds config validation and documentation for GCPPostgresConnectionConfig.