### PR TITLE
Fix: Remove debounce async

### DIFF
--- a/web/client/src/api/index.ts
+++ b/web/client/src/api/index.ts
@@ -9,7 +9,6 @@ import {
   type QueryKey,
   type UseQueryOptions,
   type QueryMeta,
-  QueryFunction,
 } from '@tanstack/react-query'
 import {
   type ContextEnvironment,
@@ -73,12 +72,9 @@ export interface ApiQueryMeta extends QueryMeta {
 const DELAY = 15000
 
 export type UseQueryWithTimeoutOptions<
-  TQueryFnData = unknown,
+  TData = any,
   TError extends ApiExceptionPayload = ApiExceptionPayload,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
 > = UseQueryResult<TData, TError> & {
-  queryFn: QueryFunction<TQueryFnData, TQueryKey>
   cancel: <TData = any>() => Promise<TData | undefined>
   isTimeout: boolean
 }

--- a/web/client/src/library/components/graph/ModelLineage.tsx
+++ b/web/client/src/library/components/graph/ModelLineage.tsx
@@ -31,10 +31,11 @@ export default function ModelLineage({
     setWithColumns,
   } = useLineageFlow()
 
-  const { refetch: getModelLineage, isFetching } = useApiModelLineage(
-    model.name,
-    { debounceDelay: 2000, debounceImmediate: false },
-  )
+  const {
+    refetch: getModelLineage,
+    isFetching,
+    cancel,
+  } = useApiModelLineage(model.name)
 
   useEffect(() => {
     if (isStringEmptyOrNil(fingerprint)) return
@@ -56,6 +57,10 @@ export default function ModelLineage({
         setHighlightedNodes(highlightedNodes)
         setWithColumns(true)
       })
+
+    return () => {
+      void cancel?.()
+    }
   }, [fingerprint])
 
   return (

--- a/web/client/src/utils/index.ts
+++ b/web/client/src/utils/index.ts
@@ -46,22 +46,12 @@ export function isObject(value: unknown): boolean {
   )
 }
 
-export function isObjectLike(value: unknown): boolean {
-  return isNotNil(value) && typeof value === 'object'
-}
-
 export function isNil(value: unknown): value is undefined | null {
   return value == null
 }
 
 export function isNotNil<T>(value: T | null | undefined): value is T {
   return value != null
-}
-
-export async function delay(time: number = 1000): Promise<void> {
-  await new Promise(resolve => {
-    setTimeout(resolve, time)
-  })
 }
 
 export function isDate(value: unknown): boolean {
@@ -159,67 +149,6 @@ export function debounceSync(
       fn(...args)
     }
   }
-}
-
-export type CallbackDebounce<TData = any, TArgs = any> = (
-  ...args: TArgs[]
-) => Promise<TData>
-
-export function debounceAsync<
-  TData = any,
-  TArgs = any,
-  Fn extends CallbackDebounce<TData, TArgs> = CallbackDebounce<TData, TArgs>,
->(
-  fn: Fn,
-  delay: number = 0,
-  immediate: boolean = false,
-): CallbackDebounce<TData, TArgs> & { cancel: () => void } {
-  let timeoutIdLeading: ReturnType<typeof setTimeout> | undefined
-  let timeoutIdTrailing: ReturnType<typeof setTimeout> | undefined
-
-  clearTimeout(timeoutIdLeading)
-
-  const callback: CallbackDebounce<TData, TArgs> & { cancel: () => void } =
-    async function callback(...args) {
-      const callNow = immediate && timeoutIdLeading == null
-
-      clearTimeout(timeoutIdTrailing)
-
-      const promise = new Promise<TData>((resolve, reject) => {
-        if (callNow) {
-          timeoutIdLeading = setTimeout(() => {
-            fn(...args)
-              .then(resolve)
-              .catch(reject)
-          })
-        }
-
-        timeoutIdTrailing = setTimeout(() => {
-          if (isFalse(immediate)) {
-            fn(...args)
-              .then(resolve)
-              .catch(reject)
-              .finally(() => {
-                timeoutIdTrailing = undefined
-              })
-          } else {
-            timeoutIdLeading = undefined
-            timeoutIdTrailing = undefined
-          }
-        }, delay)
-      })
-
-      return await promise
-    }
-
-  callback.cancel = () => {
-    clearTimeout(timeoutIdLeading)
-    clearTimeout(timeoutIdTrailing)
-    timeoutIdLeading = undefined
-    timeoutIdTrailing = undefined
-  }
-
-  return callback
 }
 
 export function uid(): string {


### PR DESCRIPTION
We are not really have a use case for async debouncing. But,  the way react works in dev mode it will run hooks twice and in our case it results in multiple request sent (and canceled -> screenshot). It should not be a problem in prod build
![Screenshot 2023-08-14 at 11 50 48 AM](https://github.com/TobikoData/sqlmesh/assets/5644753/a54ed5e6-c306-4b21-98a3-e752c9f8a070)
