### PR TITLE
Fix: CLI table-diff styling

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -665,20 +665,20 @@ class TerminalConsole(Console):
         if row_diff.target_alias:
             target_name = row_diff.target_alias.upper()
 
-        tree = Tree("[b]Outer Join Row Counts:[/b]")
-        tree.add(f" [b][blue]JOINED[/blue]:[/b] {row_diff.join_count} rows")
+        tree = Tree("[b]Row Counts:[/b]")
+        tree.add(f" [b][blue]COMMON[/blue]:[/b] {row_diff.join_count} rows")
         tree.add(f" [b][yellow]{source_name} ONLY[/yellow]:[/b] {row_diff.s_only_count} rows")
         tree.add(f" [b][green]{target_name} ONLY[/green]:[/b] {row_diff.t_only_count} rows")
         self.console.print("\n", tree)
 
-        self.console.print("\n[b][blue]JOINED ROWS[/blue] comparison stats:[/b]")
+        self.console.print("\n[b][blue]COMMON ROWS[/blue] comparison stats:[/b]")
         if row_diff.column_stats.shape[0] > 0:
             self.console.print(row_diff.column_stats.to_string(index=True), end="\n\n")
         else:
             self.console.print("  No columns with same name and data type in both tables")
 
         if show_sample:
-            self.console.print("\n[b][blue]JOINED ROWS[/blue] data differences:[/b]")
+            self.console.print("\n[b][blue]COMMON ROWS[/blue] data differences:[/b]")
             if row_diff.joined_sample.shape[0] > 0:
                 self.console.print(row_diff.joined_sample.to_string(index=False), end="\n\n")
             else:

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -674,14 +674,14 @@ class TerminalConsole(Console):
         tree.add(f" [b][green]{target_name} ONLY[/green]:[/b] {row_diff.t_only_count} rows")
         self.console.print("\n", tree)
 
-        self.console.print("\n[b][blue]COMMON ROWS[/blue] comparison stats:[/b]")
+        self.console.print("\n[b][blue]COMMON ROWS[/blue] column comparison stats:[/b]")
         if row_diff.column_stats.shape[0] > 0:
             self.console.print(row_diff.column_stats.to_string(index=True), end="\n\n")
         else:
             self.console.print("  No columns with same name and data type in both tables")
 
         if show_sample:
-            self.console.print("\n[b][blue]COMMON ROWS[/blue] data differences:[/b]")
+            self.console.print("\n[b][blue]COMMON ROWS[/blue] sample data differences:[/b]")
             if row_diff.joined_sample.shape[0] > 0:
                 self.console.print(row_diff.joined_sample.to_string(index=False), end="\n\n")
             else:


### PR DESCRIPTION
- Change "joined" to "common"
- If diff is across environments, include env name in data comparison sample column names
- Remove s__ and t__ prefixes from s-only and t-only samples

Old styling:
![Screenshot 2023-08-15 at 8 16 33 AM](https://github.com/TobikoData/sqlmesh/assets/1831878/3ab8b95c-f168-4a96-9375-f38f825507af)

New styling:
![Screenshot 2023-08-14 at 5 01 56 PM](https://github.com/TobikoData/sqlmesh/assets/1831878/3c50a993-0928-4b00-8f92-f656830b97c9)

