### PR TITLE
Feat!: Make Environment Suffix Target Configurable

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -223,8 +223,21 @@ adhere to at your organization and therefore need more control over the schema n
 
 ### View Schema Override
 
-Coming soon. Please message us on [slack](https://tobikodata.com/slack) if you are interested in this feature so we can better understand your 
-use case and make sure the new feature satisfies your needs.
+By default SQLMesh appends the environment name to the schema name when creating new environments. This can be changed
+to instead append a suffix at the end of table instead. This means that new environment views will be created in the 
+same schema as production but be differentiated having their names end with `__<env>`.
+
+Config example:
+    
+```yaml linenums="1"
+environment_suffix_target: table
+```
+
+If you had a model name of `db.users`, and you were creating a `dev` environment, then the view would be created as `db.users__dev` instead of the default behavior of `db__dev.users`.
+
+The default behavior of appending the suffix to schemas is recommended because it leaves production with a single clean
+interface for accessing the views. However if you are deploying SQLMesh in an environment with tight restrictions on 
+schema creation then this can be a useful way of reducing the number of schemas that need to be created.
 
 ## Additional details
 

--- a/examples/sushi/config.py
+++ b/examples/sushi/config.py
@@ -6,6 +6,7 @@ from sqlmesh.core.config import (
     CategorizerConfig,
     Config,
     DuckDBConnectionConfig,
+    EnvironmentSuffixTarget,
     GatewayConfig,
     ModelDefaultsConfig,
     SparkConnectionConfig,
@@ -103,4 +104,11 @@ required_approvers_config = Config(
         ),
     ],
     model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+)
+
+
+environment_suffix_config = Config(
+    default_connection=DuckDBConnectionConfig(),
+    model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+    environment_suffix_target=EnvironmentSuffixTarget.TABLE,
 )

--- a/sqlmesh/core/config/__init__.py
+++ b/sqlmesh/core/config/__init__.py
@@ -1,4 +1,5 @@
 from sqlmesh.core.config.categorizer import AutoCategorizationMode, CategorizerConfig
