### PR TITLE
Fix: Remove intervals instead missing intervals

### DIFF
--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -9,7 +9,6 @@ from sqlmesh.core import constants as c
 from sqlmesh.core.config import EnvironmentSuffixTarget
 from sqlmesh.core.snapshot import SnapshotId, SnapshotTableInfo
 from sqlmesh.utils import word_characters_only
-from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.pydantic import PydanticModel, field_validator
 
@@ -84,7 +83,6 @@ class Environment(EnvironmentNamingInfo):
     expiration_ts: t.Optional[int] = None
     finalized_ts: t.Optional[int] = None
     promoted_snapshot_ids: t.Optional[t.List[SnapshotId]] = None
-    _dag: t.Optional[DAG[str]] = None
 
     @field_validator("snapshots", mode="before")
     @classmethod
@@ -111,12 +109,3 @@ class Environment(EnvironmentNamingInfo):
     @property
     def naming_info(self) -> EnvironmentNamingInfo:
         return EnvironmentNamingInfo(name=self.name, suffix_target=self.suffix_target)
-
-    @property
-    def dag(self) -> DAG[str]:
-        if self._dag is None:
-            self._dag: DAG[str] = DAG()
-            id_mapping = {s.snapshot_id: s for s in self.snapshots}
-            for snapshot in self.snapshots:
-                self._dag.add(snapshot.name, [id_mapping[dep].name for dep in snapshot.parents])
-        return self._dag

--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -9,6 +9,7 @@ from sqlmesh.core import constants as c
 from sqlmesh.core.config import EnvironmentSuffixTarget
 from sqlmesh.core.snapshot import SnapshotId, SnapshotTableInfo
 from sqlmesh.utils import word_characters_only
+from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.pydantic import PydanticModel, field_validator
 
@@ -83,6 +84,7 @@ class Environment(EnvironmentNamingInfo):
     expiration_ts: t.Optional[int] = None
     finalized_ts: t.Optional[int] = None
     promoted_snapshot_ids: t.Optional[t.List[SnapshotId]] = None
+    _dag: t.Optional[DAG[str]] = None
 
     @field_validator("snapshots", mode="before")
     @classmethod
@@ -109,3 +111,12 @@ class Environment(EnvironmentNamingInfo):
     @property
     def naming_info(self) -> EnvironmentNamingInfo:
         return EnvironmentNamingInfo(name=self.name, suffix_target=self.suffix_target)
+
+    @property
+    def dag(self) -> DAG[str]:
+        if self._dag is None:
+            self._dag: DAG[str] = DAG()
+            id_mapping = {s.snapshot_id: s for s in self.snapshots}
+            for snapshot in self.snapshots:
+                self._dag.add(snapshot.name, [id_mapping[dep].name for dep in snapshot.parents])
+        return self._dag

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -301,12 +301,6 @@ class Plan:
         return self._restatements
 
     @property
-    def restatement_snapshots(self) -> t.List[t.Tuple[Snapshot, Interval]]:
-        return [
-            (self.context_diff.snapshots[s], interval) for s, interval in self.restatements.items()
-        ]
-
-    @property
     def loaded_snapshot_intervals(self) -> t.List[LoadedSnapshotIntervals]:
         loaded_snapshots = []
         for snapshot in self.directly_modified:
@@ -460,7 +454,7 @@ class Plan:
     def _add_restatements(self, restate_models: t.Iterable[str]) -> None:
         def is_restateable_snapshot(snapshot: Snapshot) -> bool:
             if not self.is_dev and snapshot.model.disable_restatement:
-                logger.warning("Restatement is disabled for model '%s'.", snapshot.name)
+                logger.debug("Restatement is disabled for model '%s'.", snapshot.name)
                 return False
             return not snapshot.is_symbolic and not snapshot.is_seed
 

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -482,11 +482,7 @@ class Plan:
             interval = snapshot.get_removal_interval(
                 self.start, self.end, self._execution_time, strict=False
             )
-            upstream_snapshots = [
-                s
-                for s in self._dag.upstream(snapshot_name)
-                if is_restateable_snapshot(snapshot_mapping[s])
-            ]
+            upstream_snapshots = [s for s in self._dag.upstream(snapshot_name)]
             possible_intervals = [
                 restatements.get(s, dummy_interval) for s in upstream_snapshots
             ] + [interval]

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 import typing as t
 from collections import defaultdict
 from enum import Enum
@@ -19,7 +20,7 @@ from sqlmesh.core.snapshot import (
     merge_intervals,
     missing_intervals,
 )
-from sqlmesh.core.snapshot.definition import format_intervals
+from sqlmesh.core.snapshot.definition import Interval, format_intervals
 from sqlmesh.utils import random_id
 from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.date import (
@@ -110,7 +111,7 @@ class Plan:
             self._dag.add(name, snapshot.model.depends_on)
 
         self.__missing_intervals: t.Optional[t.Dict[t.Tuple[str, str], Intervals]] = None
-        self._restatements: t.Set[str] = set()
+        self._restatements: t.Dict[str, Interval] = {}
 
         if restate_models and context_diff.new_snapshots:
             raise PlanError(
@@ -296,8 +297,14 @@ class Plan:
         )
 
     @property
-    def restatements(self) -> t.Set[str]:
+    def restatements(self) -> t.Dict[str, Interval]:
         return self._restatements
+
+    @property
+    def restatement_snapshots(self) -> t.List[t.Tuple[Snapshot, Interval]]:
+        return [
+            (self.context_diff.snapshots[s], interval) for s, interval in self.restatements.items()
+        ]
 
     @property
     def loaded_snapshot_intervals(self) -> t.List[LoadedSnapshotIntervals]:
@@ -451,30 +458,48 @@ class Plan:
         )
 
     def _add_restatements(self, restate_models: t.Iterable[str]) -> None:
-        for table in restate_models:
-            downstream = self._dag.downstream(table)
-            if table in self.context_diff.snapshots:
-                downstream.append(table)
+        def is_restateable_snapshot(snapshot: Snapshot) -> bool:
+            if not self.is_dev and snapshot.model.disable_restatement:
+                logger.warning("Restatement is disabled for model '%s'.", snapshot.name)
+                return False
+            return not snapshot.is_symbolic and not snapshot.is_seed
 
