### PR TITLE
Fix: Pass sleep generator parameters directly into the Retry instance in the BigQuery adapter

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -315,8 +315,9 @@ class BigQueryEngineAdapter(EngineAdapter):
 
         return retry.Retry(
             predicate=_ErrorCounter(self._extra_config["job_retries"]).should_retry,
-            sleep_generator=retry.exponential_sleep_generator(initial=1.0, maximum=3.0),
             deadline=self._extra_config.get("job_retry_deadline_seconds"),
+            initial=1.0,
+            maximum=3.0,
         )
 
     @contextlib.contextmanager


### PR DESCRIPTION
This seems to be a more appropriate use of the `Retry` constructor as per implementation: https://github.com/googleapis/python-api-core/blob/main/google/api_core/retry.py#L308-L324

The sleep generator is later created by the `Retry` instance itself here: https://github.com/googleapis/python-api-core/blob/main/google/api_core/retry.py#L346-L348