### PR TITLE
Fix: Support inserting dataframes into Environment on Databricks

### DIFF
--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -35,6 +35,17 @@ class SparkEngineAdapter(EngineAdapter):
     DIALECT = "spark"
     ESCAPE_JSON = True
     INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
+    SQLGLOT_TO_SPARK_TYPE_MAPPING = {
+        exp.DataType.Type.BOOLEAN: spark_types.BooleanType,
+        exp.DataType.Type.TEXT: spark_types.StringType,
+        exp.DataType.Type.INT: spark_types.IntegerType,
+        exp.DataType.Type.BIGINT: spark_types.LongType,
+        exp.DataType.Type.FLOAT: spark_types.FloatType,
+        exp.DataType.Type.DOUBLE: spark_types.DoubleType,
+        exp.DataType.Type.DECIMAL: spark_types.DecimalType,
+        exp.DataType.Type.DATE: spark_types.DateType,
+        exp.DataType.Type.TIMESTAMP: spark_types.TimestampType,
+    }
 
     @property
     def spark(self) -> PySparkSession:
@@ -50,21 +61,12 @@ class SparkEngineAdapter(EngineAdapter):
     ) -> t.Optional[spark_types.StructType]:
         from pyspark.sql import types as spark_types
 
-        mapping = {
-            exp.DataType.Type.BOOLEAN: spark_types.BooleanType,
-            exp.DataType.Type.TEXT: spark_types.StringType,
-            exp.DataType.Type.INT: spark_types.IntegerType,
-            exp.DataType.Type.BIGINT: spark_types.LongType,
-            exp.DataType.Type.FLOAT: spark_types.FloatType,
-            exp.DataType.Type.DOUBLE: spark_types.DoubleType,
-            exp.DataType.Type.DECIMAL: spark_types.DecimalType,
-            exp.DataType.Type.DATE: spark_types.DateType,
-            exp.DataType.Type.TIMESTAMP: spark_types.TimestampType,
-        }
         try:
             return spark_types.StructType(
                 [
-                    spark_types.StructField(col_name, mapping[col_type.this]())
+                    spark_types.StructField(
+                        col_name, cls.SQLGLOT_TO_SPARK_TYPE_MAPPING[col_type.this]()
+                    )
                     for col_name, col_type in columns_to_types.items()
                 ]
             )

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -35,17 +35,6 @@ class SparkEngineAdapter(EngineAdapter):
     DIALECT = "spark"
     ESCAPE_JSON = True
     INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
-    SQLGLOT_TO_SPARK_TYPE_MAPPING = {
-        exp.DataType.Type.BOOLEAN: spark_types.BooleanType,
-        exp.DataType.Type.TEXT: spark_types.StringType,
-        exp.DataType.Type.INT: spark_types.IntegerType,
-        exp.DataType.Type.BIGINT: spark_types.LongType,
-        exp.DataType.Type.FLOAT: spark_types.FloatType,
-        exp.DataType.Type.DOUBLE: spark_types.DoubleType,
-        exp.DataType.Type.DECIMAL: spark_types.DecimalType,
-        exp.DataType.Type.DATE: spark_types.DateType,
-        exp.DataType.Type.TIMESTAMP: spark_types.TimestampType,
-    }
 
     @property
     def spark(self) -> PySparkSession:
@@ -61,12 +50,22 @@ class SparkEngineAdapter(EngineAdapter):
     ) -> t.Optional[spark_types.StructType]:
         from pyspark.sql import types as spark_types
 
+        mapping = {
+            exp.DataType.Type.BOOLEAN: spark_types.BooleanType,
+            exp.DataType.Type.TEXT: spark_types.StringType,
+            exp.DataType.Type.INT: spark_types.IntegerType,
+            exp.DataType.Type.BIGINT: spark_types.LongType,
+            exp.DataType.Type.FLOAT: spark_types.FloatType,
+            exp.DataType.Type.DOUBLE: spark_types.DoubleType,
+            exp.DataType.Type.DECIMAL: spark_types.DecimalType,
+            exp.DataType.Type.DATE: spark_types.DateType,
+            exp.DataType.Type.TIMESTAMP: spark_types.TimestampType,
+        }
+
         try:
             return spark_types.StructType(
                 [
-                    spark_types.StructField(
-                        col_name, cls.SQLGLOT_TO_SPARK_TYPE_MAPPING[col_type.this]()
-                    )
+                    spark_types.StructField(col_name, mapping[col_type.this]())
                     for col_name, col_type in columns_to_types.items()
                 ]
             )

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -168,3 +168,13 @@ def test_col_to_types_to_spark_schema():
             types.StructField("col_timestamp", types.TimestampType()),
         ]
     )