-            snapshots = self.context_diff.snapshots
-            downstream = [
-                d for d in downstream if not snapshots[d].is_symbolic and not snapshots[d].is_seed
-            ]
-
-            if not self.is_dev:
-                models_with_disabled_restatement = [
-                    f"'{d}'" for d in downstream if snapshots[d].model.disable_restatement
-                ]
-                if models_with_disabled_restatement:
-                    raise PlanError(
-                        f"Restatement is disabled for models: {', '.join(models_with_disabled_restatement)}."
-                    )
-
-            if not downstream:
+        dummy_interval = (sys.maxsize, -sys.maxsize)
+        snapshot_mapping = self.context_diff.snapshots
+        restatements = {}
+        # Add restate snapshots and their downstream snapshots
+        for snapshot_name in restate_models:
+            if snapshot_name not in snapshot_mapping or not is_restateable_snapshot(
+                snapshot_mapping[snapshot_name]
+            ):
                 raise PlanError(
-                    f"Cannot restate from '{table}'. Either such model doesn't exist, no other materialized model references it, or restatement was disabled for this model."
+                    f"Cannot restate from '{snapshot_name}'. Either such model doesn't exist, no other materialized model references it, or restatement was disabled for this model."
                 )
-            self._restatements.update(downstream)
+            restatements[snapshot_name] = dummy_interval
+            for downstream_snapshot_name in self._dag.downstream(snapshot_name):
+                if is_restateable_snapshot(snapshot_mapping[downstream_snapshot_name]):
+                    restatements[downstream_snapshot_name] = dummy_interval
+        # Get restatement intervals for all restated snapshots and make sure that if a snapshot expands it's
+        # restatement range that it's downstream dependencies all expand their restatement ranges as well.
+        for snapshot_name in self._dag:
+            if snapshot_name not in restatements:
+                continue
+            snapshot = snapshot_mapping[snapshot_name]
+            interval = snapshot.get_removal_interval(
+                self.start, self.end, self._execution_time, strict=False
+            )
+            upstream_snapshots = [
+                s
+                for s in self._dag.upstream(snapshot_name)
+                if is_restateable_snapshot(snapshot_mapping[s])
+            ]
+            possible_intervals = [
+                restatements.get(s, dummy_interval) for s in upstream_snapshots
+            ] + [interval]
+            snapshot_start = min(i[0] for i in possible_intervals)
+            snapshot_end = max(i[1] for i in possible_intervals)
+            restatements[snapshot_name] = (snapshot_start, snapshot_end)
+        self._restatements = restatements
 
     def _build_directly_and_indirectly_modified(self) -> t.Tuple[t.List[Snapshot], SnapshotMapping]:
         """Builds collections of directly and indirectly modified snapshots.

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -191,7 +191,10 @@ class BuiltInPlanEvaluator(PlanEvaluator):
             return
 
         self.state_sync.remove_interval(
-            plan.restatement_snapshots,
+            [
+                (plan.context_diff.snapshots[s], interval)
+                for s, interval in plan.restatements.items()
+            ],
             plan._execution_time,
             remove_shared_versions=not plan.is_dev,
         )

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -199,7 +199,7 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         self.state_sync.remove_interval(
             snapshot_intervals,
             plan._execution_time,
-            remove_shared_versions=plan.is_dev,
+            remove_shared_versions=not plan.is_dev,
         )
 
 

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -28,7 +28,6 @@ from sqlmesh.core.snapshot import (
     SnapshotEvaluator,
     SnapshotId,
     SnapshotInfoLike,
-    get_snapshot_removal_intervals,
     has_paused_forward_only,
 )
 from sqlmesh.core.state_sync import StateSync
@@ -191,13 +190,8 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         if not plan.restatements:
             return
 
-        target_snapshots = [s for s in plan.snapshots if s.name in plan.restatements]
-
-        snapshot_intervals = get_snapshot_removal_intervals(
-            plan._dag, plan.start, plan.end, target_snapshots
-        )
         self.state_sync.remove_interval(
-            snapshot_intervals,
+            plan.restatement_snapshots,
             plan._execution_time,
             remove_shared_versions=not plan.is_dev,
         )

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -19,6 +19,7 @@ from sqlmesh.core.snapshot import (
     earliest_start_date,
     missing_intervals,
 )
+from sqlmesh.core.snapshot.definition import Interval as SnapshotInterval
 from sqlmesh.core.state_sync import StateSync
 from sqlmesh.utils import format_exception
 from sqlmesh.utils.concurrency import concurrent_apply_to_dag
@@ -75,7 +76,7 @@ class Scheduler:
         end: t.Optional[TimeLike] = None,
         execution_time: t.Optional[TimeLike] = None,
         is_dev: bool = False,
-        restatements: t.Optional[t.Set[str]] = None,
+        restatements: t.Optional[t.Dict[str, SnapshotInterval]] = None,
         ignore_cron: bool = False,
     ) -> SnapshotToBatches:
         """Find the optimal date interval paramaters based on what needs processing and maximal batch size.
@@ -97,7 +98,7 @@ class Scheduler:
             restatements: A set of snapshot names being restated.
             ignore_cron: Whether to ignore the model's cron schedule.
         """
-        restatements = restatements or set()
+        restatements = restatements or {}
         validate_date_range(start, end)
 
         snapshots = self.snapshot_per_version.values()
@@ -178,7 +179,7 @@ class Scheduler:
         start: t.Optional[TimeLike] = None,
         end: t.Optional[TimeLike] = None,
         execution_time: t.Optional[TimeLike] = None,
-        restatements: t.Optional[t.Set[str]] = None,
+        restatements: t.Optional[t.Dict[str, SnapshotInterval]] = None,
         ignore_cron: bool = False,
     ) -> bool:
         """Concurrently runs all snapshots in topological order.
@@ -190,13 +191,13 @@ class Scheduler:
             start: The start of the run. Defaults to the min model start date.
             end: The end of the run. Defaults to now.
             execution_time: The date/time time reference to use for execution time. Defaults to now.
-            restatements: A set of snapshots to restate.
+            restatements: A dict of snapshots to restate and their intervals.
             ignore_cron: Whether to ignore the model's cron schedule.
 
         Returns:
             True if the execution was successful and False otherwise.
         """
-        restatements = restatements or set()
+        restatements = restatements or {}
         validate_date_range(start, end)
         if isinstance(environment, str):
             env = self.state_sync.get_environment(environment)
@@ -313,7 +314,7 @@ def compute_interval_params(
     end: TimeLike,
     is_dev: bool,
     execution_time: t.Optional[TimeLike] = None,
-    restatements: t.Optional[t.Set[str]] = None,
+    restatements: t.Optional[t.Dict[str, SnapshotInterval]] = None,
     ignore_cron: bool = False,
 ) -> SnapshotToBatches:
     """Find the optimal date interval paramaters based on what needs processing and maximal batch size.
