### PR TITLE
Fix: Make file watcher ignore local db updates

### DIFF
--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -28,6 +28,7 @@ async def watch_project(queue: asyncio.Queue) -> None:
     ]
     ignore_entity_patterns = context.config.ignore_patterns if context else c.IGNORE_PATTERNS
     ignore_entity_patterns.append("^\\.DS_Store$")
+    ignore_entity_patterns.append("^.*\.db(\.wal)?$")
     ignore_paths = [str((context.path / c.CACHE).resolve())]
     watch_filter = DefaultFilter(
         ignore_paths=ignore_paths, ignore_entity_patterns=ignore_entity_patterns


### PR DESCRIPTION
Currently if local db present in root , changes to db triggers file watcher and that raise an error preventing from saving file after