### PR TITLE
Fix: Send cancel plan request when canceling a plan

### DIFF
--- a/web/client/src/api/index.ts
+++ b/web/client/src/api/index.ts
@@ -39,7 +39,7 @@ import {
   type GetTableDiffApiTableDiffGetParams,
   type TableDiff,
   type FetchdfInput,
-  Meta,
+  type Meta,
   getApiMetaApiMetaGet,
 } from './client'
 import {
@@ -308,6 +308,12 @@ export async function apiCancelPlanApply(client: QueryClient): Promise<void> {
   return await cancelPlanApiPlanCancelPost()
 }
 
+export async function apiCancelPlanRun(client: QueryClient): Promise<void> {
+  void client.cancelQueries({ queryKey: ['/api/plan'] })
+
+  return await cancelPlanApiPlanCancelPost()
+}
+
 export function apiCancelFetchdf(client: QueryClient): void {
   void client.cancelQueries({ queryKey: ['/api/commands/fetchdf'] })
 }
@@ -322,10 +328,6 @@ export function apiCancelEvaluate(client: QueryClient): void {
 
 export function apiCancelLineage(client: QueryClient): void {
   void client.cancelQueries({ queryKey: ['/api/lineage'] })
-}
-
-export function apiCancelPlanRun(client: QueryClient): void {
-  void client.cancelQueries({ queryKey: ['/api/plan'] })
 }
 
 export function apiCancelGetEnvironments(client: QueryClient): void {

--- a/web/client/src/library/components/plan/Plan.tsx
+++ b/web/client/src/library/components/plan/Plan.tsx
@@ -13,7 +13,12 @@ import {
   EnumPlanApplyType,
 } from '~/context/plan'
 import { Divider } from '~/library/components/divider/Divider'
-import { useApiPlanRun, useApiPlanApply, apiCancelPlanApply } from '~/api'
+import {
+  useApiPlanRun,
+  useApiPlanApply,
+  apiCancelPlanApply,
+  apiCancelPlanRun,
+} from '~/api'
 import {
   type ContextEnvironmentEnd,
   type ContextEnvironmentStart,
@@ -231,7 +236,12 @@ function Plan({
     setPlanState(EnumPlanState.Cancelling)
     setPlanAction(EnumPlanAction.Cancelling)
 
-    apiCancelPlanApply(client)
+    const cancelAction =
+      planAction === EnumPlanAction.Applying
+        ? apiCancelPlanApply
+        : apiCancelPlanRun
+
+    cancelAction(client)
       .then(() => {
         setPlanAction(EnumPlanAction.Run)
         setPlanState(EnumPlanState.Cancelled)

--- a/web/client/src/library/pages/ide/IDE.tsx
+++ b/web/client/src/library/pages/ide/IDE.tsx
@@ -8,7 +8,6 @@ import {
   useApiEnvironments,
   useApiPlanRun,
   apiCancelGetEnvironments,
-  apiCancelPlanRun,
 } from '../../../api'
 import {
   EnumPlanState,
@@ -153,7 +152,6 @@ export default function PageIDE(): JSX.Element {
       apiCancelFiles(client)
       apiCancelModels(client)
       apiCancelGetEnvironments(client)
-      apiCancelPlanRun(client)
 
       unsubscribeTasks?.()
       unsubscribeModels?.()


### PR DESCRIPTION
Before we're only sending request when canceling `apply` command