### PR TITLE
Feat: table diff sample by row source

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -675,11 +675,11 @@ class TerminalConsole(Console):
         self.console.print(row_diff.column_stats.to_string(index=True), end="\n\n")
 
         if show_sample:
+            self.console.print("\n[b][blue]JOINED ROWS[/blue] data differences:[/b]")
             if row_diff.joined_sample.shape[0] > 0:
-                self.console.print("\n[b][blue]JOINED ROWS[/blue] sample differences:[/b]")
                 self.console.print(row_diff.joined_sample.to_string(index=False), end="\n\n")
             else:
-                self.console.print("\n[b]All joined rows match![/b]")
+                self.console.print("  [b]All joined rows match![/b]")
 
             if row_diff.s_sample.shape[0] > 0:
                 self.console.print(f"\n[b][yellow]{source_name} ONLY[/yellow] sample rows:[/b]")

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -665,17 +665,30 @@ class TerminalConsole(Console):
         if row_diff.target_alias:
             target_name = row_diff.target_alias.upper()
 
-        self.console.print("\n[b]Row Count:[/b]")
-        self.console.print(f" [yellow]{source_name}[/yellow]: {row_diff.source_count} rows")
-        self.console.print(f" [green]{target_name}[/green]: {row_diff.target_count} rows")
-        self.console.print(f" Change: {row_diff.count_pct_change:.1f}%")
-        if row_diff.sample.shape[0] > 0 and show_sample:
-            self.console.print("\n[b]Sample Rows:[/b]")
-            self.console.print(row_diff.sample.to_string(index=False), end="\n\n")
-        else:
-            self.console.print("\n[b]No added/removed rows![/b]")
-        self.console.print("\n[b]Column Stats:[/b]")
+        self.console.print("\n[b]Outer Join Row Counts:[/b]")
+        self.console.print(f" [b][blue]JOINED[/blue][/b]: {row_diff.join_count} rows")
+        self.console.print(
+            f" [b][yellow]{source_name} ONLY[/yellow][/b]: {row_diff.s_only_count} rows"
+        )
+        self.console.print(
+            f" [b][green]{target_name} ONLY[/green][/b]: {row_diff.t_only_count} rows"
+        )
+        self.console.print("\n[b][blue]JOINED rows[/blue] comparison stats:[/b]")
         self.console.print(row_diff.column_stats.to_string(index=True), end="\n\n")
+        if show_sample:
+            if row_diff.joined_sample.shape[0] > 0:
+                self.console.print("\n[b][blue]JOINED rows[/blue] sample differences:[/b]")
+                self.console.print(row_diff.joined_sample.to_string(index=False), end="\n\n")
+            else:
+                self.console.print("\n[b]All joined rows match![/b]")
+
+            if row_diff.s_sample.shape[0] > 0:
+                self.console.print(f"\n[b][yellow]{source_name} ONLY[/yellow] sample rows:[/b]")
+                self.console.print(row_diff.s_sample.to_string(index=False), end="\n\n")
+
+            if row_diff.t_sample.shape[0] > 0:
+                self.console.print(f"\n[b][green]{target_name} ONLY[/green] sample rows:[/b]")
+                self.console.print(row_diff.t_sample.to_string(index=False), end="\n\n")
 
     def _get_snapshot_change_category(
         self, snapshot: Snapshot, plan: Plan, auto_apply: bool

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -665,19 +665,18 @@ class TerminalConsole(Console):
         if row_diff.target_alias:
             target_name = row_diff.target_alias.upper()
 
-        self.console.print("\n[b]Outer Join Row Counts:[/b]")
-        self.console.print(f" [b][blue]JOINED[/blue][/b]: {row_diff.join_count} rows")
-        self.console.print(
-            f" [b][yellow]{source_name} ONLY[/yellow][/b]: {row_diff.s_only_count} rows"
-        )
-        self.console.print(
-            f" [b][green]{target_name} ONLY[/green][/b]: {row_diff.t_only_count} rows"
-        )
-        self.console.print("\n[b][blue]JOINED rows[/blue] comparison stats:[/b]")
+        tree = Tree("[b]Outer Join Row Counts:[/b]")
+        tree.add(f" [b][blue]JOINED[/blue]:[/b] {row_diff.join_count} rows")
+        tree.add(f" [b][yellow]{source_name} ONLY[/yellow]:[/b] {row_diff.s_only_count} rows")
+        tree.add(f" [b][green]{target_name} ONLY[/green]:[/b] {row_diff.t_only_count} rows")
+        self.console.print("\n", tree)
+
+        self.console.print("\n[b][blue]JOINED ROWS[/blue] comparison stats:[/b]")
         self.console.print(row_diff.column_stats.to_string(index=True), end="\n\n")
+
         if show_sample:
             if row_diff.joined_sample.shape[0] > 0:
-                self.console.print("\n[b][blue]JOINED rows[/blue] sample differences:[/b]")
+                self.console.print("\n[b][blue]JOINED ROWS[/blue] sample differences:[/b]")
                 self.console.print(row_diff.joined_sample.to_string(index=False), end="\n\n")
             else:
                 self.console.print("\n[b]All joined rows match![/b]")

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -261,7 +261,7 @@ class TableDiff:
                     self.adapter.fetchdf(column_stats_query)
                     .T.rename(
                         columns={0: "pct_match"},
-                        index=lambda x: x.replace("_matches", ""),
+                        index=lambda x: str(x).replace("_matches", "") if x else "",
                     )
                     .drop(index=index_cols)
                 )

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -289,7 +289,7 @@ class TableDiff:
                     for c in column_stats[column_stats["pct_match"] < 100].index
                 ]
                 for cols in comparison_cols:
