### PR TITLE
Fix: snapshot table name to support illegal characters

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -936,9 +936,10 @@ SnapshotNameVersionLike = t.Union[SnapshotNameVersion, SnapshotTableInfo, Snapsh
 
 def table_name(physical_schema: str, name: str, version: str, is_temp: bool = False) -> str:
     temp_suffx = "__temp" if is_temp else ""
+    legal_name = name.replace("-", "").replace('"', "").replace("'", "")
     parts = [
         physical_schema,
-        f"{name.replace('.', '__')}__{version}{temp_suffx}",
+        f"{legal_name.replace('.', '__')}__{version}{temp_suffx}",
     ]
     catalog = exp.to_table(name).catalog
     if catalog:

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -783,7 +783,8 @@ class MaterializableStrategy(PromotableStrategy):
         **render_kwargs: t.Any,
     ) -> None:
         table = exp.to_table(name)
-        self.adapter.create_schema(table.db, catalog_name=table.catalog)
+        catg = str(table.parts[0]) if table.catalog else None
+        self.adapter.create_schema(table.db, catalog_name=catg)
 
         logger.info("Creating table '%s'", name)
         if model.annotated:

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -783,7 +783,7 @@ class MaterializableStrategy(PromotableStrategy):
         **render_kwargs: t.Any,
     ) -> None:
         table = exp.to_table(name)
-        catg = str(table.parts[0]) if table.catalog else ''
+        catg = str(table.parts[0]) if table.catalog else ""
         self.adapter.create_schema(table.db, catalog_name=catg)
 
         logger.info("Creating table '%s'", name)

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -783,7 +783,7 @@ class MaterializableStrategy(PromotableStrategy):
         **render_kwargs: t.Any,
     ) -> None:
         table = exp.to_table(name)
-        catg = str(table.parts[0]) if table.catalog else None
+        catg = str(table.parts[0]) if table.catalog else ''
         self.adapter.create_schema(table.db, catalog_name=catg)
 
         logger.info("Creating table '%s'", name)

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -579,12 +579,12 @@ def test_table_name(snapshot: Snapshot, make_snapshot: t.Callable):
     assert snapshot.table_name_for_mapping(is_dev=True) == "private.name__3078928823"
 
     fully_qualified_snapshot = make_snapshot(
-        SqlModel(name="catalog.db.table", query=parse_one("select 1, ds"))
+        SqlModel(name='"my-catalog".db.table', query=parse_one("select 1, ds"))
     )
     fully_qualified_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
     assert (
         fully_qualified_snapshot.table_name(is_dev=False, for_read=False)
-        == "catalog.sqlmesh__db.catalog__db__table__2528031000"
+        == "my-catalog.sqlmesh__db.mycatalog__db__table__2528031000"
     )
 
 

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -584,7 +584,7 @@ def test_table_name(snapshot: Snapshot, make_snapshot: t.Callable):
     fully_qualified_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
     assert (
         fully_qualified_snapshot.table_name(is_dev=False, for_read=False)
-        == "my-catalog.sqlmesh__db.mycatalog__db__table__2528031000"
+        == '"my-catalog".sqlmesh__db.my_catalog__db__table__2528031000'
     )
 
 


### PR DESCRIPTION
Fixes: https://github.com/TobikoData/sqlmesh/issues/1352

Maybe a better solution than `str(exp.to_table(name).parts[0])` would be if sqlglot expression would return the quoted strings by default (`exp.to_table(name).catalog`). but I'm not sure if that's really wanted