### PR TITLE
Fix: Make Databricks use replace where

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -694,7 +694,10 @@ class EngineAdapter:
             insert_exp = exp.insert(
                 query,
                 table,
-                columns=list(columns_to_types or []),
+                # Change once Databricks supports REPLACE WHERE with columns
+                columns=list(columns_to_types or [])
+                if not self.INSERT_OVERWRITE_STRATEGY.is_replace_where
+                else None,
                 overwrite=self.INSERT_OVERWRITE_STRATEGY.is_insert_overwrite,
             )
             if self.INSERT_OVERWRITE_STRATEGY.is_replace_where:

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 class DatabricksEngineAdapter(SparkEngineAdapter):
     DIALECT = "databricks"
-    INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
+    INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.REPLACE_WHERE
     SCHEMA_DIFFER = SchemaDiffer(
         support_positional_add=True,
         support_nested_operations=True,

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -157,7 +157,7 @@ def test_insert_overwrite_by_time_partition_replace_where(make_mocked_engine_ada
     )
 
     adapter.cursor.execute.assert_called_once_with(
-        """INSERT INTO "test_table" ("a", "b") REPLACE WHERE "b" BETWEEN '2022-01-01' AND '2022-01-02' SELECT * FROM (SELECT "a", "b" FROM "tbl") AS "_subquery" WHERE "b" BETWEEN '2022-01-01' AND '2022-01-02'"""
+        """INSERT INTO "test_table" REPLACE WHERE "b" BETWEEN '2022-01-01' AND '2022-01-02' SELECT * FROM (SELECT "a", "b" FROM "tbl") AS "_subquery" WHERE "b" BETWEEN '2022-01-01' AND '2022-01-02'"""
     )
 
 
@@ -176,7 +176,7 @@ def test_insert_overwrite_by_time_partition_replace_where_pandas(
     )
 
     adapter.cursor.execute.assert_called_once_with(
-        """INSERT INTO "test_table" ("a", "ds") REPLACE WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02' SELECT * FROM (SELECT CAST("a" AS INT) AS "a", CAST("ds" AS TEXT) AS "ds" FROM (VALUES (1, '2022-01-01'), (2, '2022-01-02')) AS "test_table"("a", "ds")) AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02'"""
+        """INSERT INTO "test_table" REPLACE WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02' SELECT * FROM (SELECT CAST("a" AS INT) AS "a", CAST("ds" AS TEXT) AS "ds" FROM (VALUES (1, '2022-01-01'), (2, '2022-01-02')) AS "test_table"("a", "ds")) AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02'"""
     )
 
 

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -12,7 +12,7 @@ def test_replace_query(make_mocked_engine_adapter: t.Callable):
     adapter.replace_query("test_table", parse_one("SELECT a FROM tbl"), {"a": "int"})
 
     adapter.cursor.execute.assert_called_once_with(
-        "INSERT OVERWRITE TABLE `test_table` (`a`) SELECT * FROM (SELECT `a` FROM `tbl`) AS `_subquery` WHERE 1 = 1"
+        "INSERT INTO `test_table` REPLACE WHERE 1 = 1 SELECT * FROM (SELECT `a` FROM `tbl`) AS `_subquery` WHERE 1 = 1"
     )
 
 
@@ -22,5 +22,5 @@ def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable):
     adapter.replace_query("test_table", df, {"a": "int", "b": "int"})
 
     adapter.cursor.execute.assert_called_once_with(
-        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `test_table`(`a`, `b`)) AS `_subquery` WHERE 1 = 1"
+        "INSERT INTO `test_table` REPLACE WHERE 1 = 1 SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `test_table`(`a`, `b`)) AS `_subquery` WHERE 1 = 1"
     )


### PR DESCRIPTION
By the end of October Databricks will have a release out that supports listing columns in REPLACE WHERE. Until then we will use Replace Where without the columns listed since that the only option that works with Unity currently (although they will also be fixing that too eventually). 