### PR TITLE
Feat: CI/CD Bot Add Merge Method

### DIFF
--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -66,7 +66,7 @@ jobs:
         shell: bash
       - name: Run CI/CD Bot
         run: |
-          sqlmesh_cicd -p ${{ github.workspace }} github --token ${{ secrets.GITHUB_TOKEN }} run-all --merge --delete
+          sqlmesh_cicd -p ${{ github.workspace }} github --token ${{ secrets.GITHUB_TOKEN }} run-all --merge_method merge --delete
 ```
 3. (Optional) If you want to designate users as required approvers, update your SQLMesh config file to represent this. YAML Example:
 ```yaml
@@ -98,7 +98,8 @@ See [Run All Configuration](#run-all-configuration) for the `--command_namespace
 The `run-all` config command will run all of the actions in a single step. 
 This means it checks for approvers, runs unit tests, creates PR environment, and then deploys to prod.
 It has two boolean flags that can be passed in to enable additional functionality:
-* `--merge` - This will merge the PR after deploying to production in order to keep your main branch in-sync with your data
+* `--merge_method` - Providing this option will result in merging the PR after deploying to production in order to keep your main branch in-sync with your data. 
+  * Options: `merge`, `squash`, `rebase`. Default: `merge`
 * `--delete` - This will delete the PR environment after deploying to production. 
     * Note: If using `--delete` then the runner will need a connection to the engine even if you are using Airflow. This is because the delete is done outside of Airflow.
     * Eventually want the SQLMesh Janitor to automatically do this cleanup which would remove the need for this flag.
@@ -182,7 +183,7 @@ jobs:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
       - name: Run CI/CD Bot
         run: |
-          sqlmesh_cicd -p ${{ github.workspace }} --token ${{ secrets.GITHUB_TOKEN }} run-all --merge --delete
+          sqlmesh_cicd -p ${{ github.workspace }} --token ${{ secrets.GITHUB_TOKEN }} run-all --merge_method squash --delete
 ```
 
 ## Future Improvements

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -99,7 +99,7 @@ The `run-all` config command will run all of the actions in a single step.
 This means it checks for approvers, runs unit tests, creates PR environment, and then deploys to prod.
 It has two boolean flags that can be passed in to enable additional functionality:
 * `--merge_method` - Providing this option will result in merging the PR after deploying to production in order to keep your main branch in-sync with your data. 
-  * Options: `merge`, `squash`, `rebase`. Default: `merge`
+  * Options: `merge`, `squash`, `rebase`.
 * `--delete` - This will delete the PR environment after deploying to production. 
     * Note: If using `--delete` then the runner will need a connection to the engine even if you are using Airflow. This is because the delete is done outside of Airflow.
     * Eventually want the SQLMesh Janitor to automatically do this cleanup which would remove the need for this flag.

--- a/sqlmesh/integrations/github/cicd/command.py
+++ b/sqlmesh/integrations/github/cicd/command.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 merge_method_option = click.option(
     "--merge-method",
     type=click.Choice(MergeMethod),  # type: ignore
-    help="Enables merging PR after successfully deploying to production using the provided method. Defaults to `merge`",
+    help="Enables merging PR after successfully deploying to production using the provided method.",
 )
 
 delete_option = click.option(

--- a/sqlmesh/integrations/github/cicd/command.py
+++ b/sqlmesh/integrations/github/cicd/command.py
@@ -203,5 +203,4 @@ def run_all(
     command_namespace: t.Optional[str],
 ) -> None:
     """Runs all the commands in the correct order."""
-    print("Merge method: ", merge_method)
     return _run_all(ctx.obj["github"], merge_method, delete, command_namespace)

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -664,7 +664,7 @@ class GithubController:
         Merges the PR
         """
         merge_method = merge_method or MergeMethod.MERGE
-        self._pull_request.merge(merge_method=merge_method)
+        self._pull_request.merge(merge_method=merge_method.value)
 
     def get_command_from_comment(self, namespace: t.Optional[str] = None) -> BotCommand:
         """

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -661,7 +661,7 @@ class GithubController:
 
     def merge_pr(self, merge_method: MergeMethod) -> None:
         """
-        Merges the PR
+        Merges the PR using the provided merge_method
         """
         self._pull_request.merge(merge_method=merge_method.value)
 

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -659,11 +659,10 @@ class GithubController:
             conclusion_handler=conclusion_handler,
         )
 
-    def merge_pr(self, merge_method: t.Optional[MergeMethod] = None) -> None:
+    def merge_pr(self, merge_method: MergeMethod) -> None:
         """
         Merges the PR
         """
-        merge_method = merge_method or MergeMethod.MERGE
         self._pull_request.merge(merge_method=merge_method.value)
 
     def get_command_from_comment(self, namespace: t.Optional[str] = None) -> BotCommand:

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -114,6 +114,12 @@ class GithubCheckConclusion(str, Enum):
         return self == GithubCheckConclusion.SKIPPED
 
 
+class MergeMethod(str, Enum):
+    MERGE = "merge"
+    SQUASH = "squash"
+    REBASE = "rebase"
+
+
 class BotCommand(Enum):
     INVALID = 1
     DEPLOY_PROD = 2
@@ -653,11 +659,12 @@ class GithubController:
             conclusion_handler=conclusion_handler,
         )
 
-    def merge_pr(self) -> None:
+    def merge_pr(self, merge_method: t.Optional[MergeMethod] = None) -> None:
         """
         Merges the PR
         """
-        self._pull_request.merge()
+        merge_method = merge_method or MergeMethod.MERGE
+        self._pull_request.merge(merge_method=merge_method)
 
     def get_command_from_comment(self, namespace: t.Optional[str] = None) -> BotCommand:
         """

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -130,7 +130,7 @@ def test_merge_pr(
 ):
     controller = github_pr_synchronized_approvers_controller
     controller._pull_request = mocker.MagicMock()
-    controller.merge_pr()
+    controller.merge_pr(merge_method=MergeMethod.MERGE)
     controller._pull_request.method_calls == [call.merge(merge_method=MergeMethod.MERGE)]
 
 

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -10,6 +10,7 @@ from sqlmesh.integrations.github.cicd.controller import (
     BotCommand,
     GithubController,
     GithubEvent,
+    MergeMethod,
 )
 from sqlmesh.utils import AttributeDict
 from sqlmesh.utils.errors import CICDBotError
@@ -130,7 +131,7 @@ def test_merge_pr(
     controller = github_pr_synchronized_approvers_controller
     controller._pull_request = mocker.MagicMock()
     controller.merge_pr()
-    controller._pull_request.method_calls == [call.merge()]
+    controller._pull_request.method_calls == [call.merge(merge_method=MergeMethod.MERGE)]
 
 
 def test_bot_command_parsing(


### PR DESCRIPTION
Prior to this change the CI/CD bot always used the `merge` method when merging a branch (if you enable the feature). Now you can pass in what merge method you want it to use. 