### PR TITLE
Feat: Support Table Properties on Views

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -443,6 +443,13 @@ class EngineAdapter:
         if materialized and self.SUPPORTS_MATERIALIZED_VIEWS:
             properties.append("expressions", exp.MaterializedProperty())
 
+        create_view_properties = self._create_view_properties(
+            create_kwargs.pop("table_properties", None)
+        )
+        if create_view_properties:
+            for view_property in create_view_properties.expressions:
+                properties.append("expressions", view_property)
+
         if properties.expressions:
             create_kwargs["properties"] = properties
 
@@ -954,6 +961,13 @@ class EngineAdapter:
         table_properties: t.Optional[t.Dict[str, exp.Expression]] = None,
     ) -> t.Optional[exp.Properties]:
         """Creates a SQLGlot table properties expression for ddl."""
+        return None
+
+    def _create_view_properties(
+        self,
+        table_properties: t.Optional[t.Dict[str, exp.Expression]] = None,
+    ) -> t.Optional[exp.Properties]:
+        """Creates a SQLGlot table properties expression for view"""
         return None
 
     def _to_sql(self, expression: exp.Expression, quote: bool = True, **kwargs: t.Any) -> str:

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -321,12 +321,28 @@ class SparkEngineAdapter(EngineAdapter):
                 )
             )
 
-        for key, value in (table_properties or {}).items():
-            properties.append(exp.Property(this=key, value=value))
+        properties.extend(self.__table_properties_to_expressions(table_properties))
 
         if properties:
             return exp.Properties(expressions=properties)
         return None
+
+    def _create_view_properties(
+        self,
+        table_properties: t.Optional[t.Dict[str, exp.Expression]] = None,
+    ) -> t.Optional[exp.Properties]:
+        """Creates a SQLGlot table properties expression for view"""
+        if not table_properties:
+            return None
+        return exp.Properties(expressions=self.__table_properties_to_expressions(table_properties))
+
+    @classmethod
+    def __table_properties_to_expressions(
+        cls, table_properties: t.Optional[t.Dict[str, exp.Expression]] = None
+    ) -> t.List[exp.Property]:
+        if not table_properties:
+            return []
+        return [exp.Property(this=key, value=value) for key, value in table_properties.items()]
 
     def supports_transactions(self, transaction_type: TransactionType) -> bool:
         return False

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -896,6 +896,7 @@ class ViewStrategy(PromotableStrategy):
             query_or_df,
             model.columns_to_types,
             materialized=self._is_materialized_view(model),
+            table_properties=model.table_properties,
         )
 
     def append(
@@ -923,6 +924,7 @@ class ViewStrategy(PromotableStrategy):
             name,
             model.render_query_or_raise(**render_kwargs),
             materialized=self._is_materialized_view(model),
+            table_properties=model.table_properties,
         )
 
     def migrate(
@@ -940,6 +942,7 @@ class ViewStrategy(PromotableStrategy):
             ),
             model.columns_to_types,
             materialized=self._is_materialized_view(model),
+            table_properties=model.table_properties,
         )
 
     def delete(self, name: str) -> None:

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -17,11 +17,19 @@ def test_create_view(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(EngineAdapter)
     adapter.create_view("test_view", parse_one("SELECT a FROM tbl"))
     adapter.create_view("test_view", parse_one("SELECT a FROM tbl"), replace=False)
+    # Test that `table_properties` are ignored for base engine adapter
+    adapter.create_view(
+        "test_view",
+        parse_one("SELECT a FROM tbl"),
+        replace=True,
+        table_properties={"a": exp.convert(1)},
+    )
 
     adapter.cursor.execute.assert_has_calls(
         [
             call('CREATE OR REPLACE VIEW "test_view" AS SELECT "a" FROM "tbl"'),
             call('CREATE VIEW "test_view" AS SELECT "a" FROM "tbl"'),
+            call('CREATE OR REPLACE VIEW "test_view" AS SELECT "a" FROM "tbl"'),
         ]
     )
 

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -53,6 +53,15 @@ def test_create_table_properties(make_mocked_engine_adapter: t.Callable):
         )
 
 
+def test_create_view_properties(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(SparkEngineAdapter)
+
+    adapter.create_view("test_view", parse_one("SELECT a FROM tbl"), table_properties={"a": exp.convert(1)})  # type: ignore
+    adapter.cursor.execute.assert_called_once_with(
+        "CREATE OR REPLACE VIEW `test_view` TBLPROPERTIES ('a'=1) AS SELECT `a` FROM `tbl`"
+    )
+
+
 def test_alter_table(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(SparkEngineAdapter)
     current_table_name = "test_table"


### PR DESCRIPTION
Prior to this change `TBLPROPERTIES` could only be set on tables but they are also supported on views in Spark: https://spark.apache.org/docs/3.0.0-preview/sql-ref-syntax-ddl-create-view.html

This makes it so that table properties can be set for either tables or views. Note that these will not be applied to "environment views" (views that point to the versioned tables/views). 