### PR TITLE
Fix: allow render output to wrap instead of cropping

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -194,7 +194,7 @@ class TerminalConsole(Console):
         self.loading_status: t.Dict[uuid.UUID, Status] = {}
 
     def _print(self, value: t.Any, **kwargs: t.Any) -> None:
-        self.console.print(value)
+        self.console.print(value, **kwargs)
 
     def _prompt(self, message: str, **kwargs: t.Any) -> t.Any:
         return Prompt.ask(message, console=self.console, **kwargs)
@@ -587,7 +587,7 @@ class TerminalConsole(Console):
             self._print(output)
 
     def show_sql(self, sql: str) -> None:
-        self._print(Syntax(sql, "sql"))
+        self._print(Syntax(sql, "sql", word_wrap=True), crop=False)
 
     def log_status_update(self, message: str) -> None:
         self._print(message)


### PR DESCRIPTION
2 nits I have had for awhile. 

1) `render` truncates text longer than the terminal width which makes the output unusable

<img width="1043" alt="image" src="https://github.com/TobikoData/sqlmesh/assets/41213451/8c790485-4cff-49dd-bc3c-256863dec043">

Since early on, I have replaced the `ctx.obj.show_sql` function with just regular `print` in `cli.py` to fix this issue. But have been meaning to submit something here.

This tiny change fixes it.

Before:
<img width="1236" alt="image" src="https://github.com/TobikoData/sqlmesh/assets/41213451/54053205-7b69-4269-b6ad-2df0d3cf3ec0">

After:
<img width="1237" alt="image" src="https://github.com/TobikoData/sqlmesh/assets/41213451/bed051f3-fd5e-411e-ae89-8806ca30d5ad">


The other nit thats been around, which I couldn't get Pygment to stop doing is inserting a bunch of whitespace, so when you paste it over to bq console, its almost unreadable/unusable.

<img width="1038" alt="image" src="https://github.com/TobikoData/sqlmesh/assets/41213451/ed4d45a2-112c-4fef-a273-1c81e813d15c">

My suggestion is a `--no-pretty-print` flag.
