### PR TITLE
Feat: add column statistics to output and make sample opt in on cli

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -501,6 +501,11 @@ def create_external_models(obj: Context) -> None:
     default=20,
     help="The limit of the sample dataframe.",
 )
+@click.option(
+    "--show-sample",
+    is_flag=True,
+    help="Show a sample of the rows that differ. With many columns, the output can be very wide.",
+)
 @click.pass_obj
 @error_handler
 def table_diff(

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -168,7 +168,7 @@ class Console(abc.ABC):
         """Show table schema diff."""
 
     @abc.abstractmethod
-    def show_row_diff(self, row_diff: RowDiff) -> None:
+    def show_row_diff(self, row_diff: RowDiff, show_sample: bool = True) -> None:
         """Show table summary diff."""
 
 
@@ -657,7 +657,7 @@ class TerminalConsole(Console):
 
         self.console.print(tree)
 
-    def show_row_diff(self, row_diff: RowDiff) -> None:
+    def show_row_diff(self, row_diff: RowDiff, show_sample: bool = True) -> None:
         source_name = row_diff.source
         if row_diff.source_alias:
             source_name = row_diff.source_alias.upper()
@@ -669,11 +669,13 @@ class TerminalConsole(Console):
         self.console.print(f" [yellow]{source_name}[/yellow]: {row_diff.source_count} rows")
         self.console.print(f" [green]{target_name}[/green]: {row_diff.target_count} rows")
         self.console.print(f" Change: {row_diff.count_pct_change:.1f}%")
-        if row_diff.sample.shape[0] > 0:
+        if row_diff.sample.shape[0] > 0 and show_sample:
             self.console.print("\n[b]Sample Rows:[/b]")
             self.console.print(row_diff.sample.to_string(index=False), end="\n\n")
         else:
-            self.console.print("\n[b]All rows match[/b]")
+            self.console.print("\n[b]No added/removed rows![/b]")
+        self.console.print("\n[b]Column Stats:[/b]")
+        self.console.print(row_diff.column_stats.to_string(index=True), end="\n\n")
 
     def _get_snapshot_change_category(
         self, snapshot: Snapshot, plan: Plan, auto_apply: bool

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -865,6 +865,7 @@ class Context(BaseContext):
         where: t.Optional[str | exp.Condition] = None,
         limit: int = 20,
         show: bool = True,
+        show_sample: bool = True,
     ) -> TableDiff:
         """Show a diff between two tables.
 
@@ -876,7 +877,8 @@ class Context(BaseContext):
             model_or_snapshot: The model or snapshot to use when environments are passed in.
             where: An optional where statement to filter results.
             limit: The limit of the sample dataframe.
-            show: Show the table diff in the console.
+            show: Show the table diff output in the console.
+            show_sample: Show the sample dataframe in the console. Requires show=True.
 
         Returns:
             The TableDiff object containing schema and summary differences.
@@ -920,7 +922,7 @@ class Context(BaseContext):
         )
         if show:
             self.console.show_schema_diff(table_diff.schema_diff())
-            self.console.show_row_diff(table_diff.row_diff())
+            self.console.show_row_diff(table_diff.row_diff(), show_sample=show_sample)
         return table_diff
 
     def get_dag(self, format: str = "svg") -> graphviz.Digraph:

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -55,6 +55,7 @@ class RowDiff(PydanticModel, frozen=True):
     target: str
     stats: t.Dict[str, float]
     sample: pd.DataFrame
+    column_stats: pd.DataFrame
     source_alias: t.Optional[str] = None
     target_alias: t.Optional[str] = None
     model_name: t.Optional[str] = None
@@ -157,7 +158,12 @@ class TableDiff:
                     t_index.append(col)
 
             comparisons = [
-                exp.func("IF", exp.column(c, "s").eq(exp.column(c, "t")), 1, 0).as_(f"{c}_matches")
+                exp.Case()
+                .when(exp.column(c, "s").eq(exp.column(c, "t")), 1)
+                .when(exp.column(c, "s").is_(exp.Null()) & exp.column(c, "t").is_(exp.Null()), 1)
+                .when(exp.column(c, "s").is_(exp.Null()) | exp.column(c, "t").is_(exp.Null()), 0)
+                .else_(0)
+                .as_(f"{c}_matches")
                 for c, t in self.source_schema.items()
                 if t == self.target_schema.get(c)
             ]
@@ -191,6 +197,13 @@ class TableDiff:
                     *(exp.func("SUM", c.alias).as_(c.alias) for c in comparisons),
                 ).from_(table)
 
+                column_stats_query = exp.select(
+                    *(
+                        (exp.func("SUM", c.alias) / exp.func("COUNT", c.alias)).as_(c.alias)
+                        for c in comparisons
+                    )
+                ).from_(table)
+
                 sample_query = (
                     exp.select(
                         *(c.alias for c in s_selects.values()),
@@ -210,6 +223,9 @@ class TableDiff:
                     target=self.target,
                     stats=self.adapter.fetchdf(summary_query).iloc[0].to_dict(),
                     sample=self.adapter.fetchdf(sample_query),
+                    column_stats=self.adapter.fetchdf(column_stats_query).T.rename(
+                        columns={0: "pct_match"}
+                    ),
                     source_alias=self.source_alias,
                     target_alias=self.target_alias,
                     model_name=self.model_name,


### PR DESCRIPTION
Row diff percentage alone isn't fully useful and at worst misleading for the end user. 
Sample DF width is not ergonomic in CLI at even a small number of columns due to it showing N*2 coluns; and at worst leads to bad user experience.

Solutions:
1. Add column stats that make the row diff per column available and make that show by default instead of the sample df
2. Make the sample df opt-in via `--show-sample` to avoid bad user experience

Result:
The output is significantly more insightful and builds confidence.
It is more similar now to datafold, which has had a lot of time to dial into user needs. Following suit with the column stats as the key value you are providing is ideal. 


New output:
<img width="1089" alt="image" src="https://github.com/TobikoData/sqlmesh/assets/41213451/5bf3e095-9565-4c19-9842-3f4b12298de3">


Old output:
<img width="1242" alt="image" src="https://github.com/TobikoData/sqlmesh/assets/41213451/e3e6df8b-ad41-4e44-8b7f-dba68b0e4626">
