### PR TITLE
Feat: Support custom schema name for state metadata

### DIFF
--- a/sqlmesh/core/config/gateway.py
+++ b/sqlmesh/core/config/gateway.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
+from sqlmesh.core import constants as c
 from sqlmesh.core.config.base import BaseConfig
 from sqlmesh.core.config.connection import ConnectionConfig
 from sqlmesh.core.config.scheduler import SchedulerConfig
@@ -17,9 +18,12 @@ class GatewayConfig(BaseConfig):
             the same connection as the data warehouse will be used.
         test_connection: Connection configuration for running unit tests.
         scheduler: The scheduler configuration.
+        state_schema: Schema name to use for the state tables. If None or empty string are provided
+            then no schema name is used and therefore the default schema defined for the connection will be used
     """
 
     connection: t.Optional[ConnectionConfig] = None
     state_connection: t.Optional[ConnectionConfig] = None
     test_connection: t.Optional[ConnectionConfig] = None
     scheduler: t.Optional[SchedulerConfig] = None
+    state_schema: t.Optional[str] = c.SQLMESH

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -125,6 +125,9 @@ class Config(BaseConfig):
     def get_scheduler(self, gateway_name: t.Optional[str] = None) -> SchedulerConfig:
         return self.get_gateway(gateway_name).scheduler or self.default_scheduler
 
+    def get_state_schema(self, gateway_name: t.Optional[str] = None) -> t.Optional[str]:
+        return self.get_gateway(gateway_name).state_schema
+
     @property
     def dialect(self) -> t.Optional[str]:
         return self.model_defaults.dialect

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -58,7 +58,8 @@ class BuiltInSchedulerConfig(_SchedulerConfig, BaseConfig):
         engine_adapter = (
             state_connection.create_engine_adapter() if state_connection else context.engine_adapter
         )
-        return EngineAdapterStateSync(engine_adapter, console=context.console)
+        schema = context.config.get_state_schema(context.gateway)
+        return EngineAdapterStateSync(engine_adapter, schema=schema, console=context.console)
 
     def create_plan_evaluator(self, context: Context) -> PlanEvaluator:
         return BuiltInPlanEvaluator(

--- a/sqlmesh/migrations/v0001_init.py
+++ b/sqlmesh/migrations/v0001_init.py
@@ -9,12 +9,11 @@ from sqlglot import exp
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    if schema:
-        engine_adapter.create_schema(schema)
     snapshots_table = f"_snapshots"
     environments_table = f"._environments"
     versions_table = f"._versions"
     if schema:
+        engine_adapter.create_schema(schema)
         snapshots_table = f"{schema}.{snapshots_table}"
         environments_table = f"{schema}.{environments_table}"
         versions_table = f"{schema}.{versions_table}"

--- a/sqlmesh/migrations/v0001_init.py
+++ b/sqlmesh/migrations/v0001_init.py
@@ -9,9 +9,9 @@ from sqlglot import exp
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = f"_snapshots"
-    environments_table = f"._environments"
-    versions_table = f"._versions"
+    snapshots_table = "_snapshots"
+    environments_table = "_environments"
+    versions_table = "_versions"
     if schema:
         engine_adapter.create_schema(schema)
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0001_init.py
+++ b/sqlmesh/migrations/v0001_init.py
@@ -9,11 +9,15 @@ from sqlglot import exp
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    engine_adapter.create_schema(schema)
-
-    snapshots_table = f"{schema}._snapshots"
-    environments_table = f"{schema}._environments"
-    versions_table = f"{schema}._versions"
+    if schema:
+        engine_adapter.create_schema(schema)
+    snapshots_table = f"_snapshots"
+    environments_table = f"._environments"
+    versions_table = f"._versions"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+        environments_table = f"{schema}.{environments_table}"
+        versions_table = f"{schema}.{versions_table}"
 
     engine_adapter.create_state_table(
         snapshots_table,

--- a/sqlmesh/migrations/v0003_move_batch_size.py
+++ b/sqlmesh/migrations/v0003_move_batch_size.py
@@ -6,7 +6,9 @@ from sqlglot import exp
 def migrate(state_sync):  # type: ignore
     """Move batch_size from the model and into the kind."""
 
-    snapshots_table = f"{state_sync.schema}._snapshots"
+    snapshots_table = f"_snapshots"
+    if state_sync.schema:
+        snapshots_table = f"{state_sync.schema}.{snapshots_table}"
 
     for row in state_sync.engine_adapter.fetchall(
         exp.select("*").from_(snapshots_table), quote_identifiers=True

--- a/sqlmesh/migrations/v0003_move_batch_size.py
+++ b/sqlmesh/migrations/v0003_move_batch_size.py
@@ -6,7 +6,7 @@ from sqlglot import exp
 def migrate(state_sync):  # type: ignore
     """Move batch_size from the model and into the kind."""
 
-    snapshots_table = f"_snapshots"
+    snapshots_table = "_snapshots"
     if state_sync.schema:
         snapshots_table = f"{state_sync.schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
+++ b/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
@@ -4,7 +4,9 @@ from sqlglot import exp
 
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    environments_table = f"{state_sync.schema}._environments"
+    environments_table = f"_environments"
+    if state_sync.schema:
+        environments_table = f"{state_sync.schema}._environments"
 
     alter_table_exp = exp.AlterTable(
         this=exp.to_table(environments_table),

--- a/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
+++ b/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
@@ -4,7 +4,7 @@ from sqlglot import exp
 
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    environments_table = f"_environments"
+    environments_table = "_environments"
     if state_sync.schema:
         environments_table = f"{state_sync.schema}.{environments_table}"
 

--- a/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
+++ b/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
@@ -6,7 +6,7 @@ def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = f"_environments"
     if state_sync.schema:
-        environments_table = f"{state_sync.schema}._environments"
+        environments_table = f"{state_sync.schema}.{environments_table}"
 
     alter_table_exp = exp.AlterTable(
         this=exp.to_table(environments_table),

--- a/sqlmesh/migrations/v0005_create_seed_table.py
+++ b/sqlmesh/migrations/v0005_create_seed_table.py
@@ -4,7 +4,9 @@ from sqlglot import exp
 
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    seeds_table = f"{state_sync.schema}._seeds"
+    seeds_table = f"._seeds"
+    if state_sync.schema:
+        seeds_table = f"{state_sync.schema}.{seeds_table}"
 
     engine_adapter.create_state_table(
         seeds_table,

--- a/sqlmesh/migrations/v0005_create_seed_table.py
+++ b/sqlmesh/migrations/v0005_create_seed_table.py
@@ -4,7 +4,7 @@ from sqlglot import exp
 
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    seeds_table = f"._seeds"
+    seeds_table = "_seeds"
     if state_sync.schema:
         seeds_table = f"{state_sync.schema}.{seeds_table}"
 

--- a/sqlmesh/migrations/v0007_env_table_info_to_kind.py
+++ b/sqlmesh/migrations/v0007_env_table_info_to_kind.py
@@ -13,11 +13,15 @@ def _hash(data):  # type: ignore
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    environments_table = f"{schema}._environments"
+    environments_table = f"_environments"
+    snapshots_table = f"_snapshots"
+    if schema:
+        environments_table = f"{schema}.{environments_table}"
+        snapshots_table = f"{schema}.{snapshots_table}"
     snapshots_to_kind = {}
 
     for name, identifier, snapshot in engine_adapter.fetchall(
-        exp.select("name", "identifier", "snapshot").from_(f"{schema}._snapshots"),
+        exp.select("name", "identifier", "snapshot").from_(snapshots_table),
         quote_identifiers=True,
     ):
         snapshot = json.loads(snapshot)

--- a/sqlmesh/migrations/v0007_env_table_info_to_kind.py
+++ b/sqlmesh/migrations/v0007_env_table_info_to_kind.py
@@ -13,8 +13,8 @@ def _hash(data):  # type: ignore
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    environments_table = f"_environments"
-    snapshots_table = f"_snapshots"
+    environments_table = "_environments"
+    snapshots_table = "_snapshots"
     if schema:
         environments_table = f"{schema}.{environments_table}"
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0008_create_intervals_table.py
+++ b/sqlmesh/migrations/v0008_create_intervals_table.py
@@ -4,7 +4,9 @@ from sqlglot import exp
 
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    intervals_table = f"{state_sync.schema}._intervals"
+    intervals_table = "_intervals"
+    if state_sync.schema:
+        intervals_table = f"{state_sync.schema}.{intervals_table}"
 
     engine_adapter.create_state_table(
         intervals_table,

--- a/sqlmesh/migrations/v0009_remove_pre_post_hooks.py
+++ b/sqlmesh/migrations/v0009_remove_pre_post_hooks.py
@@ -8,7 +8,7 @@ from sqlglot import exp
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = f"_snapshots"
+    snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0009_remove_pre_post_hooks.py
+++ b/sqlmesh/migrations/v0009_remove_pre_post_hooks.py
@@ -8,7 +8,9 @@ from sqlglot import exp
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = f"{schema}._snapshots"
+    snapshots_table = f"_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
 
     new_snapshots = []
 

--- a/sqlmesh/migrations/v0011_add_model_kind_name.py
+++ b/sqlmesh/migrations/v0011_add_model_kind_name.py
@@ -8,7 +8,7 @@ from sqlglot import exp
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = f"_snapshots"
+    snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0011_add_model_kind_name.py
+++ b/sqlmesh/migrations/v0011_add_model_kind_name.py
@@ -8,7 +8,9 @@ from sqlglot import exp
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = f"{schema}._snapshots"
+    snapshots_table = f"_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
 
     alter_table_exp = exp.AlterTable(
         this=exp.to_table(snapshots_table),

--- a/sqlmesh/migrations/v0012_update_jinja_expressions.py
+++ b/sqlmesh/migrations/v0012_update_jinja_expressions.py
@@ -11,7 +11,9 @@ from sqlmesh.utils.jinja import has_jinja
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = f"{schema}._snapshots"
+    snapshots_table = f"_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
 
     new_snapshots = []
 

--- a/sqlmesh/migrations/v0012_update_jinja_expressions.py
+++ b/sqlmesh/migrations/v0012_update_jinja_expressions.py
@@ -11,7 +11,7 @@ from sqlmesh.utils.jinja import has_jinja
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = f"_snapshots"
+    snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0013_serde_using_model_dialects.py
+++ b/sqlmesh/migrations/v0013_serde_using_model_dialects.py
@@ -11,7 +11,9 @@ from sqlmesh.utils.jinja import has_jinja
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = f"{schema}._snapshots"
+    snapshots_table = "_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
 
     new_snapshots = []
 

--- a/sqlmesh/migrations/v0014_fix_dev_intervals.py
+++ b/sqlmesh/migrations/v0014_fix_dev_intervals.py
@@ -3,7 +3,9 @@
 
 def migrate(state_sync):  # type: ignore
     schema = state_sync.schema
-    intervals_table = f"{schema}._intervals"
+    intervals_table = f"_intervals"
+    if schema:
+        intervals_table = f"{schema}.{intervals_table}"
 
     state_sync.engine_adapter.update_table(
         intervals_table,

--- a/sqlmesh/migrations/v0014_fix_dev_intervals.py
+++ b/sqlmesh/migrations/v0014_fix_dev_intervals.py
@@ -3,7 +3,7 @@
 
 def migrate(state_sync):  # type: ignore
     schema = state_sync.schema
-    intervals_table = f"_intervals"
+    intervals_table = "_intervals"
     if schema:
         intervals_table = f"{schema}.{intervals_table}"
 

--- a/sqlmesh/migrations/v0015_environment_add_promoted_snapshot_ids.py
+++ b/sqlmesh/migrations/v0015_environment_add_promoted_snapshot_ids.py
@@ -4,7 +4,9 @@ from sqlglot import exp
 
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    environments_table = f"{state_sync.schema}._environments"
+    environments_table = f"_environments"
+    if state_sync.schema:
+        environments_table = f"{state_sync.schema}.{environments_table}"
 
     alter_table_exp = exp.AlterTable(
         this=exp.to_table(environments_table),

--- a/sqlmesh/migrations/v0015_environment_add_promoted_snapshot_ids.py
+++ b/sqlmesh/migrations/v0015_environment_add_promoted_snapshot_ids.py
@@ -4,7 +4,7 @@ from sqlglot import exp
 
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    environments_table = f"_environments"
+    environments_table = "_environments"
     if state_sync.schema:
         environments_table = f"{state_sync.schema}.{environments_table}"
 

--- a/sqlmesh/migrations/v0016_fix_windows_path.py
+++ b/sqlmesh/migrations/v0016_fix_windows_path.py
@@ -8,7 +8,7 @@ from sqlglot import exp
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = f"_snapshots"
+    snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0016_fix_windows_path.py
+++ b/sqlmesh/migrations/v0016_fix_windows_path.py
@@ -8,7 +8,9 @@ from sqlglot import exp
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = f"{schema}._snapshots"
+    snapshots_table = f"_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
 
     new_snapshots = []
 

--- a/sqlmesh/migrations/v0017_fix_windows_seed_path.py
+++ b/sqlmesh/migrations/v0017_fix_windows_seed_path.py
@@ -8,7 +8,7 @@ from sqlglot import exp
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = f"_snapshots"
+    snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0017_fix_windows_seed_path.py
+++ b/sqlmesh/migrations/v0017_fix_windows_seed_path.py
@@ -8,7 +8,9 @@ from sqlglot import exp
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = f"{schema}._snapshots"
+    snapshots_table = f"_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
 
     new_snapshots = []
 

--- a/sqlmesh/schedulers/airflow/util.py
+++ b/sqlmesh/schedulers/airflow/util.py
@@ -43,7 +43,7 @@ def scoped_state_sync() -> t.Iterator[StateSync]:
         connection = Connection.get_connection_from_secrets(SQLMESH_STATE_CONN_ID)
 
         connection_config_dict = json.loads(connection.extra)
-        state_schema = connection_config_dict.get("state_schema", state_schema)
+        state_schema = connection_config_dict.pop("state_schema", state_schema)
         if "type" not in connection_config_dict:
             logger.info(
                 "SQLMesh connection in Airflow did not have type defined. "

--- a/sqlmesh/schedulers/airflow/util.py
+++ b/sqlmesh/schedulers/airflow/util.py
@@ -15,6 +15,7 @@ from airflow.utils.session import provide_session
 from airflow.utils.state import DagRunState
 from sqlalchemy.orm import Session
 
+from sqlmesh.core import constants as c
 from sqlmesh.core.config import ConnectionConfig
 from sqlmesh.core.engine_adapter import create_engine_adapter
 from sqlmesh.core.state_sync import EngineAdapterStateSync, StateSync
@@ -36,13 +37,23 @@ SQLMESH_STATE_CONN_ID = "sqlmesh_state_db"
 
 @contextlib.contextmanager
 def scoped_state_sync() -> t.Iterator[StateSync]:
+    state_schema = c.SQLMESH
     try:
         connection = Connection.get_connection_from_secrets(SQLMESH_STATE_CONN_ID)
+
+        connection_config_raw = connection.extra
+        state_schema = connection_config_raw.get("state_schema", state_schema)
+        if "type" not in connection_config_raw:
+            logger.info(
+                "SQLMesh connection in Airflow did not have type defined. "
+                "Therefore using Airflow database connection"
+            )
+            raise AirflowException
 
         logger.info("Using connection '%s' for state sync", connection.conn_id)
 
         connection_config: ConnectionConfig = pydantic.parse_raw_as(
-            ConnectionConfig, connection.extra  # type: ignore
+            ConnectionConfig, connection_config_raw  # type: ignore
         )
         engine_adapter = connection_config.create_engine_adapter()
     except AirflowException:
@@ -54,7 +65,7 @@ def scoped_state_sync() -> t.Iterator[StateSync]:
         )
 
     try:
-        yield EngineAdapterStateSync(engine_adapter)
+        yield EngineAdapterStateSync(engine_adapter, state_schema)
     finally:
         engine_adapter.close()
 

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -8,6 +8,7 @@ import pytest
 from pytest_mock.plugin import MockerFixture
 from sqlglot import exp, parse_one
 
+from sqlmesh.core import constants as c
 from sqlmesh.core.engine_adapter import create_engine_adapter
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.model import (
@@ -707,7 +708,9 @@ def test_get_version(state_sync: EngineAdapterStateSync) -> None:
     )
 
     # Start with a clean slate.
-    state_sync = EngineAdapterStateSync(create_engine_adapter(duckdb.connect, "duckdb"))
+    state_sync = EngineAdapterStateSync(
+        create_engine_adapter(duckdb.connect, "duckdb"), schema=c.SQLMESH
+    )
 
     with pytest.raises(
         SQLMeshError,
@@ -766,7 +769,9 @@ def test_migrate(state_sync: EngineAdapterStateSync, mocker: MockerFixture) -> N
     backup_state_mock.assert_not_called()
 
     # Start with a clean slate.
-    state_sync = EngineAdapterStateSync(create_engine_adapter(duckdb.connect, "duckdb"))
+    state_sync = EngineAdapterStateSync(
+        create_engine_adapter(duckdb.connect, "duckdb"), schema=c.SQLMESH
+    )
 
     state_sync.migrate()
     migrate_rows_mock.assert_called_once()

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -34,7 +34,9 @@ from sqlmesh.utils.errors import SQLMeshError
 
 @pytest.fixture
 def state_sync(duck_conn):
-    state_sync = EngineAdapterStateSync(create_engine_adapter(lambda: duck_conn, "duckdb"))
+    state_sync = EngineAdapterStateSync(
+        create_engine_adapter(lambda: duck_conn, "duckdb"), schema=c.SQLMESH
+    )
     state_sync.migrate()
     return state_sync
 


### PR DESCRIPTION
Allow users to customize the schema name for state metadata. If None or empty string is provided then no schema is used and therefore the default schema for the connection/user is used instead. 