### PR TITLE
Fix: Make dbt postgresql targeting read database name from profile correctly

### DIFF
--- a/sqlmesh/dbt/target.py
+++ b/sqlmesh/dbt/target.py
@@ -286,7 +286,7 @@ class PostgresConfig(TargetConfig):
             user=self.user,
             password=self.password,
             port=self.port,
-            database=self.schema_,
+            database=self.dbname,
             keepalives_idle=self.keepalives_idle,
             concurrent_tasks=self.threads,
             connect_timeout=self.connect_timeout,


### PR DESCRIPTION
dbt pgsql profile parsing was treating schema name as database name