### PR TITLE
Fix: Fix windows paths for executables

### DIFF
--- a/sqlmesh/migrations/v0016_fix_windows_path.py
+++ b/sqlmesh/migrations/v0016_fix_windows_path.py
@@ -18,13 +18,11 @@ def migrate(state_sync):  # type: ignore
         parsed_snapshot = json.loads(snapshot)
         model = parsed_snapshot["model"]
         python_env = model.get("python_env")
-        if not python_env:
-            continue
-        for py_definition in python_env.values():
-            path = py_definition.get("path")
-            if not path:
-                continue
-            py_definition["path"] = path.replace("\\", "/")
+        if python_env:
+            for py_definition in python_env.values():
+                path = py_definition.get("path")
+                if path:
+                    py_definition["path"] = path.replace("\\", "/")
 
         new_snapshots.append(
             {

--- a/sqlmesh/migrations/v0016_fix_windows_path.py
+++ b/sqlmesh/migrations/v0016_fix_windows_path.py
@@ -1,0 +1,53 @@
+"""Fix paths that have a Windows forward slash in them."""
+import json
+
+import pandas as pd
+from sqlglot import exp
+
+
+def migrate(state_sync):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = f"{schema}._snapshots"
+
+    new_snapshots = []
+
+    for name, identifier, version, snapshot, kind_name in engine_adapter.fetchall(
+        exp.select("name", "identifier", "version", "snapshot", "kind_name").from_(snapshots_table)
+    ):
+        parsed_snapshot = json.loads(snapshot)
+        model = parsed_snapshot["model"]
+        python_env = model.get("python_env")
+        if not python_env:
+            continue
+        for py_definition in python_env.values():
+            path = py_definition.get("path")
+            if not path:
+                continue
+            py_definition["path"] = path.replace("\\", "/")
+
+        new_snapshots.append(
+            {
+                "name": name,
+                "identifier": identifier,
+                "version": version,
+                "snapshot": json.dumps(parsed_snapshot),
+                "kind_name": kind_name,
+            }
+        )
+
+    if new_snapshots:
+        engine_adapter.delete_from(snapshots_table, "TRUE")
+
+        engine_adapter.insert_append(
+            snapshots_table,
+            pd.DataFrame(new_snapshots),
+            columns_to_types={
+                "name": exp.DataType.build("text"),
+                "identifier": exp.DataType.build("text"),
+                "version": exp.DataType.build("text"),
+                "snapshot": exp.DataType.build("text"),
+                "kind_name": exp.DataType.build("text"),
+            },
+            contains_json=True,
+        )

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -346,7 +346,8 @@ def serialize_env(env: t.Dict[str, t.Any], path: Path) -> t.Dict[str, Executable
                     name=name,
                     payload=normalize_source(v),
                     kind=ExecutableKind.DEFINITION,
-                    path=str(file_path.relative_to(path.absolute())),
+                    # Do `as_posix` to serialize windows path back to POSIX
+                    path=file_path.relative_to(path.absolute()).as_posix(),
                     alias=k if name != k else None,
                 )
             else:


### PR DESCRIPTION
Prior to this change if a path was generated using a Windows computer it would generate a different fingerprint than a linux/macos computer. This normalizes them. 