### PR TITLE
Fix: CI/CD bot - Always get merge commit regardless event type

### DIFF
--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -61,6 +61,8 @@ jobs:
         uses: actions/setup-python@v4
       - name: Checkout PR branch
         uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event.issue.pull_request && github.event.issue.number || github.event.pull_request.number  }}/merge
       - name: Install SQLMesh + Dependencies
         run: pip install -r requirements.txt
         shell: bash
@@ -172,6 +174,8 @@ jobs:
           python-version: '3.9'
       - name: Checkout PR branch
         uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event.issue.pull_request && github.event.issue.number || github.event.pull_request.number  }}/merge
       - name: Install Dependencies
         run: pip install -r requirements.txt
         shell: bash


### PR DESCRIPTION
Prior to this comment on a PR would actually trigger a job based on code in main instead of the merge commit for the PR. This change makes sure we always use the merge commit for checking out the project code. 