-                    joined_sample_cols.extend([*cols])
+                    joined_sample_cols.extend(cols)
                 joined_sample = sample[sample["rows_joined"] == 1][joined_sample_cols]
                 joined_sample.rename(
                     columns={
@@ -302,14 +302,14 @@ class TableDiff:
                 s_sample = sample[(sample["s_exists"] == 1) & (sample["rows_joined"] == 0)][
                     [
                         *[f"s__{c}" for c in index_cols],
-                        *[f"s__{c}" for c in column_stats.index if not c in index_cols],
+                        *[f"s__{c}" for c in self.source_schema if not c in index_cols],
                     ]
                 ]
 
                 t_sample = sample[(sample["t_exists"] == 1) & (sample["rows_joined"] == 0)][
                     [
                         *[f"t__{c}" for c in index_cols],
-                        *[f"t__{c}" for c in column_stats.index if not c in index_cols],
+                        *[f"t__{c}" for c in self.target_schema if not c in index_cols],
                     ]
                 ]
 

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -76,6 +76,9 @@ def test_data_diff(sushi_context_fixed_date):
     assert schema_diff.removed == [("y", exp.DataType.build("int"))]
 
     row_diff = diff.row_diff()
-    assert row_diff.source_count == 17
-    assert row_diff.target_count == 18
-    assert row_diff.sample.shape == (1, 10)
+    assert row_diff.join_count == 17
+    assert row_diff.s_only_count == 0
+    assert row_diff.t_only_count == 1
+    assert row_diff.joined_sample.shape == (0, 2)
+    assert row_diff.s_sample.shape == (0, 3)
+    assert row_diff.t_sample.shape == (1, 3)

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -83,5 +83,5 @@ def test_data_diff(sushi_context_fixed_date):
     assert row_diff.t_only_count == 1
     assert row_diff.sample.shape == (1, 10)
     assert row_diff.joined_sample.shape == (0, 2)
-    assert row_diff.s_sample.shape == (0, 3)
-    assert row_diff.t_sample.shape == (1, 3)
+    assert row_diff.s_sample.shape == (0, 5)
+    assert row_diff.t_sample.shape == (1, 5)

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -76,9 +76,12 @@ def test_data_diff(sushi_context_fixed_date):
     assert schema_diff.removed == [("y", exp.DataType.build("int"))]
 
     row_diff = diff.row_diff()
+    assert row_diff.source_count == 17
+    assert row_diff.target_count == 18
     assert row_diff.join_count == 17
     assert row_diff.s_only_count == 0
     assert row_diff.t_only_count == 1
+    assert row_diff.sample.shape == (1, 10)
     assert row_diff.joined_sample.shape == (0, 2)
     assert row_diff.s_sample.shape == (0, 3)
     assert row_diff.t_sample.shape == (1, 3)


### PR DESCRIPTION
This PR modifies the table diff CLI output by:
- Presenting row stats by row source (both tables, source only, target only)
- Calculating column comparison stats for joined rows only
- Removing "_matches" from column comparison stats labels
- Separating row samples by row source (both tables, source only, target only)
- Reordering sample DFs so join columns are in leftmost position
- Displaying only columns with >0 mismatches in the joined sample comparison
- Interleaving source/target cols for joined sample comparison ([s__col1, t__col1, s__col2, t__col2] instead of [s__col1, s__col2, t__col1, t__col2])

---- Previous CLI output ----

![Screenshot 2023-08-07 at 2 35 20 PM](https://github.com/TobikoData/sqlmesh/assets/1831878/ba4d0398-b506-47f5-9f0d-4f7f414beefd)

---- New CLI output ----

![Screenshot 2023-08-07 at 2 35 01 PM](https://github.com/TobikoData/sqlmesh/assets/1831878/ae8bf32b-de68-43cf-9fcc-1a65c5995d91)
