### PR TITLE
Fix: Set forward_only to true by default for the Incremental Unmanaged model kind

### DIFF
--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -262,6 +262,7 @@ class IncrementalByUniqueKeyKind(_Incremental):
 class IncrementalUnmanagedKind(ModelKind):
     name: ModelKindName = Field(ModelKindName.INCREMENTAL_UNMANAGED, const=True)
     insert_overwrite: bool = False
+    forward_only: bool = True
     disable_restatement: Literal[True] = True
 
     _bool_validator = bool_validator

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -69,6 +69,8 @@ class ModelConfig(BaseModelConfig):
     cron: t.Optional[str] = None
     batch_size: t.Optional[int] = None
     lookback: t.Optional[int] = None
+    forward_only: t.Optional[bool] = None
+    disable_restatement: t.Optional[bool] = None
 
     # DBT configuration fields
     cluster_by: t.Optional[t.List[str]] = None
@@ -263,7 +265,7 @@ class ModelConfig(BaseModelConfig):
                 d.parse_one(c, dialect=dialect).name for c in self.cluster_by
             ]
 
-        for field in ["cron"]:
+        for field in ["cron", "forward_only", "disable_restatement"]:
             field_val = getattr(self, field, None) or self.meta.get(field, None)
             if field_val:
                 optional_kwargs[field] = field_val


### PR DESCRIPTION
I've realized that Incremental Unmanaged models should be forward_only by default to err on the side of caution. 