### PR TITLE
Fix: Spark partition by on state tables

### DIFF
--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -212,7 +212,7 @@ class SparkEngineAdapter(EngineAdapter):
         self.create_table(
             table_name,
             columns_to_types,
-            partitioned_by=primary_key,
+            partitioned_by=[exp.column(x) for x in primary_key] if primary_key else None,
         )
 
     def create_view(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,8 @@ from sqlmesh.utils.date import TimeLike, to_date, to_ds
 
 pytest_plugins = ["tests.common_fixtures"]
 
+T = t.TypeVar("T", bound=EngineAdapter)
+
 
 class SushiDataValidator:
     def __init__(self, engine_adapter: EngineAdapter):
@@ -182,6 +184,17 @@ def sushi_data_validator(sushi_context: Context) -> SushiDataValidator:
 @pytest.fixture
 def sushi_fixed_date_data_validator(sushi_context_fixed_date: Context) -> SushiDataValidator:
     return SushiDataValidator.from_context(sushi_context_fixed_date)
+
+
+@pytest.fixture
+def make_mocked_engine_adapter(mocker: MockerFixture) -> t.Callable:
+    def _make_function(klass: t.Type[T], dialect: t.Optional[str] = None) -> T:
+        connection_mock = mocker.NonCallableMock()
+        cursor_mock = mocker.Mock()
+        connection_mock.cursor.return_value = cursor_mock
+        return klass(lambda: connection_mock, dialect=dialect or klass.DIALECT)
+
+    return _make_function
 
 
 def delete_cache(project_paths: str | t.List[str]) -> None:

--- a/tests/core/engine_adapter/test_base_postgres.py
+++ b/tests/core/engine_adapter/test_base_postgres.py
@@ -1,56 +1,44 @@
 # type: ignore
+import typing as t
 from unittest.mock import call
 
-from pytest_mock.plugin import MockerFixture
 from sqlglot import exp, parse_one
 
 from sqlmesh.core.engine_adapter.base_postgres import BasePostgresEngineAdapter
 
 
-def test_columns(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
-    cursor_mock.fetchall.return_value = [("col", "INT")]
-
-    adapter = BasePostgresEngineAdapter(lambda: connection_mock, "postgres")
+def test_columns(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(BasePostgresEngineAdapter)
+    adapter.cursor.fetchall.return_value = [("col", "INT")]
 
     resp = adapter.columns("db.table")
-    cursor_mock.execute.assert_called_once_with(
+    adapter.cursor.execute.assert_called_once_with(
         """SELECT "column_name", "data_type" FROM "information_schema"."columns" WHERE "table_name" = 'table' AND "table_schema" = 'db'"""
     )
     assert resp == {"col": exp.DataType.build("INT")}
 
 
-def test_table_exists(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
-    cursor_mock.fetchone.return_value = (1,)
-
-    adapter = BasePostgresEngineAdapter(lambda: connection_mock, "postgres")
+def test_table_exists(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(BasePostgresEngineAdapter)
+    adapter.cursor.fetchone.return_value = (1,)
 
     resp = adapter.table_exists("db.table")
-    cursor_mock.execute.assert_called_once_with(
+    adapter.cursor.execute.assert_called_once_with(
         """SELECT 1 FROM "information_schema"."tables" WHERE "table_name" = 'table' AND "table_schema" = 'db'"""
     )
     assert resp
-    cursor_mock.fetchone.return_value = None
+    adapter.cursor.fetchone.return_value = None
     resp = adapter.table_exists("db.table")
     assert not resp
 
 
-def test_create_view(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
-
-    adapter = BasePostgresEngineAdapter(lambda: connection_mock, "postgres")
+def test_create_view(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(BasePostgresEngineAdapter)
 
     adapter.create_view("db.view", parse_one("SELECT 1"), replace=True)
     adapter.create_view("db.view", parse_one("SELECT 1"), replace=False)
 
-    cursor_mock.execute.assert_has_calls(
+    adapter.cursor.execute.assert_has_calls(
         [
             # 1st call
             call('DROP VIEW IF EXISTS "db"."view"'),

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -16,12 +16,10 @@ from sqlmesh.core.node import IntervalUnit
 from sqlmesh.utils import AttributeDict
 
 
-def test_insert_overwrite_by_time_partition_query(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
-
-    adapter = BigQueryEngineAdapter(lambda: connection_mock)
+def test_insert_overwrite_by_time_partition_query(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+):
+    adapter = make_mocked_engine_adapter(BigQueryEngineAdapter)
     execute_mock = mocker.patch(
         "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.execute"
     )
@@ -43,12 +41,10 @@ def test_insert_overwrite_by_time_partition_query(mocker: MockerFixture):
     ]
 
 
-def test_insert_overwrite_by_partition_query(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
-
-    adapter = BigQueryEngineAdapter(lambda: connection_mock)
+def test_insert_overwrite_by_partition_query(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+):
+    adapter = make_mocked_engine_adapter(BigQueryEngineAdapter)
     execute_mock = mocker.patch(
         "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.execute"
     )
@@ -79,11 +75,11 @@ def test_insert_overwrite_by_partition_query(mocker: MockerFixture):
     ]
 
 
-def test_insert_overwrite_by_time_partition_pandas(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
-    adapter = BigQueryEngineAdapter(lambda: connection_mock)
+def test_insert_overwrite_by_time_partition_pandas(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+):
+    adapter = make_mocked_engine_adapter(BigQueryEngineAdapter)
+
     get_temp_bq_table = mocker.Mock()
     get_temp_bq_table.return_value = AttributeDict(
         {"project": "project", "dataset_id": "dataset", "table_id": "temp_table"}
@@ -151,12 +147,9 @@ def test_insert_overwrite_by_time_partition_pandas(mocker: MockerFixture):
     )
 
 
-def test_replace_query(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
+def test_replace_query(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+    adapter = make_mocked_engine_adapter(BigQueryEngineAdapter)
 
-    adapter = BigQueryEngineAdapter(lambda: connection_mock)
     execute_mock = mocker.patch(
         "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.execute"
     )
@@ -166,11 +159,9 @@ def test_replace_query(mocker: MockerFixture):
     assert sql_calls == ["CREATE OR REPLACE TABLE `test_table` AS SELECT `a` FROM `tbl`"]
 
 
-def test_replace_query_pandas(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
-    adapter = BigQueryEngineAdapter(lambda: connection_mock)
+def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+    adapter = make_mocked_engine_adapter(BigQueryEngineAdapter)
+
     get_bq_table = mocker.Mock()
     get_bq_table.return_value = AttributeDict(
         {"project": "project", "dataset_id": "dataset", "table_id": "test_table"}
@@ -229,13 +220,13 @@ def test_replace_query_pandas(mocker: MockerFixture):
     ],
 )
 def test_create_table_date_partition(
-    partition_by_cols, partition_by_statement, mocker: MockerFixture
+    make_mocked_engine_adapter: t.Callable,
+    partition_by_cols,
+    partition_by_statement,
+    mocker: MockerFixture,
 ):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
+    adapter = make_mocked_engine_adapter(BigQueryEngineAdapter)
 
-    adapter = BigQueryEngineAdapter(lambda: connection_mock)
     execute_mock = mocker.patch(
         "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.execute"
     )
@@ -264,13 +255,13 @@ def test_create_table_date_partition(
     ],
 )
 def test_create_table_time_partition(
-    partition_by_cols, partition_by_statement, mocker: MockerFixture
+    make_mocked_engine_adapter: t.Callable,
+    partition_by_cols,
+    partition_by_statement,
+    mocker: MockerFixture,
 ):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
+    adapter = make_mocked_engine_adapter(BigQueryEngineAdapter)
 
-    adapter = BigQueryEngineAdapter(lambda: connection_mock)
     execute_mock = mocker.patch(
         "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.execute"
     )
@@ -287,12 +278,9 @@ def test_create_table_time_partition(
     ]
 
 
-def test_merge(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
+def test_merge(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+    adapter = make_mocked_engine_adapter(BigQueryEngineAdapter)
 
-    adapter = BigQueryEngineAdapter(lambda: connection_mock)
     execute_mock = mocker.patch(
         "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.execute"
     )
@@ -417,12 +405,9 @@ def _to_sql_calls(execute_mock: t.Any, identify: bool = True) -> t.List[str]:
     return output
 
 
-def test_create_table_table_options(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
+def test_create_table_table_options(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+    adapter = make_mocked_engine_adapter(BigQueryEngineAdapter)
 
-    adapter = BigQueryEngineAdapter(lambda: connection_mock)
     execute_mock = mocker.patch(
         "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.execute"
     )

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -1,33 +1,26 @@
 # type: ignore
+import typing as t
+
 import pandas as pd
-from pytest_mock.plugin import MockerFixture
 from sqlglot import parse_one
 
 from sqlmesh.core.engine_adapter import DatabricksEngineAdapter
 
 
-def test_replace_query(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
-
-    adapter = DatabricksEngineAdapter(lambda: connection_mock)
+def test_replace_query(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(DatabricksEngineAdapter)
     adapter.replace_query("test_table", parse_one("SELECT a FROM tbl"), {"a": "int"})
 
-    cursor_mock.execute.assert_called_once_with(
+    adapter.cursor.execute.assert_called_once_with(
         "INSERT OVERWRITE TABLE `test_table` (`a`) SELECT * FROM (SELECT `a` FROM `tbl`) AS `_subquery` WHERE 1 = 1"
     )
 
 
-def test_replace_query_pandas(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
-
-    adapter = DatabricksEngineAdapter(lambda: connection_mock)
+def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(DatabricksEngineAdapter)
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.replace_query("test_table", df, {"a": "int", "b": "int"})
 
-    cursor_mock.execute.assert_called_once_with(
+    adapter.cursor.execute.assert_called_once_with(
         "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `test_table`(`a`, `b`)) AS `_subquery` WHERE 1 = 1"
     )

--- a/tests/core/engine_adapter/test_mixins.py
+++ b/tests/core/engine_adapter/test_mixins.py
@@ -11,21 +11,18 @@ from sqlmesh.core.engine_adapter.mixins import (
 )
 
 
-def test_logical_replace_query_already_exists(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
-    cursor_mock.fetchone.return_value = (1,)
-
+def test_logical_replace_query_already_exists(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+):
+    adapter = make_mocked_engine_adapter(LogicalReplaceQueryMixin, "postgres")
+    adapter.cursor.fetchone.return_value = (1,)
     mocker.patch(
         "sqlmesh.core.engine_adapter.postgres.LogicalReplaceQueryMixin.table_exists",
         return_value=True,
     )
 
-    adapter = LogicalReplaceQueryMixin(lambda: connection_mock, "postgres")
-
     adapter.replace_query("db.table", parse_one("SELECT col FROM db.other_table"))
-    cursor_mock.execute.assert_has_calls(
+    adapter.cursor.execute.assert_has_calls(
         [
             call('TRUNCATE "db"."table"'),
             call('INSERT INTO "db"."table" SELECT "col" FROM "db"."other_table"'),
@@ -33,33 +30,27 @@ def test_logical_replace_query_already_exists(mocker: MockerFixture):
     )
 
 
-def test_logical_replace_query_does_not_exist(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
-    cursor_mock.fetchone.return_value = (1,)
-
+def test_logical_replace_query_does_not_exist(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+):
+    adapter = make_mocked_engine_adapter(LogicalReplaceQueryMixin, "postgres")
+    adapter.cursor.fetchone.return_value = (1,)
     mocker.patch(
         "sqlmesh.core.engine_adapter.postgres.LogicalReplaceQueryMixin.table_exists",
         return_value=False,
     )
 
-    adapter = LogicalReplaceQueryMixin(lambda: connection_mock, "postgres")
-
     adapter.replace_query("db.table", parse_one("SELECT col FROM db.other_table"))
-    cursor_mock.execute.assert_called_once_with(
+    adapter.cursor.execute.assert_called_once_with(
         'CREATE TABLE "db"."table" AS SELECT "col" FROM "db"."other_table"'
     )
 
 
-def test_logical_merge(mocker: MockerFixture):
-    connection_mock = mocker.NonCallableMock()
-    cursor_mock = mocker.Mock()
-    connection_mock.cursor.return_value = cursor_mock
+def test_logical_merge(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+    adapter = make_mocked_engine_adapter(LogicalMergeMixin, "duckdb")
     temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.base.EngineAdapter._get_temp_table")
     temp_table_mock.return_value = exp.to_table("temporary")
 
-    adapter = LogicalMergeMixin(lambda: connection_mock, "duckdb")
     adapter.merge(
         target_table="target",
         source_table=t.cast(exp.Select, parse_one("SELECT id, ts, val FROM source")),
@@ -71,7 +62,7 @@ def test_logical_merge(mocker: MockerFixture):
         unique_key=["id"],
     )
 
-    cursor_mock.execute.assert_has_calls(
+    adapter.cursor.execute.assert_has_calls(
         [
             call('''CREATE TABLE "temporary" AS SELECT "id", "ts", "val" FROM "source"'''),
             call(
@@ -84,7 +75,7 @@ def test_logical_merge(mocker: MockerFixture):
         ]
     )
 
-    cursor_mock.reset_mock()
+    adapter.cursor.reset_mock()
     adapter.merge(
         target_table="target",
         source_table=t.cast(exp.Select, parse_one("SELECT id, ts, val FROM source")),
@@ -96,7 +87,7 @@ def test_logical_merge(mocker: MockerFixture):
         unique_key=["id", "ts"],
     )
 
-    cursor_mock.execute.assert_has_calls(
+    adapter.cursor.execute.assert_has_calls(
         [
             call('''CREATE TABLE "temporary" AS SELECT "id", "ts", "val" FROM "source"'''),
             call(


### PR DESCRIPTION
Also dry'd up some tests by simplifying mocked engine adapter creation. 