### PR TITLE
Feat: Determine time_column from bigquery partition_by config

### DIFF
--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import typing as t
 
-from pydantic import validator
+from pydantic import Field, validator
 from sqlglot import exp
 from sqlglot.helper import ensure_list
 
@@ -66,7 +66,7 @@ class ModelConfig(BaseModelConfig):
 
     # sqlmesh fields
     sql: SqlStr = SqlStr("")
-    time_column: t.Optional[str] = None
+    time_column_: t.Optional[str] = Field(None, alias="time_column")
     cron: t.Optional[str] = None
     dialect: t.Optional[str] = None
     batch_size: t.Optional[int] = None
@@ -118,6 +118,14 @@ class ModelConfig(BaseModelConfig):
             "time_column": UpdateStrategy.IMMUTABLE,
         },
     }
+
+    @property
+    def time_column(self) -> t.Optional[str]:
+        if self.time_column_:
+            return self.time_column_
+        if isinstance(self.partition_by, dict) and self.partition_by["data_type"] != "int64":
+            return self.partition_by["field"]
+        return None
 
     @property
     def model_dialect(self) -> t.Optional[str]:

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -115,7 +115,7 @@ class ModelConfig(BaseModelConfig):
         **BaseModelConfig._FIELD_UPDATE_STRATEGY,
         **{
             "sql": UpdateStrategy.IMMUTABLE,
-            "time_column": UpdateStrategy.IMMUTABLE,
+            "time_column_": UpdateStrategy.IMMUTABLE,
         },
     }
 
@@ -123,7 +123,11 @@ class ModelConfig(BaseModelConfig):
     def time_column(self) -> t.Optional[str]:
         if self.time_column_:
             return self.time_column_
-        if isinstance(self.partition_by, dict) and self.partition_by["data_type"] != "int64":
+        if (
+            isinstance(self.partition_by, dict)
+            and self.partition_by["data_type"] != "int64"
+            and self.incremental_strategy in INCREMENTAL_BY_TIME_STRATEGIES
+        ):
             return self.partition_by["field"]
         return None
 

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -83,6 +83,13 @@ def test_model_kind():
         time_column="foo", forward_only=True, disable_restatement=True
     )
 
+    assert ModelConfig(
+        materialized=Materialization.INCREMENTAL, time_column="foo", partition_by={"field": "bar"}
+    ).model_kind(target) == IncrementalByTimeRangeKind(time_column="foo")
+    assert ModelConfig(
+        materialized=Materialization.INCREMENTAL, partition_by={"field": "bar"}
+    ).model_kind(target) == IncrementalByTimeRangeKind(time_column="bar")
+
     with pytest.raises(ConfigError) as exception:
         ModelConfig(materialized=Materialization.INCREMENTAL).model_kind(target)
     with pytest.raises(ConfigError) as exception:
@@ -102,6 +109,11 @@ def test_model_kind():
             materialized=Materialization.INCREMENTAL,
             unique_key=["bar"],
             incremental_strategy="append",
+        ).model_kind(target)
+    with pytest.raises(ConfigError) as exception:
+        assert ModelConfig(
+            materialized=Materialization.INCREMENTAL,
+            partition_by={"field": "bar", "data_type": "int64"},
         ).model_kind(target)
 
 

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -84,10 +84,15 @@ def test_model_kind():
     )
 
     assert ModelConfig(
-        materialized=Materialization.INCREMENTAL, time_column="foo", partition_by={"field": "bar"}
+        materialized=Materialization.INCREMENTAL,
+        time_column="foo",
+        incremental_strategy="insert_overwrite",
+        partition_by={"field": "bar"},
     ).model_kind(target) == IncrementalByTimeRangeKind(time_column="foo")
     assert ModelConfig(
-        materialized=Materialization.INCREMENTAL, partition_by={"field": "bar"}
+        materialized=Materialization.INCREMENTAL,
+        incremental_strategy="insert_overwrite",
+        partition_by={"field": "bar"},
     ).model_kind(target) == IncrementalByTimeRangeKind(time_column="bar")
 
     with pytest.raises(ConfigError) as exception:
@@ -113,6 +118,7 @@ def test_model_kind():
     with pytest.raises(ConfigError) as exception:
         assert ModelConfig(
             materialized=Materialization.INCREMENTAL,
+            incremental_strategy="insert_ovewrite",
             partition_by={"field": "bar", "data_type": "int64"},
         ).model_kind(target)
 


### PR DESCRIPTION
We can discern the time column for incremental by time models automatically using the dbt bigquery partition_by config, which specifies the column.