### PR TITLE
Feat: Introduce the model test API endpoint

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 
 import abc
 import collections
-import contextlib
 import gc
 import traceback
 import typing as t
@@ -947,6 +946,7 @@ class Context(BaseContext):
         match_patterns: t.Optional[t.List[str]] = None,
         tests: t.Optional[t.List[str]] = None,
         verbose: bool = False,
+        stream: t.Optional[t.TextIO] = None,
     ) -> unittest.result.TestResult:
         """Discover and run model tests"""
         verbosity = 2 if verbose else 1
@@ -977,6 +977,7 @@ class Context(BaseContext):
                     models=self._models,
                     engine_adapter=self._test_engine_adapter,
                     verbosity=verbosity,
+                    stream=stream,
                 )
         finally:
             self._test_engine_adapter.close()
@@ -1097,8 +1098,7 @@ class Context(BaseContext):
 
     def _run_tests(self) -> t.Tuple[unittest.result.TestResult, str]:
         test_output_io = StringIO()
-        with contextlib.redirect_stderr(test_output_io):
-            result = self.test()
+        result = self.test(stream=test_output_io)
         return result, test_output_io.getvalue()
 
     def _run_plan_tests(

--- a/sqlmesh/core/test/__init__.py
+++ b/sqlmesh/core/test/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pathlib
+import typing as t
 import unittest
 
 from sqlmesh.core.engine_adapter import EngineAdapter
@@ -20,6 +21,7 @@ def run_tests(
     models: dict[str, Model],
     engine_adapter: EngineAdapter,
     verbosity: int = 1,
+    stream: t.TextIO | None = None,
 ) -> unittest.result.TestResult:
     """Create a test suite of ModelTest objects and run it.
 
@@ -39,7 +41,9 @@ def run_tests(
         )
         for metadata in model_test_metadata
     )
-    return unittest.TextTestRunner(verbosity=verbosity, resultclass=ModelTextTestResult).run(suite)
+    return unittest.TextTestRunner(
+        stream=stream, verbosity=verbosity, resultclass=ModelTextTestResult
+    ).run(suite)
 
 
 def run_model_tests(
@@ -48,6 +52,7 @@ def run_model_tests(
     engine_adapter: EngineAdapter,
     verbosity: int = 1,
     patterns: list[str] | None = None,
+    stream: t.TextIO | None = None,
 ) -> unittest.result.TestResult:
     """Load and run tests.
 
@@ -68,4 +73,4 @@ def run_model_tests(
             loaded_tests.extend(load_model_test_file(path).values())
     if patterns:
         loaded_tests = filter_tests_by_patterns(loaded_tests, patterns)
-    return run_tests(loaded_tests, models, engine_adapter, verbosity)
+    return run_tests(loaded_tests, models, engine_adapter, verbosity, stream)

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -102,6 +102,10 @@ class ModelTest(unittest.TestCase):
     def runTest(self) -> None:
         raise NotImplementedError
 
+    def path_relative_to(self, other: pathlib.Path) -> pathlib.Path | None:
+        """Compute a version of this test's path relative to the `other` path"""
+        return self.path.relative_to(other) if self.path else None
+
     @staticmethod
     def create_test(
         body: dict[str, t.Any],

--- a/web/server/models.py
+++ b/web/server/models.py
@@ -301,3 +301,23 @@ class TableDiff(BaseModel):
     schema_diff: SchemaDiff
     row_diff: RowDiff
     on: t.List[t.Tuple[str, str]]
+
+
+class TestCase(BaseModel):
+    name: str
+    path: pathlib.Path
+
+
+class TestErrorOrFailure(TestCase):
+    tb: str
+
+
+class TestSkipped(TestCase):
+    reason: str
+
+
+class TestResult(BaseModel):
+    tests_run: int
+    failures: t.List[TestErrorOrFailure]
+    errors: t.List[TestErrorOrFailure]
+    skipped: t.List[TestSkipped]


### PR DESCRIPTION
This PR introduces an endpoint for the UI to trigger one or all model tests. The endpoint serializes test error and failures in the response, as well as sends the console output via the sse endpoint.