### PR TITLE
Feat!: Make all incremental models in a dbt project forward-only by default

### DIFF
--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -72,7 +72,7 @@ class ModelConfig(BaseModelConfig):
     interval_unit: t.Optional[str] = None
     batch_size: t.Optional[int] = None
     lookback: t.Optional[int] = None
-    forward_only: t.Optional[bool] = None
+    forward_only: bool = True
     disable_restatement: t.Optional[bool] = None
 
     # DBT configuration fields
@@ -152,7 +152,7 @@ class ModelConfig(BaseModelConfig):
             return ViewKind()
         if materialization == Materialization.INCREMENTAL:
             incremental_kwargs = {}
-            for field in ("batch_size", "lookback"):
+            for field in ("batch_size", "lookback", "forward_only", "disable_restatement"):
                 field_val = getattr(self, field, None) or self.meta.get(field, None)
                 if field_val:
                     incremental_kwargs[field] = field_val
@@ -162,7 +162,6 @@ class ModelConfig(BaseModelConfig):
                     IncrementalByTimeRangeKind
                 )
 
-                is_supported = True
                 if strategy not in INCREMENTAL_BY_TIME_STRATEGIES:
                     logger.warning(
                         "SQLMesh incremental by time strategy is not compatible with '%s' incremental strategy in model '%s'. Supported strategies include %s.",
@@ -170,13 +169,10 @@ class ModelConfig(BaseModelConfig):
                         self.sql_name,
                         collection_to_str(INCREMENTAL_BY_TIME_STRATEGIES),
                     )
-                    is_supported = False
 
                 return IncrementalByTimeRangeKind(
                     time_column=self.time_column,
                     **incremental_kwargs,
-                    forward_only=not is_supported,
-                    disable_restatement=not is_supported,
                 )
 
             if self.unique_key:
@@ -203,7 +199,8 @@ class ModelConfig(BaseModelConfig):
                 IncrementalUnmanagedKind
             )
             return IncrementalUnmanagedKind(
-                insert_overwrite=strategy in INCREMENTAL_BY_TIME_STRATEGIES
+                insert_overwrite=strategy in INCREMENTAL_BY_TIME_STRATEGIES,
+                forward_only=self.forward_only,
             )
         if materialization == Materialization.EPHEMERAL:
             return EmbeddedKind()
@@ -278,7 +275,7 @@ class ModelConfig(BaseModelConfig):
                 d.parse_one(c, dialect=dialect).name for c in self.cluster_by
             ]
 
-        for field in ["cron", "interval_unit", "forward_only", "disable_restatement"]:
+        for field in ["cron", "interval_unit"]:
             field_val = getattr(self, field, None) or self.meta.get(field, None)
             if field_val:
                 optional_kwargs[field] = field_val

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -47,36 +47,40 @@ def test_model_kind():
 
     assert ModelConfig(materialized=Materialization.INCREMENTAL, time_column="foo").model_kind(
         target
-    ) == IncrementalByTimeRangeKind(time_column="foo")
+    ) == IncrementalByTimeRangeKind(time_column="foo", forward_only=True)
     assert ModelConfig(
         materialized=Materialization.INCREMENTAL,
         time_column="foo",
         incremental_strategy="delete+insert",
+        forward_only=False,
     ).model_kind(target) == IncrementalByTimeRangeKind(time_column="foo")
     assert ModelConfig(
         materialized=Materialization.INCREMENTAL,
         time_column="foo",
         incremental_strategy="insert_overwrite",
-    ).model_kind(target) == IncrementalByTimeRangeKind(time_column="foo")
+    ).model_kind(target) == IncrementalByTimeRangeKind(time_column="foo", forward_only=True)
     assert ModelConfig(
         materialized=Materialization.INCREMENTAL, time_column="foo", unique_key=["bar"]
-    ).model_kind(target) == IncrementalByTimeRangeKind(time_column="foo")
+    ).model_kind(target) == IncrementalByTimeRangeKind(time_column="foo", forward_only=True)
 
     assert ModelConfig(
         materialized=Materialization.INCREMENTAL, unique_key=["bar"], incremental_strategy="merge"
-    ).model_kind(target) == IncrementalByUniqueKeyKind(unique_key=["bar"])
+    ).model_kind(target) == IncrementalByUniqueKeyKind(unique_key=["bar"], forward_only=True)
     assert ModelConfig(materialized=Materialization.INCREMENTAL, unique_key=["bar"]).model_kind(
         target
-    ) == IncrementalByUniqueKeyKind(unique_key=["bar"])
+    ) == IncrementalByUniqueKeyKind(unique_key=["bar"], forward_only=True)
 
     assert ModelConfig(
         materialized=Materialization.INCREMENTAL, time_column="foo", incremental_strategy="merge"
     ).model_kind(target) == IncrementalByTimeRangeKind(
-        time_column="foo", forward_only=True, disable_restatement=True
+        time_column="foo", forward_only=True, disable_restatement=False
     )
 
     assert ModelConfig(
-        materialized=Materialization.INCREMENTAL, time_column="foo", incremental_strategy="append"
+        materialized=Materialization.INCREMENTAL,
+        time_column="foo",
+        incremental_strategy="append",
+        disable_restatement=True,
     ).model_kind(target) == IncrementalByTimeRangeKind(
         time_column="foo", forward_only=True, disable_restatement=True
     )
@@ -86,6 +90,7 @@ def test_model_kind():
         time_column="foo",
         incremental_strategy="insert_overwrite",
         partition_by={"field": "bar"},
+        forward_only=False,
     ).model_kind(target) == IncrementalByTimeRangeKind(time_column="foo")
 
     assert ModelConfig(


### PR DESCRIPTION
After conversation with @crericha, we concluded that making all incremental models in a dbt project forward-only by default is a safer approach since it's better aligned with dbt users' expectations.  Provided that incremental models in a typical dbt project appear to be either append-only, missing upstream history, or are non-idempotent in some other way, this update should help prevent unexpected or incorrect behavior.