+from sqlmesh.core.config.common import EnvironmentSuffixTarget
 from sqlmesh.core.config.connection import (
     BigQueryConnectionConfig,
     ConnectionConfig,

--- a/sqlmesh/core/config/common.py
+++ b/sqlmesh/core/config/common.py
@@ -1,10 +1,29 @@
 from __future__ import annotations
 
 import typing as t
+from enum import Enum
 
 from pydantic import validator
 
+from sqlmesh.utils import classproperty
 from sqlmesh.utils.errors import ConfigError
+
+
+class EnvironmentSuffixTarget(str, Enum):
+    SCHEMA = "schema"
+    TABLE = "table"
+
+    @property
+    def is_schema(self) -> bool:
+        return self == EnvironmentSuffixTarget.SCHEMA
+
+    @property
+    def is_table(self) -> bool:
+        return self == EnvironmentSuffixTarget.TABLE
+
+    @classproperty
+    def default(cls) -> EnvironmentSuffixTarget:
+        return EnvironmentSuffixTarget.SCHEMA
 
 
 def _concurrent_tasks_validator(v: t.Any) -> int:

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-from pydantic import root_validator, validator
+from pydantic import Field, root_validator, validator
 
 from sqlmesh.core import constants as c
 from sqlmesh.core.config import EnvironmentSuffixTarget
@@ -65,7 +65,9 @@ class Config(BaseConfig):
     username: str = ""
     include_unmodified: bool = False
     physical_schema_override: t.Dict[str, str] = {}
-    environment_suffix_target: EnvironmentSuffixTarget = EnvironmentSuffixTarget.default
+    environment_suffix_target: EnvironmentSuffixTarget = Field(
+        default=EnvironmentSuffixTarget.default
+    )
 
     _FIELD_UPDATE_STRATEGY: t.ClassVar[t.Dict[str, UpdateStrategy]] = {
         "gateways": UpdateStrategy.KEY_UPDATE,

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -5,6 +5,7 @@ import typing as t
 from pydantic import root_validator, validator
 
 from sqlmesh.core import constants as c
+from sqlmesh.core.config import EnvironmentSuffixTarget
 from sqlmesh.core.config.base import BaseConfig, UpdateStrategy
 from sqlmesh.core.config.categorizer import CategorizerConfig
 from sqlmesh.core.config.connection import ConnectionConfig, DuckDBConnectionConfig
@@ -41,6 +42,7 @@ class Config(BaseConfig):
         pinned_environments: A list of development environment names that should not be deleted by the janitor task.
         model_defaults: Default values for model definitions.
         include_unmodified: Indicates whether to include unmodified models in the target development environment.
+        environment_suffix_target: Indicates whether to append the environment name to the schema or table name.
     """
 
     gateways: t.Union[t.Dict[str, GatewayConfig], GatewayConfig] = GatewayConfig()
@@ -63,6 +65,7 @@ class Config(BaseConfig):
     username: str = ""
     include_unmodified: bool = False
     physical_schema_override: t.Dict[str, str] = {}
+    environment_suffix_target: EnvironmentSuffixTarget = EnvironmentSuffixTarget.default
 
     _FIELD_UPDATE_STRATEGY: t.ClassVar[t.Dict[str, UpdateStrategy]] = {
         "gateways": UpdateStrategy.KEY_UPDATE,

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -782,6 +782,7 @@ class Context(BaseContext):
             is_dev=environment != c.PROD,
             forward_only=forward_only,
             environment_ttl=environment_ttl,
+            environment_suffix_target=self.config.environment_suffix_target,
             categorizer_config=self.auto_categorize_changes,
             auto_categorization_enabled=not no_auto_categorization,
             effective_from=effective_from,

--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -3,55 +3,28 @@ from __future__ import annotations
 import json
 import typing as t
 
-from pydantic import validator
+from pydantic import Field, validator
 
+from sqlmesh.core import constants as c
+from sqlmesh.core.config import EnvironmentSuffixTarget
 from sqlmesh.core.snapshot import SnapshotId, SnapshotTableInfo
 from sqlmesh.utils import word_characters_only
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.pydantic import PydanticModel
 
 
-class Environment(PydanticModel):
-    """Represents an isolated environment.
-
-    Environments are isolated workspaces that hold pointers to physical tables.
+class EnvironmentNamingInfo(PydanticModel):
+    """
+    Information required for creating an object within an environment
 
     Args:
         name: The name of the environment.
-        snapshots: The snapshots that are part of this environment.
-        start_at: The start time of the environment.
-        end_at: The end time of the environment.
-        plan_id: The ID of the plan that last updated this environment.
-        previous_plan_id: The ID of the previous plan that updated this enviornment.
-        expiration_ts: The timestamp when this environment will expire.
-        finalized_ts: The timestamp when this environment was finalized.
-        promotion_snapshot_ids: The IDs of the snapshots that are promoted in this environment
-            (i.e. for which the views are created). If not specified, all snapshots are promoted.
+        suffix_target: Indicates whether to append the environment name to the schema or table name.
+
     """
 
-    name: str
-    snapshots: t.List[SnapshotTableInfo]
-    start_at: TimeLike
-    end_at: t.Optional[TimeLike]
-    plan_id: str
-    previous_plan_id: t.Optional[str]
-    expiration_ts: t.Optional[int]
-    finalized_ts: t.Optional[int]
-    promoted_snapshot_ids: t.Optional[t.List[SnapshotId]] = None
-
-    @validator("snapshots", pre=True)
-    @classmethod
-    def _convert_snapshots(cls, v: str | t.List[SnapshotTableInfo]) -> t.List[SnapshotTableInfo]:
-        if isinstance(v, str):
-            return [SnapshotTableInfo.parse_obj(obj) for obj in json.loads(v)]
-        return v
-
-    @validator("promoted_snapshot_ids", pre=True)
-    @classmethod
-    def _convert_snapshot_ids(cls, v: str | t.List[SnapshotId]) -> t.List[SnapshotId]:
-        if isinstance(v, str):
-            return [SnapshotId.parse_obj(obj) for obj in json.loads(v)]
-        return v
+    name: str = c.PROD
+    suffix_target: EnvironmentSuffixTarget = Field(default=EnvironmentSuffixTarget.SCHEMA)
 
     @validator("name", pre=True)
     @classmethod
@@ -84,6 +57,47 @@ class Environment(PydanticModel):
     def normalize_names(cls, values: t.Iterable[str]) -> t.Set[str]:
         return {cls.normalize_name(value) for value in values}
 
+
+class Environment(EnvironmentNamingInfo):
+    """Represents an isolated environment.
+
+    Environments are isolated workspaces that hold pointers to physical tables.
+
+    Args:
+        snapshots: The snapshots that are part of this environment.
+        start_at: The start time of the environment.
+        end_at: The end time of the environment.
+        plan_id: The ID of the plan that last updated this environment.
+        previous_plan_id: The ID of the previous plan that updated this environment.
+        expiration_ts: The timestamp when this environment will expire.
+        finalized_ts: The timestamp when this environment was finalized.
+        promoted_snapshot_ids: The IDs of the snapshots that are promoted in this environment
+            (i.e. for which the views are created). If not specified, all snapshots are promoted.
+    """
+
+    snapshots: t.List[SnapshotTableInfo]
+    start_at: TimeLike
+    end_at: t.Optional[TimeLike]
+    plan_id: str
+    previous_plan_id: t.Optional[str]
+    expiration_ts: t.Optional[int]
+    finalized_ts: t.Optional[int]
+    promoted_snapshot_ids: t.Optional[t.List[SnapshotId]] = None
+
+    @validator("snapshots", pre=True)
+    @classmethod
+    def _convert_snapshots(cls, v: str | t.List[SnapshotTableInfo]) -> t.List[SnapshotTableInfo]:
+        if isinstance(v, str):
+            return [SnapshotTableInfo.parse_obj(obj) for obj in json.loads(v)]
+        return v
+
+    @validator("promoted_snapshot_ids", pre=True)
+    @classmethod
+    def _convert_snapshot_ids(cls, v: str | t.List[SnapshotId]) -> t.List[SnapshotId]:
+        if isinstance(v, str):
+            return [SnapshotId.parse_obj(obj) for obj in json.loads(v)]
+        return v
+
     @property
     def promoted_snapshots(self) -> t.List[SnapshotTableInfo]:
         if self.promoted_snapshot_ids is None:
@@ -91,3 +105,7 @@ class Environment(PydanticModel):
 
         promoted_snapshot_ids = set(self.promoted_snapshot_ids)
         return [s for s in self.snapshots if s.snapshot_id in promoted_snapshot_ids]
+
+    @property
+    def naming_info(self) -> EnvironmentNamingInfo:
+        return EnvironmentNamingInfo(name=self.name, suffix_target=self.suffix_target)

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -151,18 +151,18 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         """
         environment = plan.environment
 
-        added, (removed, removed_environment_naming_info) = self.state_sync.promote(
-            environment, no_gaps=plan.no_gaps
-        )
+        promotion_result = self.state_sync.promote(environment, no_gaps=plan.no_gaps)
 
-        self.console.start_promotion_progress(environment.name, len(added) + len(removed))
+        self.console.start_promotion_progress(
+            environment.name, len(promotion_result.added) + len(promotion_result.removed)
+        )
 
         if not plan.is_dev:
             self.snapshot_evaluator.migrate(
                 [s for s in plan.snapshots if s.is_paused],
                 {s.snapshot_id: s for s in plan.snapshots},
             )
-            self.state_sync.unpause_snapshots(added, now())
+            self.state_sync.unpause_snapshots(promotion_result.added, now())
 
         def on_complete(snapshot: SnapshotInfoLike) -> None:
             self.console.update_promotion_progress(1)
@@ -170,14 +170,14 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         completed = False
         try:
             self.snapshot_evaluator.promote(
-                added,
+                promotion_result.added,
                 environment.naming_info,
                 is_dev=plan.is_dev,
                 on_complete=on_complete,
             )
             self.snapshot_evaluator.demote(
-                removed,
-                removed_environment_naming_info,
+                promotion_result.removed,
+                promotion_result.removed_environment_naming_info,
                 on_complete=on_complete,
             )
             self.state_sync.finalize(environment)

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -103,7 +103,7 @@ class BuiltInPlanEvaluator(PlanEvaluator):
             notification_target_manager=self.notification_target_manager,
         )
         is_run_successful = scheduler.run(
-            plan.environment_name,
+            plan.environment_naming_info,
             plan.start,
             plan.end,
             restatements=plan.restatements,
@@ -151,7 +151,9 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         """
         environment = plan.environment
 
-        added, removed = self.state_sync.promote(environment, no_gaps=plan.no_gaps)
+        added, (removed, removed_environment_naming_info) = self.state_sync.promote(
+            environment, no_gaps=plan.no_gaps
+        )
 
         self.console.start_promotion_progress(environment.name, len(added) + len(removed))
 
@@ -169,13 +171,13 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         try:
             self.snapshot_evaluator.promote(
                 added,
-                environment=environment.name,
+                environment.naming_info,
                 is_dev=plan.is_dev,
                 on_complete=on_complete,
             )
             self.snapshot_evaluator.demote(
                 removed,
-                environment=environment.name,
+                removed_environment_naming_info,
                 on_complete=on_complete,
             )
             self.state_sync.finalize(environment)

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -175,11 +175,12 @@ class BuiltInPlanEvaluator(PlanEvaluator):
                 is_dev=plan.is_dev,
                 on_complete=on_complete,
             )
-            self.snapshot_evaluator.demote(
-                promotion_result.removed,
-                promotion_result.removed_environment_naming_info,
-                on_complete=on_complete,
-            )
+            if promotion_result.removed_environment_naming_info:
+                self.snapshot_evaluator.demote(
+                    promotion_result.removed,
+                    promotion_result.removed_environment_naming_info,
+                    on_complete=on_complete,
+                )
             self.state_sync.finalize(environment)
             completed = True
         finally:

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -289,6 +289,9 @@ class SnapshotTableInfo(PydanticModel, SnapshotInfoMixin, frozen=True):
     change_category: t.Optional[SnapshotChangeCategory]
     kind_name: ModelKindName
 
+    def __lt__(self, other: SnapshotTableInfo) -> bool:
+        return self.name < other.name
+
     def table_name(self, is_dev: bool = False, for_read: bool = False) -> str:
         """Full table name pointing to the materialized location of the snapshot.
 

--- a/sqlmesh/core/state_sync/__init__.py
+++ b/sqlmesh/core/state_sync/__init__.py
@@ -15,5 +15,5 @@ adapter to read and write state to the underlying data store.
 """
 from sqlmesh.core.state_sync.base import StateReader, StateSync, Versions
 from sqlmesh.core.state_sync.cache import CachingStateSync
-from sqlmesh.core.state_sync.common import CommonStateSyncMixin
+from sqlmesh.core.state_sync.common import CommonStateSyncMixin, cleanup_expired_views
 from sqlmesh.core.state_sync.engine_adapter import EngineAdapterStateSync

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -43,6 +43,12 @@ MIGRATIONS = [
 SCHEMA_VERSION: int = len(MIGRATIONS)
 
 
+class PromotionResult(PydanticModel):
+    added: t.List[SnapshotTableInfo]
+    removed: t.List[SnapshotTableInfo]
+    removed_environment_naming_info: EnvironmentNamingInfo
+
+
 class StateReader(abc.ABC):
     """Abstract base class for read-only operations on snapshot and environment state."""
 
@@ -246,11 +252,7 @@ class StateSync(StateReader, abc.ABC):
         """
 
     @abc.abstractmethod
-    def promote(
-        self, environment: Environment, no_gaps: bool = False
-    ) -> t.Tuple[
-        t.List[SnapshotTableInfo], t.Tuple[t.List[SnapshotTableInfo], EnvironmentNamingInfo]
-    ]:
+    def promote(self, environment: Environment, no_gaps: bool = False) -> PromotionResult:
         """Update the environment to reflect the current state.
 
         This method verifies that snapshots have been pushed.

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -6,6 +6,7 @@ import logging
 import pkgutil
 import typing as t
 
+from pydantic import validator
 from sqlglot import __version__ as SQLGLOT_VERSION
 
 from sqlmesh import migrations
@@ -46,7 +47,15 @@ SCHEMA_VERSION: int = len(MIGRATIONS)
 class PromotionResult(PydanticModel):
     added: t.List[SnapshotTableInfo]
     removed: t.List[SnapshotTableInfo]
-    removed_environment_naming_info: EnvironmentNamingInfo
+    removed_environment_naming_info: t.Optional[EnvironmentNamingInfo]
+
+    @validator("removed_environment_naming_info")
+    def _validate_removed_environment_naming_info(
+        cls, v: t.Optional[EnvironmentNamingInfo], values: t.Dict
+    ) -> t.Optional[EnvironmentNamingInfo]:
+        if v and not values["removed"]:
+            raise ValueError("removed_environment_naming_info must be None if removed is empty")
+        return v
 
 
 class StateReader(abc.ABC):

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -9,7 +9,7 @@ import typing as t
 from sqlglot import __version__ as SQLGLOT_VERSION
 
 from sqlmesh import migrations
-from sqlmesh.core.environment import Environment
+from sqlmesh.core.environment import Environment, EnvironmentNamingInfo
 from sqlmesh.core.snapshot import (
     Snapshot,
     SnapshotId,
@@ -248,7 +248,9 @@ class StateSync(StateReader, abc.ABC):
     @abc.abstractmethod
     def promote(
         self, environment: Environment, no_gaps: bool = False
-    ) -> t.Tuple[t.List[SnapshotTableInfo], t.List[SnapshotTableInfo]]:
+    ) -> t.Tuple[
+        t.List[SnapshotTableInfo], t.Tuple[t.List[SnapshotTableInfo], EnvironmentNamingInfo]
+    ]:
         """Update the environment to reflect the current state.
 
         This method verifies that snapshots have been pushed.

--- a/sqlmesh/core/state_sync/cache.py
+++ b/sqlmesh/core/state_sync/cache.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import typing as t
 
-from sqlmesh.core.environment import Environment
+from sqlmesh.core.environment import Environment, EnvironmentNamingInfo
 from sqlmesh.core.model import SeedModel
 from sqlmesh.core.snapshot import (
     Snapshot,
@@ -177,7 +177,9 @@ class CachingStateSync(StateSync):
 
     def promote(
         self, environment: Environment, no_gaps: bool = False
-    ) -> t.Tuple[t.List[SnapshotTableInfo], t.List[SnapshotTableInfo]]:
+    ) -> t.Tuple[
+        t.List[SnapshotTableInfo], t.Tuple[t.List[SnapshotTableInfo], EnvironmentNamingInfo]
+    ]:
         return self.state_sync.promote(environment, no_gaps)
 
     def finalize(self, environment: Environment) -> None:

--- a/sqlmesh/core/state_sync/cache.py
+++ b/sqlmesh/core/state_sync/cache.py
@@ -3,16 +3,10 @@ from __future__ import annotations
 import sys
 import typing as t
 
-from sqlmesh.core.environment import Environment, EnvironmentNamingInfo
+from sqlmesh.core.environment import Environment
 from sqlmesh.core.model import SeedModel
-from sqlmesh.core.snapshot import (
-    Snapshot,
-    SnapshotId,
-    SnapshotIdLike,
-    SnapshotInfoLike,
-    SnapshotTableInfo,
-)
-from sqlmesh.core.state_sync.base import StateSync, Versions
+from sqlmesh.core.snapshot import Snapshot, SnapshotId, SnapshotIdLike, SnapshotInfoLike
+from sqlmesh.core.state_sync.base import PromotionResult, StateSync, Versions
 from sqlmesh.utils.date import TimeLike, now_timestamp
 
 if sys.version_info >= (3, 8):
@@ -175,11 +169,7 @@ class CachingStateSync(StateSync):
             self.snapshot_cache.pop(s.snapshot_id, None)
         self.state_sync.remove_interval(snapshots, start, end, all_snapshots)
 
-    def promote(
-        self, environment: Environment, no_gaps: bool = False
-    ) -> t.Tuple[
-        t.List[SnapshotTableInfo], t.Tuple[t.List[SnapshotTableInfo], EnvironmentNamingInfo]
-    ]:
+    def promote(self, environment: Environment, no_gaps: bool = False) -> PromotionResult:
         return self.state_sync.promote(environment, no_gaps)
 
     def finalize(self, environment: Environment) -> None:

--- a/sqlmesh/core/state_sync/common.py
+++ b/sqlmesh/core/state_sync/common.py
@@ -149,9 +149,9 @@ class CommonStateSyncMixin(StateSync):
             else [existing_table_infos[name] for name in missing_models]
         )
         return PromotionResult(
-            added=sorted(*table_infos),
+            added=sorted(table_infos),
             removed=removed,
-            removed_environment_naming_info=removed_environment_naming_info,
+            removed_environment_naming_info=removed_environment_naming_info if removed else None,
         )
 
     @transactional()

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -105,6 +105,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
             "expiration_ts": exp.DataType.build("bigint"),
             "finalized_ts": exp.DataType.build("bigint"),
             "promoted_snapshot_ids": exp.DataType.build("text"),
+            "suffix_target": exp.DataType.build("text"),
         }
 
         self._seed_columns_to_types = {
@@ -934,6 +935,7 @@ def _environment_to_df(environment: Environment) -> pd.DataFrame:
                 )
                 if environment.promoted_snapshot_ids is not None
                 else None,
+                "suffix_target": environment.suffix_target.value,
             }
         ]
     )

--- a/sqlmesh/engines/commands.py
+++ b/sqlmesh/engines/commands.py
@@ -8,6 +8,7 @@ from sqlmesh.core.snapshot import (
     SnapshotId,
     SnapshotTableInfo,
 )
+from sqlmesh.core.state_sync import cleanup_expired_views
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.pydantic import PydanticModel
 
@@ -118,13 +119,7 @@ def cleanup(
     if isinstance(command_payload, str):
         command_payload = CleanupCommandPayload.parse_raw(command_payload)
 
-    expired_schemas = {
-        snapshot.qualified_view_name.schema_for_environment(environment.naming_info)
-        for environment in command_payload.environments
-        for snapshot in environment.snapshots
-    }
-    for expired_schema in expired_schemas:
-        evaluator.adapter.drop_schema(expired_schema, ignore_if_not_exists=True, cascade=True)
+    cleanup_expired_views(evaluator.adapter, command_payload.environments)
     evaluator.cleanup(command_payload.snapshots)
 
 

--- a/sqlmesh/engines/commands.py
+++ b/sqlmesh/engines/commands.py
@@ -1,7 +1,7 @@
 import typing as t
 from enum import Enum
 
-from sqlmesh.core.environment import Environment
+from sqlmesh.core.environment import Environment, EnvironmentNamingInfo
 from sqlmesh.core.snapshot import (
     Snapshot,
     SnapshotEvaluator,
@@ -38,13 +38,13 @@ class EvaluateCommandPayload(PydanticModel):
 
 class PromoteCommandPayload(PydanticModel):
     snapshots: t.List[SnapshotTableInfo]
-    environment: str
+    environment_naming_info: EnvironmentNamingInfo
     is_dev: bool
 
 
 class DemoteCommandPayload(PydanticModel):
     snapshots: t.List[SnapshotTableInfo]
-    environment: str
+    environment_naming_info: EnvironmentNamingInfo
 
 
 class CleanupCommandPayload(PydanticModel):
@@ -96,7 +96,7 @@ def promote(
         command_payload = PromoteCommandPayload.parse_raw(command_payload)
     evaluator.promote(
         command_payload.snapshots,
-        command_payload.environment,
+        command_payload.environment_naming_info,
         is_dev=command_payload.is_dev,
     )
 
@@ -106,7 +106,10 @@ def demote(
 ) -> None:
     if isinstance(command_payload, str):
         command_payload = DemoteCommandPayload.parse_raw(command_payload)
-    evaluator.demote(command_payload.snapshots, command_payload.environment)
+    evaluator.demote(
+        command_payload.snapshots,
+        command_payload.environment_naming_info,
+    )
 
 
 def cleanup(
@@ -116,7 +119,7 @@ def cleanup(
         command_payload = CleanupCommandPayload.parse_raw(command_payload)
 
     expired_schemas = {
-        snapshot.qualified_view_name.schema_for_environment(environment.name)
+        snapshot.qualified_view_name.schema_for_environment(environment.naming_info)
         for environment in command_payload.environments
         for snapshot in environment.snapshots
     }

--- a/sqlmesh/migrations/v0018_rename_snapshot_model_to_node.py
+++ b/sqlmesh/migrations/v0018_rename_snapshot_model_to_node.py
@@ -10,7 +10,9 @@ from sqlmesh.utils.migration import index_text_type
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = f"{schema}._snapshots"
+    snapshots_table = "_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
 
     new_snapshots = []
 

--- a/sqlmesh/migrations/v0019_add_env_suffix_target.py
+++ b/sqlmesh/migrations/v0019_add_env_suffix_target.py
@@ -1,0 +1,61 @@
+"""Add support for environment suffix target."""
+import pandas as pd
+from sqlglot import exp
+
+from sqlmesh.utils.migration import index_text_type
+
+
+def migrate(state_sync):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    environments_table = "_environments"
+    if state_sync.schema:
+        environments_table = f"{state_sync.schema}.{environments_table}"
+
+    alter_table_exp = exp.AlterTable(
+        this=exp.to_table(environments_table),
+        actions=[
+            exp.ColumnDef(
+                this=exp.to_column("suffix_target"),
+                kind=exp.DataType.build("text"),
+            )
+        ],
+    )
+    engine_adapter.execute(alter_table_exp)
+
+    environments = []
+    columns = [
+        "name",
+        "snapshots",
+        "start_at",
+        "end_at",
+        "plan_id",
+        "previous_plan_id",
+        "expiration_ts",
+        "finalized_ts",
+        "promoted_snapshot_ids",
+    ]
+    for row in engine_adapter.fetchall(
+        exp.select(*columns).from_(environments_table), quote_identifiers=True
+    ):
+        environments.append({**dict(zip(columns, row)), "suffix_target": "schema"})
+    if environments:
+        engine_adapter.delete_from(environments_table, "TRUE")
+
+        text_type = index_text_type(engine_adapter.dialect)
+
+        engine_adapter.insert_append(
+            environments_table,
+            pd.DataFrame(environments),
+            columns_to_types={
+                "name": exp.DataType.build(text_type),
+                "snapshots": exp.DataType.build(text_type),
+                "start_at": exp.DataType.build(text_type),
+                "end_at": exp.DataType.build(text_type),
+                "plan_id": exp.DataType.build(text_type),
+                "previous_plan_id": exp.DataType.build(text_type),
+                "expiration_ts": exp.DataType.build("bigint"),
+                "finalized_ts": exp.DataType.build("bigint"),
+                "promoted_snapshot_ids": exp.DataType.build(text_type),
+                "suffix_target": exp.DataType.build(text_type),
+            },
+        )

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 
 from sqlmesh.core import constants as c
-from sqlmesh.core.environment import Environment
+from sqlmesh.core.environment import Environment, EnvironmentNamingInfo
 from sqlmesh.core.notification_target import NotificationTarget
 from sqlmesh.core.scheduler import Interval
 from sqlmesh.core.snapshot import (
@@ -60,7 +60,7 @@ class BackfillIntervalsPerSnapshot(PydanticModel):
 
 class PlanDagSpec(PydanticModel):
     request_id: str
-    environment_name: str
+    environment_naming_info: EnvironmentNamingInfo
     new_snapshots: t.List[Snapshot]
     backfill_intervals_per_snapshot: t.List[BackfillIntervalsPerSnapshot]
     promoted_snapshots: t.List[SnapshotTableInfo]

--- a/sqlmesh/schedulers/airflow/operators/targets.py
+++ b/sqlmesh/schedulers/airflow/operators/targets.py
@@ -8,6 +8,7 @@ from airflow.utils.session import provide_session
 from sqlalchemy.orm import Session
 
 from sqlmesh.core.engine_adapter import create_engine_adapter
+from sqlmesh.core.environment import EnvironmentNamingInfo
 from sqlmesh.core.model import SeedModel
 from sqlmesh.core.snapshot import Snapshot, SnapshotEvaluator, SnapshotTableInfo
 from sqlmesh.engines import commands
@@ -169,7 +170,7 @@ class SnapshotPromotionTarget(BaseTarget[commands.PromoteCommandPayload], Pydant
 
     Args:
         snapshots: The list of snapshots that should be promoted in the target environment.
-        environment: The target environment.
+        environment_naming_info: Naming information for the target environment.
         ddl_concurrent_tasks: The number of concurrent tasks used for DDL
             operations (table / view creation, deletion, etc). Default: 1.
         is_dev: Indicates whether the promotion happens in the development mode and temporary
@@ -182,14 +183,14 @@ class SnapshotPromotionTarget(BaseTarget[commands.PromoteCommandPayload], Pydant
     ] = commands.promote
 
     snapshots: t.List[SnapshotTableInfo]
-    environment: str
+    environment_naming_info: EnvironmentNamingInfo
     ddl_concurrent_tasks: int
     is_dev: bool
 
     def _get_command_payload(self, context: Context) -> t.Optional[commands.PromoteCommandPayload]:
         return commands.PromoteCommandPayload(
             snapshots=self.snapshots,
-            environment=self.environment,
+            environment_naming_info=self.environment_naming_info,
             is_dev=self.is_dev,
         )
 
@@ -201,7 +202,7 @@ class SnapshotDemotionTarget(BaseTarget[commands.DemoteCommandPayload], Pydantic
 
     Args:
         snapshots: The list of snapshots that should be demoted in the target environment.
-        environment: The target environment.
+        environment_naming_info: Naming information for the target environment.
     """
 
     command_type: commands.CommandType = commands.CommandType.DEMOTE
@@ -210,13 +211,13 @@ class SnapshotDemotionTarget(BaseTarget[commands.DemoteCommandPayload], Pydantic
     ] = commands.demote
 
     snapshots: t.List[SnapshotTableInfo]
-    environment: str
+    environment_naming_info: EnvironmentNamingInfo
     ddl_concurrent_tasks: int
 
     def _get_command_payload(self, context: Context) -> t.Optional[commands.DemoteCommandPayload]:
         return commands.DemoteCommandPayload(
             snapshots=self.snapshots,
-            environment=self.environment,
+            environment_naming_info=self.environment_naming_info,
         )
 
 

--- a/sqlmesh/schedulers/airflow/plan.py
+++ b/sqlmesh/schedulers/airflow/plan.py
@@ -79,7 +79,7 @@ def create_plan_dag_spec(
 
     return common.PlanDagSpec(
         request_id=request.request_id,
-        environment_name=request.environment.name,
+        environment_naming_info=request.environment.naming_info,
         new_snapshots=request.new_snapshots,
         backfill_intervals_per_snapshot=backfill_intervals_per_snapshot,
         promoted_snapshots=request.environment.snapshots,

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -209,7 +209,7 @@ class HttpStateSync(StateSync):
                 snapshots for same models.
 
         Returns:
-           A tuple of (added snapshot table infos, removed snapshot table infos)
+           A promotion result object containing added, removed, and removed environment naming info
         """
         raise NotImplementedError(
             "Promoting environments is not supported by the Airflow state sync."

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -4,15 +4,10 @@ import logging
 import typing as t
 
 from sqlmesh.core.console import Console
-from sqlmesh.core.environment import Environment, EnvironmentNamingInfo
-from sqlmesh.core.snapshot import (
-    Snapshot,
-    SnapshotId,
-    SnapshotIdLike,
-    SnapshotInfoLike,
-    SnapshotTableInfo,
-)
+from sqlmesh.core.environment import Environment
+from sqlmesh.core.snapshot import Snapshot, SnapshotId, SnapshotIdLike, SnapshotInfoLike
 from sqlmesh.core.state_sync import StateSync, Versions
+from sqlmesh.core.state_sync.base import PromotionResult
 from sqlmesh.schedulers.airflow.client import AirflowClient
 
 if t.TYPE_CHECKING:
@@ -202,11 +197,7 @@ class HttpStateSync(StateSync):
         """
         raise NotImplementedError("Removing intervals is not supported by the Airflow state sync.")
 
-    def promote(
-        self, environment: Environment, no_gaps: bool = False
-    ) -> t.Tuple[
-        t.List[SnapshotTableInfo], t.Tuple[t.List[SnapshotTableInfo], EnvironmentNamingInfo]
-    ]:
+    def promote(self, environment: Environment, no_gaps: bool = False) -> PromotionResult:
         """Update the environment to reflect the current state.
 
         This method verifies that snapshots have been pushed.

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -4,7 +4,7 @@ import logging
 import typing as t
 
 from sqlmesh.core.console import Console
-from sqlmesh.core.environment import Environment
+from sqlmesh.core.environment import Environment, EnvironmentNamingInfo
 from sqlmesh.core.snapshot import (
     Snapshot,
     SnapshotId,
@@ -204,7 +204,9 @@ class HttpStateSync(StateSync):
 
     def promote(
         self, environment: Environment, no_gaps: bool = False
-    ) -> t.Tuple[t.List[SnapshotTableInfo], t.List[SnapshotTableInfo]]:
+    ) -> t.Tuple[
+        t.List[SnapshotTableInfo], t.Tuple[t.List[SnapshotTableInfo], EnvironmentNamingInfo]
+    ]:
         """Update the environment to reflect the current state.
 
         This method verifies that snapshots have been pushed.

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -27,7 +27,7 @@ from sqlmesh.core.snapshot import (
     SnapshotTableInfo,
 )
 from sqlmesh.utils.date import TimeLike, to_date, to_ds, to_timestamp
-from tests.conftest import SushiDataValidator
+from tests.conftest import DuckDBMetadata, SushiDataValidator, init_and_plan_context
 
 
 @pytest.fixture(autouse=True)
@@ -715,29 +715,63 @@ def test_incremental_time_self_reference(
 @pytest.mark.integration
 @pytest.mark.core_integration
 def test_invalidating_environment(sushi_context: Context):
-    def get_schemas() -> t.Set[str]:
-        return set(
-            sushi_context.state_sync.state_sync.engine_adapter.fetchdf("SELECT * FROM information_schema.schemata")["schema_name"]  # type: ignore
-            .to_dict()
-            .values()
-        )
-
-    environment = "dev"
-    apply_to_environment(sushi_context, environment)
+    apply_to_environment(sushi_context, "dev")
     start_environment = sushi_context.state_sync.get_environment("dev")
     assert start_environment is not None
-    start_schemas = get_schemas()
+    metadata = DuckDBMetadata.from_context(sushi_context)
+    start_schemas = set(metadata.schemas)
     assert "sushi__dev" in start_schemas
     sushi_context.invalidate_environment("dev")
     invalidate_environment = sushi_context.state_sync.get_environment("dev")
     assert invalidate_environment is not None
-    schemas_prior_to_janitor = get_schemas()
+    schemas_prior_to_janitor = set(metadata.schemas)
     assert invalidate_environment.expiration_ts < start_environment.expiration_ts  # type: ignore
     assert start_schemas == schemas_prior_to_janitor
     sushi_context._run_janitor()
-    schemas_after_janitor = get_schemas()
+    schemas_after_janitor = set(metadata.schemas)
     assert sushi_context.state_sync.get_environment("dev") is None
     assert start_schemas - schemas_after_janitor == {"sushi__dev"}
+
+
+@pytest.mark.integration
+@pytest.mark.core_integration
+def test_environment_suffix_target_table(mocker: MockerFixture):
+    context, plan = init_and_plan_context(
+        "examples/sushi", mocker, config="environment_suffix_config"
+    )
+    context.apply(plan)
+    metadata = DuckDBMetadata.from_context(context)
+    environments_schemas = {"raw", "sushi"}
+    internal_schemas = {"sqlmesh", "sqlmesh__sushi"}
+    starting_schemas = environments_schemas | internal_schemas
+    # Make sure no new schemas are created
+    assert set(metadata.schemas) - starting_schemas == set()
+    prod_views = {x for x in metadata.qualified_views if x.db in environments_schemas}
+    # Make sure that all models are present
+    assert len(prod_views) == 10
+    apply_to_environment(context, "dev")
+    # Make sure no new schemas are created
+    assert set(metadata.schemas) - starting_schemas == set()
+    dev_views = {
+        x for x in metadata.qualified_views if x.db in environments_schemas and "__dev" in x.name
+    }
+    # Make sure that there is a view with `__dev` for each view that exists in prod
+    assert len(dev_views) == len(prod_views)
+    assert {x.name.replace("__dev", "") for x in dev_views} - {x.name for x in prod_views} == set()
+    context.invalidate_environment("dev")
+    context._run_janitor()
+    views_after_janitor = metadata.qualified_views
+    # Make sure that the number of views after the janitor is the same as when you subtract away dev views
+    assert len(views_after_janitor) == len(
+        {x.sql(dialect="duckdb") for x in views_after_janitor}
+        - {x.sql(dialect="duckdb") for x in dev_views}
+    )
+    # Double check there are no dev views
+    assert len({x for x in views_after_janitor if "__dev" in x.name}) == 0
+    # Make sure prod views were not removed
+    assert {x.sql(dialect="duckdb") for x in prod_views} - {
+        x.sql(dialect="duckdb") for x in views_after_janitor
+    } == set()
 
 
 def initial_add(context: Context, environment: str):
@@ -875,7 +909,9 @@ def validate_environment_views(
         if snapshot.is_symbolic:
             continue
         view_name = snapshot.qualified_view_name.for_environment(
-            EnvironmentNamingInfo(name=environment)
+            EnvironmentNamingInfo(
+                name=environment, suffix_target=context.config.environment_suffix_target
+            )
         )
 
         assert adapter.table_exists(view_name)

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -10,6 +10,7 @@ from sqlmesh.core.config import AutoCategorizationMode
 from sqlmesh.core.console import Console
 from sqlmesh.core.context import Context
 from sqlmesh.core.engine_adapter import EngineAdapter
+from sqlmesh.core.environment import EnvironmentNamingInfo
 from sqlmesh.core.model import (
     IncrementalByTimeRangeKind,
     IncrementalByUniqueKeyKind,
@@ -873,7 +874,9 @@ def validate_environment_views(
     for snapshot in snapshots:
         if snapshot.is_symbolic:
             continue
-        view_name = snapshot.qualified_view_name.for_environment(environment=environment)
+        view_name = snapshot.qualified_view_name.for_environment(
+            EnvironmentNamingInfo(name=environment)
+        )
 
         assert adapter.table_exists(view_name)
         assert select_all(

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -2,8 +2,8 @@ import pytest
 from pytest_mock.plugin import MockerFixture
 from sqlglot import parse_one
 
-from sqlmesh.core import constants as c
 from sqlmesh.core.context import Context
+from sqlmesh.core.environment import EnvironmentNamingInfo
 from sqlmesh.core.model.definition import SqlModel
 from sqlmesh.core.model.kind import (
     IncrementalByTimeRangeKind,
@@ -79,7 +79,7 @@ def test_run(sushi_context_fixed_date: Context, scheduler: Scheduler):
     adapter = sushi_context_fixed_date.engine_adapter
     snapshot = sushi_context_fixed_date.snapshots["sushi.items"]
     scheduler.run(
-        c.PROD,
+        EnvironmentNamingInfo(),
         "2022-01-01",
         "2022-01-03",
         "2022-01-30",

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -8,6 +8,7 @@ from sqlglot import parse, parse_one
 
 from sqlmesh.core.engine_adapter import EngineAdapter, create_engine_adapter
 from sqlmesh.core.engine_adapter.base import InsertOverwriteStrategy
+from sqlmesh.core.environment import EnvironmentNamingInfo
 from sqlmesh.core.macros import macro
 from sqlmesh.core.model import (
     IncrementalByTimeRangeKind,
@@ -186,7 +187,7 @@ def test_promote(mocker: MockerFixture, adapter_mock, make_snapshot):
     snapshot = make_snapshot(model)
     snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
 
-    evaluator.promote([snapshot], "test_env")
+    evaluator.promote([snapshot], EnvironmentNamingInfo(name="test_env"))
 
     adapter_mock.create_schema.assert_called_once_with("test_schema__test_env")
     adapter_mock.create_view.assert_called_once_with(
@@ -355,7 +356,7 @@ def test_promote_model_info(mocker: MockerFixture):
                 kind_name=ModelKindName.FULL,
             )
         ],
-        "test_env",
+        EnvironmentNamingInfo(name="test_env"),
     )
 
     adapter_mock.create_schema.assert_called_once_with("test_schema__test_env")

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -9,9 +9,10 @@ from pytest_mock.plugin import MockerFixture
 from sqlglot import exp
 
 from sqlmesh.core import constants as c
+from sqlmesh.core.config import EnvironmentSuffixTarget
 from sqlmesh.core.dialect import parse_one
 from sqlmesh.core.engine_adapter import create_engine_adapter
-from sqlmesh.core.environment import Environment, EnvironmentNamingInfo
+from sqlmesh.core.environment import Environment
 from sqlmesh.core.model import (
     IncrementalByTimeRangeKind,
     ModelKind,
@@ -21,14 +22,14 @@ from sqlmesh.core.model import (
     SeedModel,
     SqlModel,
 )
-from sqlmesh.core.snapshot import (
-    Snapshot,
-    SnapshotChangeCategory,
-    SnapshotTableInfo,
-    missing_intervals,
-)
+from sqlmesh.core.snapshot import Snapshot, SnapshotChangeCategory, missing_intervals
 from sqlmesh.core.state_sync import CachingStateSync, EngineAdapterStateSync
-from sqlmesh.core.state_sync.base import SCHEMA_VERSION, SQLGLOT_VERSION, Versions
+from sqlmesh.core.state_sync.base import (
+    SCHEMA_VERSION,
+    SQLGLOT_VERSION,
+    PromotionResult,
+    Versions,
+)
 from sqlmesh.utils.date import now_timestamp, to_datetime, to_timestamp
 from sqlmesh.utils.errors import SQLMeshError
 
@@ -67,9 +68,11 @@ def promote_snapshots(
     snapshots: t.List[Snapshot],
     environment: str,
     no_gaps: bool = False,
-) -> t.Tuple[t.List[SnapshotTableInfo], t.Tuple[t.List[SnapshotTableInfo], EnvironmentNamingInfo]]:
+    environment_suffix_target: EnvironmentSuffixTarget = EnvironmentSuffixTarget.SCHEMA,
+) -> PromotionResult:
     env = Environment(
         name=environment,
+        suffix_target=environment_suffix_target,
         snapshots=[snapshot.table_info for snapshot in snapshots],
         start_at="2022-01-01",
         end_at="2022-01-01",
@@ -380,36 +383,35 @@ def test_promote_snapshots(state_sync: EngineAdapterStateSync, make_snapshot: t.
 
     state_sync.push_snapshots([snapshot_a, snapshot_b, snapshot_c])
 
-    added, (removed, removed_environment_naming_info) = promote_snapshots(
-        state_sync, [snapshot_a, snapshot_b], "prod"
-    )
+    promotion_result = promote_snapshots(state_sync, [snapshot_a, snapshot_b], "prod")
 
-    assert set(added) == set([snapshot_a.table_info, snapshot_b.table_info])
-    assert not removed
-    assert removed_environment_naming_info.suffix_target.is_schema
-    added, (removed, removed_environment_naming_info) = promote_snapshots(
+    assert set(promotion_result.added) == set([snapshot_a.table_info, snapshot_b.table_info])
+    assert not promotion_result.removed
+    assert not promotion_result.removed_environment_naming_info
+    promotion_result = promote_snapshots(
         state_sync,
         [snapshot_a, snapshot_b, snapshot_c],
         "prod",
     )
-    assert set(added) == set(
+    assert set(promotion_result.added) == set(
         [
             snapshot_a.table_info,
             snapshot_b.table_info,
             snapshot_c.table_info,
         ]
     )
-    assert not removed
-    assert removed_environment_naming_info.suffix_target.is_schema
+    assert not promotion_result.removed
+    assert not promotion_result.removed_environment_naming_info
 
-    added, (removed, removed_environment_naming_info) = promote_snapshots(
+    promotion_result = promote_snapshots(
         state_sync,
         [snapshot_a, snapshot_b],
         "prod",
     )
-    assert set(added) == {snapshot_a.table_info, snapshot_b.table_info}
-    assert set(removed) == {snapshot_c.table_info}
-    assert removed_environment_naming_info.suffix_target.is_schema
+    assert set(promotion_result.added) == {snapshot_a.table_info, snapshot_b.table_info}
+    assert set(promotion_result.removed) == {snapshot_c.table_info}
+    assert promotion_result.removed_environment_naming_info
+    assert promotion_result.removed_environment_naming_info.suffix_target.is_schema
 
     snapshot_d = make_snapshot(
         SqlModel(
@@ -420,12 +422,71 @@ def test_promote_snapshots(state_sync: EngineAdapterStateSync, make_snapshot: t.
     snapshot_d.categorize_as(SnapshotChangeCategory.BREAKING)
 
     state_sync.push_snapshots([snapshot_d])
-    added, (removed, removed_environment_naming_info) = promote_snapshots(
-        state_sync, [snapshot_d], "prod"
+    promotion_result = promote_snapshots(state_sync, [snapshot_d], "prod")
+    assert set(promotion_result.added) == {snapshot_d.table_info}
+    assert set(promotion_result.removed) == {snapshot_b.table_info}
+    assert promotion_result.removed_environment_naming_info
+    assert promotion_result.removed_environment_naming_info.suffix_target.is_schema
+
+
+def test_promote_snapshots_suffix_change(
+    state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
+):
+    snapshot_a = make_snapshot(
+        SqlModel(
+            name="a",
+            query=parse_one("select 1, ds"),
+        ),
     )
-    assert set(added) == {snapshot_d.table_info}
-    assert set(removed) == {snapshot_b.table_info}
-    assert removed_environment_naming_info.suffix_target.is_schema
+    snapshot_a.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    snapshot_b = make_snapshot(
+        SqlModel(
+            name="b",
+            kind=ModelKind(name=ModelKindName.FULL),
+            query=parse_one("select * from a"),
+        ),
+        nodes={"a": snapshot_a.model},
+    )
+    snapshot_b.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    state_sync.push_snapshots([snapshot_a, snapshot_b])
+
+    promotion_result = promote_snapshots(
+        state_sync,
+        [snapshot_a, snapshot_b],
+        "prod",
+        environment_suffix_target=EnvironmentSuffixTarget.TABLE,
+    )
+
+    assert set(promotion_result.added) == set([snapshot_a.table_info, snapshot_b.table_info])
+    assert not promotion_result.removed
+    assert not promotion_result.removed_environment_naming_info
+
+    snapshot_c = make_snapshot(
+        SqlModel(
+            name="c",
+            query=parse_one("select 3, ds"),
+        ),
+    )
+    snapshot_c.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    state_sync.push_snapshots([snapshot_c])
+
+    promotion_result = promote_snapshots(
+        state_sync,
+        [snapshot_b, snapshot_c],
+        "prod",
+        environment_suffix_target=EnvironmentSuffixTarget.SCHEMA,
+    )
+
+    # We still only add the snapshots that are included in the promotion
+    assert set(promotion_result.added) == set([snapshot_b.table_info, snapshot_c.table_info])
+    # We also remove b because of the suffix target change. The new one will be created in the new suffix target
+    assert set(promotion_result.removed) == set([snapshot_a.table_info, snapshot_b.table_info])
+    # Make sure the removed suffix target is correctly seen as table
+    assert promotion_result.removed_environment_naming_info
+    assert promotion_result.removed_environment_naming_info.suffix_target.is_table
 
 
 def test_promote_snapshots_parent_plan_id_mismatch(

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -32,7 +32,7 @@ def test_github_controller_pr_plan(
     mocked_apply = mocker.MagicMock()
     mocker.patch("sqlmesh.core.context.Context.apply", mocked_apply)
     pr_plan = controller.pr_plan
-    assert pr_plan.environment_name == "hello_world_2"
+    assert pr_plan.environment_naming_info.name == "hello_world_2"
     assert pr_plan.skip_backfill
     assert not pr_plan.auto_categorization_enabled
     assert not pr_plan.no_gaps
@@ -48,7 +48,7 @@ def test_github_controller_prod_plan(
     mocked_apply = mocker.MagicMock()
     mocker.patch("sqlmesh.core.context.Context.apply", mocked_apply)
     prod_plan = controller.prod_plan
-    assert prod_plan.environment_name == c.PROD
+    assert prod_plan.environment_naming_info.name == c.PROD
     assert not prod_plan.skip_backfill
     assert not prod_plan.auto_categorization_enabled
     assert prod_plan.no_gaps
@@ -64,7 +64,7 @@ def test_github_controller_prod_plan_with_gaps(
     mocked_apply = mocker.MagicMock()
     mocker.patch("sqlmesh.core.context.Context.apply", mocked_apply)
     prod_plan_with_gaps = controller.prod_plan_with_gaps
-    assert prod_plan_with_gaps.environment_name == c.PROD
+    assert prod_plan_with_gaps.environment_naming_info.name == c.PROD
     assert not prod_plan_with_gaps.skip_backfill
     assert not prod_plan_with_gaps.auto_categorization_enabled
     assert not prod_plan_with_gaps.no_gaps

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -132,6 +132,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
                     "identifier": "3192766394",
                 }
             ],
+            "suffix_target": "schema",
         },
         "no_gaps": False,
         "skip_backfill": False,

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -6,6 +6,7 @@ import requests
 from pytest_mock.plugin import MockerFixture
 from sqlglot import parse_one
 
+from sqlmesh.core.config import EnvironmentSuffixTarget
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.model import IncrementalByTimeRangeKind, SqlModel
 from sqlmesh.core.snapshot import Snapshot, SnapshotChangeCategory
@@ -218,6 +219,7 @@ def test_get_environment(mocker: MockerFixture, snapshot: Snapshot):
         end_at="2022-01-01",
         plan_id="test_plan_id",
         previous_plan_id=None,
+        suffix_target=EnvironmentSuffixTarget.TABLE,
     )
 
     get_environment_response_mock = mocker.Mock()

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -84,6 +84,7 @@ def test_create_plan_dag_spec(
         start_at="2022-01-01",
         end_at="2022-01-04",
         plan_id="test_plan_id",
+        suffix_target=EnvironmentSuffixTarget.TABLE,
     )
 
     plan_request = common.PlanApplicationRequest(
@@ -116,6 +117,7 @@ def test_create_plan_dag_spec(
         start_at="2022-01-01",
         end_at="2022-01-01",
         plan_id="test_plan_id",
+        suffix_target=EnvironmentSuffixTarget.SCHEMA,
     )
 
     state_sync_mock = mocker.Mock()
@@ -127,7 +129,7 @@ def test_create_plan_dag_spec(
     assert plan_spec == common.PlanDagSpec(
         request_id="test_request_id",
         environment_naming_info=EnvironmentNamingInfo(
-            name=environment_name, suffix_target=EnvironmentSuffixTarget.SCHEMA
+            name=environment_name, suffix_target=EnvironmentSuffixTarget.TABLE
         ),
         new_snapshots=[the_snapshot],
         backfill_intervals_per_snapshot=[

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -8,7 +8,8 @@ from pytest_lazyfixture import lazy_fixture
 from pytest_mock.plugin import MockerFixture
 from sqlglot import parse_one
 
-from sqlmesh.core.environment import Environment
+from sqlmesh.core.config import EnvironmentSuffixTarget
+from sqlmesh.core.environment import Environment, EnvironmentNamingInfo
 from sqlmesh.core.model import (
     IncrementalByTimeRangeKind,
     ModelKindName,
@@ -125,7 +126,9 @@ def test_create_plan_dag_spec(
     plan_spec = create_plan_dag_spec(plan_request, state_sync_mock)
     assert plan_spec == common.PlanDagSpec(
         request_id="test_request_id",
-        environment_name=environment_name,
+        environment_naming_info=EnvironmentNamingInfo(
+            name=environment_name, suffix_target=EnvironmentSuffixTarget.SCHEMA
+        ),
         new_snapshots=[the_snapshot],
         backfill_intervals_per_snapshot=[
             common.BackfillIntervalsPerSnapshot(
@@ -242,7 +245,9 @@ def test_restatement(
         plan_spec = create_plan_dag_spec(plan_request, state_sync_mock)
     assert plan_spec == common.PlanDagSpec(
         request_id="test_request_id",
-        environment_name=environment_name,
+        environment_naming_info=EnvironmentNamingInfo(
+            name=environment_name, suffix_target=EnvironmentSuffixTarget.SCHEMA
+        ),
         new_snapshots=[],
         backfill_intervals_per_snapshot=[
             common.BackfillIntervalsPerSnapshot(

--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -479,6 +479,7 @@ def test_get_environments(project_context: Context) -> None:
             "expiration_ts": None,
             "finalized_ts": None,
             "promoted_snapshot_ids": None,
+            "suffix_target": "schema",
         }
     }
 

--- a/web/server/api/endpoints/plan.py
+++ b/web/server/api/endpoints/plan.py
@@ -69,7 +69,7 @@ async def run_plan(
                 model_name=interval.snapshot_name,
                 view_name=plan.context_diff.snapshots[
                     interval.snapshot_name
-                ].qualified_view_name.for_environment(plan.environment.name)
+                ].qualified_view_name.for_environment(plan.environment.naming_info)
                 if interval.snapshot_name in plan.context_diff.snapshots
                 else interval.snapshot_name,
                 interval=[

--- a/web/server/console.py
+++ b/web/server/console.py
@@ -8,10 +8,14 @@ import unittest
 from sse_starlette.sse import ServerSentEvent
 
 from sqlmesh.core.console import TerminalConsole
+from sqlmesh.core.environment import EnvironmentNamingInfo
 from sqlmesh.core.snapshot import Snapshot
 from sqlmesh.core.test import ModelTest
 from sqlmesh.utils.date import now_timestamp
 from web.server.exceptions import ApiException
+
+if t.TYPE_CHECKING:
+    pass
 
 
 class ApiConsole(TerminalConsole):
@@ -36,13 +40,17 @@ class ApiConsole(TerminalConsole):
             data=json.dumps(payload),
         )
 
-    def start_evaluation_progress(self, batches: t.Dict[Snapshot, int], environment: str) -> None:
+    def start_evaluation_progress(
+        self,
+        batches: t.Dict[Snapshot, int],
+        environment_naming_info: EnvironmentNamingInfo,
+    ) -> None:
         self.current_task_status = {
             snapshot.name: {
                 "completed": 0,
                 "total": total_tasks,
                 "start": now_timestamp(),
-                "view_name": snapshot.qualified_view_name.for_environment(environment),
+                "view_name": snapshot.qualified_view_name.for_environment(environment_naming_info),
             }
             for snapshot, total_tasks in batches.items()
         }

--- a/web/server/console.py
+++ b/web/server/console.py
@@ -14,9 +14,6 @@ from sqlmesh.core.test import ModelTest
 from sqlmesh.utils.date import now_timestamp
 from web.server.exceptions import ApiException
 
-if t.TYPE_CHECKING:
-    pass
-
 
 class ApiConsole(TerminalConsole):
     def __init__(self) -> None:


### PR DESCRIPTION
This PR allows users to add environment suffix to either the schema name or the table name. It makes sure that when cleaning up environments/views that we drop the objects using the appropriate strategy. 