@@ -333,7 +334,7 @@ def compute_interval_params(
         end: End of the interval.
         is_dev: Whether or not these intervals are for development.
         execution_time: The date/time time reference to use for execution time.
-        restatements: A set of snapshot names being restated.
+        restatements: A dict of snapshot names being restated and their intervals.
         ignore_cron: Whether to ignore the model's cron schedule.
 
     Returns:

--- a/sqlmesh/core/snapshot/__init__.py
+++ b/sqlmesh/core/snapshot/__init__.py
@@ -16,6 +16,7 @@ from sqlmesh.core.snapshot.definition import (
     SnapshotTableInfo,
     earliest_start_date,
     fingerprint_from_node,
+    get_snapshot_removal_intervals,
     has_paused_forward_only,
     merge_intervals,
     missing_intervals,

--- a/sqlmesh/core/snapshot/__init__.py
+++ b/sqlmesh/core/snapshot/__init__.py
@@ -16,7 +16,6 @@ from sqlmesh.core.snapshot.definition import (
     SnapshotTableInfo,
     earliest_start_date,
     fingerprint_from_node,
-    get_snapshot_removal_intervals,
     has_paused_forward_only,
     merge_intervals,
     missing_intervals,

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1083,17 +1083,20 @@ def missing_intervals(
 
     for snapshot in snapshots:
         interval = restatements.get(snapshot.name)
+        snapshot_start_date = start_dt
+        snapshot_end_date = end_date
         if interval:
+            snapshot_start_date, snapshot_end_date = interval
             snapshot = snapshot.copy()
             snapshot.intervals = snapshot.intervals.copy()
             snapshot.remove_interval(interval, execution_time)
 
         intervals = snapshot.missing_intervals(
             max(
-                start_dt,
-                to_datetime(start_date(snapshot, snapshots, cache) or start_dt),
+                to_datetime(snapshot_start_date),
+                to_datetime(start_date(snapshot, snapshots, cache) or snapshot_start_date),
             ),
-            end_date,
+            snapshot_end_date,
             execution_time=execution_time,
             is_dev=is_dev,
             ignore_cron=ignore_cron,

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -118,9 +118,6 @@ class SnapshotNameVersion(PydanticModel, frozen=True):
     name: str
     version: str
 
-    def __str__(self) -> str:
-        return "__".join([self.name, self.version])
-
 
 class SnapshotIntervals(PydanticModel, frozen=True):
     name: str

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -17,6 +17,7 @@ from sqlmesh.core.snapshot import (
     SnapshotInfoLike,
     SnapshotTableInfo,
 )
+from sqlmesh.core.snapshot.definition import Interval
 from sqlmesh.utils import major_minor
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.errors import SQLMeshError
@@ -247,10 +248,9 @@ class StateSync(StateReader, abc.ABC):
     @abc.abstractmethod
     def remove_interval(
         self,
-        snapshots: t.Iterable[SnapshotInfoLike],
-        start: TimeLike,
-        end: TimeLike,
-        all_snapshots: t.Optional[t.Iterable[Snapshot]] = None,
+        snapshot_intervals: t.Sequence[t.Tuple[SnapshotInfoLike, Interval]],
+        execution_time: t.Optional[TimeLike] = None,
+        remove_shared_versions: bool = False,
     ) -> None:
         """Remove an interval from a list of snapshots and sync it to the store.
 

--- a/sqlmesh/core/state_sync/cache.py
+++ b/sqlmesh/core/state_sync/cache.py
@@ -5,6 +5,7 @@ import typing as t
 
 from sqlmesh.core.model import SeedModel
 from sqlmesh.core.snapshot import Snapshot, SnapshotId, SnapshotIdLike, SnapshotInfoLike
+from sqlmesh.core.snapshot.definition import Interval
 from sqlmesh.core.state_sync.base import DelegatingStateSync, StateSync
 from sqlmesh.utils.date import TimeLike, now_timestamp
 
@@ -134,12 +135,10 @@ class CachingStateSync(DelegatingStateSync):
 
     def remove_interval(
         self,
-        snapshots: t.Iterable[SnapshotInfoLike],
-        start: TimeLike,
-        end: TimeLike,
-        all_snapshots: t.Optional[t.Iterable[Snapshot]] = None,
+        snapshot_intervals: t.Sequence[t.Tuple[SnapshotInfoLike, Interval]],
+        execution_time: t.Optional[TimeLike] = None,
+        remove_shared_versions: bool = False,
     ) -> None:
-        snapshots = tuple(snapshots)
-        for s in snapshots:
+        for s, _ in snapshot_intervals:
             self.snapshot_cache.pop(s.snapshot_id, None)
-        self.state_sync.remove_interval(snapshots, start, end, all_snapshots)
+        self.state_sync.remove_interval(snapshot_intervals, execution_time, remove_shared_versions)

--- a/sqlmesh/core/state_sync/common.py
+++ b/sqlmesh/core/state_sync/common.py
@@ -239,7 +239,7 @@ class CommonStateSyncMixin(StateSync):
                         target_snapshot.snapshot_id,
                     )
                     self.remove_interval(
-                        [], effective_from_ts, current_ts, all_snapshots=[snapshot]
+                        [(snapshot, snapshot.get_removal_interval(effective_from_ts, current_ts))]
                     )
 
                 if snapshot.unpaused_ts:

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -500,21 +500,17 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         execution_time: t.Optional[TimeLike] = None,
         remove_shared_versions: bool = False,
     ) -> None:
-        def get_name_version_key(snapshot: SnapshotInfoLike) -> str:
-            assert snapshot.version
-            return "__".join([snapshot.name, snapshot.version])
-
         if remove_shared_versions:
             name_version_mapping = {
-                get_name_version_key(s): (s, interval) for s, interval in snapshot_intervals
+                str(s.name_version): (s, interval) for s, interval in snapshot_intervals
             }
             all_snapshots = self._get_snapshots_with_same_version(
                 [s[0] for s in snapshot_intervals]
             )
-            snapshot_intervals = []
-            for snapshot in all_snapshots:
-                key = get_name_version_key(snapshot)
-                snapshot_intervals.append((snapshot, name_version_mapping[key][1]))
+            snapshot_intervals = [
+                (snapshot, name_version_mapping[str(snapshot.name_version)][1])
+                for snapshot in all_snapshots
+            ]
 
         if logger.isEnabledFor(logging.INFO):
             snapshot_ids = ", ".join(str(s.snapshot_id) for s, _ in snapshot_intervals)

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -502,13 +502,13 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
     ) -> None:
         if remove_shared_versions:
             name_version_mapping = {
-                str(s.name_version): (s, interval) for s, interval in snapshot_intervals
+                s.name_version: (s, interval) for s, interval in snapshot_intervals
             }
             all_snapshots = self._get_snapshots_with_same_version(
                 [s[0] for s in snapshot_intervals]
             )
             snapshot_intervals = [
-                (snapshot, name_version_mapping[str(snapshot.name_version)][1])
+                (snapshot, name_version_mapping[snapshot.name_version][1])
                 for snapshot in all_snapshots
             ]
 

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -67,7 +67,7 @@ class AirflowClient:
             no_gaps=no_gaps,
             skip_backfill=skip_backfill,
             request_id=request_id,
-            restatements=set(restatements or []),
+            restatements=restatements or {},
             notification_targets=notification_targets or [],
             backfill_concurrent_tasks=backfill_concurrent_tasks,
             ddl_concurrent_tasks=ddl_concurrent_tasks,

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -11,6 +11,7 @@ from sqlmesh.core.console import Console
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.notification_target import NotificationTarget
 from sqlmesh.core.snapshot import Snapshot, SnapshotId
+from sqlmesh.core.snapshot.definition import Interval
 from sqlmesh.core.state_sync import Versions
 from sqlmesh.core.user import User
 from sqlmesh.schedulers.airflow import common
@@ -52,7 +53,7 @@ class AirflowClient:
         request_id: str,
         no_gaps: bool = False,
         skip_backfill: bool = False,
-        restatements: t.Optional[t.Iterable[str]] = None,
+        restatements: t.Optional[t.Dict[str, Interval]] = None,
         notification_targets: t.Optional[t.List[NotificationTarget]] = None,
         backfill_concurrent_tasks: int = 1,
         ddl_concurrent_tasks: int = 1,

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -14,6 +14,7 @@ from sqlmesh.core.snapshot import (
     SnapshotIntervals,
     SnapshotTableInfo,
 )
+from sqlmesh.core.snapshot.definition import Interval as SnapshotInterval
 from sqlmesh.core.user import User
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.errors import SQLMeshError
@@ -44,7 +45,7 @@ class PlanApplicationRequest(PydanticModel):
     environment: Environment
     no_gaps: bool
     skip_backfill: bool
-    restatements: t.Set[str]
+    restatements: t.Dict[str, SnapshotInterval]
     notification_targets: t.List[NotificationTarget]
     backfill_concurrent_tasks: int
     ddl_concurrent_tasks: int

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -6,6 +6,7 @@ import typing as t
 from sqlmesh.core.console import Console
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.snapshot import Snapshot, SnapshotId, SnapshotIdLike, SnapshotInfoLike
+from sqlmesh.core.snapshot.definition import Interval
 from sqlmesh.core.state_sync import StateSync, Versions
 from sqlmesh.core.state_sync.base import PromotionResult
 from sqlmesh.schedulers.airflow.client import AirflowClient
@@ -179,10 +180,9 @@ class HttpStateSync(StateSync):
 
     def remove_interval(
         self,
-        snapshots: t.Iterable[SnapshotInfoLike],
-        start: TimeLike,
-        end: TimeLike,
-        all_snapshots: t.Optional[t.Iterable[Snapshot]] = None,
+        snapshot_intervals: t.Sequence[t.Tuple[SnapshotInfoLike, Interval]],
+        execution_time: t.Optional[TimeLike] = None,
+        remove_shared_versions: bool = False,
     ) -> None:
         """Remove an interval from a list of snapshots and sync it to the store.
 

--- a/sqlmesh/utils/dag.py
+++ b/sqlmesh/utils/dag.py
@@ -139,3 +139,10 @@ class DAG(t.Generic[T]):
             A new dag consisting of the dependent and descendant nodes.
         """
         return self.subdag(node, *self.downstream(node))
+
+    def __contains__(self, item: T) -> bool:
+        return item in self.graph
+
+    def __iter__(self) -> t.Iterator[T]:
+        for node in self.sorted:
+            yield node

--- a/sqlmesh/utils/dag.py
+++ b/sqlmesh/utils/dag.py
@@ -99,7 +99,9 @@ class DAG(t.Generic[T]):
                 for deps in unprocessed_nodes.values():
                     deps -= next_nodes
 
-                self._sorted.extend(next_nodes)
+                # Sort to make the order deterministic
+                # TODO: Make protocol that makes the type var both hashable and sortable once we are on Python 3.8+
+                self._sorted.extend(sorted(next_nodes))  # type: ignore
 
         return self._sorted
 
@@ -146,3 +148,9 @@ class DAG(t.Generic[T]):
     def __iter__(self) -> t.Iterator[T]:
         for node in self.sorted:
             yield node
+
+    def __len__(self) -> int:
+        return len(self.sorted)
+
+    def __bool__(self) -> bool:
+        return bool(self.sorted)

--- a/sqlmesh/utils/dag.py
+++ b/sqlmesh/utils/dag.py
@@ -148,9 +148,3 @@ class DAG(t.Generic[T]):
     def __iter__(self) -> t.Iterator[T]:
         for node in self.sorted:
             yield node
-
-    def __len__(self) -> int:
-        return len(self.sorted)
-
-    def __bool__(self) -> bool:
-        return bool(self.sorted)

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -677,21 +677,20 @@ def test_incremental_time_self_reference(
             SnapshotIntervals(
                 snapshot_name="sushi.customer_revenue_lifetime",
                 intervals=[
-                    (
-                        to_timestamp(to_date(f"{x + 1} days ago")),
-                        to_timestamp(to_date(f"{x} days ago")),
-                    )
-                    for x in reversed(range(7))
+                    (to_timestamp(to_date("1 week ago")), to_timestamp(to_date("6 days ago"))),
+                    (to_timestamp(to_date("6 days ago")), to_timestamp(to_date("5 days ago"))),
+                    (to_timestamp(to_date("5 days ago")), to_timestamp(to_date("4 days ago"))),
+                    (to_timestamp(to_date("4 days ago")), to_timestamp(to_date("3 days ago"))),
+                    (to_timestamp(to_date("3 days ago")), to_timestamp(to_date("2 days ago"))),
+                    (to_timestamp(to_date("2 days ago")), to_timestamp(to_date("1 days ago"))),
+                    (to_timestamp(to_date("1 day ago")), to_timestamp(to_date("today"))),
                 ],
             ),
             SnapshotIntervals(
                 snapshot_name="sushi.customer_revenue_by_day",
                 intervals=[
-                    (
-                        to_timestamp(to_date(f"{x + 1} days ago")),
-                        to_timestamp(to_date(f"{x} days ago")),
-                    )
-                    for x in reversed(range(5, 7))
+                    (to_timestamp(to_date("1 week ago")), to_timestamp(to_date("6 days ago"))),
+                    (to_timestamp(to_date("6 days ago")), to_timestamp(to_date("5 days ago"))),
                 ],
             ),
         ],

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -1,3 +1,4 @@
+import typing as t
 from datetime import timedelta
 
 import pytest
@@ -13,6 +14,7 @@ from sqlmesh.core.snapshot import (
     SnapshotDataVersion,
     SnapshotFingerprint,
 )
+from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.date import now, to_date, to_ds, to_timestamp
 from sqlmesh.utils.errors import PlanError
 
@@ -62,6 +64,7 @@ def test_forward_only_dev(make_snapshot, mocker: MockerFixture):
 
     expected_start = to_date("2022-01-01")
     expected_end = to_date("2022-01-02")
+    expected_interval_end = to_timestamp(to_date("2022-01-03"))
 
     context_diff_mock = mocker.Mock()
     context_diff_mock.snapshots = {"a": snapshot_a}
@@ -79,7 +82,7 @@ def test_forward_only_dev(make_snapshot, mocker: MockerFixture):
 
     plan = Plan(context_diff_mock, forward_only=True, is_dev=True)
 
-    assert plan.restatements == {"a"}
+    assert plan.restatements == {"a": (to_timestamp(expected_start), expected_interval_end)}
     assert plan.start == expected_start
     assert plan.end == expected_end
 
@@ -145,7 +148,10 @@ def test_restate_models(sushi_context_pre_scheduling: Context):
     plan = sushi_context_pre_scheduling.plan(
         restate_models=["sushi.waiter_revenue_by_day"], no_prompts=True
     )
-    assert plan.restatements == {"sushi.waiter_revenue_by_day", "sushi.top_waiters"}
+    assert plan.restatements == {
+        "sushi.waiter_revenue_by_day": (plan.start, to_timestamp(to_date("today"))),
+        "sushi.top_waiters": (plan.start, to_timestamp(to_date("today"))),
+    }
     assert plan.requires_backfill
 
     with pytest.raises(PlanError, match=r"Cannot restate from 'unknown_model'.*"):
@@ -235,6 +241,7 @@ def test_end_validation(make_snapshot, mocker: MockerFixture):
     context_diff_mock.new_snapshots = {}
     restatement_prod_plan = Plan(
         context_diff_mock,
+        start="2022-01-01",
         end="2022-01-03",
         restate_models=["a"],
     )
@@ -614,7 +621,7 @@ def test_disable_restatement(make_snapshot, mocker: MockerFixture):
     context_diff_mock.environment = "test_dev"
     context_diff_mock.previous_plan_id = "previous_plan_id"
 
-    with pytest.raises(PlanError, match="Restatement is disabled for models: 'a'.*"):
+    with pytest.raises(PlanError, match="Cannot restate from 'a'.*"):
         Plan(context_diff_mock, restate_models=["a"])
 
     # Effective from doesn't apply to snapshots for which restatements are disabled.
@@ -624,7 +631,7 @@ def test_disable_restatement(make_snapshot, mocker: MockerFixture):
 
     # Restatements should still be supported when in dev.
     plan = Plan(context_diff_mock, is_dev=True, restate_models=["a"])
-    assert plan.restatements == {"a"}
+    assert plan.restatements == {"a": (plan.start, to_timestamp(to_date("today")))}
 
 
 def test_revert_to_previous_value(make_snapshot, mocker: MockerFixture):
@@ -661,3 +668,207 @@ def test_revert_to_previous_value(make_snapshot, mocker: MockerFixture):
     plan.set_choice(snapshot_a, SnapshotChangeCategory.BREAKING)
     # Make sure it does not get assigned INDIRECT_BREAKING
     assert snapshot_b.change_category == SnapshotChangeCategory.FORWARD_ONLY
+
+
+test_add_restatement_fixtures = [
+    (
+        "No dependencies single depends on past",
+        {
+            "a": {},
+            "b": {},
+        },
+        set("b"),
+        {"a", "b"},
+        "1 week ago",
+        "1 week ago",
+        "1 day ago",
+        {
+            "a": ("1 week ago", "6 days ago"),
+            "b": ("1 week ago", "today"),
+        },
+    ),
+    (
+        "Simple dependency with leaf depends on past",
+        {
+            "a": {},
+            "b": {"a"},
+        },
+        set("b"),
+        {"a", "b"},
+        "1 week ago",
+        "1 week ago",
+        "1 day ago",
+        {
+            "a": ("1 week ago", "6 days ago"),
+            "b": ("1 week ago", "today"),
+        },
+    ),
+    (
+        "Simple dependency with root depends on past",
+        {
+            "a": {},
+            "b": {"a"},
+        },
+        set("a"),
+        {"a", "b"},
+        "1 week ago",
+        "1 week ago",
+        "1 day ago",
+        {
+            "a": ("1 week ago", "today"),
+            "b": ("1 week ago", "today"),
+        },
+    ),
+    (
+        "Two unrelated subgraphs with root depends on past",
+        {
+            "a": {},
+            "b": {},
+            "c": {"a"},
+            "d": {"b"},
+        },
+        set("a"),
+        {"a", "b"},
+        "1 week ago",
+        "1 week ago",
+        "1 day ago",
+        {
+            "a": ("1 week ago", "today"),
+            "b": ("1 week ago", "6 days ago"),
+            "c": ("1 week ago", "today"),
+            "d": ("1 week ago", "6 days ago"),
+        },
+    ),
+    (
+        "Simple root depends on past with adjusted execution time",
+        {
+            "a": {},
+            "b": {"a"},
+        },
+        set("a"),
+        {"a", "b"},
+        "1 week ago",
+        "1 week ago",
+        "3 day ago",
+        {
+            "a": ("1 week ago", "2 days ago"),
+            "b": ("1 week ago", "2 days ago"),
+        },
+    ),
+    (
+        """
+        a -> c -> d
+        b -> c -> e -> g
+        b -> f -> g
+        c depends on past
+        restate a and b
+        """,
+        {
+            "a": {},
+            "b": {},
+            "c": {"a", "b"},
+            "d": {"c"},
+            "e": {"c"},
+            "f": {"b"},
+            "g": {"f", "e"},
+        },
+        set("c"),
+        {"a", "b"},
+        "1 week ago",
+        "1 week ago",
+        "1 day ago",
+        {
+            "a": ("1 week ago", "6 days ago"),
+            "b": ("1 week ago", "6 days ago"),
+            "c": ("1 week ago", "today"),
+            "d": ("1 week ago", "today"),
+            "e": ("1 week ago", "today"),
+            "f": ("1 week ago", "6 days ago"),
+            "g": ("1 week ago", "today"),
+        },
+    ),
+    (
+        """
+        a -> c -> d
+        b -> c -> e -> g
+        b -> f -> g
+        c depends on past
+        restate e
+        """,
+        {
+            "a": {},
+            "b": {},
+            "c": {"a", "b"},
+            "d": {"c"},
+            "e": {"c"},
+            "f": {"b"},
+            "g": {"f", "e"},
+        },
+        set("c"),
+        {"e"},
+        "1 week ago",
+        "1 week ago",
+        "1 day ago",
+        {
+            "e": ("1 week ago", "6 days ago"),
+            "g": ("1 week ago", "6 days ago"),
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "graph,depends_on_past_names,restatement_names,start,end,execution_time,expected",
+    [test[1:] for test in test_add_restatement_fixtures],
+    ids=[test[0] for test in test_add_restatement_fixtures],
+)
+def test_add_restatements(
+    graph: t.Dict[str, t.Set[str]],
+    depends_on_past_names: t.Set[str],
+    restatement_names: t.Set[str],
+    start: str,
+    end: str,
+    execution_time: str,
+    expected: t.Dict[str, t.Tuple[str, str]],
+    make_snapshot,
+    mocker,
+):
+    dag = DAG(graph)
+    context_diff_mock = mocker.Mock()
+    context_diff_mock.snapshots = {
+        snapshot_name: make_snapshot(
+            SqlModel(
+                name=snapshot_name,
+                kind=IncrementalByTimeRangeKind(time_column="ds"),
+                cron="@daily",
+                start="1 week ago",
+                query=parse_one(
+                    f"SELECT 1 FROM {snapshot_name}"
+                    if snapshot_name in depends_on_past_names
+                    else "SELECT 1"
+                ),
+                depends_on=dag.upstream(snapshot_name),
+            )
+        )
+        for snapshot_name in dag
+    }
+    context_diff_mock.removed = set()
+    context_diff_mock.added = set()
+    context_diff_mock.added_materialized_models = set()
+    context_diff_mock.modified_snapshots = {}
+    context_diff_mock.new_snapshots = {}
+    context_diff_mock.has_snapshot_changes = False
+    context_diff_mock.is_new_environment = False
+    context_diff_mock.environment = "test_dev"
+    context_diff_mock.previous_plan_id = "previous_plan_id"
+    plan = Plan(
+        context_diff_mock,
+        start=to_date(start),
+        end=to_date(end),
+        execution_time=to_date(execution_time),
+        restate_models=restatement_names,
+    )
+    assert plan.restatements == {
+        name: (to_timestamp(to_date(start)), to_timestamp(to_date(end)))
+        for name, (start, end) in expected.items()
+    }

--- a/tests/core/test_plan_evaluator.py
+++ b/tests/core/test_plan_evaluator.py
@@ -82,7 +82,7 @@ def test_airflow_evaluator(sushi_plan: Plan, mocker: MockerFixture):
         mocker.ANY,
         no_gaps=False,
         notification_targets=[],
-        restatements=set(),
+        restatements={},
         backfill_concurrent_tasks=1,
         ddl_concurrent_tasks=1,
         skip_backfill=False,

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -236,12 +236,13 @@ def test_incremental_time_self_reference(make_snapshot):
     )
     snapshot.add_interval(to_date("1 week ago"), to_date("1 day ago"))
     assert snapshot.missing_intervals(to_date("1 week ago"), to_date("1 day ago")) == []
-    snapshot.remove_interval(to_date("1 week ago"), to_date("1 week ago"))
-    assert snapshot.missing_intervals(
-        to_date("1 week ago"), to_date("1 week ago"), restatements={"name"}
-    ) == [
-        (to_timestamp(to_date(f"{x + 1} days ago")), to_timestamp(to_date(f"{x} days ago")))
-        for x in reversed(range(7))
+    # Remove should take away not only 3 days ago but also everything after since this model
+    # depends on past
+    snapshot.remove_interval(to_date("3 days ago"), to_date("3 days ago"))
+    assert snapshot.missing_intervals(to_date("1 week ago"), to_date("1 day ago")) == [
+        (to_timestamp(to_date("3 days ago")), to_timestamp(to_date("2 days ago"))),
+        (to_timestamp(to_date("2 days ago")), to_timestamp(to_date("1 days ago"))),
+        (to_timestamp(to_date("1 days ago")), to_timestamp(to_date("today"))),
     ]
 
 

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -28,10 +28,8 @@ from sqlmesh.core.snapshot import (
     SnapshotFingerprint,
     categorize_change,
     fingerprint_from_node,
-    get_snapshot_removal_intervals,
     has_paused_forward_only,
 )
-from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.date import to_date, to_datetime, to_timestamp
 from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.jinja import JinjaMacroRegistry, MacroInfo
@@ -240,7 +238,8 @@ def test_incremental_time_self_reference(make_snapshot):
     assert snapshot.missing_intervals(to_date("1 week ago"), to_date("1 day ago")) == []
     # Remove should take away not only 3 days ago but also everything after since this model
     # depends on past
-    snapshot.remove_interval(to_date("3 days ago"), to_date("3 days ago"))
+    interval = snapshot.get_removal_interval(to_date("3 days ago"), to_date("3 days ago"))
+    snapshot.remove_interval(interval)
     assert snapshot.missing_intervals(to_date("1 week ago"), to_date("1 day ago")) == [
         (to_timestamp(to_date("3 days ago")), to_timestamp(to_date("2 days ago"))),
         (to_timestamp(to_date("2 days ago")), to_timestamp(to_date("1 days ago"))),
@@ -339,49 +338,49 @@ def test_seed_intervals(make_snapshot):
 
 def test_remove_intervals(snapshot: Snapshot):
     snapshot.add_interval("2020-01-01", "2020-01-01")
-    snapshot.remove_interval("2020-01-01", "2020-01-01")
+    snapshot.remove_interval(snapshot.get_removal_interval("2020-01-01", "2020-01-01"))
     assert snapshot.intervals == []
 
     snapshot.add_interval("2020-01-01", "2020-01-01")
     snapshot.add_interval("2020-01-03", "2020-01-03")
-    snapshot.remove_interval("2020-01-01", "2020-01-01")
+    snapshot.remove_interval(snapshot.get_removal_interval("2020-01-01", "2020-01-01"))
     assert snapshot.intervals == [(to_timestamp("2020-01-03"), to_timestamp("2020-01-04"))]
 
-    snapshot.remove_interval("2020-01-01", "2020-01-05")
+    snapshot.remove_interval(snapshot.get_removal_interval("2020-01-01", "2020-01-05"))
     assert snapshot.intervals == []
 
     snapshot.add_interval("2020-01-01", "2020-01-05")
     snapshot.add_interval("2020-01-07", "2020-01-10")
-    snapshot.remove_interval("2020-01-03", "2020-01-04")
+    snapshot.remove_interval(snapshot.get_removal_interval("2020-01-03", "2020-01-04"))
     assert snapshot.intervals == [
         (to_timestamp("2020-01-01"), to_timestamp("2020-01-03")),
         (to_timestamp("2020-01-05"), to_timestamp("2020-01-06")),
         (to_timestamp("2020-01-07"), to_timestamp("2020-01-11")),
     ]
-    snapshot.remove_interval("2020-01-01", "2020-01-01")
+    snapshot.remove_interval(snapshot.get_removal_interval("2020-01-01", "2020-01-01"))
     assert snapshot.intervals == [
         (to_timestamp("2020-01-02"), to_timestamp("2020-01-03")),
         (to_timestamp("2020-01-05"), to_timestamp("2020-01-06")),
         (to_timestamp("2020-01-07"), to_timestamp("2020-01-11")),
     ]
-    snapshot.remove_interval("2020-01-10", "2020-01-10")
+    snapshot.remove_interval(snapshot.get_removal_interval("2020-01-10", "2020-01-10"))
     assert snapshot.intervals == [
         (to_timestamp("2020-01-02"), to_timestamp("2020-01-03")),
         (to_timestamp("2020-01-05"), to_timestamp("2020-01-06")),
         (to_timestamp("2020-01-07"), to_timestamp("2020-01-10")),
     ]
-    snapshot.remove_interval("2020-01-07", "2020-01-07")
+    snapshot.remove_interval(snapshot.get_removal_interval("2020-01-07", "2020-01-07"))
     assert snapshot.intervals == [
         (to_timestamp("2020-01-02"), to_timestamp("2020-01-03")),
         (to_timestamp("2020-01-05"), to_timestamp("2020-01-06")),
         (to_timestamp("2020-01-08"), to_timestamp("2020-01-10")),
     ]
-    snapshot.remove_interval("2020-01-06", "2020-01-21")
+    snapshot.remove_interval(snapshot.get_removal_interval("2020-01-06", "2020-01-21"))
     assert snapshot.intervals == [
         (to_timestamp("2020-01-02"), to_timestamp("2020-01-03")),
         (to_timestamp("2020-01-05"), to_timestamp("2020-01-06")),
     ]
-    snapshot.remove_interval("2019-01-01", "2022-01-01")
+    snapshot.remove_interval(snapshot.get_removal_interval("2019-01-01", "2022-01-01"))
     assert snapshot.intervals == []
 
 
@@ -1110,166 +1109,3 @@ def test_model_custom_interval_unit(make_snapshot):
     )
 
     assert len(snapshot.missing_intervals("2023-01-29", "2023-01-29")) == 24
-
-
-@pytest.mark.parametrize(
-    "graph,depends_on_past_names,start,end,execution_time,expected",
-    [
-        (
-            # Empty DAG
-            {},
-            set(),
-            "1 week ago",
-            "1 week ago",
-            "1 day ago",
-            [],
-        ),
-        (
-            # No dependencies single depends on past
-            {
-                "a": {},
-                "b": {},
-            },
-            set("b"),
-            "1 week ago",
-            "1 week ago",
-            "1 day ago",
-            [
-                ("a", ("1 week ago", "6 days ago")),
-                ("b", ("1 week ago", "today")),
-            ],
-        ),
-        # Simple dependency with leaf depends on past
-        (
-            {
-                "a": {},
-                "b": {"a"},
-            },
-            set("b"),
-            "1 week ago",
-            "1 week ago",
-            "1 day ago",
-            [
-                ("a", ("1 week ago", "6 days ago")),
-                ("b", ("1 week ago", "today")),
-            ],
-        ),
-        # Simple dependency with root depends on past
-        (
-            {
-                "a": {},
-                "b": {"a"},
-            },
-            set("a"),
-            "1 week ago",
-            "1 week ago",
-            "1 day ago",
-            [
-                ("a", ("1 week ago", "today")),
-                ("b", ("1 week ago", "today")),
-            ],
-        ),
-        # Two unrelated subgraphs with root depends on past
-        (
-            {
-                "a": {},
-                "b": {},
-                "c": {"a"},
-                "d": {"b"},
-            },
-            set("a"),
-            "1 week ago",
-            "1 week ago",
-            "1 day ago",
-            [
-                ("a", ("1 week ago", "today")),
-                ("b", ("1 week ago", "6 days ago")),
-                ("c", ("1 week ago", "today")),
-                ("d", ("1 week ago", "6 days ago")),
-            ],
-        ),
-        # Simple root depends on past with adjusted execution time
-        (
-            {
-                "a": {},
-                "b": {"a"},
-            },
-            set("a"),
-            "1 week ago",
-            "1 week ago",
-            "3 day ago",
-            [
-                ("a", ("1 week ago", "2 days ago")),
-                ("b", ("1 week ago", "2 days ago")),
-            ],
-        ),
-        (
-            # a -> c -> d
-            # b -> c -> e -> g
-            # b -> f -> g
-            # c depends on past
-            {
-                "a": {},
-                "b": {},
-                "c": {"a", "b"},
-                "d": {"c"},
-                "e": {"c"},
-                "f": {"b"},
-                "g": {"f", "e"},
-            },
-            set("c"),
-            "1 week ago",
-            "1 week ago",
-            "1 day ago",
-            [
-                ("a", ("1 week ago", "6 days ago")),
-                ("b", ("1 week ago", "6 days ago")),
-                ("c", ("1 week ago", "today")),
-                ("d", ("1 week ago", "today")),
-                ("e", ("1 week ago", "today")),
-                ("f", ("1 week ago", "6 days ago")),
-                ("g", ("1 week ago", "today")),
-            ],
-        ),
-    ],
-)
-def test_get_snapshot_removal_intervals(
-    graph: t.Dict[str, t.Set[str]],
-    depends_on_past_names: t.Set[str],
-    start: str,
-    end: str,
-    execution_time: str,
-    expected: t.List[t.Tuple[str, t.Tuple[str, str]]],
-    make_snapshot,
-):
-    dag = DAG(graph)
-    start_date = to_date(start)
-    end_date = to_date(end)
-    execution_time_date = to_date(execution_time)
-    snapshot_mapping = {
-        snapshot_name: make_snapshot(
-            SqlModel(
-                name=snapshot_name,
-                kind=IncrementalByTimeRangeKind(time_column="ds"),
-                cron="@daily",
-                start="1 week ago",
-                query=parse_one(
-                    f"SELECT 1 FROM {snapshot_name}"
-                    if snapshot_name in depends_on_past_names
-                    else "SELECT 1"
-                ),
-            )
-        )
-        for snapshot_name in dag
-    }
-    result = get_snapshot_removal_intervals(
-        dag=dag,
-        start=start_date,
-        end=end_date,
-        snapshots=snapshot_mapping.values(),
-        execution_time=execution_time_date,
-    )
-    assert sorted([(x[0].name, x[1]) for x in result]) == [
-        (name, (to_timestamp(to_date(start)), to_timestamp(to_date(end))))
-        for name, (start, end) in expected
-    ]

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -274,7 +274,10 @@ def test_remove_interval(state_sync: EngineAdapterStateSync, make_snapshot: t.Ca
     state_sync.add_interval(snapshot_a, "2020-01-01", "2020-01-10")
     state_sync.add_interval(snapshot_b, "2020-01-11", "2020-01-30")
 
-    state_sync.remove_interval([snapshot_a], "2020-01-15", "2020-01-17")
+    state_sync.remove_interval(
+        [(snapshot_a, snapshot_a.inclusive_exclusive("2020-01-15", "2020-01-17"))],
+        remove_shared_versions=True,
+    )
 
     snapshots = state_sync.get_snapshots([snapshot_a, snapshot_b])
 
@@ -332,9 +335,13 @@ def test_compact_intervals(state_sync: EngineAdapterStateSync, make_snapshot: t.
 
     state_sync.add_interval(snapshot, "2020-01-01", "2020-01-10")
     state_sync.add_interval(snapshot, "2020-01-11", "2020-01-15")
-    state_sync.remove_interval([snapshot], "2020-01-05", "2020-01-12")
+    state_sync.remove_interval(
+        [(snapshot, snapshot.inclusive_exclusive("2020-01-05", "2020-01-12"))]
+    )
     state_sync.add_interval(snapshot, "2020-01-12", "2020-01-16")
-    state_sync.remove_interval([snapshot], "2020-01-14", "2020-01-16")
+    state_sync.remove_interval(
+        [(snapshot, snapshot.inclusive_exclusive("2020-01-14", "2020-01-16"))]
+    )
 
     expected_intervals = [
         (to_timestamp("2020-01-01"), to_timestamp("2020-01-05")),
@@ -1128,7 +1135,7 @@ def test_cache(state_sync, make_snapshot, mocker):
         mock.assert_called()
 
     # clear the cache by removing intervals
-    cache.remove_interval([snapshot], "2020-01-01", "2020-01-01")
+    cache.remove_interval([(snapshot, snapshot.inclusive_exclusive("2020-01-01", "2020-01-01"))])
 
     # prime the cache
     assert cache.get_snapshots([snapshot.snapshot_id]) == {snapshot.snapshot_id: snapshot}

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -140,7 +140,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
         "skip_backfill": False,
         "notification_targets": [],
         "request_id": request_id,
-        "restatements": [],
+        "restatements": {},
         "backfill_concurrent_tasks": 1,
         "ddl_concurrent_tasks": 1,
         "users": [],

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -93,7 +93,7 @@ def test_create_plan_dag_spec(
         environment=new_environment,
         no_gaps=True,
         skip_backfill=False,
-        restatements={"raw.items"},
+        restatements=set(),
         notification_targets=[],
         backfill_concurrent_tasks=1,
         ddl_concurrent_tasks=1,
@@ -164,7 +164,6 @@ def test_create_plan_dag_spec(
 
 
 @pytest.mark.airflow
-@pytest.mark.airflow
 @pytest.mark.parametrize(
     "the_snapshot, intervals_after_restatement, expected_intervals",
     [
@@ -182,14 +181,6 @@ def test_create_plan_dag_spec(
             [
                 (to_datetime("2022-01-02"), to_datetime("2022-01-03")),
                 (to_datetime("2022-01-03"), to_datetime("2022-01-04")),
-                (to_datetime("2022-01-04"), to_datetime("2022-01-05")),
-                (to_datetime("2022-01-05"), to_datetime("2022-01-06")),
-                (to_datetime("2022-01-06"), to_datetime("2022-01-07")),
-                (to_datetime("2022-01-07"), to_datetime("2022-01-08")),
-                # Unexpected behavior: We restate up until "now" therefore we go until 2022-01-10.
-                # Ideally we would return to the "latest" which would be the largest we have ever loaded which is the
-                # 7th
-                (to_datetime("2022-01-08"), to_datetime("2022-01-09")),
             ],
         ),
     ],
@@ -352,7 +343,7 @@ def test_create_plan_dag_spec_unbounded_end(
         environment=new_environment,
         no_gaps=True,
         skip_backfill=False,
-        restatements={"raw.items"},
+        restatements=set(),
         notification_targets=[],
         backfill_concurrent_tasks=1,
         ddl_concurrent_tasks=1,

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -24,7 +24,7 @@ from sqlmesh.core.snapshot import (
 )
 from sqlmesh.schedulers.airflow import common
 from sqlmesh.schedulers.airflow.plan import create_plan_dag_spec
-from sqlmesh.utils.date import to_datetime, to_timestamp
+from sqlmesh.utils.date import to_date, to_datetime, to_timestamp
 from sqlmesh.utils.errors import SQLMeshError
 
 
@@ -93,7 +93,7 @@ def test_create_plan_dag_spec(
         environment=new_environment,
         no_gaps=True,
         skip_backfill=False,
-        restatements=set(),
+        restatements={},
         notification_targets=[],
         backfill_concurrent_tasks=1,
         ddl_concurrent_tasks=1,
@@ -208,7 +208,12 @@ def test_restatement(
         environment=new_environment,
         no_gaps=True,
         skip_backfill=False,
-        restatements={the_snapshot.name},
+        restatements={
+            the_snapshot.name: (
+                to_timestamp(to_date("2022-01-02")),
+                to_timestamp(to_date("2022-01-04")),
+            )
+        },
         notification_targets=[],
         backfill_concurrent_tasks=1,
         ddl_concurrent_tasks=1,
@@ -295,7 +300,7 @@ def test_create_plan_dag_spec_duplicated_snapshot(
         environment=new_environment,
         no_gaps=False,
         skip_backfill=False,
-        restatements=set(),
+        restatements={},
         notification_targets=[],
         backfill_concurrent_tasks=1,
         ddl_concurrent_tasks=1,
@@ -343,7 +348,7 @@ def test_create_plan_dag_spec_unbounded_end(
         environment=new_environment,
         no_gaps=True,
         skip_backfill=False,
-        restatements=set(),
+        restatements={},
         notification_targets=[],
         backfill_concurrent_tasks=1,
         ddl_concurrent_tasks=1,


### PR DESCRIPTION
In main we only remove the intervals that are explicitly passed in for a snapshot. In order to have this work with depends_on_past where the intervals can expand beyond that range we have missing_intervals check if intervals beyond that range should be considered missing.

This change flips that so we now remove intervals beyond the range defined if needed and then missing intervals is now more simple again and just returns what is missing for the given range.

This PR also addresses an issue (thanks for catching @crericha) where if a depends_on_past model removes intervals beyond the range then we need to make sure all downstream snapshots also remove intervals beyond that range.