### PR TITLE
Fix(snowflake): extract date from datetime values, quote audit's this_model

### DIFF
--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -77,7 +77,7 @@ class SnowflakeEngineAdapter(EngineAdapter):
         # See: https://stackoverflow.com/a/75627721
         for column, kind in (columns_to_types or {}).items():
             if kind.is_type("date") and is_datetime64_dtype(df.dtypes[column]):
-                df[column] = pd.to_datetime(df[column], errors="coerce").dt.date
+                df[column] = pd.to_datetime(df[column]).dt.date
 
         write_pandas(
             self._connection_pool.get(),

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 
 import pandas as pd
-from pandas.api.types import is_datetime64_dtype
+from pandas.api.types import is_datetime64_dtype  # type: ignore
 from sqlglot import exp
 
 from sqlmesh.core.engine_adapter.base import EngineAdapter

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import typing as t
 
 import pandas as pd
+from pandas.api.types import is_datetime64_dtype
 from sqlglot import exp
 
 from sqlmesh.core.engine_adapter.base import EngineAdapter
@@ -72,6 +73,11 @@ class SnowflakeEngineAdapter(EngineAdapter):
         # The above issue has already been fixed upstream, but we keep the following
         # line anyway in order to support a wider range of Snowflake versions.
         self.cursor.execute(f'USE SCHEMA "{table.db}"')
+
+        # See: https://stackoverflow.com/a/75627721
+        for column, kind in (columns_to_types or {}).items():
+            if kind.is_type("date") and is_datetime64_dtype(df.dtypes[column]):
+                df[column] = pd.to_datetime(df[column], errors="coerce").dt.date
 
         write_pandas(
             self._connection_pool.get(),


### PR DESCRIPTION
These changes ensure that we can successfully run the quickstart example in Snowflake (tested).

The two issues I faced when I tried to run `sqlmesh plan` for it were:

1) Got the error `Failed to cast variant value .... to DATE` when trying to evaluate the seed model. The problem was that the dataframe we pass in `write_pandas` had a column of type `datetime64[ns]`, but the underlying column's type was `DATE` (`ds`'s type). See related SO discussion which I included in a comment [here](https://stackoverflow.com/a/75627721).

2) After fixing the above issue, I got another error when trying to evaluate the full model, specifically when trying to run its `assert_positive_order_ids` audit. The reason was that in `Audit.render_query` we were creating a query with a table whose name is produced by the snapshot's `table_name` method. Since the resulting name is prefixed with the (case-sensitive) physical schema, we would then normalize it in the renderer's `render` method and hence produce an invalid schema reference. For example, `sqlmesh__SQLMESH_EXAMPLE.<model_name>` would be converted into `SQLMESH__SQLMESH_EXAMPLE.<model_name>`, which didn't exist. I fixed this error by enforcing quotes in said name before rendering, which I believe should be ok because the model name is already normalized, only the schema isn't.