### PR TITLE
Fix: Allow reverting to previous versions

### DIFF
--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -337,9 +337,9 @@ class Plan:
 
         for child in self.indirectly_modified[snapshot.name]:
             child_snapshot = self.context_diff.snapshots[child]
-            # If the child already has a version then the snapshot must have previously existed
-            # and therefore we don't want to change its categorization.
-            if child_snapshot.version:
+            # If the snapshot isn't new then we are reverting to a previously existing snapshot
+            # and therefore we don't want to recategorize it.
+            if not self.is_new_snapshot(child_snapshot):
                 continue
 
             if choice in (

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -337,6 +337,10 @@ class Plan:
 
         for child in self.indirectly_modified[snapshot.name]:
             child_snapshot = self.context_diff.snapshots[child]
+            # If the child already has a version then the snapshot must have previously existed
+            # and therefore we don't want to change its categorization.
+            if child_snapshot.version:
+                continue
 
             if choice in (
                 SnapshotChangeCategory.BREAKING,


### PR DESCRIPTION
Prior to this change if someone makes a change and the fingerprint is for a snapshot that already exists then we would throw an error saying that the snapshot already has intervals and that is unexpected. This enables us to do this again. 