### PR TITLE
Fix: Fix Windows faulthandler and seed path

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -73,7 +73,9 @@ def cli(
 
         # Enable threadumps.
         faulthandler.enable()
-        faulthandler.register(signal.SIGUSR1.value)
+        # Windows doesn't support register so we check for it here
+        if hasattr(faulthandler, "register"):
+            faulthandler.register(signal.SIGUSR1.value)
         enable_logging(level=logging.DEBUG)
     elif ignore_warnings:
         logging.getLogger().setLevel(logging.ERROR)

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -344,12 +344,6 @@ def _model_sql(self: Generator, expression: Model) -> str:
 
 
 def _model_kind_sql(self: Generator, expression: ModelKind) -> str:
-    # props = {
-    #     prop.this: self.sql(prop, "value") for prop in expression.expressions
-    # }
-    # if "path" in props:
-    #     # Replace windows paths with unix paths
-    #     props["path"] = props["path"].replace("\\", "/")
     props = ",\n".join(
         self.indent(f"{prop.this} {self.sql(prop, 'value')}") for prop in expression.expressions
     )

--- a/sqlmesh/core/model/seed.py
+++ b/sqlmesh/core/model/seed.py
@@ -53,5 +53,5 @@ class Seed(PydanticModel):
 
 
 def create_seed(path: str | Path) -> Seed:
-    with open(path, "r") as fd:
+    with open(Path(path), "r") as fd:
         return Seed(content=fd.read())

--- a/sqlmesh/dbt/seed.py
+++ b/sqlmesh/dbt/seed.py
@@ -22,6 +22,6 @@ class SeedConfig(BaseModelConfig):
         """Converts the dbt seed into a SQLMesh model."""
         return create_seed_model(
             self.sql_name,
-            SeedKind(path=self.path.absolute()),
+            SeedKind(path=self.path.absolute().as_posix()),
             **self.sqlmesh_model_kwargs(context),
         )

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -151,7 +151,7 @@ class GithubEvent:
 
     @classmethod
     def from_path(cls, path: t.Union[str, pathlib.Path]) -> GithubEvent:
-        with open(path) as f:
+        with open(pathlib.Path(path)) as f:
             return cls.from_obj(json.load(f))
 
     @classmethod

--- a/sqlmesh/migrations/v0017_fix_windows_seed_path.py
+++ b/sqlmesh/migrations/v0017_fix_windows_seed_path.py
@@ -1,0 +1,47 @@
+"""Fix seed paths that have a Windows forward slash in them."""
+import json
+
+import pandas as pd
+from sqlglot import exp
+
+
+def migrate(state_sync):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = f"{schema}._snapshots"
+
+    new_snapshots = []
+
+    for name, identifier, version, snapshot, kind_name in engine_adapter.fetchall(
+        exp.select("name", "identifier", "version", "snapshot", "kind_name").from_(snapshots_table)
+    ):
+        parsed_snapshot = json.loads(snapshot)
+        model_kind = parsed_snapshot["model"]["kind"]
+        if "path" in model_kind:
+            model_kind["path"] = model_kind["path"].replace("\\", "/")
+
+        new_snapshots.append(
+            {
+                "name": name,
+                "identifier": identifier,
+                "version": version,
+                "snapshot": json.dumps(parsed_snapshot),
+                "kind_name": kind_name,
+            }
+        )
+
+    if new_snapshots:
+        engine_adapter.delete_from(snapshots_table, "TRUE")
+
+        engine_adapter.insert_append(
+            snapshots_table,
+            pd.DataFrame(new_snapshots),
+            columns_to_types={
+                "name": exp.DataType.build("text"),
+                "identifier": exp.DataType.build("text"),
+                "version": exp.DataType.build("text"),
+                "snapshot": exp.DataType.build("text"),
+                "kind_name": exp.DataType.build("text"),
+            },
+            contains_json=True,
+        )

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -197,3 +197,17 @@ def test_parse_jinja_with_semicolons():
     assert isinstance(expressions[2], JinjaStatement)
     assert isinstance(expressions[3], exp.Drop)
     assert isinstance(expressions[4], exp.Drop)
+
+
+def test_seed():
+    expressions = parse(
+        """
+        MODEL (
+            kind SEED (
+                path '..\..\..\data\data.csv',
+            ),
+        );
+    """
+    )
+    assert len(expressions) == 1
+    assert "../../../data/data.csv" in expressions[0].sql()


### PR DESCRIPTION
Two fixes:
1. Windows does not support `faulthandler.register` so I just check if the attribute exists and if so then we error. Docs: https://docs.python.org/3/library/faulthandler.html#faulthandler.register
2. If a user wrote a seed path in windows format then that is how it would be stored in state. Now we ensure that windows paths are converted to linux. 