### PR TITLE
Fix: Improve Databricks Catalog setting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,6 +84,9 @@ ignore_missing_imports = True
 [mypy-slack_sdk.*]
 ignore_missing_imports = True
 
+[mypy-py4j.*]
+ignore_missing_imports = True
+
 [autoflake]
 in-place = True
 expand-star-imports = True

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -103,8 +103,16 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
             ).getOrCreate()
             catalog = self._extra_config.get("catalog")
             if catalog:
+                from py4j.protocol import Py4JError
+
                 # Note: Spark 3.4+ Only API
-                self.spark.sql(f"USE CATALOG {catalog}")
+                try:
+                    self.spark.catalog.setCurrentCatalog(catalog)
+                # If `setCurrentCatalog` should work for both non-unity and Unity single user
+                # clusters. If it fails then we try `USE CATALOG` which is Unity only but works
+                # across all clusters
+                except Py4JError:
+                    self.spark.sql(f"USE CATALOG {catalog}")
             self._spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
         return self._spark
 

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -104,7 +104,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
             catalog = self._extra_config.get("catalog")
             if catalog:
                 # Note: Spark 3.4+ Only API
-                self._spark.catalog.setCurrentCatalog(catalog)
+                self.spark.sql(f"USE CATALOG {catalog}")
             self._spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
         return self._spark
 

--- a/sqlmesh/engines/spark/db_api/spark_session.py
+++ b/sqlmesh/engines/spark/db_api/spark_session.py
@@ -78,7 +78,7 @@ class SparkSessionConnection:
             try:
                 self.spark.catalog.setCurrentCatalog(self.catalog)
             # Databricks does not support `setCurrentCatalog` with Unity catalog
-            # and shared clusters so we use the Databricks only SQL command instead
+            # and shared clusters so we use the Databricks Unity only SQL command instead
             except Py4JError:
                 self.spark.sql(f"USE CATALOG {self.catalog}")
         self.spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")


### PR DESCRIPTION
I tested in Databricks running this:
```
%sql
USE CATALOG example;
```

And then 
```python
spark.read.table(table)
```
That table only exists in `example` and it worked. So you can set `USE CATALOG` and have it work across both SQL and Dataframe operations. The trick though is that you must be on Unity Catalog for this to work so we initially try `setCurrentCatalog` and then fallback to this. 