### PR TITLE
Fix: Correctly check schema names when cleaning up

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -449,13 +449,14 @@ class SnapshotEvaluator:
     def _cleanup_snapshot(self, snapshot: SnapshotInfoLike) -> None:
         snapshot = snapshot.table_info
         table_names = [snapshot.table_name()]
-        if snapshot.version != snapshot.fingerprint:
+        if snapshot.version != snapshot.fingerprint.to_version():
             table_names.append(snapshot.table_name(is_dev=True))
 
         evaluation_strategy = _evaluation_strategy(snapshot, self.adapter)
 
         for table_name in table_names:
-            if not table_name.startswith(snapshot.physical_schema):
+            table = exp.to_table(table_name)
+            if table.db != snapshot.physical_schema:
                 raise SQLMeshError(
                     f"Table '{table_name}' is not a part of the physical schema '{snapshot.physical_schema}' and so can't be dropped."
                 )

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -225,6 +225,11 @@ def test_cleanup(mocker: MockerFixture, adapter_mock, make_snapshot):
     adapter_mock.drop_table.assert_called_once_with(
         f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}"
     )
+    adapter_mock.reset_mock()
+    snapshot = create_and_cleanup("test_model")
+    adapter_mock.drop_table.assert_called_once_with(
+        f"sqlmesh__default.test_model__{snapshot.version}"
+    )
 
 
 @pytest.mark.parametrize("view_exists", [True, False])


### PR DESCRIPTION
Prior to this change we would check if the name started with a physical schema name but that assumes there is no catalog on the name. This makes it so we parse the name and then check if the database matches the physical schema.