### PR TITLE
Fix!: Exclude redundant keys from the config attribute in dbt models

### DIFF
--- a/sqlmesh/dbt/basemodel.py
+++ b/sqlmesh/dbt/basemodel.py
@@ -210,7 +210,7 @@ class BaseModelConfig(GeneralConfig):
         )
 
     def model_function(self) -> AttributeDict[str, t.Any]:
-        return AttributeDict({"config": self.attribute_dict})
+        return AttributeDict({"config": self.config_attribute_dict})
 
     def sqlmesh_model_kwargs(self, context: DbtContext) -> t.Dict[str, t.Any]:
         """Get common sqlmesh model parameters"""
@@ -223,7 +223,7 @@ class BaseModelConfig(GeneralConfig):
                 "this": self.relation_info,
                 "model": self.model_function(),
                 "schema": self.table_schema,
-                "config": self.attribute_dict,
+                "config": self.config_attribute_dict,
                 **model_context.jinja_globals,  # type: ignore
             }
         )

--- a/sqlmesh/dbt/common.py
+++ b/sqlmesh/dbt/common.py
@@ -140,8 +140,8 @@ class GeneralConfig(DbtConfig):
     _SQL_FIELDS: t.ClassVar[t.List[str]] = []
 
     @property
-    def attribute_dict(self) -> AttributeDict[str, t.Any]:
-        return AttributeDict(self.dict())
+    def config_attribute_dict(self) -> AttributeDict[str, t.Any]:
+        return AttributeDict(self.dict(exclude=EXCLUDED_CONFIG_ATTRIBUTE_KEYS))
 
     def replace(self, other: T) -> None:
         """
@@ -223,3 +223,25 @@ def extract_jinja_config(input: str) -> t.Tuple[str, str]:
         no_config = SqlStr(no_config.replace(extracted, "").strip())
 
     return (no_config, only_config)
+
+
+EXCLUDED_CONFIG_ATTRIBUTE_KEYS = {
+    "config",
+    "config_call_dict",
+    "depends_on",
+    "dependencies",
+    "metrics",
+    "original_file_path",
+    "packages",
+    "patch_path",
+    "path",
+    "post_hook",
+    "pre_hook",
+    "raw_code",
+    "refs",
+    "resource_type",
+    "sources",
+    "sql",
+    "tests",
+    "unrendered_config",
+}

--- a/sqlmesh/dbt/test.py
+++ b/sqlmesh/dbt/test.py
@@ -105,7 +105,7 @@ class TestConfig(GeneralConfig):
         )
         jinja_macros.global_objs.update(
             {
-                "config": self.attribute_dict,
+                "config": self.config_attribute_dict,
                 **test_context.jinja_globals,  # type: ignore
             }
         )

--- a/sqlmesh/migrations/v0020_remove_redundant_attributes_from_dbt_models.py
+++ b/sqlmesh/migrations/v0020_remove_redundant_attributes_from_dbt_models.py
@@ -1,0 +1,79 @@
+"""Remove redundant attributes from dbt models."""
+import json
+
+import pandas as pd
+from sqlglot import exp
+
+from sqlmesh.utils.migration import index_text_type
+
+
+def migrate(state_sync):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+
+    new_snapshots = []
+
+    for name, identifier, version, snapshot, kind_name in engine_adapter.fetchall(
+        exp.select("name", "identifier", "version", "snapshot", "kind_name").from_(snapshots_table),
+        quote_identifiers=True,
+    ):
+        parsed_snapshot = json.loads(snapshot)
+        jinja_macros_global_objs = parsed_snapshot["node"]["jinja_macros"]["global_objs"]
+        if "config" in jinja_macros_global_objs and isinstance(
+            jinja_macros_global_objs["config"], dict
+        ):
+            for key in CONFIG_ATTRIBUTE_KEYS_TO_REMOVE:
+                jinja_macros_global_objs["config"].pop(key, None)
+
+        new_snapshots.append(
+            {
+                "name": name,
+                "identifier": identifier,
+                "version": version,
+                "snapshot": json.dumps(parsed_snapshot),
+                "kind_name": kind_name,
+            }
+        )
+
+    if new_snapshots:
+        engine_adapter.delete_from(snapshots_table, "TRUE")
+
+        text_type = index_text_type(engine_adapter.dialect)
+
+        engine_adapter.insert_append(
+            snapshots_table,
+            pd.DataFrame(new_snapshots),
+            columns_to_types={
+                "name": exp.DataType.build(text_type),
+                "identifier": exp.DataType.build(text_type),
+                "version": exp.DataType.build(text_type),
+                "snapshot": exp.DataType.build("text"),
+                "kind_name": exp.DataType.build("text"),
+            },
+            contains_json=True,
+        )
+
+
+CONFIG_ATTRIBUTE_KEYS_TO_REMOVE = [
+    "config",
+    "config_call_dict",
+    "depends_on",
+    "dependencies",
+    "metrics",
+    "original_file_path",
+    "packages",
+    "patch_path",
+    "path",
+    "post-hook",
+    "pre-hook",
+    "raw_code",
+    "refs",
+    "resource_type",
+    "sources",
+    "sql",
+    "tests",
+    "unrendered_config",
+]


### PR DESCRIPTION
Amount of data in the `config` attribute of the `sushi.customer_revenue_by_day` model before the fix: 10KB
After the fix: 1.5KB