### PR TITLE
Feat: Raise error if Run DAG Fails

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -299,7 +299,9 @@ def plan(ctx: click.Context, environment: t.Optional[str] = None, **kwargs: t.An
 def run(ctx: click.Context, environment: t.Optional[str] = None, **kwargs: t.Any) -> None:
     """Evaluates the DAG of models using the built-in scheduler."""
     context = ctx.obj
-    context.run(environment, **kwargs)
+    success = context.run(environment, **kwargs)
+    if not success:
+        raise click.ClickException("Run DAG Failed. See output for details.")
 
 
 @cli.command("invalidate")

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -22,7 +22,7 @@ from sqlmesh.core.dialect import format_model_expressions, parse
 from sqlmesh.core.model import load_sql_based_model
 from sqlmesh.core.test import ModelTestMetadata, get_all_model_tests
 from sqlmesh.utils import sqlglot_dialects, yaml
-from sqlmesh.utils.errors import MagicError, MissingContextException
+from sqlmesh.utils.errors import MagicError, MissingContextException, SQLMeshError
 
 CONTEXT_VARIABLE_NAMES = [
     "context",
@@ -358,7 +358,7 @@ class SQLMeshMagics(Magics):
         console = self._context.console
         self._context.console = get_console(display=self.display)
 
-        self._context.run(
+        success = self._context.run(
             args.environment,
             start=args.start,
             end=args.end,
@@ -366,6 +366,8 @@ class SQLMeshMagics(Magics):
             ignore_cron=args.ignore_cron,
         )
         self._context.console = console
+        if not success:
+            raise SQLMeshError("Error Running DAG. Check logs for details.")
 
     @magic_arguments()
     @argument("model", type=str, help="The model.")

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -184,7 +184,7 @@ def test_diff(sushi_context: Context, mocker: MockerFixture):
     mock_console = mocker.Mock()
     sushi_context.console = mock_console
     yesterday = yesterday_ds()
-    sushi_context.run(start=yesterday, end=yesterday)
+    success = sushi_context.run(start=yesterday, end=yesterday)
 
     plan_evaluator = BuiltInPlanEvaluator(
         sushi_context.state_sync, sushi_context.snapshot_evaluator
@@ -198,6 +198,7 @@ def test_diff(sushi_context: Context, mocker: MockerFixture):
     sushi_context.upsert_model("sushi.customers", query=parse_one("select 1 as customer_id"))
     sushi_context.diff("test")
     assert mock_console.show_model_difference_summary.called
+    assert success
 
 
 def test_evaluate_limit():


### PR DESCRIPTION
Currently if you do run dag from magics and CLI it will not raise an exception if there is an error while applying. That means the scheduler will think that it was successful when it failed. In addition notifications would tell you it succeeded when it didn't. This change makes it so that the interfaces are aware of the outcome and can raise accordingly. 