+
+    assert (
+        SparkEngineAdapter.convert_columns_to_types_to_pyspark_schema(
+            {
+                "col_text": exp.DataType.build("text"),
+                "col_array": exp.DataType.build("array<int>"),
+            }
+        )
+        is None
+    )

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -141,7 +141,7 @@ def test_create_state_table(make_mocked_engine_adapter: t.Callable):
 
 
 def test_col_to_types_to_spark_schema():
-    from pyspark.sql import types
+    from pyspark.sql import types as spark_types
 
     assert SparkEngineAdapter.convert_columns_to_types_to_pyspark_schema(
         {
@@ -155,17 +155,17 @@ def test_col_to_types_to_spark_schema():
             "col_date": exp.DataType.build("date"),
             "col_timestamp": exp.DataType.build("timestamp"),
         }
-    ) == types.StructType(
+    ) == spark_types.StructType(
         [
-            types.StructField("col_text", types.StringType()),
-            types.StructField("col_boolean", types.BooleanType()),
-            types.StructField("col_int", types.IntegerType()),
-            types.StructField("col_bigint", types.LongType()),
-            types.StructField("col_float", types.FloatType()),
-            types.StructField("col_double", types.DoubleType()),
-            types.StructField("col_decimal", types.DecimalType()),
-            types.StructField("col_date", types.DateType()),
-            types.StructField("col_timestamp", types.TimestampType()),
+            spark_types.StructField("col_text", spark_types.StringType()),
+            spark_types.StructField("col_boolean", spark_types.BooleanType()),
+            spark_types.StructField("col_int", spark_types.IntegerType()),
+            spark_types.StructField("col_bigint", spark_types.LongType()),
+            spark_types.StructField("col_float", spark_types.FloatType()),
+            spark_types.StructField("col_double", spark_types.DoubleType()),
+            spark_types.StructField("col_decimal", spark_types.DecimalType()),
+            spark_types.StructField("col_date", spark_types.DateType()),
+            spark_types.StructField("col_timestamp", spark_types.TimestampType()),
         ]
     )
 

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -138,3 +138,33 @@ def test_create_state_table(make_mocked_engine_adapter: t.Callable):
     adapter.cursor.execute.assert_called_once_with(
         "CREATE TABLE IF NOT EXISTS `test_table` (`a` int, `b` int) PARTITIONED BY (`a`)"
     )
+
+
+def test_col_to_types_to_spark_schema():
+    from pyspark.sql import types
+
+    assert SparkEngineAdapter.convert_columns_to_types_to_pyspark_schema(
+        {
+            "col_text": exp.DataType.build("text"),
+            "col_boolean": exp.DataType.build("boolean"),
+            "col_int": exp.DataType.build("int"),
+            "col_bigint": exp.DataType.build("bigint"),
+            "col_float": exp.DataType.build("float"),
+            "col_double": exp.DataType.build("double"),
+            "col_decimal": exp.DataType.build("decimal"),
+            "col_date": exp.DataType.build("date"),
+            "col_timestamp": exp.DataType.build("timestamp"),
+        }
+    ) == types.StructType(
+        [
+            types.StructField("col_text", types.StringType()),
+            types.StructField("col_boolean", types.BooleanType()),
+            types.StructField("col_int", types.IntegerType()),
+            types.StructField("col_bigint", types.LongType()),
+            types.StructField("col_float", types.FloatType()),
+            types.StructField("col_double", types.DoubleType()),
+            types.StructField("col_decimal", types.DecimalType()),
+            types.StructField("col_date", types.DateType()),
+            types.StructField("col_timestamp", types.TimestampType()),
+        ]
+    )


### PR DESCRIPTION
When running on latest Databricks I got an error saying it could not infer the schema for a Pandas Dataframe when inserting a new environment record. So this allows us to define the schema when we get a `columns_to_type` and the columns are all non-complex. Otherwise we still pass in None and let it infer. 