### PR TITLE
Feat: re-use ModelConfirmation component from IDE page

### DIFF
--- a/web/client/src/context/context.ts
+++ b/web/client/src/context/context.ts
@@ -1,3 +1,4 @@
+import { type Confirmation } from '@components/modal/ModalConfirmation'
 import { ModelSQLMeshModel } from '@models/sqlmesh-model'
 import { create } from 'zustand'
 import {
@@ -14,11 +15,16 @@ import {
 import { isStringEmptyOrNil } from '~/utils'
 
 interface ContextStore {
+  showConfirmation: boolean
+  confirmations: Confirmation[]
   environment: ModelEnvironment
   environments: Set<ModelEnvironment>
   initialStartDate?: ContextEnvironmentStart
   initialEndDate?: ContextEnvironmentEnd
   models: Map<string, ModelSQLMeshModel>
+  setShowConfirmation: (showConfirmation: boolean) => void
+  addConfirmation: (confirmation: Confirmation) => void
+  removeConfirmation: () => void
   setModels: (models?: Model[]) => void
   isExistingEnvironment: (
     environment: ModelEnvironment | EnvironmentName,
@@ -42,11 +48,36 @@ const environments = new Set(ModelEnvironment.getDefaultEnvironments())
 const environment = environments.values().next().value
 
 export const useStoreContext = create<ContextStore>((set, get) => ({
+  showConfirmation: false,
+  confirmations: [],
   environment,
   environments,
   initialStartDate: undefined,
   initialEndDate: undefined,
   models: new Map(),
+  setShowConfirmation(showConfirmation) {
+    set(() => ({
+      showConfirmation,
+    }))
+  },
+  addConfirmation(confirmation) {
+    set(s => {
+      s.confirmations.push(confirmation)
+
+      return {
+        confirmations: Array.from(s.confirmations),
+      }
+    })
+  },
+  removeConfirmation() {
+    const s = get()
+
+    s.confirmations.shift()
+
+    set(() => ({
+      confirmations: Array.from(s.confirmations),
+    }))
+  },
   setModels(models = []) {
     const s = get()
 

--- a/web/client/src/library/components/button/Button.tsx
+++ b/web/client/src/library/components/button/Button.tsx
@@ -132,14 +132,7 @@ function ButtonPlain(
       disabled={disabled}
       onClick={onClick}
       onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) => {
-        if (e.key === 'Enter') {
-          e.preventDefault()
-          e.stopPropagation()
-
-          onClick?.(e as unknown as React.MouseEvent<HTMLButtonElement>)
-        }
-
-        if (e.key === ' ') {
+        if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault()
           e.stopPropagation()
 

--- a/web/client/src/library/components/button/Button.tsx
+++ b/web/client/src/library/components/button/Button.tsx
@@ -94,9 +94,9 @@ const SHAPE = new Map<ButtonShape, string>([
 
 const SIZE = new Map<ButtonSize, string>([
   [EnumSize.xs, `px-2 py-0 text-xs leading-2 border`],
-  [EnumSize.sm, `px-2 py-[0.125rem] text-xs leading-4 border-2`],
-  [EnumSize.md, `px-3 py-2 text-base leading-6 border-2`],
-  [EnumSize.lg, `px-4 py-3 text-lg border-4`],
+  [EnumSize.sm, `px-2 py-[0.125rem] text-xs leading-2 border-2`],
+  [EnumSize.md, `px-3 py-2 text-base leading-4 border-2`],
+  [EnumSize.lg, `px-4 py-3 text-lg leading-6 border-4`],
 ])
 
 const Button = makeButton(
@@ -131,6 +131,21 @@ function ButtonPlain(
       form={form}
       disabled={disabled}
       onClick={onClick}
+      onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) => {
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          e.stopPropagation()
+
+          onClick?.(e as unknown as React.MouseEvent<HTMLButtonElement>)
+        }
+
+        if (e.key === ' ') {
+          e.preventDefault()
+          e.stopPropagation()
+
+          onClick?.(e as unknown as React.MouseEvent<HTMLButtonElement>)
+        }
+      }}
       className={className}
     >
       {children}

--- a/web/client/src/library/components/fileExplorer/FileExplorer.tsx
+++ b/web/client/src/library/components/fileExplorer/FileExplorer.tsx
@@ -237,7 +237,7 @@ function FileExplorerArtifactContainer({
         activeRange.has(artifact)
           ? 'text-brand-100 !bg-brand-500 dark:bg-brand-700 dark:text-brand-100'
           : isSelected &&
-          'bg-neutral-200 text-neutral-600 dark:bg-dark-lighter dark:text-primary-500',
+              'bg-neutral-200 text-neutral-600 dark:bg-dark-lighter dark:text-primary-500',
       )}
       style={style}
       onClick={handleSelect}

--- a/web/client/src/library/components/fileExplorer/FileExplorer.tsx
+++ b/web/client/src/library/components/fileExplorer/FileExplorer.tsx
@@ -1,7 +1,5 @@
 import React, { type MouseEvent } from 'react'
 import clsx from 'clsx'
-import ModalConfirmation from '../modal/ModalConfirmation'
-import { Button } from '../button/Button'
 import Directory from './Directory'
 import { useStoreProject } from '@context/project'
 import * as ContextMenu from '@radix-ui/react-context-menu'
@@ -14,6 +12,8 @@ import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/solid'
 import SearchList from '@components/search/SearchList'
 import { type ModelFile } from '@models/file'
 import { EnumSize } from '~/types/enum'
+import { useStoreContext } from '@context/context'
+
 /* TODO:
   - add drag and drop files/directories from desktop
   - add copy and paste
@@ -28,12 +28,10 @@ const FileExplorer = function FileExplorer({
   const project = useStoreProject(s => s.project)
   const setSelectedFile = useStoreProject(s => s.setSelectedFile)
 
+  const addConfirmation = useStoreContext(s => s.addConfirmation)
+
   const {
     activeRange,
-    confirmation,
-    showConfirmation,
-    setShowConfirmation,
-    setConfirmation,
     removeArtifacts,
     setActiveRange,
     createDirectory,
@@ -46,7 +44,7 @@ const FileExplorer = function FileExplorer({
     }
 
     if (e.metaKey && e.key === 'Backspace' && activeRange.size > 0) {
-      setConfirmation({
+      addConfirmation({
         headline: 'Removing Selected Files/Directories',
         description: `Are you sure you want to remove ${activeRange.size} items?`,
         yesText: 'Yes, Remove',
@@ -116,57 +114,6 @@ const FileExplorer = function FileExplorer({
           <div className="ml-auto pl-5"></div>
         </ContextMenu.Item>
       </FileExplorer.ContextMenu>
-      <ModalConfirmation
-        show={showConfirmation}
-        onClose={() => {
-          setShowConfirmation(false)
-        }}
-      >
-        <ModalConfirmation.Main>
-          {confirmation?.headline != null && (
-            <ModalConfirmation.Headline>
-              {confirmation?.headline}
-            </ModalConfirmation.Headline>
-          )}
-          {confirmation?.description != null && (
-            <ModalConfirmation.Description>
-              {confirmation?.description}
-            </ModalConfirmation.Description>
-          )}
-          {confirmation?.details != null && (
-            <ModalConfirmation.Details details={confirmation?.details} />
-          )}
-        </ModalConfirmation.Main>
-        <ModalConfirmation.Actions>
-          <Button
-            className="font-bold"
-            size="md"
-            variant="danger"
-            onClick={(e: MouseEvent) => {
-              e.stopPropagation()
-
-              confirmation?.action?.()
-
-              setShowConfirmation(false)
-            }}
-          >
-            {confirmation?.yesText ?? 'Confirm'}
-          </Button>
-          <Button
-            size="md"
-            variant="alternative"
-            onClick={(e: MouseEvent) => {
-              e.stopPropagation()
-
-              confirmation?.cancel?.()
-
-              setShowConfirmation(false)
-            }}
-          >
-            {confirmation?.noText ?? 'Cancel'}
-          </Button>
-        </ModalConfirmation.Actions>
-      </ModalConfirmation>
     </div>
   )
 }
@@ -290,7 +237,7 @@ function FileExplorerArtifactContainer({
         activeRange.has(artifact)
           ? 'text-brand-100 !bg-brand-500 dark:bg-brand-700 dark:text-brand-100'
           : isSelected &&
-              'bg-neutral-200 text-neutral-600 dark:bg-dark-lighter dark:text-primary-500',
+          'bg-neutral-200 text-neutral-600 dark:bg-dark-lighter dark:text-primary-500',
       )}
       style={style}
       onClick={handleSelect}

--- a/web/client/src/library/components/fileExplorer/context.tsx
+++ b/web/client/src/library/components/fileExplorer/context.tsx
@@ -13,6 +13,7 @@ import { getAllFilesInDirectory } from './help'
 import {
   isArrayNotEmpty,
   isFalse,
+  isNotNil,
   isStringEmptyOrNil,
   toUniqueName,
 } from '@utils/index'
@@ -277,16 +278,8 @@ export default function FileExplorerProvider({
         yesText: 'Yes, Remove',
         noText: 'No, Cancel',
         action: () => {
-          if (artifact instanceof ModelDirectory) {
-            if (artifact.parent != null) {
-              removeArtifacts(new Set([artifact]))
-            }
-          }
-
-          if (artifact instanceof ModelFile) {
-            if (artifact.parent != null) {
-              removeArtifacts(new Set([artifact]))
-            }
+          if (isNotNil(artifact.parent)) {
+            removeArtifacts(new Set([artifact]))
           }
         },
       })

--- a/web/client/src/library/components/fileExplorer/context.tsx
+++ b/web/client/src/library/components/fileExplorer/context.tsx
@@ -9,22 +9,14 @@ import {
 import { useStoreProject } from '@context/project'
 import { ModelArtifact } from '@models/artifact'
 import { ModelDirectory } from '@models/directory'
-import { getAllFilesInDirectory } from './help'
-import {
-  isArrayNotEmpty,
-  isFalse,
-  isNotNil,
-  isStringEmptyOrNil,
-  toUniqueName,
-} from '@utils/index'
+import { getAllFilesInDirectory, toUniqueName } from './help'
+import { isArrayNotEmpty, isFalse, isStringEmptyOrNil } from '@utils/index'
 import { ModelFile } from '@models/file'
 import { useStoreEditor } from '@context/editor'
-import { type Confirmation } from '@components/modal/ModalConfirmation'
 import { type ResponseWithDetail } from '@api/instance'
+import { useStoreContext } from '@context/context'
 
 interface FileExplorer {
-  confirmation?: Confirmation
-  showConfirmation: boolean
   activeRange: Set<ModelArtifact>
   setActiveRange: (activeRange: Set<ModelArtifact>) => void
   selectArtifactsInRange: (to: ModelArtifact) => void
@@ -34,24 +26,18 @@ interface FileExplorer {
   removeArtifacts: (artifacts: Set<ModelArtifact>) => void
   removeArtifactWithConfirmation: (artifact: ModelArtifact) => void
   moveArtifacts: (artifacts: Set<ModelArtifact>, target: ModelDirectory) => void
-  setShowConfirmation: (show: boolean) => void
-  setConfirmation: (confirmation?: Confirmation) => void
 }
 
 export const FileExplorerContext = createContext<FileExplorer>({
-  confirmation: undefined,
-  showConfirmation: false,
   activeRange: new Set(),
-  setActiveRange: () => {},
-  selectArtifactsInRange: () => {},
-  createDirectory: () => {},
-  createFile: () => {},
-  renameArtifact: () => {},
-  removeArtifacts: () => {},
-  removeArtifactWithConfirmation: () => {},
-  moveArtifacts: () => {},
-  setShowConfirmation: () => {},
-  setConfirmation: () => {},
+  setActiveRange: () => { },
+  selectArtifactsInRange: () => { },
+  createDirectory: () => { },
+  createFile: () => { },
+  renameArtifact: () => { },
+  removeArtifacts: () => { },
+  removeArtifactWithConfirmation: () => { },
+  moveArtifacts: () => { },
 })
 
 export default function FileExplorerProvider({
@@ -64,17 +50,13 @@ export default function FileExplorerProvider({
   const setSelectedFile = useStoreProject(s => s.setSelectedFile)
   const setFiles = useStoreProject(s => s.setFiles)
 
+  const addConfirmation = useStoreContext(s => s.addConfirmation)
+
   const tab = useStoreEditor(s => s.tab)
   const closeTab = useStoreEditor(s => s.closeTab)
 
   const [isLoading, setIsLoading] = useState(false)
   const [activeRange, setActiveRange] = useState(new Set<ModelArtifact>())
-  const [confirmation, setConfirmation] = useState<Confirmation>()
-  const [showConfirmation, setShowConfirmation] = useState(false)
-
-  useEffect(() => {
-    setShowConfirmation(isNotNil(confirmation))
-  }, [confirmation])
 
   useEffect(() => {
     setSelectedFile(tab?.file)
@@ -266,34 +248,10 @@ export default function FileExplorerProvider({
   }
 
   function removeArtifactWithConfirmation(artifact: ModelArtifact): void {
-    let confirmation: Confirmation = {
-      headline: `Removing ${
-        artifact instanceof ModelDirectory ? 'Directory' : 'File'
-      }`,
-      description: `Are you sure you want to remove the ${
-        artifact instanceof ModelDirectory ? 'directory' : 'file'
-      } "${artifact.name}"?`,
-      yesText: 'Yes, Remove',
-      noText: 'No, Cancel',
-      action: () => {
-        if (artifact instanceof ModelDirectory) {
-          if (artifact.parent != null) {
-            removeArtifacts(new Set([artifact]))
-          }
-        }
-
-        if (artifact instanceof ModelFile) {
-          if (artifact.parent != null) {
-            removeArtifacts(new Set([artifact]))
-          }
-        }
-      },
-    }
-
     if (activeRange.has(artifact)) {
       // User selected multiple including current directory
       // so here we should prompt to delete all selected
-      confirmation = {
+      addConfirmation({
         headline: 'Removing Selected Files/Directories',
         description: `Are you sure you want to remove ${activeRange.size} items?`,
         yesText: 'Yes, Remove',
@@ -302,10 +260,30 @@ export default function FileExplorerProvider({
         action: () => {
           removeArtifacts(activeRange)
         },
-      }
-    }
+      })
+    } else {
+      addConfirmation({
+        headline: `Removing ${artifact instanceof ModelDirectory ? 'Directory' : 'File'
+          }`,
+        description: `Are you sure you want to remove the ${artifact instanceof ModelDirectory ? 'directory' : 'file'
+          } "${artifact.name}"?`,
+        yesText: 'Yes, Remove',
+        noText: 'No, Cancel',
+        action: () => {
+          if (artifact instanceof ModelDirectory) {
+            if (artifact.parent != null) {
+              removeArtifacts(new Set([artifact]))
+            }
+          }
 
-    setConfirmation(confirmation)
+          if (artifact instanceof ModelFile) {
+            if (artifact.parent != null) {
+              removeArtifacts(new Set([artifact]))
+            }
+          }
+        },
+      })
+    }
   }
 
   function moveArtifacts(
@@ -362,7 +340,7 @@ export default function FileExplorerProvider({
     })
 
     if (isArrayNotEmpty(duplicates)) {
-      setConfirmation({
+      addConfirmation({
         headline: 'Moving Duplicates',
         description: `All duplicated names will be renamed!`,
         yesText: 'Yes, Rename',
@@ -394,8 +372,6 @@ export default function FileExplorerProvider({
   return (
     <FileExplorerContext.Provider
       value={{
-        confirmation,
-        showConfirmation,
         activeRange,
         createDirectory,
         createFile,
@@ -404,8 +380,6 @@ export default function FileExplorerProvider({
         removeArtifactWithConfirmation,
         moveArtifacts,
         selectArtifactsInRange,
-        setConfirmation,
-        setShowConfirmation,
         setActiveRange(activeRange) {
           setActiveRange(
             () =>

--- a/web/client/src/library/components/fileExplorer/context.tsx
+++ b/web/client/src/library/components/fileExplorer/context.tsx
@@ -9,8 +9,13 @@ import {
 import { useStoreProject } from '@context/project'
 import { ModelArtifact } from '@models/artifact'
 import { ModelDirectory } from '@models/directory'
-import { getAllFilesInDirectory, toUniqueName } from './help'
-import { isArrayNotEmpty, isFalse, isStringEmptyOrNil } from '@utils/index'
+import { getAllFilesInDirectory } from './help'
+import {
+  isArrayNotEmpty,
+  isFalse,
+  isStringEmptyOrNil,
+  toUniqueName,
+} from '@utils/index'
 import { ModelFile } from '@models/file'
 import { useStoreEditor } from '@context/editor'
 import { type ResponseWithDetail } from '@api/instance'
@@ -30,14 +35,14 @@ interface FileExplorer {
 
 export const FileExplorerContext = createContext<FileExplorer>({
   activeRange: new Set(),
-  setActiveRange: () => { },
-  selectArtifactsInRange: () => { },
-  createDirectory: () => { },
-  createFile: () => { },
-  renameArtifact: () => { },
-  removeArtifacts: () => { },
-  removeArtifactWithConfirmation: () => { },
-  moveArtifacts: () => { },
+  setActiveRange: () => {},
+  selectArtifactsInRange: () => {},
+  createDirectory: () => {},
+  createFile: () => {},
+  renameArtifact: () => {},
+  removeArtifacts: () => {},
+  removeArtifactWithConfirmation: () => {},
+  moveArtifacts: () => {},
 })
 
 export default function FileExplorerProvider({
@@ -263,10 +268,12 @@ export default function FileExplorerProvider({
       })
     } else {
       addConfirmation({
-        headline: `Removing ${artifact instanceof ModelDirectory ? 'Directory' : 'File'
-          }`,
-        description: `Are you sure you want to remove the ${artifact instanceof ModelDirectory ? 'directory' : 'file'
-          } "${artifact.name}"?`,
+        headline: `Removing ${
+          artifact instanceof ModelDirectory ? 'Directory' : 'File'
+        }`,
+        description: `Are you sure you want to remove the ${
+          artifact instanceof ModelDirectory ? 'directory' : 'file'
+        } "${artifact.name}"?`,
         yesText: 'Yes, Remove',
         noText: 'No, Cancel',
         action: () => {

--- a/web/client/src/library/components/modal/ModalConfirmation.tsx
+++ b/web/client/src/library/components/modal/ModalConfirmation.tsx
@@ -3,7 +3,8 @@ import Modal from './Modal'
 
 interface PropsModalConfirmation extends React.HTMLAttributes<HTMLElement> {
   show: boolean
-  onClose: () => void
+  onClose?: () => void
+  afterLeave?: () => void
 }
 
 export interface Confirmation {
@@ -15,6 +16,7 @@ export interface Confirmation {
   tagline?: string
   yesText: string
   noText: string
+  children?: React.ReactNode
 }
 
 export interface WithConfirmation {
@@ -25,11 +27,13 @@ function ModalConfirmation({
   show,
   children,
   onClose,
+  afterLeave,
 }: PropsModalConfirmation): JSX.Element {
   return (
     <Modal
       show={show}
       onClose={onClose}
+      afterLeave={afterLeave}
     >
       <Dialog.Panel className="w-[30rem] transform rounded-xl bg-theme text-left align-middle shadow-xl transition-all">
         {children}

--- a/web/client/src/library/pages/ide/IDE.tsx
+++ b/web/client/src/library/pages/ide/IDE.tsx
@@ -182,7 +182,6 @@ export default function PageIDE(): JSX.Element {
   }, [models])
 
   useEffect(() => {
-    console.log('confirmations', confirmations)
     setShowConfirmation(confirmations.length > 0)
   }, [confirmations])
 
@@ -318,6 +317,7 @@ export default function PageIDE(): JSX.Element {
               e.stopPropagation()
 
               confirmation?.action?.()
+              setShowConfirmation(false)
             }}
           >
             {confirmation?.yesText ?? 'Confirm'}

--- a/web/client/src/library/pages/ide/RunPlan.tsx
+++ b/web/client/src/library/pages/ide/RunPlan.tsx
@@ -58,7 +58,7 @@ export default function RunPlan(): JSX.Element {
 
   const [hasChanges, setHasChanges] = useState(false)
   const [plan, setPlan] = useState<ContextEnvironment | undefined>()
-  const [shouldStartPlanAutomatically, setShouldSartPlanAutomatically] =
+  const [shouldStartPlanAutomatically, setShouldStartPlanAutomatically] =
     useState(false)
 
   const {
@@ -76,7 +76,7 @@ export default function RunPlan(): JSX.Element {
   useEffect(() => {
     if (shouldStartPlanAutomatically) {
       startPlan()
-      setShouldSartPlanAutomatically(false)
+      setShouldStartPlanAutomatically(false)
     }
 
     if (isFalse(environment.isSynchronized)) return
@@ -166,9 +166,9 @@ export default function RunPlan(): JSX.Element {
                           className="mr-2"
                           side="left"
                           environment={environment}
-                          showAddEnvironemnt={false}
+                          showAddEnvironment={false}
                           onSelect={() => {
-                            setShouldSartPlanAutomatically(true)
+                            setShouldStartPlanAutomatically(true)
                             setShowConfirmation(false)
                           }}
                           size={EnumSize.md}
@@ -184,7 +184,7 @@ export default function RunPlan(): JSX.Element {
                         className="w-full"
                         size={EnumSize.md}
                         onAdd={() => {
-                          setShouldSartPlanAutomatically(true)
+                          setShouldStartPlanAutomatically(true)
                           setShowConfirmation(false)
                         }}
                       />
@@ -304,7 +304,7 @@ function SelectEnvironemnt({
   disabled,
   side = EnumSide.Right,
   className,
-  showAddEnvironemnt = true,
+  showAddEnvironment = true,
   size = EnumSize.sm,
 }: {
   environment: ModelEnvironment
@@ -313,7 +313,7 @@ function SelectEnvironemnt({
   size?: ButtonSize
   side?: Side
   onSelect?: () => void
-  showAddEnvironemnt?: boolean
+  showAddEnvironment?: boolean
 }): JSX.Element {
   const environments = useStoreContext(s => s.environments)
   const setEnvironment = useStoreContext(s => s.setEnvironment)
@@ -426,7 +426,7 @@ function SelectEnvironemnt({
                     )}
                   </Menu.Item>
                 ))}
-                {showAddEnvironemnt && (
+                {showAddEnvironment && (
                   <>
                     <Divider />
                     <AddEnvironemnt


### PR DESCRIPTION
We have Confirmation component in multiple places , moving it to higher scope should help just reuse it from one place