### PR TITLE
Feat: Add SCD Type 2 Support

### DIFF
--- a/docs/concepts/models/model_kinds.md
+++ b/docs/concepts/models/model_kinds.md
@@ -267,14 +267,16 @@ SCD Type 2 is a model kind that supports [slowly changing dimensions](https://en
 
 SQLMesh achieves this by adding a `valid_from` and `valid_to` column to your model. The `valid_from` column is the date that the record became valid (inclusive) and the `valid_to` column is the date that the record became invalid (exclusive). The `valid_to` column is set to `NULL` for the latest record.
 
-Therefore you can use these models to not only tell you what the latest value is for a given record but also what the values were anytime in the past. Note that maintaining this history does come at a cost of increased storage and compute and this may not be a good fit for sources that change frequently since the history could get very large. 
+Therefore you can use these models to not only tell you what the latest value is for a given record but also what the values were anytime in the past. Note that maintaining this history does come at a cost of increased storage and compute and this may not be a good fit for sources that change frequently since the history could get very large.
+
+Currently SCD Type 2 only supports sourcing from tables that have an "Updated At" timestamp defined in the table that tells you when a given was last updated. Soon we will also be supporting checking column values in cases where an update column is not available.
 
 This example specifies a `SCD_TYPE_2` model kind:
 ```sql linenums="1" hl_lines="3"
 MODEL (
   name db.menu_items,
   kind SCD_TYPE_2 (
-    unique_key (id),
+    unique_key id,
   )
 );
 
@@ -305,7 +307,7 @@ SQLMesh will automatically add the `valid_from` and `valid_to` columns to your t
 MODEL (
   name db.menu_items,
   kind SCD_TYPE_2 (
-    unique_key (id),
+    unique_key id,
     valid_from_name my_valid_from,
     valid_to_name my_valid_to
   )
@@ -329,7 +331,7 @@ The `updated_at` column name can also be changed by adding the following to your
 MODEL (
   name db.menu_items,
   kind SCD_TYPE_2 (
-    unique_key (id),
+    unique_key id,
     updated_at_name my_updated_at
   )
 );

--- a/docs/concepts/models/model_kinds.md
+++ b/docs/concepts/models/model_kinds.md
@@ -261,5 +261,273 @@ FROM db.employees;
 ## SEED
 The `SEED` model kind is used to specify [seed models](./seed_models.md) for using static CSV datasets in your SQLMesh project.
 
+## SCD Type 2
+
+SCD Type 2 is a model kind that supports [slowly changing dimensions](https://en.wikipedia.org/wiki/Slowly_changing_dimension#Type_2:_add_new_row) (SCDs) in your SQLMesh project. SCDs are a common pattern in data warehousing that allow you to track changes to records over time. 
+
+SQLMesh achieves this by adding a `valid_from` and `valid_to` column to your model. The `valid_from` column is the date that the record became valid (inclusive) and the `valid_to` column is the date that the record became invalid (exclusive). The `valid_to` column is set to `NULL` for the latest record.
+
+Therefore you can use these models to not only tell you what the latest value is for a given record but also what the values were anytime in the past. Note that maintaining this history does come at a cost of increased storage and compute and this may not be a good fit for sources that change frequently since the history could get very large. 
+
+This example specifies a `SCD_TYPE_2` model kind:
+```sql linenums="1" hl_lines="3"
+MODEL (
+  name db.menu_items,
+  kind SCD_TYPE_2 (
+    unique_key (id),
+  )
+);
+
+SELECT
+  id::INT,
+  name::STRING,
+  price::DOUBLE,
+  updated_at::TIMESTAMP
+FROM 
+  stg.current_menu_items;
+```
+
+SQLMesh will materialize this table with the following structure:
+```sql linenums="1" hl_lines="3"
+TABLE db.menu_items (
+  id INT,
+  name STRING,
+  price DOUBLE,
+  updated_at TIMESTAMP,
+  valid_from TIMESTAMP,
+  valid_to TIMESTAMP
+);
+```
+
+### Column Names
+SQLMesh will automatically add the `valid_from` and `valid_to` columns to your table. If you would like to specify the names of these columns you can do so by adding the following to your model definition:
+```sql linenums="1" hl_lines="3"
+MODEL (
+  name db.menu_items,
+  kind SCD_TYPE_2 (
+    unique_key (id),
+    valid_from_name my_valid_from,
+    valid_to_name my_valid_to
+  )
+);
+```
+
+SQLMesh will materialize this table with the following structure:
+```sql linenums="1" hl_lines="3"
+TABLE db.menu_items (
+  id INT,
+  name STRING,
+  price DOUBLE,
+  updated_at TIMESTAMP,
+  my_valid_from TIMESTAMP,
+  my_valid_to TIMESTAMP
+);
+```
+
+The `updated_at` column name can also be changed by adding the following to your model definition:
+```sql linenums="1" hl_lines="3"
+MODEL (
+  name db.menu_items,
+  kind SCD_TYPE_2 (
+    unique_key (id),
+    updated_at_name my_updated_at
+  )
+);
+
+SELECT
+    id,
+    name,
+    price,
+    my_updated_at
+FROM
+    stg.current_menu_items;
+```
+
+SQLMesh will materialize this table with the following structure:
+```sql linenums="1" hl_lines="3"
+TABLE db.menu_items (
+  id INT,
+  name STRING,
+  price DOUBLE,
+  my_updated_at TIMESTAMP,
+  valid_from TIMESTAMP,
+  valid_to TIMESTAMP
+);
+```
+
+### Deletes
+
+Deletes are supported and when an item is detected as deleted then the `valid_to` column will be set to the time when SQLMesh started running (called `execution_time`). If a deleted column is added back in the source then it will be inserted back into the table with `valid_from` set to the largest of either the `updated_at` timestamp of the new record or the `valid_from` timestamp of the deleted record in the SCD Type 2 table.
+
+### Example of SCD Type 2 in Action
+
+Lets say that you started with the following data in your source table:
+
+| ID | Name             | Price |     Updated At      |
+|----|------------------|:-----:|:-------------------:|
+| 1  | Chicken Sandwich | 10.99 | 2020-01-01 00:00:00 |
+| 2  | Cheeseburger     | 8.99  | 2020-01-01 00:00:00 |
+| 3  | French Fries     | 4.99  | 2020-01-01 00:00:00 |
+
+The target table, which is currently empty, will be materialized with the following data:
+
+| ID | Name             | Price |     Updated At      |     Valid From      | Valid To |
+|----|------------------|:-----:|:-------------------:|:-------------------:|:--------:|
+| 1  | Chicken Sandwich | 10.99 | 2020-01-01 00:00:00 | 1970-01-01 00:00:00 |   NULL   |
+| 2  | Cheeseburger     | 8.99  | 2020-01-01 00:00:00 | 1970-01-01 00:00:00 |   NULL   |
+| 3  | French Fries     | 4.99  | 2020-01-01 00:00:00 | 1970-01-01 00:00:00 |   NULL   |
+
+Now lets say that you update the source table with the following data:
+
+| ID | Name             | Price |     Updated At      |
+|----|------------------|:-----:|:-------------------:|
+| 1  | Chicken Sandwich | 12.99 | 2020-01-02 00:00:00 |
+| 3  | French Fries     | 4.99  | 2020-01-01 00:00:00 |
+| 4  | Milkshake        | 3.99  | 2020-01-02 00:00:00 |
+
+Summary of Changes: 
+* The price of the Chicken Sandwich was increased from $10.99 to $12.99.
+* Cheeseburger was removed from the menu.
+* Milkshakes were added to the menu.
+
+Assuming your pipeline ran at `2020-01-02 02:00:00`, target table will be updated with the following data:
+
+| ID | Name             | Price |     Updated At      |     Valid From      |      Valid To       |
+|----|------------------|:-----:|:-------------------:|:-------------------:|:-------------------:|
+| 1  | Chicken Sandwich | 10.99 | 2020-01-01 00:00:00 | 1970-01-01 00:00:00 | 2020-01-02 00:00:00 |
+| 1  | Chicken Sandwich | 12.99 | 2020-01-02 00:00:00 | 2020-01-02 00:00:00 |        NULL         |
+| 2  | Cheeseburger     | 8.99  | 2020-01-01 00:00:00 | 1970-01-01 00:00:00 | 2020-01-02 02:00:00 |
+| 3  | French Fries     | 4.99  | 2020-01-01 00:00:00 | 1970-01-01 00:00:00 |        NULL         |
+| 4  | Milkshake        | 3.99  | 2020-01-02 00:00:00 | 2020-01-02 00:00:00 |        NULL         |
+
+For our final pass, lets say that you update the source table with the following data:
+
+| ID | Name                | Price |     Updated At      |
+|----|---------------------|:-----:|:-------------------:|
+| 1  | Chicken Sandwich    | 14.99 | 2020-01-03 00:00:00 |
+| 2  | Cheeseburger        | 8.99  | 2020-01-03 00:00:00 |
+| 3  | French Fries        | 4.99  | 2020-01-01 00:00:00 |
+| 4  | Chocolate Milkshake | 3.99  | 2020-01-02 00:00:00 |
+
+Summary of changes:
+* The price of the Chicken Sandwich was increased from $12.99 to $14.99 (must be good!)
+* Cheeseburger was added back to the menu with original name and price.
+* Milkshake name was updated to be "Chocolate Milkshake".
+
+Target table will be updated with the following data:
+
+| ID | Name                | Price |     Updated At      |     Valid From      |      Valid To       |
+|----|---------------------|:-----:|:-------------------:|:-------------------:|:-------------------:|
+| 1  | Chicken Sandwich    | 10.99 | 2020-01-01 00:00:00 | 1970-01-01 00:00:00 | 2020-01-02 00:00:00 |
+| 1  | Chicken Sandwich    | 12.99 | 2020-01-02 00:00:00 | 2020-01-02 00:00:00 | 2020-01-03 00:00:00 |
+| 1  | Chicken Sandwich    | 14.99 | 2020-01-03 00:00:00 | 2020-01-03 00:00:00 |        NULL         |
+| 2  | Cheeseburger        | 8.99  | 2020-01-01 00:00:00 | 1970-01-01 00:00:00 | 2020-01-02 02:00:00 |
+| 2  | Cheeseburger        | 8.99  | 2020-01-03 00:00:00 | 2020-01-03 00:00:00 |        NULL         |
+| 3  | French Fries        | 4.99  | 2020-01-01 00:00:00 | 1970-01-01 00:00:00 |        NULL         |
+| 4  | Milkshake           | 3.99  | 2020-01-02 00:00:00 | 2020-01-02 00:00:00 | 2020-01-03 00:00:00 |
+| 4  | Chocolate Milkshake | 3.99  | 2020-01-03 00:00:00 | 2020-01-03 00:00:00 |        NULL         |
+
+Note: `Cheeseburger` was deleted from `2020-01-02 02:00:00` to `2020-01-03 00:00:00` meaning if you queried the table during that time range then you would not see `Cheeseburger` in the menu. This is the most accurate representation of the menu based on the source data provided. If `Cheeseburger` were added back to the menu with it's original updated at timestamp of `2020-01-01 00:00:00` then the `valid_from` timestamp of the new record would have been `2020-01-02 02:00:00` resulting in no period of time where the item was deleted. Since in this case the updated at timestamp did not change it is likely the item was removed in error and this again most accurately represents the menu based on the source data. 
+
+### Querying SCD Type 2 Models
+
+#### Querying the current version of a record
+
+Although SCD Type 2 models support history, it is still very easy to querying just the latest version of a record. Simply query the model as you would any other table. For example, if you wanted to query the latest version of the `menu_items` table you would simply run:
+
+```sql linenums="1" hl_lines="3"
+SELECT 
+    * 
+FROM 
+    menu_items
+WHERE 
+    valid_to IS NULL;
+```
+
+One could also create a view on top of the SCD Type 2 model that creates a new `is_current` column to make it easy for consumers to identify the current record.
+    
+```sql linenums="1" hl_lines="3"
+SELECT 
+    *, 
+    valid_to IS NULL AS is_current
+FROM
+    menu_items;
+```
+
+#### Querying for a specific version of a record at a give point in time
+
+If you wanted to query the `menu_items` table as it was on `2020-01-02 01:00:00` you would simply run:
+
+```sql linenums="1" hl_lines="3"
+SELECT 
+    *
+FROM
+    menu_items
+WHERE
+    id = 1
+    AND '2020-01-02 01:00:00' >= valid_from
+    AND '2020-01-02 01:00:00' < COALESCE(valid_to, '2199-12-31 23:59:59');
+```
+
+Example in a join:
+
+```sql linenums="1" hl_lines="3"
+SELECT 
+    *
+FROM
+    orders
+    INNER JOIN
+    menu_items
+    ON orders.menu_item_id = menu_items.id
+    AND orders.created_at >= menu_items.valid_from
+    AND orders.created_at < COALESCE(menu_items.valid_to, '2199-12-31 23:59:59');
+```
+
+A view can be created to do the `COALESCE` automatically. This, combined with the `is_current` flag, makes it easier to query for a specific version of a record.
+
+```sql linenums="1" hl_lines="3"
+SELECT
+    id,
+    name,
+    price,
+    updated_at,
+    valid_from,
+    COALESCE(valid_to, '2199-12-31 23:59:59') AS valid_to
+    valid_to IS NULL AS is_current,
+FROM
+    menu_items;
+```
+
+Furthermore if you want to make it so users can use `BETWEEN` when querying by making `valid_to` inclusive you can do the following:
+```sql linenums="1" hl_lines="3"
+SELECT
+    id,
+    name,
+    price,
+    updated_at,
+    valid_from,
+    COALESCE(valid_to, '2200-01-01 00:00:00') - INTERVAL 1 SECOND AS valid_to
+    valid_to IS NULL AS is_current,
+```
+
+Note: The precision of the timestamps in this example is second so I subtract 1 second. Make sure to subtract a value equal to the precision of your timestamps.
+
+#### Querying for deleted records
+
+One way to identify deleted records is to query for records that do not have a `valid_to` record of `NULL`. For example, if you wanted to query for all deleted ids in the `menu_items` table you would simply run:
+
+```sql linenums="1" hl_lines="3"
+SELECT 
+    id,
+    MAX(CASE WHEN valid_to IS NULL THEN 0 ELSE 1 END) AS is_deleted
+FROM
+    menu_items
+GROUP BY 
+    id
+```
+
+### Limitations
+* Currently SCD Type 2 requires an update column to be defined on the table you are sourcing your data from. Soon we will also be supporting checking column values in cases where an update column is not available.
+
 ## EXTERNAL
 The EXTERNAL model kind is used to specify [external models](./external_models.md) that store metadata about external tables. External models are special; they are not specified in .sql files like the other model kinds. They are optional but useful for propagating column and type information for external tables queried in your SQLMesh project.

--- a/examples/sushi/models/customers.sql
+++ b/examples/sushi/models/customers.sql
@@ -8,25 +8,23 @@ MODEL (
 );
 
 CREATE SCHEMA IF NOT EXISTS raw;
-CREATE TABLE IF NOT EXISTS raw.marketing AS (
-  SELECT 1 AS customer_id, 'active' AS status
-);
 CREATE TABLE IF NOT EXISTS raw.demographics AS (
   SELECT 1 AS customer_id, '00000' AS zip
 );
 
-WITH distinct_marketing AS (
-  SELECT DISTINCT
+WITH current_marketing AS (
+  SELECT
     customer_id,
     status
-  FROM raw.marketing
+  FROM sushi.marketing
+  WHERE valid_to is null
 )
 SELECT DISTINCT
   o.customer_id::INT AS customer_id,
-  COALESCE(m.status, 'UNKNOWN') AS status,
+  m.status,
   d.zip
 FROM sushi.orders AS o
-LEFT JOIN distinct_marketing AS m
+LEFT JOIN current_marketing AS m
     ON o.customer_id = m.customer_id
 LEFT JOIN raw.demographics AS d
     ON o.customer_id = d.customer_id

--- a/examples/sushi/models/marketing.sql
+++ b/examples/sushi/models/marketing.sql
@@ -1,0 +1,15 @@
+MODEL (
+  name sushi.marketing,
+  kind SCD_TYPE_2(unique_key customer_id),
+  owner jen,
+  cron '@daily',
+  grain customer_id,
+);
+
+SELECT
+    customer_id::INT AS customer_id,
+    status::TEXT AS status,
+    updated_at::TIMESTAMP AS updated_at
+FROM
+    sushi.raw_marketing
+

--- a/examples/sushi/models/raw_marketing.py
+++ b/examples/sushi/models/raw_marketing.py
@@ -1,0 +1,51 @@
+import random
+import typing as t
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+from helper import iter_dates  # type: ignore
+
+from sqlmesh import ExecutionContext, model
+from sqlmesh.core.model import FullKind
+
+
+@model(
+    "sushi.raw_marketing",
+    description="Table of marketing status.",
+    kind=FullKind(),
+    start="1 week ago",
+    cron="@daily",
+    grains=[
+        "customer_id",
+    ],
+    columns={
+        "customer_id": "int",
+        "status": "text",
+        "updated_at": "timestamp",
+    },
+)
+def execute(
+    context: ExecutionContext,
+    end: datetime,
+    execution_time: datetime,
+    **kwargs: t.Any,
+) -> pd.DataFrame:
+    existing_table = context.table("sushi.raw_marketing")
+    df_existing = context.fetchdf(f"SELECT customer_id, status, updated_at FROM {existing_table}")
+    seed = int(end.strftime("%Y%m%d"))
+    np.random.seed(seed)
+    num_customers = random.randint(30, 100)
+    df_new = pd.DataFrame(
+        {
+            "customer_id": random.sample(range(0, 100), k=num_customers),
+            "status": np.random.choice(["active", "inactive"], size=num_customers, p=[0.8, 0.2]),
+            "updated_at": [execution_time] * num_customers,
+        }
+    )
+    df = df_new.merge(df_existing, on="customer_id", how="left", suffixes=(None, "_old"))
+    df["updated_at"] = np.where(  # type: ignore
+        df["status_old"] != df["status"], execution_time, df["updated_at_old"]
+    )
+    df = df.drop(columns=["status_old", "updated_at_old"])
+    return df

--- a/examples/sushi/schema.yaml
+++ b/examples/sushi/schema.yaml
@@ -1,8 +1,3 @@
-- name: raw.marketing
-  description: Table containing marketing information
-  columns:
-    customer_id: int
-    status: text
 - name: raw.demographics
   description: Table containing demographics information
   columns:

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -337,6 +337,7 @@ def _create_parser(parser_type: t.Type[exp.Expression], table_keys: t.List[str])
                         ModelKindName.INCREMENTAL_BY_UNIQUE_KEY,
                         ModelKindName.SEED,
                         ModelKindName.VIEW,
+                        ModelKindName.SCD_TYPE_2,
                     ) and self._match(TokenType.L_PAREN):
                         self._retreat(index)
                         props = self._parse_wrapped_csv(functools.partial(_parse_props, self))

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -806,7 +806,7 @@ class EngineAdapter:
                     },
                 )
             )
-        start_time = "CAST('1970-01-01 00:00:00' AS TIMESTAMP)"
+        start_time = "CAST('1970-01-01 00:00:00+00:00' AS TIMESTAMP)"
         query = (
             exp.Select()  # type: ignore
             .with_(

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -858,7 +858,7 @@ class EngineAdapter:
             )
             # Get deleted, new, no longer current, or unchanged records
             .with_(
-                "non_updated_rows",
+                "updated_rows",
                 exp.select(
                     *(f"COALESCE(t_{col}, s_{col}) as {col}" for col in unmanaged_columns),
                     f"""
@@ -894,7 +894,7 @@ class EngineAdapter:
             )
             # Get records that have been "updated" which means inserting a new record with previous `valid_from`
             .with_(
-                "updated_rows",
+                "inserted_rows",
                 exp.select(
                     *(f"s_{col} as {col}" for col in unmanaged_columns),
                     f"s_{updated_at_name} as {valid_from_name}",
@@ -908,11 +908,11 @@ class EngineAdapter:
             .select("*")
             .from_("static")
             .union(
-                "SELECT * FROM non_updated_rows",
+                "SELECT * FROM updated_rows",
                 distinct=False,
             )
             .union(
-                "SELECT * FROM updated_rows",
+                "SELECT * FROM inserted_rows",
                 distinct=False,
             )
         )

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -851,7 +851,7 @@ class EngineAdapter:
                 "joined",
                 exp.select(
                     *(f"latest.{col} AS t_{col}" for col in columns_to_types),
-                    *(f"source.{col} as s_{col}" for col in unmanaged_columns),
+                    *(f"source.{col} AS s_{col}" for col in unmanaged_columns),
                 )
                 .from_("latest")
                 .join("source", using=unique_key, join_type="full"),

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -27,7 +27,7 @@ from sqlmesh.core.model.kind import TimeColumn
 from sqlmesh.core.schema_diff import SchemaDiffer
 from sqlmesh.utils import double_escape, optional_import
 from sqlmesh.utils.connection_pool import create_connection_pool
-from sqlmesh.utils.date import TimeLike, make_inclusive
+from sqlmesh.utils.date import TimeLike, make_inclusive, to_ts
 from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.pandas import columns_to_types_from_df
 
@@ -663,6 +663,7 @@ class EngineAdapter:
         ],
         time_column: TimeColumn | exp.Column | str,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        **kwargs: t.Any,
     ) -> None:
         if columns_to_types is None:
             columns_to_types = self.columns(table_name)
@@ -772,6 +773,153 @@ class EngineAdapter:
                 on=on,
                 expressions=match_expressions,
             )
+        )
+
+    def scd_type_2(
+        self,
+        target_table: TableName,
+        source_table: QueryOrDF,
+        unique_key: t.Sequence[str],
+        valid_from_name: str,
+        valid_to_name: str,
+        updated_at_name: str,
+        execution_time: TimeLike,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        **kwargs: t.Any,
+    ) -> None:
+        if columns_to_types is None:
+            columns_to_types = self.columns(target_table)
+        if updated_at_name not in columns_to_types:
+            raise SQLMeshError(
+                f"Column {updated_at_name} not found in {target_table}. Table must contain an `updated_at` timestamp for SCD Type 2"
+            )
+        unmanaged_columns = [
+            col for col in columns_to_types if col not in {valid_from_name, valid_to_name}
+        ]
+        df = self.try_get_pandas_df(source_table)
+        if df is not None:
+            source_table = next(
+                pandas_to_sql(
+                    df,
+                    columns_to_types={
+                        k: v for k, v in columns_to_types.items() if k in unmanaged_columns
+                    },
+                )
+            )
+        start_time = "CAST('1970-01-01 00:00:00' AS TIMESTAMP)"
+        query = (
+            exp.Select()  # type: ignore
+            .with_(
+                "source",
+                exp.select(*unmanaged_columns)
+                .distinct(*unique_key)
+                .from_(source_table.subquery("raw_source")),  # type: ignore
+            )
+            # Historical Records that Do Not Change
+            .with_(
+                "static",
+                exp.Select()
+                .from_(target_table)
+                .select(*columns_to_types)
+                .where(f"{valid_to_name} IS NOT NULL"),
+            )
+            # Latest Records that can be updated
+            .with_(
+                "latest",
+                exp.select(*columns_to_types).from_(target_table).where(f"{valid_to_name} IS NULL"),
+            )
+            # Deleted records which can be used to determine `valid_from` for undeleted source records
+            .with_(
+                "deleted",
+                exp.select(*[f"static.{col}" for col in columns_to_types])
+                .from_("static")
+                .join("latest", using=unique_key, join_type="left")
+                .where(f"latest.{valid_to_name} IS NULL"),
+            )
+            # Get the latest `valid_to` deleted record for each unique key
+            .with_(
+                "latest_deleted",
+                exp.select(
+                    *unique_key,
+                    f"MAX({valid_to_name}) AS {valid_to_name}",
+                )
+                .from_("deleted")
+                .group_by(*unique_key),
+            )
+            # Do a full join between latest records and source table in order to combine them together
+            .with_(
+                "joined",
+                exp.select(
+                    *(f"latest.{col} AS t_{col}" for col in columns_to_types),
+                    *(f"source.{col} as s_{col}" for col in unmanaged_columns),
+                )
+                .from_("latest")
+                .join("source", using=unique_key, join_type="full"),
+            )
+            # Get deleted, new, no longer current, or unchanged records
+            .with_(
+                "non_updated_rows",
+                exp.select(
+                    *(f"COALESCE(t_{col}, s_{col}) as {col}" for col in unmanaged_columns),
+                    f"""
+                    CASE 
+                        WHEN t_{valid_from_name} IS NULL 
+                             AND latest_deleted.{unique_key[0]} IS NOT NULL 
+                        THEN CASE 
+                                WHEN latest_deleted.{valid_to_name} > s_{updated_at_name} 
+                                THEN latest_deleted.{valid_to_name} 
+                                ELSE s_{updated_at_name} 
+                             END 
+                        WHEN t_{valid_from_name} IS NULL 
+                        THEN {start_time} 
+                        ELSE t_{valid_from_name} 
+                    END AS {valid_from_name}""",
+                    f"""
+                    CASE 
+                        WHEN s_{updated_at_name} > t_{updated_at_name} 
+                        THEN s_{updated_at_name} 
+                        WHEN s_{unique_key[0]} IS NULL 
+                        THEN CAST('{to_ts(execution_time)}' AS TIMESTAMP) 
+                        ELSE t_{valid_to_name} 
+                    END AS {valid_to_name}""",
+                )
+                .from_("joined")
+                .join(
+                    "latest_deleted",
+                    on=" AND ".join(
+                        [f"joined.s_{col} = latest_deleted.{col}" for col in unique_key]
+                    ),
+                    join_type="left",
+                ),
+            )
+            # Get records that have been "updated" which means inserting a new record with previous `valid_from`
+            .with_(
+                "updated_rows",
+                exp.select(
+                    *(f"s_{col} as {col}" for col in unmanaged_columns),
+                    f"s_{updated_at_name} as {valid_from_name}",
+                    f"NULL as {valid_to_name}",
+                )
+                .from_("joined")
+                .where(
+                    f"t_{unique_key[0]} IS NOT NULL AND s_{unique_key[0]} IS NOT NULL AND s_{updated_at_name} > t_{updated_at_name}"
+                ),
+            )
+            .select("*")
+            .from_("static")
+            .union(
+                "SELECT * FROM non_updated_rows",
+                distinct=False,
+            )
+            .union(
+                "SELECT * FROM updated_rows",
+                distinct=False,
+            )
+        )
+        self.replace_query(
+            target_table,
+            query,
+            columns_to_types=columns_to_types,
         )
 
     def merge(

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -818,9 +818,8 @@ class EngineAdapter:
             # Historical Records that Do Not Change
             .with_(
                 "static",
-                exp.Select()
+                exp.select(*columns_to_types)
                 .from_(target_table)
-                .select(*columns_to_types)
                 .where(f"{valid_to_name} IS NOT NULL"),
             )
             # Latest Records that can be updated
@@ -886,9 +885,7 @@ class EngineAdapter:
                 .from_("joined")
                 .join(
                     "latest_deleted",
-                    on=" AND ".join(
-                        [f"joined.s_{col} = latest_deleted.{col}" for col in unique_key]
-                    ),
+                    on=" AND ".join(f"joined.s_{col} = latest_deleted.{col}" for col in unique_key),
                     join_type="left",
                 ),
             )

--- a/sqlmesh/core/model/__init__.py
+++ b/sqlmesh/core/model/__init__.py
@@ -21,6 +21,7 @@ from sqlmesh.core.model.kind import (
     ModelKind,
     ModelKindMixin,
     ModelKindName,
+    SCDType2Kind,
     SeedKind,
     TimeColumn,
     ViewKind,

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -380,7 +380,16 @@ class _Model(ModelMeta, frozen=True):
         for select in query.find_all(exp.Select):
             if select.args.get("from"):
                 select.where(exp.false(), copy=False)
-
+        if self.managed_columns:
+            query.select(
+                *[
+                    exp.alias_(exp.cast(exp.Null(), to=col_type), col)
+                    for col, col_type in self.managed_columns.items()
+                    if col not in query.named_selects
+                ],
+                append=True,
+                copy=False,
+            )
         return query
 
     def referenced_audits(self, audits: t.Dict[str, Audit]) -> t.List[Audit]:
@@ -517,7 +526,9 @@ class _Model(ModelMeta, frozen=True):
     @property
     def columns_to_types(self) -> t.Optional[t.Dict[str, exp.DataType]]:
         """Returns the mapping of column names to types of this model."""
-        return self.columns_to_types_
+        if self.columns_to_types_ is None:
+            return None
+        return {**self.columns_to_types_, **self.managed_columns}
 
     @property
     def columns_to_types_or_raise(self) -> t.Dict[str, exp.DataType]:
@@ -530,8 +541,12 @@ class _Model(ModelMeta, frozen=True):
     @property
     def annotated(self) -> bool:
         """Checks if all column projection types of this model are known."""
-        columns_to_types = self.columns_to_types
-        if columns_to_types is None:
+        if self.columns_to_types is None:
+            return False
+        columns_to_types = {
+            k: v for k, v in self.columns_to_types.items() if k not in self.managed_columns
+        }
+        if not columns_to_types:
             return False
         return all(
             column_type.this != exp.DataType.Type.UNKNOWN
@@ -976,9 +991,8 @@ class SqlModel(_SqlBasedModel):
     @property
     def columns_to_types(self) -> t.Optional[t.Dict[str, exp.DataType]]:
         if self.columns_to_types_ is not None:
-            return self.columns_to_types_
-
-        if self._columns_to_types is None:
+            self._columns_to_types = self.columns_to_types_
+        elif self._columns_to_types is None:
             query = self._query_renderer.render()
             if query is None:
                 return None
@@ -986,7 +1000,8 @@ class SqlModel(_SqlBasedModel):
 
         if "*" in self._columns_to_types:
             return None
-        return self._columns_to_types
+
+        return {**self._columns_to_types, **self.managed_columns}
 
     @property
     def column_descriptions(self) -> t.Dict[str, str]:

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1660,8 +1660,9 @@ def create_python_model(
         depends_on: The custom set of model's upstream dependencies.
     """
     # Find dependencies for python models by parsing code if they are not explicitly defined
+    # Also remove self-references that are found
     depends_on = (
-        _parse_depends_on(entrypoint, python_env)
+        _parse_depends_on(entrypoint, python_env) - {name}
         if depends_on is None and python_env is not None
         else None
     )

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -101,10 +101,10 @@ class ModelKindName(str, ModelKindMixin, Enum):
 
 def _unique_key_validator(v: t.Any) -> t.List[str]:
     if isinstance(v, exp.Identifier):
-        return [v.this]
+        return [v.name]
     if isinstance(v, exp.Tuple):
-        return [e.this for e in v.expressions]
-    return [i.this if isinstance(i, exp.Identifier) else str(i) for i in v]
+        return [e.name for e in v.expressions]
+    return [i.name if isinstance(i, exp.Identifier) else str(i) for i in v]
 
 
 unique_key_validator = field_validator("unique_key", mode="before")(_unique_key_validator)
@@ -299,7 +299,7 @@ class SCDType2Kind(_ModelKind):
     _unique_key_validator = unique_key_validator
 
     @property
-    def _managed_columns(self) -> t.Dict[str, exp.DataType]:
+    def managed_columns(self) -> t.Dict[str, exp.DataType]:
         return {
             self.valid_from_name: exp.DataType.build("TIMESTAMP"),
             self.valid_to_name: exp.DataType.build("TIMESTAMP"),

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -372,4 +372,4 @@ class ModelMeta(Node, extra="allow"):
 
     @property
     def managed_columns(self) -> t.Dict[str, exp.DataType]:
-        return getattr(self.kind, "_managed_columns", {})
+        return getattr(self.kind, "managed_columns", {})

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -11,6 +11,7 @@ from sqlmesh.core import dialect as d
 from sqlmesh.core.model.kind import (
     IncrementalByUniqueKeyKind,
     ModelKind,
+    SCDType2Kind,
     TimeColumn,
     ViewKind,
     _Incremental,
@@ -315,7 +316,7 @@ class ModelMeta(Node, extra="allow"):
 
     @property
     def unique_key(self) -> t.List[str]:
-        if isinstance(self.kind, IncrementalByUniqueKeyKind):
+        if isinstance(self.kind, (IncrementalByUniqueKeyKind, SCDType2Kind)):
             return self.kind.unique_key
         return []
 
@@ -368,3 +369,7 @@ class ModelMeta(Node, extra="allow"):
     @property
     def _partition_by_columns(self) -> t.List[exp.Column]:
         return [col for expr in self.partitioned_by_ for col in expr.find_all(exp.Column)]
+
+    @property
+    def managed_columns(self) -> t.Dict[str, exp.DataType]:
+        return getattr(self.kind, "_managed_columns", {})

--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -216,6 +216,7 @@ def to_ds(obj: TimeLike) -> str:
 
 
 def to_ts(obj: TimeLike) -> str:
+    """Converts a TimeLike object into YYYY-MM-DD HH:MM:SS formatted string."""
     return to_datetime(obj).isoformat()
 
 

--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -212,7 +212,11 @@ def date_dict(
 
 def to_ds(obj: TimeLike) -> str:
     """Converts a TimeLike object into YYYY-MM-DD formatted string."""
-    return to_datetime(obj).isoformat()[0:10]
+    return to_ts(obj)[0:10]
+
+
+def to_ts(obj: TimeLike) -> str:
+    return to_datetime(obj).isoformat()
 
 
 def is_date(obj: TimeLike) -> bool:
@@ -276,4 +280,4 @@ def time_like_to_str(time_like: TimeLike) -> str:
         return time_like
     if is_date(time_like):
         return to_ds(time_like)
-    return to_datetime(time_like).isoformat()
+    return to_ts(time_like)

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -711,7 +711,7 @@ def test_scd_type_2(make_mocked_engine_adapter: t.Callable):
     adapter.scd_type_2(
         target_table="target",
         source_table=t.cast(
-            exp.Select, parse_one("SELECT id, name, price, updated_at FROM source")
+            exp.Select, parse_one("SELECT id, name, price, test_updated_at FROM source")
         ),
         unique_key=["id"],
         valid_from_name="test_valid_from",
@@ -742,7 +742,7 @@ WITH "source" AS (
       "id",
       "name",
       "price",
-      "updated_at"
+      "test_updated_at"
     FROM "source"
   ) AS "raw_source"
 ), "static" AS (
@@ -794,7 +794,7 @@ WITH "source" AS (
   FROM "latest"
   FULL JOIN "source"
     USING ("id")
-), "non_updated_rows" AS (
+), "updated_rows" AS (
   SELECT
     COALESCE("t_id", "s_id") AS "id",
     COALESCE("t_name", "s_name") AS "name",
@@ -808,20 +808,20 @@ WITH "source" AS (
         ELSE "s_test_updated_at"
       END
       WHEN "t_test_valid_from" IS NULL
-      THEN CAST(\'1970-01-01 00:00:00\' AS TIMESTAMP)
+      THEN CAST('1970-01-01 00:00:00' AS TIMESTAMP)
       ELSE "t_test_valid_from"
     END AS "test_valid_from",
     CASE
       WHEN "s_test_updated_at" > "t_test_updated_at"
       THEN "s_test_updated_at"
       WHEN "s_id" IS NULL
-      THEN CAST(\'2020-01-01T00:00:00+00:00\' AS TIMESTAMP)
+      THEN CAST('2020-01-01T00:00:00+00:00' AS TIMESTAMP)
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
   FROM "joined"
   LEFT JOIN "latest_deleted"
     ON "joined"."s_id" = "latest_deleted"."id"
-), "updated_rows" AS (
+), "inserted_rows" AS (
   SELECT
     "s_id" AS "id",
     "s_name" AS "name",
@@ -839,11 +839,11 @@ FROM "static"
 UNION ALL
 SELECT
   *
-FROM "non_updated_rows"
+FROM "updated_rows"
 UNION ALL
 SELECT
   *
-FROM "updated_rows"
+FROM "inserted_rows"
     """
         ).sql()
     )
@@ -898,9 +898,9 @@ WITH "source" AS (
       CAST("price" AS DOUBLE) AS "price",
       CAST("test_updated_at" AS TIMESTAMP) AS "test_updated_at"
     FROM (VALUES
-      (1, 4, \'muffins\', 4.0, \'2020-01-01 10:00:00\'),
-      (2, 5, \'chips\', 5.0, \'2020-01-02 15:00:00\'),
-      (3, 6, \'soda\', 6.0, \'2020-01-03 12:00:00\')) AS "t"("id1", "id2", "name", "price", "test_updated_at")
+      (1, 4, 'muffins', 4.0, '2020-01-01 10:00:00'),
+      (2, 5, 'chips', 5.0, '2020-01-02 15:00:00'),
+      (3, 6, 'soda', 6.0, '2020-01-03 12:00:00')) AS "t"("id1", "id2", "name", "price", "test_updated_at")
   ) AS "raw_source"
 ), "static" AS (
   SELECT
@@ -971,14 +971,14 @@ WITH "source" AS (
         ELSE "s_test_updated_at"
       END
       WHEN "t_test_valid_from" IS NULL
-      THEN CAST(\'1970-01-01 00:00:00\' AS TIMESTAMP)
+      THEN CAST('1970-01-01 00:00:00' AS TIMESTAMP)
       ELSE "t_test_valid_from"
     END AS "test_valid_from",
     CASE
       WHEN "s_test_updated_at" > "t_test_updated_at"
       THEN "s_test_updated_at"
       WHEN "s_id" IS NULL
-      THEN CAST(\'2020-01-01T00:00:00+00:00\' AS TIMESTAMP)
+      THEN CAST('2020-01-01T00:00:00+00:00' AS TIMESTAMP)
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
   FROM "joined"

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -725,8 +725,127 @@ def test_scd_type_2(make_mocked_engine_adapter: t.Callable):
         },
         execution_time=datetime(2020, 1, 1, 0, 0, 0),
     )
-    adapter.cursor.execute.assert_called_once_with(
-        '''CREATE OR REPLACE TABLE "target" AS WITH "source" AS (SELECT DISTINCT ON ("id") "id", "name", "price", "test_updated_at" FROM (SELECT "id", "name", "price", "updated_at" FROM "source") AS "raw_source"), "static" AS (SELECT "id", "name", "price", "test_updated_at" FROM "target" WHERE NOT "test_valid_to" IS NULL), "latest" AS (SELECT "id", "name", "price", "test_updated_at" FROM "target" WHERE "test_valid_to" IS NULL), "deleted" AS (SELECT "static"."id", "static"."name", "static"."price", "static"."test_updated_at" FROM "static" LEFT JOIN "latest" USING ("id") WHERE "latest"."test_valid_to" IS NULL), "latest_deleted" AS (SELECT "id", MAX("test_valid_to") AS "test_valid_to" FROM "deleted" GROUP BY "id"), "joined" AS (SELECT "latest"."id" AS "t_id", "latest"."name" AS "t_name", "latest"."price" AS "t_price", "latest"."test_updated_at" AS "t_test_updated_at", "source"."id" AS "s_id", "source"."name" AS "s_name", "source"."price" AS "s_price", "source"."test_updated_at" AS "s_test_updated_at" FROM "latest" FULL JOIN "source" USING ("id")), "non_updated_rows" AS (SELECT COALESCE("t_id", "s_id") AS "id", COALESCE("t_name", "s_name") AS "name", COALESCE("t_price", "s_price") AS "price", COALESCE("t_test_updated_at", "s_test_updated_at") AS "test_updated_at", CASE WHEN "t_test_valid_from" IS NULL AND NOT "latest_deleted"."id" IS NULL THEN CASE WHEN "latest_deleted"."test_valid_to" > "s_test_updated_at" THEN "latest_deleted"."test_valid_to" ELSE "s_test_updated_at" END WHEN "t_test_valid_from" IS NULL THEN CAST(\'1970-01-01 00:00:00\' AS TIMESTAMP) ELSE "t_test_valid_from" END AS "test_valid_from", CASE WHEN "s_test_updated_at" > "t_test_updated_at" THEN "s_test_updated_at" WHEN "s_id" IS NULL THEN CAST(\'2020-01-01T00:00:00+00:00\' AS TIMESTAMP) ELSE "t_test_valid_to" END AS "test_valid_to" FROM "joined" LEFT JOIN "latest_deleted" ON "joined"."s_id" = "latest_deleted"."id"), "updated_rows" AS (SELECT "s_id" AS "id", "s_name" AS "name", "s_price" AS "price", "s_test_updated_at" AS "test_updated_at", "s_test_updated_at" AS "test_valid_from", NULL AS "test_valid_to" FROM "joined" WHERE NOT "t_id" IS NULL AND NOT "s_id" IS NULL AND "s_test_updated_at" > "t_test_updated_at") SELECT * FROM "static" UNION ALL SELECT * FROM "non_updated_rows" UNION ALL SELECT * FROM "updated_rows"'''
+
+    assert (
+        adapter.cursor.execute.call_args[0][0]
+        == parse_one(
+            """
+CREATE OR REPLACE TABLE "target" AS
+WITH "source" AS (
+  SELECT DISTINCT ON ("id")
+    "id",
+    "name",
+    "price",
+    "test_updated_at"
+  FROM (
+    SELECT
+      "id",
+      "name",
+      "price",
+      "updated_at"
+    FROM "source"
+  ) AS "raw_source"
+), "static" AS (
+  SELECT
+    "id",
+    "name",
+    "price",
+    "test_updated_at"
+  FROM "target"
+  WHERE
+    NOT "test_valid_to" IS NULL
+), "latest" AS (
+  SELECT
+    "id",
+    "name",
+    "price",
+    "test_updated_at"
+  FROM "target"
+  WHERE
+    "test_valid_to" IS NULL
+), "deleted" AS (
+  SELECT
+    "static"."id",
+    "static"."name",
+    "static"."price",
+    "static"."test_updated_at"
+  FROM "static"
+  LEFT JOIN "latest"
+    USING ("id")
+  WHERE
+    "latest"."test_valid_to" IS NULL
+), "latest_deleted" AS (
+  SELECT
+    "id",
+    MAX("test_valid_to") AS "test_valid_to"
+  FROM "deleted"
+  GROUP BY
+    "id"
+), "joined" AS (
+  SELECT
+    "latest"."id" AS "t_id",
+    "latest"."name" AS "t_name",
+    "latest"."price" AS "t_price",
+    "latest"."test_updated_at" AS "t_test_updated_at",
+    "source"."id" AS "s_id",
+    "source"."name" AS "s_name",
+    "source"."price" AS "s_price",
+    "source"."test_updated_at" AS "s_test_updated_at"
+  FROM "latest"
+  FULL JOIN "source"
+    USING ("id")
+), "non_updated_rows" AS (
+  SELECT
+    COALESCE("t_id", "s_id") AS "id",
+    COALESCE("t_name", "s_name") AS "name",
+    COALESCE("t_price", "s_price") AS "price",
+    COALESCE("t_test_updated_at", "s_test_updated_at") AS "test_updated_at",
+    CASE
+      WHEN "t_test_valid_from" IS NULL AND NOT "latest_deleted"."id" IS NULL
+      THEN CASE
+        WHEN "latest_deleted"."test_valid_to" > "s_test_updated_at"
+        THEN "latest_deleted"."test_valid_to"
+        ELSE "s_test_updated_at"
+      END
+      WHEN "t_test_valid_from" IS NULL
+      THEN CAST(\'1970-01-01 00:00:00\' AS TIMESTAMP)
+      ELSE "t_test_valid_from"
+    END AS "test_valid_from",
+    CASE
+      WHEN "s_test_updated_at" > "t_test_updated_at"
+      THEN "s_test_updated_at"
+      WHEN "s_id" IS NULL
+      THEN CAST(\'2020-01-01T00:00:00+00:00\' AS TIMESTAMP)
+      ELSE "t_test_valid_to"
+    END AS "test_valid_to"
+  FROM "joined"
+  LEFT JOIN "latest_deleted"
+    ON "joined"."s_id" = "latest_deleted"."id"
+), "updated_rows" AS (
+  SELECT
+    "s_id" AS "id",
+    "s_name" AS "name",
+    "s_price" AS "price",
+    "s_test_updated_at" AS "test_updated_at",
+    "s_test_updated_at" AS "test_valid_from",
+    NULL AS "test_valid_to"
+  FROM "joined"
+  WHERE
+    NOT "t_id" IS NULL AND NOT "s_id" IS NULL AND "s_test_updated_at" > "t_test_updated_at"
+)
+SELECT
+  *
+FROM "static"
+UNION ALL
+SELECT
+  *
+FROM "non_updated_rows"
+UNION ALL
+SELECT
+  *
+FROM "updated_rows"
+    """
+        ).sql()
     )
 
 
@@ -758,8 +877,139 @@ def test_merge_scd_type_2_pandas(make_mocked_engine_adapter: t.Callable):
         },
         execution_time=datetime(2020, 1, 1, 0, 0, 0),
     )
-    adapter.cursor.execute.assert_called_once_with(
-        '''CREATE OR REPLACE TABLE "target" AS WITH "source" AS (SELECT DISTINCT ON ("id") "id1", "id2", "name", "price", "test_updated_at" FROM (SELECT CAST("id1" AS INT) AS "id1", CAST("id2" AS INT) AS "id2", CAST("name" AS VARCHAR) AS "name", CAST("price" AS DOUBLE) AS "price", CAST("test_updated_at" AS TIMESTAMP) AS "test_updated_at" FROM (VALUES (1, 4, \'muffins\', 4.0, \'2020-01-01 10:00:00\'), (2, 5, \'chips\', 5.0, \'2020-01-02 15:00:00\'), (3, 6, \'soda\', 6.0, \'2020-01-03 12:00:00\')) AS "t"("id1", "id2", "name", "price", "test_updated_at")) AS "raw_source"), "static" AS (SELECT "id1", "id2", "name", "price", "test_updated_at" FROM "target" WHERE NOT "test_valid_to" IS NULL), "latest" AS (SELECT "id1", "id2", "name", "price", "test_updated_at" FROM "target" WHERE "test_valid_to" IS NULL), "deleted" AS (SELECT "static"."id1", "static"."id2", "static"."name", "static"."price", "static"."test_updated_at" FROM "static" LEFT JOIN "latest" USING ("id") WHERE "latest"."test_valid_to" IS NULL), "latest_deleted" AS (SELECT "id", MAX("test_valid_to") AS "test_valid_to" FROM "deleted" GROUP BY "id"), "joined" AS (SELECT "latest"."id1" AS "t_id1", "latest"."id2" AS "t_id2", "latest"."name" AS "t_name", "latest"."price" AS "t_price", "latest"."test_updated_at" AS "t_test_updated_at", "source"."id1" AS "s_id1", "source"."id2" AS "s_id2", "source"."name" AS "s_name", "source"."price" AS "s_price", "source"."test_updated_at" AS "s_test_updated_at" FROM "latest" FULL JOIN "source" USING ("id")), "non_updated_rows" AS (SELECT COALESCE("t_id1", "s_id1") AS "id1", COALESCE("t_id2", "s_id2") AS "id2", COALESCE("t_name", "s_name") AS "name", COALESCE("t_price", "s_price") AS "price", COALESCE("t_test_updated_at", "s_test_updated_at") AS "test_updated_at", CASE WHEN "t_test_valid_from" IS NULL AND NOT "latest_deleted"."id" IS NULL THEN CASE WHEN "latest_deleted"."test_valid_to" > "s_test_updated_at" THEN "latest_deleted"."test_valid_to" ELSE "s_test_updated_at" END WHEN "t_test_valid_from" IS NULL THEN CAST(\'1970-01-01 00:00:00\' AS TIMESTAMP) ELSE "t_test_valid_from" END AS "test_valid_from", CASE WHEN "s_test_updated_at" > "t_test_updated_at" THEN "s_test_updated_at" WHEN "s_id" IS NULL THEN CAST(\'2020-01-01T00:00:00+00:00\' AS TIMESTAMP) ELSE "t_test_valid_to" END AS "test_valid_to" FROM "joined" LEFT JOIN "latest_deleted" ON "joined"."s_id" = "latest_deleted"."id"), "updated_rows" AS (SELECT "s_id1" AS "id1", "s_id2" AS "id2", "s_name" AS "name", "s_price" AS "price", "s_test_updated_at" AS "test_updated_at", "s_test_updated_at" AS "test_valid_from", NULL AS "test_valid_to" FROM "joined" WHERE NOT "t_id" IS NULL AND NOT "s_id" IS NULL AND "s_test_updated_at" > "t_test_updated_at") SELECT * FROM "static" UNION ALL SELECT * FROM "non_updated_rows" UNION ALL SELECT * FROM "updated_rows"'''
+
+    assert (
+        adapter.cursor.execute.call_args[0][0]
+        == parse_one(
+            """
+CREATE OR REPLACE TABLE "target" AS
+WITH "source" AS (
+  SELECT DISTINCT ON ("id")
+    "id1",
+    "id2",
+    "name",
+    "price",
+    "test_updated_at"
+  FROM (
+    SELECT
+      CAST("id1" AS INT) AS "id1",
+      CAST("id2" AS INT) AS "id2",
+      CAST("name" AS VARCHAR) AS "name",
+      CAST("price" AS DOUBLE) AS "price",
+      CAST("test_updated_at" AS TIMESTAMP) AS "test_updated_at"
+    FROM (VALUES
+      (1, 4, \'muffins\', 4.0, \'2020-01-01 10:00:00\'),
+      (2, 5, \'chips\', 5.0, \'2020-01-02 15:00:00\'),
+      (3, 6, \'soda\', 6.0, \'2020-01-03 12:00:00\')) AS "t"("id1", "id2", "name", "price", "test_updated_at")
+  ) AS "raw_source"
+), "static" AS (
+  SELECT
+    "id1",
+    "id2",
+    "name",
+    "price",
+    "test_updated_at"
+  FROM "target"
+  WHERE
+    NOT "test_valid_to" IS NULL
+), "latest" AS (
+  SELECT
+    "id1",
+    "id2",
+    "name",
+    "price",
+    "test_updated_at"
+  FROM "target"
+  WHERE
+    "test_valid_to" IS NULL
+), "deleted" AS (
+  SELECT
+    "static"."id1",
+    "static"."id2",
+    "static"."name",
+    "static"."price",
+    "static"."test_updated_at"
+  FROM "static"
+  LEFT JOIN "latest"
+    USING ("id")
+  WHERE
+    "latest"."test_valid_to" IS NULL
+), "latest_deleted" AS (
+  SELECT
+    "id",
+    MAX("test_valid_to") AS "test_valid_to"
+  FROM "deleted"
+  GROUP BY
+    "id"
+), "joined" AS (
+  SELECT
+    "latest"."id1" AS "t_id1",
+    "latest"."id2" AS "t_id2",
+    "latest"."name" AS "t_name",
+    "latest"."price" AS "t_price",
+    "latest"."test_updated_at" AS "t_test_updated_at",
+    "source"."id1" AS "s_id1",
+    "source"."id2" AS "s_id2",
+    "source"."name" AS "s_name",
+    "source"."price" AS "s_price",
+    "source"."test_updated_at" AS "s_test_updated_at"
+  FROM "latest"
+  FULL JOIN "source"
+    USING ("id")
+), "non_updated_rows" AS (
+  SELECT
+    COALESCE("t_id1", "s_id1") AS "id1",
+    COALESCE("t_id2", "s_id2") AS "id2",
+    COALESCE("t_name", "s_name") AS "name",
+    COALESCE("t_price", "s_price") AS "price",
+    COALESCE("t_test_updated_at", "s_test_updated_at") AS "test_updated_at",
+    CASE
+      WHEN "t_test_valid_from" IS NULL AND NOT "latest_deleted"."id" IS NULL
+      THEN CASE
+        WHEN "latest_deleted"."test_valid_to" > "s_test_updated_at"
+        THEN "latest_deleted"."test_valid_to"
+        ELSE "s_test_updated_at"
+      END
+      WHEN "t_test_valid_from" IS NULL
+      THEN CAST(\'1970-01-01 00:00:00\' AS TIMESTAMP)
+      ELSE "t_test_valid_from"
+    END AS "test_valid_from",
+    CASE
+      WHEN "s_test_updated_at" > "t_test_updated_at"
+      THEN "s_test_updated_at"
+      WHEN "s_id" IS NULL
+      THEN CAST(\'2020-01-01T00:00:00+00:00\' AS TIMESTAMP)
+      ELSE "t_test_valid_to"
+    END AS "test_valid_to"
+  FROM "joined"
+  LEFT JOIN "latest_deleted"
+    ON "joined"."s_id" = "latest_deleted"."id"
+), "updated_rows" AS (
+  SELECT
+    "s_id1" AS "id1",
+    "s_id2" AS "id2",
+    "s_name" AS "name",
+    "s_price" AS "price",
+    "s_test_updated_at" AS "test_updated_at",
+    "s_test_updated_at" AS "test_valid_from",
+    NULL AS "test_valid_to"
+  FROM "joined"
+  WHERE
+    NOT "t_id" IS NULL AND NOT "s_id" IS NULL AND "s_test_updated_at" > "t_test_updated_at"
+)
+SELECT
+  *
+FROM "static"
+UNION ALL
+SELECT
+  *
+FROM "non_updated_rows"
+UNION ALL
+SELECT
+  *
+FROM "updated_rows"
+"""
+        ).sql()
     )
 
 

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -1,5 +1,6 @@
 # type: ignore
 import typing as t
+from datetime import datetime
 from unittest.mock import call
 
 import pandas as pd
@@ -629,7 +630,7 @@ def test_alter_table(
     adapter.cursor.execute.assert_has_calls([call(x) for x in expected])
 
 
-def test_merge(make_mocked_engine_adapter: t.Callable):
+def test_merge_upsert(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(EngineAdapter)
 
     adapter.merge(
@@ -666,7 +667,7 @@ def test_merge(make_mocked_engine_adapter: t.Callable):
     )
 
 
-def test_merge_pandas(make_mocked_engine_adapter: t.Callable):
+def test_merge_upsert_pandas(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(EngineAdapter)
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
@@ -701,6 +702,64 @@ def test_merge_pandas(make_mocked_engine_adapter: t.Callable):
         'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT CAST("id" AS INT) AS "id", CAST("ts" AS TIMESTAMP) AS "ts", CAST("val" AS INT) AS "val" FROM (VALUES (1, 4), (2, 5), (3, 6)) AS "t"("id", "ts", "val")) AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" AND "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts" '
         'WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" '
         'WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val")'
+    )
+
+
+def test_scd_type_2(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+
+    adapter.scd_type_2(
+        target_table="target",
+        source_table=t.cast(
+            exp.Select, parse_one("SELECT id, name, price, updated_at FROM source")
+        ),
+        unique_key=["id"],
+        valid_from_name="test_valid_from",
+        valid_to_name="test_valid_to",
+        updated_at_name="test_updated_at",
+        columns_to_types={
+            "id": exp.DataType.Type.INT,
+            "name": exp.DataType.Type.VARCHAR,
+            "price": exp.DataType.Type.DOUBLE,
+            "test_updated_at": exp.DataType.Type.TIMESTAMP,
+        },
+        execution_time=datetime(2020, 1, 1, 0, 0, 0),
+    )
+    adapter.cursor.execute.assert_called_once_with(
+        '''CREATE OR REPLACE TABLE "target" AS WITH "source" AS (SELECT DISTINCT ON ("id") "id", "name", "price", "test_updated_at" FROM (SELECT "id", "name", "price", "updated_at" FROM "source") AS "raw_source"), "static" AS (SELECT "id", "name", "price", "test_updated_at" FROM "target" WHERE NOT "test_valid_to" IS NULL), "latest" AS (SELECT "id", "name", "price", "test_updated_at" FROM "target" WHERE "test_valid_to" IS NULL), "deleted" AS (SELECT "static"."id", "static"."name", "static"."price", "static"."test_updated_at" FROM "static" LEFT JOIN "latest" USING ("id") WHERE "latest"."test_valid_to" IS NULL), "latest_deleted" AS (SELECT "id", MAX("test_valid_to") AS "test_valid_to" FROM "deleted" GROUP BY "id"), "joined" AS (SELECT "latest"."id" AS "t_id", "latest"."name" AS "t_name", "latest"."price" AS "t_price", "latest"."test_updated_at" AS "t_test_updated_at", "source"."id" AS "s_id", "source"."name" AS "s_name", "source"."price" AS "s_price", "source"."test_updated_at" AS "s_test_updated_at" FROM "latest" FULL JOIN "source" USING ("id")), "non_updated_rows" AS (SELECT COALESCE("t_id", "s_id") AS "id", COALESCE("t_name", "s_name") AS "name", COALESCE("t_price", "s_price") AS "price", COALESCE("t_test_updated_at", "s_test_updated_at") AS "test_updated_at", CASE WHEN "t_test_valid_from" IS NULL AND NOT "latest_deleted"."id" IS NULL THEN CASE WHEN "latest_deleted"."test_valid_to" > "s_test_updated_at" THEN "latest_deleted"."test_valid_to" ELSE "s_test_updated_at" END WHEN "t_test_valid_from" IS NULL THEN CAST(\'1970-01-01 00:00:00\' AS TIMESTAMP) ELSE "t_test_valid_from" END AS "test_valid_from", CASE WHEN "s_test_updated_at" > "t_test_updated_at" THEN "s_test_updated_at" WHEN "s_id" IS NULL THEN CAST(\'2020-01-01T00:00:00+00:00\' AS TIMESTAMP) ELSE "t_test_valid_to" END AS "test_valid_to" FROM "joined" LEFT JOIN "latest_deleted" ON "joined"."s_id" = "latest_deleted"."id"), "updated_rows" AS (SELECT "s_id" AS "id", "s_name" AS "name", "s_price" AS "price", "s_test_updated_at" AS "test_updated_at", "s_test_updated_at" AS "test_valid_from", NULL AS "test_valid_to" FROM "joined" WHERE NOT "t_id" IS NULL AND NOT "s_id" IS NULL AND "s_test_updated_at" > "t_test_updated_at") SELECT * FROM "static" UNION ALL SELECT * FROM "non_updated_rows" UNION ALL SELECT * FROM "updated_rows"'''
+    )
+
+
+def test_merge_scd_type_2_pandas(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+
+    df = pd.DataFrame(
+        {
+            "id1": [1, 2, 3],
+            "id2": [4, 5, 6],
+            "name": ["muffins", "chips", "soda"],
+            "price": [4.0, 5.0, 6.0],
+            "updated_at": ["2020-01-01 10:00:00", "2020-01-02 15:00:00", "2020-01-03 12:00:00"],
+        }
+    )
+    adapter.scd_type_2(
+        target_table="target",
+        source_table=df,
+        unique_key=["id"],
+        valid_from_name="test_valid_from",
+        valid_to_name="test_valid_to",
+        updated_at_name="test_updated_at",
+        columns_to_types={
+            "id1": exp.DataType.Type.INT,
+            "id2": exp.DataType.Type.INT,
+            "name": exp.DataType.Type.VARCHAR,
+            "price": exp.DataType.Type.DOUBLE,
+            "test_updated_at": exp.DataType.Type.TIMESTAMP,
+        },
+        execution_time=datetime(2020, 1, 1, 0, 0, 0),
+    )
+    adapter.cursor.execute.assert_called_once_with(
+        '''CREATE OR REPLACE TABLE "target" AS WITH "source" AS (SELECT DISTINCT ON ("id") "id1", "id2", "name", "price", "test_updated_at" FROM (SELECT CAST("id1" AS INT) AS "id1", CAST("id2" AS INT) AS "id2", CAST("name" AS VARCHAR) AS "name", CAST("price" AS DOUBLE) AS "price", CAST("test_updated_at" AS TIMESTAMP) AS "test_updated_at" FROM (VALUES (1, 4, \'muffins\', 4.0, \'2020-01-01 10:00:00\'), (2, 5, \'chips\', 5.0, \'2020-01-02 15:00:00\'), (3, 6, \'soda\', 6.0, \'2020-01-03 12:00:00\')) AS "t"("id1", "id2", "name", "price", "test_updated_at")) AS "raw_source"), "static" AS (SELECT "id1", "id2", "name", "price", "test_updated_at" FROM "target" WHERE NOT "test_valid_to" IS NULL), "latest" AS (SELECT "id1", "id2", "name", "price", "test_updated_at" FROM "target" WHERE "test_valid_to" IS NULL), "deleted" AS (SELECT "static"."id1", "static"."id2", "static"."name", "static"."price", "static"."test_updated_at" FROM "static" LEFT JOIN "latest" USING ("id") WHERE "latest"."test_valid_to" IS NULL), "latest_deleted" AS (SELECT "id", MAX("test_valid_to") AS "test_valid_to" FROM "deleted" GROUP BY "id"), "joined" AS (SELECT "latest"."id1" AS "t_id1", "latest"."id2" AS "t_id2", "latest"."name" AS "t_name", "latest"."price" AS "t_price", "latest"."test_updated_at" AS "t_test_updated_at", "source"."id1" AS "s_id1", "source"."id2" AS "s_id2", "source"."name" AS "s_name", "source"."price" AS "s_price", "source"."test_updated_at" AS "s_test_updated_at" FROM "latest" FULL JOIN "source" USING ("id")), "non_updated_rows" AS (SELECT COALESCE("t_id1", "s_id1") AS "id1", COALESCE("t_id2", "s_id2") AS "id2", COALESCE("t_name", "s_name") AS "name", COALESCE("t_price", "s_price") AS "price", COALESCE("t_test_updated_at", "s_test_updated_at") AS "test_updated_at", CASE WHEN "t_test_valid_from" IS NULL AND NOT "latest_deleted"."id" IS NULL THEN CASE WHEN "latest_deleted"."test_valid_to" > "s_test_updated_at" THEN "latest_deleted"."test_valid_to" ELSE "s_test_updated_at" END WHEN "t_test_valid_from" IS NULL THEN CAST(\'1970-01-01 00:00:00\' AS TIMESTAMP) ELSE "t_test_valid_from" END AS "test_valid_from", CASE WHEN "s_test_updated_at" > "t_test_updated_at" THEN "s_test_updated_at" WHEN "s_id" IS NULL THEN CAST(\'2020-01-01T00:00:00+00:00\' AS TIMESTAMP) ELSE "t_test_valid_to" END AS "test_valid_to" FROM "joined" LEFT JOIN "latest_deleted" ON "joined"."s_id" = "latest_deleted"."id"), "updated_rows" AS (SELECT "s_id1" AS "id1", "s_id2" AS "id2", "s_name" AS "name", "s_price" AS "price", "s_test_updated_at" AS "test_updated_at", "s_test_updated_at" AS "test_valid_from", NULL AS "test_valid_to" FROM "joined" WHERE NOT "t_id" IS NULL AND NOT "s_id" IS NULL AND "s_test_updated_at" > "t_test_updated_at") SELECT * FROM "static" UNION ALL SELECT * FROM "non_updated_rows" UNION ALL SELECT * FROM "updated_rows"'''
     )
 
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -410,7 +410,8 @@ def test_janitor(sushi_context, mocker: MockerFixture) -> None:
     ]
     # Assert that the views are dropped for each snapshot just once and make sure that the name used is the
     # view name with the environment as a suffix
-    assert adapter_mock.drop_view.call_count == 13
+    # TODO: It appears we try to drop views for external models which shouldn't hurt but we should fix this
+    assert adapter_mock.drop_view.call_count == 14
     adapter_mock.drop_view.assert_has_calls(
         [
             call("raw.demographics__test_environment", ignore_if_not_exists=True),

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -759,7 +759,7 @@ def test_environment_suffix_target_table(mocker: MockerFixture):
     assert set(metadata.schemas) - starting_schemas == set()
     prod_views = {x for x in metadata.qualified_views if x.db in environments_schemas}
     # Make sure that all models are present
-    assert len(prod_views) == 10
+    assert len(prod_views) == 12
     apply_to_environment(context, "dev")
     # Make sure no new schemas are created
     assert set(metadata.schemas) - starting_schemas == set()
@@ -811,29 +811,27 @@ def test_ignored_snapshots(sushi_context: Context):
 @pytest.mark.integration
 @pytest.mark.core_integration
 def test_scd_type_2(tmp_path: pathlib.Path):
-    def create_source_dataframe(values: t.List[t.Tuple[int, int, str, str]]) -> pd.DataFrame:
+    def create_source_dataframe(values: t.List[t.Tuple[int, str, str]]) -> pd.DataFrame:
         return pd.DataFrame(
             np.array(
                 values,
                 [
-                    ("id1", "int32"),
-                    ("id2", "int32"),
-                    ("name", "object"),
+                    ("customer_id", "int32"),
+                    ("status", "object"),
                     ("updated_at", "datetime64[ns]"),
                 ],
             ),
         )
 
     def create_target_dataframe(
-        values: t.List[t.Tuple[int, int, str, str, str, t.Optional[str]]]
+        values: t.List[t.Tuple[int, str, str, str, t.Optional[str]]]
     ) -> pd.DataFrame:
         return pd.DataFrame(
             np.array(
                 values,
                 [
-                    ("id1", "int32"),
-                    ("id2", "int32"),
-                    ("name", "object"),
+                    ("customer_id", "int32"),
+                    ("status", "object"),
                     ("updated_at", "datetime64[ns]"),
                     ("valid_from", "datetime64[ns]"),
                     ("valid_to", "datetime64[ns]"),
@@ -843,63 +841,53 @@ def test_scd_type_2(tmp_path: pathlib.Path):
 
     def replace_source_table(
         context: Context,
-        values: t.List[t.Tuple[int, int, str, str]],
+        values: t.List[t.Tuple[int, str, str]],
     ):
         df = create_source_dataframe(values)
         context.engine_adapter.replace_query(
-            "scd_type_2_input",
+            "sushi.raw_marketing",
             df,
             columns_to_types={
-                "id1": exp.DataType.build("int"),
-                "id2": exp.DataType.build("int"),
-                "name": exp.DataType.build("STRING"),
+                "customer_id": exp.DataType.build("int"),
+                "status": exp.DataType.build("STRING"),
                 "updated_at": exp.DataType.build("TIMESTAMP"),
             },
         )
 
     def compare_dataframes(df1: pd.DataFrame, df2: pd.DataFrame):
-        df1 = df1.sort_values(by=["id1", "id2"]).reset_index(drop=True)
-        df2 = df2.sort_values(by=["id1", "id2"]).reset_index(drop=True)
+        df1 = df1.sort_values(by=["customer_id"]).reset_index(drop=True)
+        df2 = df2.sort_values(by=["customer_id"]).reset_index(drop=True)
         pd.testing.assert_frame_equal(df1, df2)
 
-    shutil.copy(str(pathlib.Path("examples/sushi/config.py")), str(tmp_path / "config.py"))
-    (tmp_path / "models").mkdir()
-    with open(tmp_path / "models" / "scd_type_2.sql", "w+") as f:
-        f.write(
-            """
-MODEL (
-   name db.scd_type_2,
-   kind SCD_TYPE_2(unique_key (id1, id2)),
-   owner jen,
-   start "1 week ago",
-);
+    def get_current_df(context: Context):
+        return context.engine_adapter.fetchdf("SELECT * FROM sushi.marketing")
 
-SELECT
-    id1,
-    id2,
-    name,
-    updated_at
-FROM
-    scd_type_2_input
-;"""
-        )
+    sushi_root = pathlib.Path("examples/sushi")
+    shutil.copy(str(pathlib.Path(sushi_root / "config.py")), str(tmp_path / "config.py"))
+    (tmp_path / "models").mkdir()
+    shutil.copy(
+        str(pathlib.Path(sushi_root / "models" / "marketing.sql")),
+        str(tmp_path / "models" / "marketing.sql"),
+    )
+
     context = Context(paths=[str(tmp_path)], config="test_config")
+    context.engine_adapter.create_schema("sushi")
     replace_source_table(
         context,
         [
-            (1, 4, "a", "2020-01-01 00:00:00"),
-            (2, 5, "b", "2020-01-01 00:00:00"),
-            (3, 6, "c", "2020-01-01 00:00:00"),
+            (1, "a", "2020-01-01 00:00:00"),
+            (2, "b", "2020-01-01 00:00:00"),
+            (3, "c", "2020-01-01 00:00:00"),
         ],
     )
     plan = context.plan("prod")
     plan.apply()
-    df_actual = context.engine_adapter.fetchdf("SELECT * FROM db.scd_type_2")
+    df_actual = get_current_df(context)
     df_expected = create_target_dataframe(
         [
-            (1, 4, "a", "2020-01-01 00:00:00", "1970-01-01 00:00:00", None),
-            (2, 5, "b", "2020-01-01 00:00:00", "1970-01-01 00:00:00", None),
-            (3, 6, "c", "2020-01-01 00:00:00", "1970-01-01 00:00:00", None),
+            (1, "a", "2020-01-01 00:00:00", "1970-01-01 00:00:00", None),
+            (2, "b", "2020-01-01 00:00:00", "1970-01-01 00:00:00", None),
+            (3, "c", "2020-01-01 00:00:00", "1970-01-01 00:00:00", None),
         ]
     )
     compare_dataframes(df_actual, df_expected)
@@ -908,25 +896,25 @@ FROM
         context,
         [
             # Update to "x"
-            (1, 4, "x", "2020-01-02 00:00:00"),
+            (1, "x", "2020-01-02 00:00:00"),
             # No Change
-            (2, 5, "b", "2020-01-01 00:00:00"),
-            # Deleted 3, 6
-            # (3, 6, "c", "2020-01-01 00:00:00"),
-            # Added 3,7
-            (3, 7, "d", "2020-01-02 00:00:00"),
+            (2, "b", "2020-01-01 00:00:00"),
+            # Deleted 3
+            # (3, "c", "2020-01-01 00:00:00"),
+            # Added 4
+            (4, "d", "2020-01-02 00:00:00"),
         ],
     )
     tomorrow = to_datetime("tomorrow")
     context.run("prod", start=to_datetime("today"), end=tomorrow, execution_time=tomorrow)
-    df_actual = context.engine_adapter.fetchdf("SELECT * FROM db.scd_type_2")
+    df_actual = get_current_df(context)
     df_expected = create_target_dataframe(
         [
-            (1, 4, "a", "2020-01-01 00:00:00", "1970-01-01 00:00:00", "2020-01-02 00:00:00"),
-            (1, 4, "x", "2020-01-02 00:00:00", "2020-01-02 00:00:00", None),
-            (2, 5, "b", "2020-01-01 00:00:00", "1970-01-01 00:00:00", None),
-            (3, 6, "c", "2020-01-01 00:00:00", "1970-01-01 00:00:00", to_ts(tomorrow)),
-            (3, 7, "d", "2020-01-02 00:00:00", "1970-01-01 00:00:00", None),
+            (1, "a", "2020-01-01 00:00:00", "1970-01-01 00:00:00", "2020-01-02 00:00:00"),
+            (1, "x", "2020-01-02 00:00:00", "2020-01-02 00:00:00", None),
+            (2, "b", "2020-01-01 00:00:00", "1970-01-01 00:00:00", None),
+            (3, "c", "2020-01-01 00:00:00", "1970-01-01 00:00:00", to_ts(tomorrow)),
+            (4, "d", "2020-01-02 00:00:00", "1970-01-01 00:00:00", None),
         ]
     )
     compare_dataframes(df_actual, df_expected)
@@ -935,15 +923,15 @@ FROM
         context,
         [
             # Update to "y"
-            (1, 4, "y", "2020-01-03 00:00:00"),
-            # Delete 2, 5
-            # (2, 5, "b", "2020-01-01 00:00:00"),
-            # Add back 3, 6
-            (3, 6, "c", "2099-01-01 00:00:00"),
+            (1, "y", "2020-01-03 00:00:00"),
+            # Delete 2
+            # (2, "b", "2020-01-01 00:00:00"),
+            # Add back 3
+            (3, "c", "2099-01-01 00:00:00"),
             # No Change
-            (3, 7, "d", "2020-01-02 00:00:00"),
-            # Added 3, 8
-            (3, 8, "e", "2020-01-03 00:00:00"),
+            (4, "d", "2020-01-02 00:00:00"),
+            # Added 5
+            (5, "e", "2020-01-03 00:00:00"),
         ],
     )
     two_days_from_now = to_datetime("in 2 days")
@@ -953,23 +941,23 @@ FROM
         end=two_days_from_now,
         execution_time=two_days_from_now,
     )
-    df_actual = context.engine_adapter.fetchdf("SELECT * FROM db.scd_type_2")
+    df_actual = get_current_df(context)
     df_expected = create_target_dataframe(
         [
-            (1, 4, "a", "2020-01-01 00:00:00", "1970-01-01 00:00:00", "2020-01-02 00:00:00"),
-            (1, 4, "x", "2020-01-02 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:00:00"),
-            (1, 4, "y", "2020-01-03 00:00:00", "2020-01-03 00:00:00", None),
-            (2, 5, "b", "2020-01-01 00:00:00", "1970-01-01 00:00:00", to_ts(two_days_from_now)),
-            (3, 6, "c", "2020-01-01 00:00:00", "1970-01-01 00:00:00", to_ts(tomorrow)),
-            # Since 3, 6 was deleted and came back and the updated at time when it came back
+            (1, "a", "2020-01-01 00:00:00", "1970-01-01 00:00:00", "2020-01-02 00:00:00"),
+            (1, "x", "2020-01-02 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:00:00"),
+            (1, "y", "2020-01-03 00:00:00", "2020-01-03 00:00:00", None),
+            (2, "b", "2020-01-01 00:00:00", "1970-01-01 00:00:00", to_ts(two_days_from_now)),
+            (3, "c", "2020-01-01 00:00:00", "1970-01-01 00:00:00", to_ts(tomorrow)),
+            # Since 3 was deleted and came back and the updated at time when it came back
             # is greater than the execution time when it was deleted, we have the valid_from
             # match the updated_at time. If it was less then the valid_from would match the
             # execution time when it was deleted.
-            (3, 6, "c", "2099-01-01 00:00:00", "2099-01-01 00:00:00", None),
+            (3, "c", "2099-01-01 00:00:00", "2099-01-01 00:00:00", None),
             # What the result would be if the updated_at time was `2020-01-03`
-            # (3, 6, "c", "2020-01-03 00:00:00", to_ts(tomorrow), None),
-            (3, 7, "d", "2020-01-02 00:00:00", "1970-01-01 00:00:00", None),
-            (3, 8, "e", "2020-01-03 00:00:00", "1970-01-01 00:00:00", None),
+            # (3, "c", "2020-01-03 00:00:00", to_ts(tomorrow), None),
+            (4, "d", "2020-01-02 00:00:00", "1970-01-01 00:00:00", None),
+            (5, "e", "2020-01-03 00:00:00", "1970-01-01 00:00:00", None),
         ]
     )
     compare_dataframes(df_actual, df_expected)

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -762,9 +762,7 @@ def test_create_scd_type_2(mocker: MockerFixture, adapter_mock, make_snapshot):
             MODEL (
                 name test_schema.test_model,
                 kind SCD_TYPE_2 (
-                    unique_key (
-                        id
-                    ),
+                    unique_key id,
                 )
             );
             
@@ -804,9 +802,7 @@ def test_create_ctas_scd_type_2(mocker: MockerFixture, adapter_mock, make_snapsh
             MODEL (
                 name test_schema.test_model,
                 kind SCD_TYPE_2 (
-                    unique_key (
-                        id
-                    ),
+                    unique_key id,
                 )
             );
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -835,7 +835,7 @@ def test_create_ctas_scd_type_2(mocker: MockerFixture, adapter_mock, make_snapsh
     )
 
 
-def test_insert_into_scd_type_2(mocker: MockerFixture, adapter_mock, make_snapshot):
+def test_insert_into_scd_type_2(adapter_mock, make_snapshot):
     evaluator = SnapshotEvaluator(adapter_mock)
     model = load_sql_based_model(
         parse(  # type: ignore
@@ -843,9 +843,7 @@ def test_insert_into_scd_type_2(mocker: MockerFixture, adapter_mock, make_snapsh
             MODEL (
                 name test_schema.test_model,
                 kind SCD_TYPE_2 (
-                    unique_key (
-                        id
-                    ),
+                    unique_key id,
                 )
             );
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -752,3 +752,135 @@ def test_create_clone_in_dev(mocker: MockerFixture, adapter_mock, make_snapshot)
     adapter_mock.drop_table.assert_called_once_with(
         f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp__schema_migration_source"
     )
+
+
+def test_create_scd_type_2(mocker: MockerFixture, adapter_mock, make_snapshot):
+    evaluator = SnapshotEvaluator(adapter_mock)
+    model = load_sql_based_model(
+        parse(  # type: ignore
+            """
+            MODEL (
+                name test_schema.test_model,
+                kind SCD_TYPE_2 (
+                    unique_key (
+                        id
+                    ),
+                )
+            );
+            
+            SELECT id::int, name::string, updated_at::timestamp FROM tbl;
+            """
+        )
+    )
+
+    snapshot = make_snapshot(model)
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    evaluator.create([snapshot], {})
+
+    adapter_mock.create_table.assert_called_once_with(
+        snapshot.table_name(),
+        columns_to_types={
+            "id": exp.DataType.build("INT"),
+            "name": exp.DataType.build("STRING"),
+            "updated_at": exp.DataType.build("TIMESTAMP"),
+            # Make sure that the call includes these extra columns
+            "valid_from": exp.DataType.build("TIMESTAMP"),
+            "valid_to": exp.DataType.build("TIMESTAMP"),
+        },
+        storage_format=None,
+        partitioned_by=[],
+        partition_interval_unit=IntervalUnit.DAY,
+        clustered_by=[],
+        table_properties={},
+    )
+
+
+def test_create_ctas_scd_type_2(mocker: MockerFixture, adapter_mock, make_snapshot):
+    evaluator = SnapshotEvaluator(adapter_mock)
+    model = load_sql_based_model(
+        parse(  # type: ignore
+            """
+            MODEL (
+                name test_schema.test_model,
+                kind SCD_TYPE_2 (
+                    unique_key (
+                        id
+                    ),
+                )
+            );
+
+            SELECT * FROM tbl;
+            """
+        )
+    )
+
+    snapshot = make_snapshot(model)
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    evaluator.create([snapshot], {})
+
+    adapter_mock.ctas.assert_called_once_with(
+        snapshot.table_name(),
+        # Verify that managed columns are included in CTAS with types
+        parse_one(
+            """SELECT *, CAST(NULL AS TIMESTAMP) AS valid_from, CAST(NULL AS TIMESTAMP) AS valid_to FROM "tbl" AS "tbl" WHERE FALSE"""
+        ),
+        None,
+        storage_format=None,
+        partitioned_by=[],
+        partition_interval_unit=IntervalUnit.DAY,
+        clustered_by=[],
+        table_properties={},
+    )
+
+
+def test_insert_into_scd_type_2(mocker: MockerFixture, adapter_mock, make_snapshot):
+    evaluator = SnapshotEvaluator(adapter_mock)
+    model = load_sql_based_model(
+        parse(  # type: ignore
+            """
+            MODEL (
+                name test_schema.test_model,
+                kind SCD_TYPE_2 (
+                    unique_key (
+                        id
+                    ),
+                )
+            );
+
+            SELECT id::int, name::string, updated_at::timestamp FROM tbl;
+            """
+        )
+    )
+
+    snapshot = make_snapshot(model)
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    evaluator.evaluate(
+        snapshot,
+        "2020-01-01",
+        "2020-01-02",
+        "2020-01-02",
+        snapshots={},
+    )
+
+    adapter_mock.scd_type_2.assert_called_once_with(
+        target_table=snapshot.table_name(),
+        source_table=model.render_query(),
+        columns_to_types={
+            "id": exp.DataType.build("INT"),
+            "name": exp.DataType.build("STRING"),
+            "updated_at": exp.DataType.build("TIMESTAMP"),
+            # Make sure that the call includes these extra columns
+            "valid_from": exp.DataType.build("TIMESTAMP"),
+            "valid_to": exp.DataType.build("TIMESTAMP"),
+        },
+        unique_key=["id"],
+        valid_from_name="valid_from",
+        valid_to_name="valid_to",
+        updated_at_name="updated_at",
+        start="2020-01-01",
+        end="2020-01-02",
+        execution_time="2020-01-02",
+    )


### PR DESCRIPTION
This PR adds support for SCD Type 2 using `updated_at` timestamps. 

Follow Up PRs:
* Cleanup engine adapter Pandas overrides so it is easy to get the correct pandas implementation per engine
* Add "check column" support (checking values of columns instead of `updated_at`)
* Add dbt adapter support