### PR TITLE
Chore: Improve Engine Adapter Abstraction for Handling DataFrames

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ markers =
     airflow_integration: mark test as needing the Airflow cluster to run successfully
     spark: mark test as requiring the PySpark dependency
     airflow: mark test as requiring the Airflow dependency
+    engine_integration: Engine adapter tests that require external services
 
 # Set this to True to enable logging during tests
 log_cli = False

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "requests",
         "rich",
         "ruamel.yaml",
-        "sqlglot~=18.1.0",
+        "sqlglot~=18.3.0",
     ],
     extras_require={
         "bigquery": [

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import re
+import sys
 import typing as t
 from difflib import unified_diff
 from enum import Enum, auto
@@ -654,36 +655,46 @@ def extend_sqlglot() -> None:
 
 
 def select_from_values(
-    values: t.Iterable[t.Tuple[t.Any, ...]],
+    values: t.List[t.Tuple[t.Any, ...]],
     columns_to_types: t.Dict[str, exp.DataType],
-    batch_size: int = 0,
+    batch_size: int = sys.maxsize,
     alias: str = "t",
-) -> t.Generator[exp.Select, None, None]:
+) -> t.Iterator[exp.Select]:
     """Generate a VALUES expression that has a select wrapped around it to cast the values to their correct types.
 
     Args:
         values: List of values to use for the VALUES expression.
         columns_to_types: Mapping of column names to types to assign to the values.
-        batch_size: The maximum number of tuples per batch, if <= 0 then no batching will occur.
+        batch_size: The maximum number of tuples per batch.
         alias: The alias to assign to the values expression. If not provided then will default to "t"
 
     Returns:
         This method operates as a generator and yields a VALUES expression.
     """
+    num_rows = len(values)
+    for i in range(0, num_rows, batch_size):
+        yield select_from_values_for_batch_range(
+            values=values,
+            columns_to_types=columns_to_types,
+            batch_start=i,
+            batch_end=min(i + batch_size, num_rows),
+            alias=alias,
+        )
+
+
+def select_from_values_for_batch_range(
+    values: t.List[t.Tuple[t.Any, ...]],
+    columns_to_types: t.Dict[str, exp.DataType],
+    batch_start: int,
+    batch_end: int,
+    alias: str = "t",
+) -> exp.Select:
     casted_columns = [
         exp.alias_(exp.cast(column, to=kind), column, copy=False)
         for column, kind in columns_to_types.items()
     ]
-    batch = []
-    for row in values:
-        batch.append(row)
-        if batch_size > 0 and len(batch) >= batch_size:
-            values_exp = exp.values(batch, alias=alias, columns=columns_to_types)
-            yield exp.select(*casted_columns).from_(values_exp)
-            batch.clear()
-    if batch:
-        values_exp = exp.values(batch, alias=alias, columns=columns_to_types)
-        yield exp.select(*casted_columns).from_(values_exp)
+    values_exp = exp.values(values[batch_start:batch_end], alias=alias, columns=columns_to_types)
+    return exp.select(*casted_columns).from_(values_exp, copy=False)
 
 
 def pandas_to_sql(
@@ -704,7 +715,7 @@ def pandas_to_sql(
         This method operates as a generator and yields a VALUES expression.
     """
     yield from select_from_values(
-        values=df.itertuples(index=False, name=None),
+        values=list(df.itertuples(index=False, name=None)),
         columns_to_types=columns_to_types or columns_to_types_from_df(df),
         batch_size=batch_size,
         alias=alias,

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -677,7 +677,7 @@ def select_from_values(
     batch = []
     for row in values:
         batch.append(row)
-        if batch_size > 0 and len(batch) > batch_size:
+        if batch_size > 0 and len(batch) >= batch_size:
             values_exp = exp.values(batch, alias=alias, columns=columns_to_types)
             yield exp.select(*casted_columns).from_(values_exp)
             batch.clear()

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -826,8 +826,10 @@ class EngineAdapter:
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         **kwargs: t.Any,
     ) -> None:
-        if columns_to_types is None:
-            columns_to_types = self.columns(target_table)
+        source_queries, columns_to_types = self._get_source_query_and_columns_to_types(
+            source_table, columns_to_types, target_table=target_table, batch_size=0
+        )
+        columns_to_types = columns_to_types or self.columns(target_table)
         if updated_at_name not in columns_to_types:
             raise SQLMeshError(
                 f"Column {updated_at_name} not found in {target_table}. Table must contain an `updated_at` timestamp for SCD Type 2"
@@ -835,128 +837,123 @@ class EngineAdapter:
         unmanaged_columns = [
             col for col in columns_to_types if col not in {valid_from_name, valid_to_name}
         ]
-        df = self.try_get_pandas_df(source_table)
-        if df is not None:
-            source_table = next(
-                pandas_to_sql(
-                    df,
-                    columns_to_types={
-                        k: v for k, v in columns_to_types.items() if k in unmanaged_columns
-                    },
+        with source_queries[0] as source_query:
+            start_time = "CAST('1970-01-01 00:00:00+00:00' AS TIMESTAMP)"
+            query = (
+                exp.Select()  # type: ignore
+                .with_(
+                    "source",
+                    exp.select(*unmanaged_columns)
+                    .distinct(*unique_key)
+                    .from_(source_query.subquery("raw_source")),  # type: ignore
                 )
-            )
-        start_time = "CAST('1970-01-01 00:00:00+00:00' AS TIMESTAMP)"
-        query = (
-            exp.Select()  # type: ignore
-            .with_(
-                "source",
-                exp.select(*unmanaged_columns).from_(
-                    source_table.subquery("raw_source")  # type: ignore
-                ),
-            )
-            # Historical Records that Do Not Change
-            .with_(
-                "static",
-                exp.select(*columns_to_types)
-                .from_(target_table)
-                .where(f"{valid_to_name} IS NOT NULL"),
-            )
-            # Latest Records that can be updated
-            .with_(
-                "latest",
-                exp.select(*columns_to_types).from_(target_table).where(f"{valid_to_name} IS NULL"),
-            )
-            # Deleted records which can be used to determine `valid_from` for undeleted source records
-            .with_(
-                "deleted",
-                exp.select(*[f"static.{col}" for col in columns_to_types])
-                .from_("static")
-                .join("latest", using=unique_key, join_type="left")
-                .where(f"latest.{valid_to_name} IS NULL"),
-            )
-            # Get the latest `valid_to` deleted record for each unique key
-            .with_(
-                "latest_deleted",
-                exp.select(
-                    *unique_key,
-                    f"MAX({valid_to_name}) AS {valid_to_name}",
+                # Historical Records that Do Not Change
+                .with_(
+                    "static",
+                    exp.select(*columns_to_types)
+                    .from_(target_table)
+                    .where(f"{valid_to_name} IS NOT NULL"),
                 )
-                .from_("deleted")
-                .group_by(*unique_key),
-            )
-            # Do a full join between latest records and source table in order to combine them together
-            .with_(
-                "joined",
-                exp.select(
-                    *(f"latest.{col} AS t_{col}" for col in columns_to_types),
-                    *(f"source.{col} AS s_{col}" for col in unmanaged_columns),
+                # Latest Records that can be updated
+                .with_(
+                    "latest",
+                    exp.select(*columns_to_types)
+                    .from_(target_table)
+                    .where(f"{valid_to_name} IS NULL"),
                 )
-                .from_("latest")
-                .join("source", using=unique_key, join_type="full"),
-            )
-            # Get deleted, new, no longer current, or unchanged records
-            .with_(
-                "updated_rows",
-                exp.select(
-                    *(f"COALESCE(t_{col}, s_{col}) as {col}" for col in unmanaged_columns),
-                    f"""
-                    CASE 
-                        WHEN t_{valid_from_name} IS NULL 
-                             AND latest_deleted.{unique_key[0]} IS NOT NULL 
-                        THEN CASE 
-                                WHEN latest_deleted.{valid_to_name} > s_{updated_at_name} 
-                                THEN latest_deleted.{valid_to_name} 
-                                ELSE s_{updated_at_name} 
-                             END 
-                        WHEN t_{valid_from_name} IS NULL 
-                        THEN {start_time} 
-                        ELSE t_{valid_from_name} 
-                    END AS {valid_from_name}""",
-                    f"""
-                    CASE 
-                        WHEN s_{updated_at_name} > t_{updated_at_name} 
-                        THEN s_{updated_at_name} 
-                        WHEN s_{unique_key[0]} IS NULL 
-                        THEN CAST('{to_ts(execution_time)}' AS TIMESTAMP) 
-                        ELSE t_{valid_to_name} 
-                    END AS {valid_to_name}""",
+                # Deleted records which can be used to determine `valid_from` for undeleted source records
+                .with_(
+                    "deleted",
+                    exp.select(*[f"static.{col}" for col in columns_to_types])
+                    .from_("static")
+                    .join("latest", using=unique_key, join_type="left")
+                    .where(f"latest.{valid_to_name} IS NULL"),
                 )
-                .from_("joined")
-                .join(
+                # Get the latest `valid_to` deleted record for each unique key
+                .with_(
                     "latest_deleted",
-                    on=" AND ".join(f"joined.s_{col} = latest_deleted.{col}" for col in unique_key),
-                    join_type="left",
-                ),
-            )
-            # Get records that have been "updated" which means inserting a new record with previous `valid_from`
-            .with_(
-                "inserted_rows",
-                exp.select(
-                    *(f"s_{col} as {col}" for col in unmanaged_columns),
-                    f"s_{updated_at_name} as {valid_from_name}",
-                    f"NULL as {valid_to_name}",
+                    exp.select(
+                        *unique_key,
+                        f"MAX({valid_to_name}) AS {valid_to_name}",
+                    )
+                    .from_("deleted")
+                    .group_by(*unique_key),
                 )
-                .from_("joined")
-                .where(
-                    f"t_{unique_key[0]} IS NOT NULL AND s_{unique_key[0]} IS NOT NULL AND s_{updated_at_name} > t_{updated_at_name}"
-                ),
+                # Do a full join between latest records and source table in order to combine them together
+                .with_(
+                    "joined",
+                    exp.select(
+                        *(f"latest.{col} AS t_{col}" for col in columns_to_types),
+                        *(f"source.{col} AS s_{col}" for col in unmanaged_columns),
+                    )
+                    .from_("latest")
+                    .join("source", using=unique_key, join_type="full"),
+                )
+                # Get deleted, new, no longer current, or unchanged records
+                .with_(
+                    "updated_rows",
+                    exp.select(
+                        *(f"COALESCE(t_{col}, s_{col}) as {col}" for col in unmanaged_columns),
+                        f"""
+                        CASE 
+                            WHEN t_{valid_from_name} IS NULL 
+                                 AND latest_deleted.{unique_key[0]} IS NOT NULL 
+                            THEN CASE 
+                                    WHEN latest_deleted.{valid_to_name} > s_{updated_at_name} 
+                                    THEN latest_deleted.{valid_to_name} 
+                                    ELSE s_{updated_at_name} 
+                                 END 
+                            WHEN t_{valid_from_name} IS NULL 
+                            THEN {start_time} 
+                            ELSE t_{valid_from_name} 
+                        END AS {valid_from_name}""",
+                        f"""
+                        CASE 
+                            WHEN s_{updated_at_name} > t_{updated_at_name} 
+                            THEN s_{updated_at_name} 
+                            WHEN s_{unique_key[0]} IS NULL 
+                            THEN CAST('{to_ts(execution_time)}' AS TIMESTAMP) 
+                            ELSE t_{valid_to_name} 
+                        END AS {valid_to_name}""",
+                    )
+                    .from_("joined")
+                    .join(
+                        "latest_deleted",
+                        on=" AND ".join(
+                            f"joined.s_{col} = latest_deleted.{col}" for col in unique_key
+                        ),
+                        join_type="left",
+                    ),
+                )
+                # Get records that have been "updated" which means inserting a new record with previous `valid_from`
+                .with_(
+                    "inserted_rows",
+                    exp.select(
+                        *(f"s_{col} as {col}" for col in unmanaged_columns),
+                        f"s_{updated_at_name} as {valid_from_name}",
+                        f"NULL as {valid_to_name}",
+                    )
+                    .from_("joined")
+                    .where(
+                        f"t_{unique_key[0]} IS NOT NULL AND s_{unique_key[0]} IS NOT NULL AND s_{updated_at_name} > t_{updated_at_name}"
+                    ),
+                )
+                .select("*")
+                .from_("static")
+                .union(
+                    "SELECT * FROM updated_rows",
+                    distinct=False,
+                )
+                .union(
+                    "SELECT * FROM inserted_rows",
+                    distinct=False,
+                )
             )
-            .select("*")
-            .from_("static")
-            .union(
-                "SELECT * FROM updated_rows",
-                distinct=False,
+            self.replace_query(
+                target_table,
+                query,
+                columns_to_types=columns_to_types,
             )
-            .union(
-                "SELECT * FROM inserted_rows",
-                distinct=False,
-            )
-        )
-        self.replace_query(
-            target_table,
-            query,
-            columns_to_types=columns_to_types,
-        )
 
     def merge(
         self,

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -518,6 +518,10 @@ class EngineAdapter:
             materialized: Whether to create a a materialized view. Only used for engines that support this feature.
             create_kwargs: Additional kwargs to pass into the Create expression
         """
+        if self.is_pandas_df(query_or_df):
+            raise SQLMeshError(
+                "Creating views from Pandas Dataframes is not supported. Use `FULL` instead."
+            )
         source_queries, columns_to_types = self._get_source_query_and_columns_to_types(
             query_or_df, columns_to_types, batch_size=0
         )

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -797,7 +797,9 @@ class EngineAdapter:
                         if i == 0:
                             assert where is not None
                             self.delete_from(table_name, where=where)
-                        self.insert_append(table_name, query, columns_to_types=columns_to_types)
+                        self._insert_append_query(
+                            table_name, query, columns_to_types=columns_to_types
+                        )
                     else:
                         insert_exp = exp.insert(
                             query,

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -519,8 +519,14 @@ class EngineAdapter:
             create_kwargs: Additional kwargs to pass into the Create expression
         """
         if self.is_pandas_df(query_or_df):
-            raise SQLMeshError(
-                "Creating views from Pandas Dataframes is not supported. Use `FULL` instead."
+            values = list(t.cast(pd.DataFrame, query_or_df).itertuples(index=False, name=None))
+            columns_to_types = columns_to_types or self._columns_to_types(query_or_df)
+            assert columns_to_types
+            query_or_df = self._values_to_sql(
+                values,
+                columns_to_types,
+                batch_start=0,
+                batch_end=len(values),
             )
         source_queries, columns_to_types = self._get_source_query_and_columns_to_types(
             query_or_df, columns_to_types, batch_size=0

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -409,7 +409,14 @@ class EngineAdapter:
             for i, source_query in enumerate(source_queries):
                 with source_query as query:
                     if i == 0:
-                        self._create_table(table, query, exists=exists, replace=replace, **kwargs)
+                        self._create_table(
+                            table,
+                            query,
+                            columns_to_types=columns_to_types,
+                            exists=exists,
+                            replace=replace,
+                            **kwargs,
+                        )
                     else:
                         self._insert_append_query(
                             table_name, query, columns_to_types or self.columns(table)

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -14,7 +14,7 @@ from sqlmesh.utils.errors import SQLMeshError
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import TableName
-    from sqlmesh.core.engine_adapter._typing import QueryOrDF
+    from sqlmesh.core.engine_adapter.base import QueryOrDF
 
 
 class BasePostgresEngineAdapter(CommitOnExecuteMixin):
@@ -90,7 +90,6 @@ class BasePostgresEngineAdapter(CommitOnExecuteMixin):
             super().create_view(
                 view_name,
                 query_or_df,
-                columns_to_types=columns_to_types,
                 replace=False,
                 materialized=materialized,
                 **create_kwargs,

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -29,12 +29,14 @@ class BasePostgresEngineAdapter(CommitOnExecuteMixin):
         sql = (
             exp.select("column_name", "data_type")
             .from_(self.COLUMNS_TABLE)
-            .where(f"table_name = '{table.alias_or_name}' AND table_schema = '{table.args['db']}'")
+            .where(
+                f"table_name = '{table.alias_or_name}' AND table_schema = '{table.args['db'].name}'"
+            )
         )
         self.execute(sql)
         resp = self.cursor.fetchall()
         if not resp:
-            SQLMeshError("Could not get columns for table '%s'. Table not found.", table_name)
+            raise SQLMeshError("Could not get columns for table '%s'. Table not found.", table_name)
         return {
             column_name: exp.DataType.build(data_type, dialect=self.dialect)
             for column_name, data_type in resp
@@ -60,7 +62,7 @@ class BasePostgresEngineAdapter(CommitOnExecuteMixin):
         )
         database_name = table.args.get("db")
         if database_name:
-            sql = sql.where(f"table_schema = '{database_name}'")
+            sql = sql.where(f"table_schema = '{database_name.this}'")
 
         self.execute(sql)
 

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -60,9 +60,9 @@ class BasePostgresEngineAdapter(CommitOnExecuteMixin):
             .from_("information_schema.tables")
             .where(f"table_name = '{table.alias_or_name}'")
         )
-        database_name = table.args.get("db")
+        database_name = table.db
         if database_name:
-            sql = sql.where(f"table_schema = '{database_name.this}'")
+            sql = sql.where(f"table_schema = '{database_name}'")
 
         self.execute(sql)
 

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -94,7 +94,8 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
         batch_size: int,
         target_table: TableName,
     ) -> t.List[SourceQuery]:
-        assert columns_to_types
+        if not columns_to_types:
+            raise SQLMeshError("columns_to_types is required when using a dataframe.")
         temp_bq_table = self.__get_temp_bq_table(
             self._get_temp_table(target_table or "pandas"), columns_to_types
         )

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import logging
 import typing as t
 
@@ -10,7 +9,8 @@ from sqlglot.errors import ErrorLevel
 from sqlglot.helper import ensure_list
 from sqlglot.transforms import remove_precision_parameterized_types
 
-from sqlmesh.core.engine_adapter.base import EngineAdapter
+from sqlmesh.core.engine_adapter.base import SourceQuery
+from sqlmesh.core.engine_adapter.mixins import InsertOverwriteWithMergeMixin
 from sqlmesh.core.engine_adapter.shared import (
     DataObject,
     DataObjectType,
@@ -32,13 +32,13 @@ if t.TYPE_CHECKING:
     from google.cloud.bigquery.table import Table as BigQueryTable
 
     from sqlmesh.core._typing import TableName
-    from sqlmesh.core.engine_adapter._typing import DF, Query, QueryOrDF
-
+    from sqlmesh.core.engine_adapter._typing import DF, Query
+    from sqlmesh.core.engine_adapter.base import QueryOrDF
 
 logger = logging.getLogger(__name__)
 
 
-class BigQueryEngineAdapter(EngineAdapter):
+class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
     """
     BigQuery Engine Adapter using the `google-cloud-bigquery` library's DB API.
     """
@@ -68,7 +68,7 @@ class BigQueryEngineAdapter(EngineAdapter):
 
     @property
     def client(self) -> BigQueryClient:
-        return self.cursor.connection._client
+        return self.connection._client
 
     @property
     def connection(self) -> BigQueryConnection:
@@ -87,6 +87,44 @@ class BigQueryEngineAdapter(EngineAdapter):
         if self._extra_config.get("maximum_bytes_billed"):
             params["maximum_bytes_billed"] = self._extra_config.get("maximum_bytes_billed")
         return params
+
+    def _df_to_source_query(
+        self,
+        df: DF,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        batch_size: int,
+        target_table: t.Optional[TableName] = None,
+    ) -> SourceQuery:
+        def generator(
+            df: pd.DataFrame,
+            columns_to_types: t.Dict[str, exp.DataType],
+            target_table: t.Optional[TableName] = None,
+        ) -> t.Generator[Query, None, None]:
+            temp_table = self._get_temp_table(target_table or "pandas")
+            temp_bq_table = self.__get_temp_bq_table(temp_table, columns_to_types)
+            self._db_call(self.client.create_table, table=temp_bq_table, exists_ok=False)
+            result = self.__load_pandas_to_table(temp_bq_table, df, columns_to_types, replace=False)
+            if result.errors:
+                raise SQLMeshError(result.errors)
+
+            temp_table = exp.table_(
+                temp_bq_table.table_id,
+                db=temp_bq_table.dataset_id,
+                catalog=temp_bq_table.project,
+            )
+            try:
+                yield exp.select(*columns_to_types).from_(temp_table)
+            finally:
+                self.drop_table(temp_table)
+
+        assert isinstance(df, pd.DataFrame)
+        columns_to_types = columns_to_types or columns_to_types_from_df(df)
+        return SourceQuery(
+            generator=generator(df, columns_to_types, target_table),
+            columns_to_types=columns_to_types,
+            batched=False,
+            is_from_df=True,
+        )
 
     def _begin_session(self) -> None:
         from google.cloud.bigquery import QueryJobConfig
@@ -204,41 +242,6 @@ class BigQueryEngineAdapter(EngineAdapter):
         )
         return list(self._query_data)
 
-    def _create_table_from_df(
-        self,
-        table_name: TableName,
-        df: DF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
-        exists: bool = True,
-        replace: bool = False,
-        **kwargs: t.Any,
-    ) -> None:
-        """
-        Creates a table from a pandas dataframe. Will create the table if it doesn't exist. Will replace the contents
-        of the table if `replace` is true.
-        """
-        assert isinstance(df, pd.DataFrame)
-        if columns_to_types is None:
-            columns_to_types = columns_to_types_from_df(df)
-        table = self.__get_bq_table(table_name, columns_to_types)
-        self._db_call(self.client.create_table, table=table, exists_ok=exists)
-        self.__load_pandas_to_table(table, df, columns_to_types, replace=replace)
-
-    def _insert_append_pandas_df(
-        self,
-        table_name: TableName,
-        df: pd.DataFrame,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
-        contains_json: bool = False,
-    ) -> None:
-        """
-        Appends to a table from a pandas dataframe. Will create the table if it doesn't exist.
-        """
-        if columns_to_types is None:
-            columns_to_types = columns_to_types_from_df(df)
-        table = self.__get_bq_table(table_name, columns_to_types)
-        self.__load_pandas_to_table(table, df, columns_to_types, replace=False)
-
     def __load_pandas_to_table(
         self,
         table: bigquery.Table,
@@ -290,12 +293,12 @@ class BigQueryEngineAdapter(EngineAdapter):
         ]
 
     def __get_temp_bq_table(
-        self, table: TableName, columns_to_type: t.Dict[str, exp.DataType]
+        self, table: exp.Table, columns_to_type: t.Dict[str, exp.DataType]
     ) -> bigquery.Table:
         """
         Returns a bigquery table object that is temporary and will expire in 3 hours.
         """
-        bq_table = self.__get_bq_table(self._get_temp_table(table), columns_to_type)
+        bq_table = self.__get_bq_table(table, columns_to_type)
         bq_table.expires = to_datetime("in 3 hours")
         return bq_table
 
@@ -328,48 +331,6 @@ class BigQueryEngineAdapter(EngineAdapter):
             maximum=3.0,
         )
 
-    @contextlib.contextmanager
-    def __try_load_pandas_to_temp_table(
-        self,
-        reference_table_name: TableName,
-        query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
-    ) -> t.Generator[Query, None, None]:
-        reference_table = exp.to_table(reference_table_name)
-        df = self.try_get_pandas_df(query_or_df)
-        if df is None:
-            yield t.cast("Query", query_or_df)
-            return
-        if columns_to_types is None:
-            raise SQLMeshError("columns_to_types must be provided when using Pandas DataFrames")
-        if reference_table.db is None:
-            raise SQLMeshError("table must be qualified when using Pandas DataFrames")
-        temp_bq_table = self.__get_temp_bq_table(reference_table, columns_to_types)
-        self._db_call(self.client.create_table, table=temp_bq_table, exists_ok=False)
-        result = self.__load_pandas_to_table(temp_bq_table, df, columns_to_types, replace=False)
-        if result.errors:
-            raise SQLMeshError(result.errors)
-
-        temp_table = exp.table_(
-            temp_bq_table.table_id,
-            db=temp_bq_table.dataset_id,
-            catalog=temp_bq_table.project,
-        )
-        yield exp.select(*columns_to_types).from_(temp_table)
-        self.drop_table(temp_table)
-
-    def merge(
-        self,
-        target_table: TableName,
-        source_table: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
-        unique_key: t.Sequence[str],
-    ) -> None:
-        with self.__try_load_pandas_to_temp_table(
-            target_table, source_table, columns_to_types
-        ) as source_table:
-            return super().merge(target_table, source_table, columns_to_types, unique_key)
-
     def insert_overwrite_by_partition(
         self,
         table_name: TableName,
@@ -390,7 +351,6 @@ class BigQueryEngineAdapter(EngineAdapter):
             raise SQLMeshError(
                 f"The partition expression '{partition_sql}' doesn't contain a column."
             )
-
         with self.session(), self.temp_table(query_or_df, name=table_name) as temp_table_name:
             if columns_to_types is None or columns_to_types[
                 partition_column.name
@@ -407,55 +367,13 @@ class BigQueryEngineAdapter(EngineAdapter):
 
             self._insert_overwrite_by_condition(
                 table_name,
-                exp.select("*").from_(temp_table_name),
-                where=where,
-                columns_to_types=columns_to_types,
-            )
-
-    def _insert_overwrite_by_condition(
-        self,
-        table_name: TableName,
-        query_or_df: QueryOrDF,
-        where: t.Optional[exp.Condition] = None,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
-    ) -> None:
-        """
-        Bigquery does not directly support `INSERT OVERWRITE` but it does support `MERGE` with a `False`
-        condition and delete that mimics an `INSERT OVERWRITE`. Based on documentation this should have the
-        same runtime performance as `INSERT OVERWRITE`.
-
-        If a Pandas DataFrame is provided, it will be loaded into a temporary table and then merged with the
-        target table. This temporary table is deleted after the merge is complete or after it's expiration time has
-        passed.
-        """
-        with self.__try_load_pandas_to_temp_table(
-            table_name, query_or_df, columns_to_types
-        ) as source_table:
-            query = self._add_where_to_query(source_table, where)
-
-            columns = [
-                exp.to_column(col)
-                for col in (columns_to_types or [col.alias_or_name for col in query.expressions])
-            ]
-            when_not_matched_by_source = exp.When(
-                matched=False,
-                source=True,
-                condition=where,
-                then=exp.Delete(),
-            )
-            when_not_matched_by_target = exp.When(
-                matched=False,
-                source=False,
-                then=exp.Insert(
-                    this=exp.Tuple(expressions=columns),
-                    expression=exp.Tuple(expressions=columns),
+                SourceQuery(
+                    generator=iter([exp.select("*").from_(temp_table_name)]),
+                    columns_to_types=columns_to_types,
+                    batched=False,
+                    is_from_df=False,
                 ),
-            )
-            self._merge(
-                target_table=table_name,
-                source_table=query,
-                on=exp.false(),
-                match_expressions=[when_not_matched_by_source, when_not_matched_by_target],
+                where=where,
             )
 
     def table_exists(self, table_name: TableName) -> bool:

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -92,7 +92,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
         df: DF,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         batch_size: int,
-        target_table: t.Optional[TableName] = None,
+        target_table: TableName,
     ) -> t.List[SourceQuery]:
         assert columns_to_types
         temp_bq_table = self.__get_temp_bq_table(

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -3,28 +3,12 @@ from __future__ import annotations
 import math
 import typing as t
 
-import pandas as pd
-from sqlglot import exp
-
 from sqlmesh.core.engine_adapter.mixins import LogicalMergeMixin
 from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
-
-if t.TYPE_CHECKING:
-    from sqlmesh.core._typing import TableName
 
 
 class DuckDBEngineAdapter(LogicalMergeMixin):
     DIALECT = "duckdb"
-
-    def _insert_append_pandas_df(
-        self,
-        table_name: TableName,
-        df: pd.DataFrame,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
-        contains_json: bool = False,
-    ) -> None:
-        column_names = list(columns_to_types or [])
-        self.execute(exp.insert("SELECT * FROM df", table_name, columns=column_names))
 
     def _get_data_objects(
         self, schema_name: str, catalog_name: t.Optional[str] = None

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -3,12 +3,34 @@ from __future__ import annotations
 import math
 import typing as t
 
+from sqlglot import exp
+
+from sqlmesh.core.engine_adapter.base import SourceQuery
 from sqlmesh.core.engine_adapter.mixins import LogicalMergeMixin
-from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
+
+if t.TYPE_CHECKING:
+
+    from sqlmesh.core._typing import TableName
+    from sqlmesh.core.engine_adapter._typing import DF
+    from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 
 
 class DuckDBEngineAdapter(LogicalMergeMixin):
     DIALECT = "duckdb"
+
+    def _df_to_source_queries(
+        self,
+        df: DF,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        batch_size: int,
+        target_table: t.Optional[TableName] = None,
+    ) -> t.List[SourceQuery]:
+        assert columns_to_types
+        return [
+            SourceQuery(
+                query_factory=lambda: exp.select(*columns_to_types).from_("df"),  # type: ignore
+            )
+        ]
 
     def _get_data_objects(
         self, schema_name: str, catalog_name: t.Optional[str] = None

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 import math
 import typing as t
 
+import pandas as pd
 from sqlglot import exp
 
 from sqlmesh.core.engine_adapter.base import SourceQuery
 from sqlmesh.core.engine_adapter.mixins import LogicalMergeMixin
+from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 
 if t.TYPE_CHECKING:
-
     from sqlmesh.core._typing import TableName
-    from sqlmesh.core.engine_adapter._typing import DF
-    from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
+    from sqlmesh.core.engine_adapter._typing import DF, QueryOrDF
 
 
 class DuckDBEngineAdapter(LogicalMergeMixin):
@@ -26,11 +26,42 @@ class DuckDBEngineAdapter(LogicalMergeMixin):
         target_table: t.Optional[TableName] = None,
     ) -> t.List[SourceQuery]:
         assert columns_to_types
+        temp_table = self._get_temp_table(target_table or "pandas")
+        temp_table_sql = exp.select(*columns_to_types).from_("df").sql(dialect=self.dialect)
+        self.cursor.sql(f"CREATE TABLE {temp_table} AS {temp_table_sql}")
         return [
             SourceQuery(
-                query_factory=lambda: exp.select(*columns_to_types).from_("df"),  # type: ignore
+                query_factory=lambda: exp.select(*columns_to_types).from_(temp_table),  # type: ignore
             )
         ]
+
+    def create_view(
+        self,
+        view_name: TableName,
+        query_or_df: QueryOrDF,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        replace: bool = True,
+        materialized: bool = False,
+        **create_kwargs: t.Any,
+    ) -> None:
+        """
+        We only support Pandas for views on DuckDB in order to provide more robust local testing support.
+        """
+        if not self.is_pandas_df(query_or_df):
+            return super().create_view(
+                view_name, query_or_df, columns_to_types, replace, materialized, **create_kwargs
+            )
+        assert columns_to_types, "Pandas requires columns_to_types to be set"
+        values = list(t.cast(pd.DataFrame, query_or_df).itertuples(index=False, name=None))
+        sql = self._values_to_sql(
+            values,
+            columns_to_types,
+            batch_start=0,
+            batch_end=len(values),
+        )
+        super().create_view(
+            view_name, sql, columns_to_types, replace, materialized, **create_kwargs
+        )
 
     def _get_data_objects(
         self, schema_name: str, catalog_name: t.Optional[str] = None

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import math
 import typing as t
 
-import pandas as pd
 from sqlglot import exp
 
 from sqlmesh.core.engine_adapter.base import SourceQuery
@@ -12,7 +11,7 @@ from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import TableName
-    from sqlmesh.core.engine_adapter._typing import DF, QueryOrDF
+    from sqlmesh.core.engine_adapter._typing import DF
 
 
 class DuckDBEngineAdapter(LogicalMergeMixin):
@@ -34,34 +33,6 @@ class DuckDBEngineAdapter(LogicalMergeMixin):
                 query_factory=lambda: exp.select(*columns_to_types).from_(temp_table),  # type: ignore
             )
         ]
-
-    def create_view(
-        self,
-        view_name: TableName,
-        query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
-        replace: bool = True,
-        materialized: bool = False,
-        **create_kwargs: t.Any,
-    ) -> None:
-        """
-        We only support Pandas for views on DuckDB in order to provide more robust local testing support.
-        """
-        if not self.is_pandas_df(query_or_df):
-            return super().create_view(
-                view_name, query_or_df, columns_to_types, replace, materialized, **create_kwargs
-            )
-        assert columns_to_types, "Pandas requires columns_to_types to be set"
-        values = list(t.cast(pd.DataFrame, query_or_df).itertuples(index=False, name=None))
-        sql = self._values_to_sql(
-            values,
-            columns_to_types,
-            batch_start=0,
-            batch_end=len(values),
-        )
-        super().create_view(
-            view_name, sql, columns_to_types, replace, materialized, **create_kwargs
-        )
 
     def _get_data_objects(
         self, schema_name: str, catalog_name: t.Optional[str] = None

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -95,11 +95,9 @@ class LogicalReplaceQueryMixin(EngineAdapter):
                 target_table = exp.to_table(table_name)
                 # Check if self-referencing
                 if any(
-                    [
-                        table
-                        for table in query.find_all(exp.Table)
-                        if quote_identifiers(table) == quote_identifiers(target_table)
-                    ]
+                    table
+                    for table in query.find_all(exp.Table)
+                    if quote_identifiers(table) == quote_identifiers(target_table)
                 ):
                     with self.temp_table(
                         exp.select(*columns_to_types).from_(target_table),
@@ -108,9 +106,7 @@ class LogicalReplaceQueryMixin(EngineAdapter):
                     ) as temp_table:
                         for table in query.find_all(exp.Table):
                             if table == target_table:
-                                table.set("this", temp_table.this)
-                                table.set("db", temp_table.args.get("db"))
-                                table.set("catalog", temp_table.args.get("catalog"))
+                                table.replace(temp_table.copy())
                         self.execute(get_truncate(table_name))
                         return self._insert_append_query(table_name, query, columns_to_types)
                 self.execute(get_truncate(table_name))

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -154,7 +154,7 @@ class CommitOnExecuteMixin(EngineAdapter):
 
 
 class InsertOverwriteWithMergeMixin(EngineAdapter):
-    FALSE_PREDICATE: exp.Condition = exp.FALSE
+    FALSE_PREDICATE: exp.Condition = exp.false()
 
     def _insert_overwrite_by_condition(
         self,

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -75,7 +75,6 @@ class RedshiftEngineAdapter(BasePostgresEngineAdapter, LogicalReplaceQueryMixin)
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         exists: bool = True,
         replace: bool = False,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         **kwargs: t.Any,
     ) -> None:
         """

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -29,38 +29,6 @@ class RedshiftEngineAdapter(BasePostgresEngineAdapter, LogicalReplaceQueryMixin)
         cursor.paramstyle = "qmark"
         return cursor
 
-    def create_view(
-        self,
-        view_name: TableName,
-        query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
-        replace: bool = True,
-        materialized: bool = False,
-        **create_kwargs: t.Any,
-    ) -> None:
-        """
-        Redshift doesn't support `VALUES` expressions outside of a `INSERT` statement. Currently sqlglot cannot
-        performantly convert a values expression into a series of `UNION ALL` statements. Therefore we just don't
-        support views for Redshift until sqlglot is updated to performantly support large union statements.
-
-        Also Redshift views are "binding" by default to their underlying table which means you can't drop that
-        underlying table without dropping the view first. This is a problem for us since we want to be able to
-        swap tables out from under views. Therefore we create the view as non-binding.
-        """
-        if self.is_pandas_df(query_or_df):
-            raise NotImplementedError(
-                "DataFrames are not supported for Redshift views because Redshift doesn't "
-                "support using `VALUES` in a `CREATE VIEW` statement."
-            )
-        return super().create_view(
-            view_name,
-            query_or_df,
-            replace=replace,
-            materialized=materialized,
-            no_schema_binding=True,
-            **create_kwargs,
-        )
-
     def _fetch_native_df(
         self, query: t.Union[exp.Expression, str], quote_identifiers: bool = False
     ) -> pd.DataFrame:

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -6,13 +6,14 @@ import pandas as pd
 from pandas.api.types import is_datetime64_dtype  # type: ignore
 from sqlglot import exp
 
-from sqlmesh.core.engine_adapter.base import EngineAdapter
+from sqlmesh.core.engine_adapter.base import EngineAdapter, SourceQuery
 from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 from sqlmesh.utils import nullsafe_join
+from sqlmesh.utils.pandas import columns_to_types_from_df
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import TableName
-    from sqlmesh.core.engine_adapter._typing import DF
+    from sqlmesh.core.engine_adapter._typing import DF, Query
 
 
 class SnowflakeEngineAdapter(EngineAdapter):
@@ -21,6 +22,53 @@ class SnowflakeEngineAdapter(EngineAdapter):
     ESCAPE_JSON = True
     SUPPORTS_MATERIALIZED_VIEWS = True
     SUPPORTS_CLONING = True
+
+    def _df_to_source_query(
+        self,
+        df: DF,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        batch_size: int,
+        target_table: t.Optional[TableName] = None,
+    ) -> SourceQuery:
+        def generator(
+            df: pd.DataFrame,
+            columns_to_types: t.Dict[str, exp.DataType],
+            target_table: t.Optional[TableName] = None,
+        ) -> t.Generator[Query, None, None]:
+            from snowflake.connector.pandas_tools import write_pandas
+
+            temp_table = self._get_temp_table(target_table or "pandas")
+            # Workaround for https://github.com/snowflakedb/snowflake-connector-python/issues/1034
+            #
+            # The above issue has already been fixed upstream, but we keep the following
+            # line anyway in order to support a wider range of Snowflake versions.
+            self.cursor.execute(f'USE SCHEMA "{temp_table.db}"')
+
+            # See: https://stackoverflow.com/a/75627721
+            for column, kind in (columns_to_types or {}).items():
+                if kind.is_type("date") and is_datetime64_dtype(df.dtypes[column]):
+                    df[column] = pd.to_datetime(df[column]).dt.date
+
+            write_pandas(
+                self._connection_pool.get(),
+                df,
+                temp_table.name,
+                schema=temp_table.db,
+                chunk_size=self.DEFAULT_BATCH_SIZE,
+            )
+            try:
+                yield exp.select(*columns_to_types).from_(temp_table)
+            finally:
+                self.drop_table(temp_table)
+
+        assert isinstance(df, pd.DataFrame)
+        columns_to_types = columns_to_types or columns_to_types_from_df(df)
+        return SourceQuery(
+            generator=generator(df, columns_to_types, target_table),
+            columns_to_types=columns_to_types,
+            batched=False,
+            is_from_df=True,
+        )
 
     def _fetch_native_df(
         self, query: t.Union[exp.Expression, str], quote_identifiers: bool = False
@@ -57,33 +105,3 @@ class SnowflakeEngineAdapter(EngineAdapter):
             )
             for row in df[["database_name", "schema_name", "name", "kind"]].itertuples()
         ]
-
-    def _insert_append_pandas_df(
-        self,
-        table_name: TableName,
-        df: pd.DataFrame,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
-        contains_json: bool = False,
-    ) -> None:
-        from snowflake.connector.pandas_tools import write_pandas
-
-        table = exp.to_table(table_name)
-
-        # Workaround for https://github.com/snowflakedb/snowflake-connector-python/issues/1034
-        #
-        # The above issue has already been fixed upstream, but we keep the following
-        # line anyway in order to support a wider range of Snowflake versions.
-        self.cursor.execute(f'USE SCHEMA "{table.db}"')
-
-        # See: https://stackoverflow.com/a/75627721
-        for column, kind in (columns_to_types or {}).items():
-            if kind.is_type("date") and is_datetime64_dtype(df.dtypes[column]):
-                df[column] = pd.to_datetime(df[column]).dt.date
-
-        write_pandas(
-            self._connection_pool.get(),
-            df,
-            table.name,
-            schema=table.db,
-            chunk_size=self.DEFAULT_BATCH_SIZE,
-        )

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -6,7 +6,11 @@ import typing as t
 import pandas as pd
 from sqlglot import exp
 
-from sqlmesh.core.engine_adapter.base import EngineAdapter, InsertOverwriteStrategy
+from sqlmesh.core.engine_adapter.base import (
+    EngineAdapter,
+    InsertOverwriteStrategy,
+    SourceQuery,
+)
 from sqlmesh.core.engine_adapter.shared import (
     DataObject,
     DataObjectType,
@@ -19,12 +23,8 @@ if t.TYPE_CHECKING:
     from pyspark.sql import types as spark_types
 
     from sqlmesh.core._typing import TableName
-    from sqlmesh.core.engine_adapter._typing import (
-        DF,
-        PySparkDataFrame,
-        PySparkSession,
-        QueryOrDF,
-    )
+    from sqlmesh.core.engine_adapter._typing import DF, PySparkDataFrame, PySparkSession
+    from sqlmesh.core.engine_adapter.base import QueryOrDF
     from sqlmesh.core.node import IntervalUnit
 
 
@@ -77,6 +77,50 @@ class SparkEngineAdapter(EngineAdapter):
             )
             return None
 
+    @classmethod
+    def is_pyspark_df(cls, value: t.Any) -> bool:
+        return hasattr(value, "sparkSession")
+
+    @classmethod
+    def try_get_pyspark_df(cls, value: t.Any) -> t.Optional[PySparkDataFrame]:
+        if cls.is_pyspark_df(value):
+            return value
+        return None
+
+    @classmethod
+    def try_get_pandas_df(cls, value: t.Any) -> t.Optional[pd.DataFrame]:
+        if cls.is_pandas_df(value):
+            return value
+        return None
+
+    def _df_to_source_query(
+        self,
+        df: DF,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        batch_size: int,
+        target_table: t.Optional[TableName] = None,
+    ) -> SourceQuery:
+        def generator(
+            df: DF,
+            columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+            target_table: t.Optional[TableName] = None,
+        ) -> t.Generator[exp.Select, None, None]:
+            df = self._ensure_pyspark_df(df, columns_to_types)
+            temp_table = self._get_temp_table(target_table or "spark", table_only=True)
+            df.createOrReplaceTempView(temp_table.sql(dialect=self.dialect))
+            temp_table.set("db", "global_temp")
+            yield exp.select("*").from_(temp_table)
+
+        if self._use_spark_session:
+            return SourceQuery(
+                generator=generator(df, columns_to_types, target_table),
+                columns_to_types=columns_to_types,
+                batched=False,
+                is_from_df=True,
+            )
+        else:
+            return super()._df_to_source_query(df, columns_to_types, batch_size, target_table)
+
     def _ensure_pyspark_df(
         self, generic_df: DF, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
     ) -> PySparkDataFrame:
@@ -104,122 +148,6 @@ class SparkEngineAdapter(EngineAdapter):
         return self._ensure_pyspark_df(
             self._fetch_native_df(query, quote_identifiers=quote_identifiers)
         )
-
-    def _insert_overwrite_by_condition(
-        self,
-        table_name: TableName,
-        query_or_df: QueryOrDF,
-        where: t.Optional[exp.Condition] = None,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
-    ) -> None:
-        df = self.try_get_df(query_or_df)
-        if self._use_spark_session and df is not None:
-            self._insert_pyspark_df(
-                table_name,
-                self._ensure_pyspark_df(df, columns_to_types),
-                overwrite=True,
-                where=where,
-            )
-        else:
-            super()._insert_overwrite_by_condition(table_name, query_or_df, where, columns_to_types)
-
-    def insert_append(
-        self,
-        table_name: TableName,
-        query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
-        contains_json: bool = False,
-    ) -> None:
-        df = self.try_get_df(query_or_df)
-        if self._use_spark_session and df is not None:
-            self._insert_append_pyspark_df(
-                table_name, self._ensure_pyspark_df(df, columns_to_types)
-            )
-        else:
-            super().insert_append(table_name, query_or_df, columns_to_types, contains_json)
-
-    def merge(
-        self,
-        target_table: TableName,
-        source_table: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
-        unique_key: t.Sequence[str],
-    ) -> None:
-        if columns_to_types is None:
-            columns_to_types = self.columns(target_table)
-
-        column_names = columns_to_types.keys()
-        df = self.try_get_df(source_table)
-        if self._use_spark_session and df is not None:
-            pyspark_df = self._ensure_pyspark_df(df, columns_to_types)
-            temp_view = self._get_temp_table(target_table, table_only=True)
-            pyspark_df.createOrReplaceGlobalTempView(temp_view.sql(dialect=self.dialect))
-            temp_view.set("db", "global_temp")
-            query = exp.select(*column_names).from_(temp_view.sql(dialect=self.dialect))
-            super().merge(target_table, query, columns_to_types, unique_key)
-        else:
-            super().merge(target_table, source_table, columns_to_types, unique_key)
-
-    def _insert_append_pandas_df(
-        self,
-        table_name: TableName,
-        df: pd.DataFrame,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
-        contains_json: bool = False,
-    ) -> None:
-        if self._use_spark_session:
-            self._insert_pyspark_df(
-                table_name, self._ensure_pyspark_df(df, columns_to_types), overwrite=False
-            )
-        else:
-            super()._insert_append_pandas_df(table_name, df, columns_to_types, contains_json)
-
-    def _insert_append_pyspark_df(
-        self,
-        table_name: TableName,
-        df: PySparkDataFrame,
-    ) -> None:
-        self._insert_pyspark_df(table_name, df, overwrite=False)
-
-    def _insert_pyspark_df(
-        self,
-        table_name: TableName,
-        df: PySparkDataFrame,
-        overwrite: bool = False,
-        where: t.Optional[exp.Condition] = None,
-    ) -> None:
-        if isinstance(table_name, exp.Table):
-            table_name = table_name.sql(dialect=self.dialect)
-
-        df = df.where(where.sql(dialect=self.dialect)) if where else df
-
-        df_writer = df.select(*self.spark.table(table_name).columns).write
-        if overwrite:
-            df_writer = df_writer.mode("overwrite")
-            if self.INSERT_OVERWRITE_STRATEGY.is_replace_where:
-                if where is None:
-                    raise SQLMeshError(
-                        "Cannot use Replace Where Insert/Overwrite without a where clause"
-                    )
-                df_writer = df_writer.option("replaceWhere", where.sql(dialect=self.dialect))
-        df_writer.insertInto(table_name)
-
-    def _create_table_from_df(
-        self,
-        table_name: TableName,
-        df: DF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
-        exists: bool = True,
-        replace: bool = True,
-        **kwargs: t.Any,
-    ) -> None:
-        if self._use_spark_session:
-            df = self._ensure_pyspark_df(df, columns_to_types)
-            if isinstance(table_name, exp.Table):
-                table_name = table_name.sql(dialect=self.dialect)
-            df.write.saveAsTable(table_name, mode="overwrite")
-        else:
-            super()._create_table_from_df(table_name, df, columns_to_types, exists, replace)
 
     def _get_data_objects(
         self, schema_name: str, catalog_name: t.Optional[str] = None
@@ -252,8 +180,11 @@ class SparkEngineAdapter(EngineAdapter):
     ) -> None:
         # Note: Some storage formats (like Delta and Iceberg) support REPLACE TABLE but since we don't
         # currently check for storage formats we will just do an insert/overwrite.
+        source_query = self._ensure_source_query(
+            query_or_df, columns_to_types, target_table=table_name
+        )
         return self._insert_overwrite_by_condition(
-            table_name, query_or_df, columns_to_types=columns_to_types, where=exp.condition("1=1")
+            table_name, source_query, where=exp.condition("1=1")
         )
 
     def create_state_table(

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -111,7 +111,7 @@ class SparkEngineAdapter(EngineAdapter):
 
         def query_factory() -> Query:
             temp_table = self._get_temp_table(target_table or "spark", table_only=True)
-            df.createOrReplaceTempView(temp_table.sql(dialect=self.dialect))  # type: ignore
+            df.createOrReplaceGlobalTempView(temp_table.sql(dialect=self.dialect))  # type: ignore
             temp_table.set("db", "global_temp")
             return exp.select("*").from_(temp_table)
 

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -117,8 +117,7 @@ class SparkEngineAdapter(EngineAdapter):
 
         if self._use_spark_session:
             return [SourceQuery(query_factory=query_factory)]
-        else:
-            return super()._df_to_source_queries(df, columns_to_types, batch_size, target_table)
+        return super()._df_to_source_queries(df, columns_to_types, batch_size, target_table)
 
     def _ensure_pyspark_df(
         self, generic_df: DF, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
@@ -187,7 +186,7 @@ class SparkEngineAdapter(EngineAdapter):
             raise SQLMeshError("Cannot replace table without columns to types")
         self.create_table(table_name, columns_to_types)
         return self._insert_overwrite_by_condition(
-            table_name, source_queries, columns_to_types, where=exp.condition("1=1")
+            table_name, source_queries, columns_to_types, where=exp.true()
         )
 
     def create_state_table(

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -195,9 +195,9 @@ class SnapshotEvaluator:
                 and snapshot.is_incremental_by_time_range
             ):
                 query_or_df = reduce(
-                    lambda a, b: a.union_all(b)  # type: ignore
-                    if self.adapter.is_pyspark_df(a)
-                    else pd.concat([a, b], ignore_index=True),  # type: ignore
+                    lambda a, b: pd.concat([a, b], ignore_index=True)  # type: ignore
+                    if self.adapter.is_pandas_df(a)
+                    else a.union_all(b),  # type: ignore
                     queries_or_dfs,
                 )
                 apply(query_or_df, index=0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,6 +248,7 @@ def make_mocked_engine_adapter(mocker: MockerFixture) -> t.Callable:
         connection_mock = mocker.NonCallableMock()
         cursor_mock = mocker.Mock()
         connection_mock.cursor.return_value = cursor_mock
+        cursor_mock.connection.return_value = connection_mock
         return klass(lambda: connection_mock, dialect=dialect or klass.DIALECT)
 
     return _make_function

--- a/tests/core/engine_adapter/__init__.py
+++ b/tests/core/engine_adapter/__init__.py
@@ -1,0 +1,19 @@
+import typing as t
+
+from sqlglot import exp
+
+from sqlmesh import EngineAdapter
+
+
+def to_sql_calls(adapter: EngineAdapter, identify: bool = True) -> t.List[str]:
+    output = []
+    for call in adapter.cursor.execute.call_args_list:
+        # Python 3.7 support
+        value = call[0][0] if isinstance(call[0], tuple) else call[0]
+        sql = (
+            value.sql(dialect=adapter.dialect, identify=identify)
+            if isinstance(value, exp.Expression)
+            else str(value)
+        )
+        output.append(sql)
+    return output

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -13,6 +13,7 @@ from sqlmesh.core.engine_adapter import EngineAdapter, EngineAdapterWithIndexSup
 from sqlmesh.core.engine_adapter.base import InsertOverwriteStrategy
 from sqlmesh.core.schema_diff import SchemaDiffer, TableAlterOperation
 from sqlmesh.utils.date import to_ds
+from sqlmesh.utils.errors import SQLMeshError
 from tests.core.engine_adapter import to_sql_calls
 
 
@@ -37,18 +38,10 @@ def test_create_view(make_mocked_engine_adapter: t.Callable):
 
 def test_create_view_pandas(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(EngineAdapter)
-    adapter.create_view("test_view", pd.DataFrame({"a": [1, 2, 3]}), replace=False)
-    adapter.create_view(
-        "test_view",
-        pd.DataFrame({"a": [1, 2, 3]}),
-        replace=True,
-        table_properties={"a": exp.convert(1)},
-    )
-
-    assert to_sql_calls(adapter) == [
-        'CREATE VIEW "test_view" ("a") AS SELECT CAST("a" AS BIGINT) AS "a" FROM (VALUES (1), (2), (3)) AS "t"("a")',
-        'CREATE OR REPLACE VIEW "test_view" ("a") AS SELECT CAST("a" AS BIGINT) AS "a" FROM (VALUES (1), (2), (3)) AS "t"("a")',
-    ]
+    with pytest.raises(
+        SQLMeshError, match=r"Creating views from Pandas Dataframes is not supported.*"
+    ):
+        adapter.create_view("test_view", pd.DataFrame({"a": [1, 2, 3]}))
 
 
 def test_create_materialized_view(make_mocked_engine_adapter: t.Callable):

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -785,6 +785,7 @@ def test_scd_type_2(make_mocked_engine_adapter: t.Callable):
 CREATE OR REPLACE TABLE "target" AS
 WITH "source" AS (
   SELECT
+    DISTINCT ON ("id")
     "id",
     "name",
     "price",
@@ -962,6 +963,7 @@ def test_merge_scd_type_2_pandas(make_mocked_engine_adapter: t.Callable):
 CREATE OR REPLACE TABLE "target" AS
 WITH "source" AS (
   SELECT
+    DISTINCT ON ("id1", "id2")
     "id1",
     "id2",
     "name",

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -1084,9 +1084,7 @@ def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable):
     adapter.replace_query("test_table", df, {"a": "int", "b": "int"})
 
     assert to_sql_calls(adapter) == [
-        'DROP TABLE IF EXISTS "test_table"',
-        'CREATE TABLE IF NOT EXISTS "test_table" ("a" int, "b" int)',
-        'INSERT INTO "test_table" ("a", "b") SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (VALUES (1, 4)) AS "t"("a", "b")',
+        'CREATE OR REPLACE TABLE "test_table" AS SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (VALUES (1, 4)) AS "t"("a", "b")',
         'INSERT INTO "test_table" ("a", "b") SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (VALUES (2, 5)) AS "t"("a", "b")',
         'INSERT INTO "test_table" ("a", "b") SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (VALUES (3, 6)) AS "t"("a", "b")',
     ]

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -22,7 +22,7 @@ def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable):
     adapter.replace_query("test_table", df, {"a": "int", "b": "int"})
 
     adapter.cursor.execute.assert_called_once_with(
-        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `test_table`(`a`, `b`)) AS `_subquery` WHERE 1 = 1"
+        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `t`(`a`, `b`)) AS `_subquery` WHERE 1 = 1"
     )
 
 

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -14,7 +14,7 @@ def test_replace_query(make_mocked_engine_adapter: t.Callable):
 
     assert to_sql_calls(adapter) == [
         "CREATE TABLE IF NOT EXISTS `test_table` (`a` int)",
-        "INSERT OVERWRITE TABLE `test_table` (`a`) SELECT * FROM (SELECT `a` FROM `tbl`) AS `_subquery` WHERE 1 = 1",
+        "INSERT OVERWRITE TABLE `test_table` (`a`) SELECT * FROM (SELECT `a` FROM `tbl`) AS `_subquery` WHERE TRUE",
     ]
 
 
@@ -25,7 +25,7 @@ def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable):
 
     assert to_sql_calls(adapter) == [
         "CREATE TABLE IF NOT EXISTS `test_table` (`a` int, `b` int)",
-        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `t`(`a`, `b`)) AS `_subquery` WHERE 1 = 1",
+        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `t`(`a`, `b`)) AS `_subquery` WHERE TRUE",
     ]
 
 

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -5,15 +5,17 @@ import pandas as pd
 from sqlglot import parse_one
 
 from sqlmesh.core.engine_adapter import DatabricksEngineAdapter
+from tests.core.engine_adapter import to_sql_calls
 
 
 def test_replace_query(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(DatabricksEngineAdapter)
     adapter.replace_query("test_table", parse_one("SELECT a FROM tbl"), {"a": "int"})
 
-    adapter.cursor.execute.assert_called_once_with(
-        "INSERT OVERWRITE TABLE `test_table` (`a`) SELECT * FROM (SELECT `a` FROM `tbl`) AS `_subquery` WHERE 1 = 1"
-    )
+    assert to_sql_calls(adapter) == [
+        "CREATE TABLE IF NOT EXISTS `test_table` (`a` int)",
+        "INSERT OVERWRITE TABLE `test_table` (`a`) SELECT * FROM (SELECT `a` FROM `tbl`) AS `_subquery` WHERE 1 = 1",
+    ]
 
 
 def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable):
@@ -21,9 +23,10 @@ def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.replace_query("test_table", df, {"a": "int", "b": "int"})
 
-    adapter.cursor.execute.assert_called_once_with(
-        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `t`(`a`, `b`)) AS `_subquery` WHERE 1 = 1"
-    )
+    assert to_sql_calls(adapter) == [
+        "CREATE TABLE IF NOT EXISTS `test_table` (`a` int, `b` int)",
+        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `t`(`a`, `b`)) AS `_subquery` WHERE 1 = 1",
+    ]
 
 
 def test_clone_table(make_mocked_engine_adapter: t.Callable):

--- a/tests/core/engine_adapter/test_duckdb.py
+++ b/tests/core/engine_adapter/test_duckdb.py
@@ -58,7 +58,7 @@ def test_create_table(adapter: EngineAdapter, duck_conn):
 def test_replace_query_pandas(adapter: EngineAdapter, duck_conn):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.replace_query(
-        "test_table", df, {"a": exp.DataType.build("int"), "b": exp.DataType.build("int")}
+        "test_table", df, {"a": exp.DataType.build("long"), "b": exp.DataType.build("long")}
     )
     pd.testing.assert_frame_equal(adapter.fetchdf("SELECT * FROM test_table"), df)
 

--- a/tests/core/engine_adapter/test_duckdb.py
+++ b/tests/core/engine_adapter/test_duckdb.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 from sqlglot import expressions as exp
 from sqlglot import parse_one
@@ -52,6 +53,14 @@ def test_create_table(adapter: EngineAdapter, duck_conn):
         partitioned_by=[exp.to_column("colb")],
     )
     assert duck_conn.execute("DESCRIBE test_table").fetchall() == expected_columns
+
+
+def test_replace_query_pandas(adapter: EngineAdapter, duck_conn):
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    adapter.replace_query(
+        "test_table", df, {"a": exp.DataType.build("int"), "b": exp.DataType.build("int")}
+    )
+    pd.testing.assert_frame_equal(adapter.fetchdf("SELECT * FROM test_table"), df)
 
 
 def test_transaction(adapter: EngineAdapter, duck_conn):

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -1,0 +1,626 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import typing as t
+
+import pandas as pd
+import pytest
+from pandas._libs import NaTType
+from sqlglot import exp, parse_one
+from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
+
+from sqlmesh import Config, EngineAdapter
+from sqlmesh.core.config import load_config_from_paths
+from sqlmesh.core.engine_adapter.shared import DataObject
+from sqlmesh.utils.date import to_ds
+from sqlmesh.utils.pydantic import PydanticModel
+
+if t.TYPE_CHECKING:
+    from sqlmesh.core.engine_adapter._typing import Query
+
+
+TEST_SCHEMA = "test_schema"
+
+
+class Formatter:
+    def __init__(
+        self,
+        test_type: str,
+        engine_adapter: EngineAdapter,
+        columns_to_types: t.Dict[str, t.Union[str, exp.DataType]],
+    ):
+        self.test_type = test_type
+        self.engine_adapter = engine_adapter
+        self.columns_to_types = {k: exp.DataType.build(v) for k, v in columns_to_types.items()}
+
+    @property
+    def time_columns(self) -> t.List[str]:
+        return [
+            k
+            for k, v in self.columns_to_types.items()
+            if v.sql().lower().startswith("timestamp")
+            or v.sql().lower().startswith("date")
+            or k.lower() == "ds"
+        ]
+
+    @property
+    def timestamp_columns(self) -> t.List[str]:
+        return [
+            k for k, v in self.columns_to_types.items() if v.sql().lower().startswith("timestamp")
+        ]
+
+    @property
+    def time_column(self) -> str:
+        return self.time_columns[0]
+
+    @property
+    def time_formatter(self) -> t.Callable:
+        return lambda x, _: exp.Literal.string(to_ds(x))
+
+    @property
+    def partitioned_by(self) -> t.List[exp.Expression]:
+        return [parse_one(self.time_column)]
+
+    def input_data(
+        self, data: pd.DataFrame, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
+    ) -> t.Union[Query, pd.DataFrame]:
+        columns_to_types = columns_to_types or self.columns_to_types
+        if self.test_type == "query":
+            return self.engine_adapter._values_to_sql(
+                list(data.itertuples(index=False, name=None)),
+                batch_start=0,
+                batch_end=sys.maxsize,
+                columns_to_types=columns_to_types,
+            )
+        return self._format_df(data)
+
+    def output_data(self, data: pd.DataFrame) -> pd.DataFrame:
+        return self._format_df(
+            data, include_tz=self.engine_adapter.dialect in ["spark", "databricks"]
+        )
+
+    def table(self, table_name: str, schema: str = TEST_SCHEMA) -> exp.Table:
+        return normalize_identifiers(
+            exp.to_table(".".join([schema, table_name]), dialect=self.engine_adapter.dialect),
+            dialect=self.engine_adapter.dialect,
+        )
+
+    def _format_df(self, data: pd.DataFrame, include_tz: bool = False) -> pd.DataFrame:
+        for timestamp_column in self.timestamp_columns:
+            if timestamp_column in data.columns:
+                data[timestamp_column] = pd.to_datetime(data[timestamp_column], utc=include_tz)
+        return data
+
+
+class MetadataResults(PydanticModel):
+    tables: t.List[str] = []
+    views: t.List[str] = []
+
+    @classmethod
+    def from_data_objects(cls, data_objects: t.List[DataObject]) -> MetadataResults:
+        tables = []
+        views = []
+        for obj in data_objects:
+            if obj.type.is_table:
+                tables.append(obj.name)
+            elif obj.type.is_view:
+                views.append(obj.name)
+            else:
+                raise ValueError(f"Unexpected object type: {obj.type}")
+        return MetadataResults(tables=tables, views=views)
+
+    @property
+    def non_temp_tables(self) -> t.List[str]:
+        return [x for x in self.tables if not x.startswith("__temp")]
+
+
+@pytest.fixture(params=["df", "query"])
+def test_type(request):
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def config() -> Config:
+    return load_config_from_paths(
+        project_paths=[pathlib.Path("examples/wursthall/config.yaml")],
+        personal_paths=[pathlib.Path("~/.sqlmesh/config.yaml").expanduser()],
+    )
+
+
+@pytest.fixture(
+    params=[
+        "duckdb",
+        pytest.param("postgres", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
+        pytest.param("mysql", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
+        pytest.param("bigquery", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
+        pytest.param("databricks", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
+        pytest.param("redshift", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
+        pytest.param("snowflake", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
+    ]
+)
+def engine_adapter(request, config) -> EngineAdapter:
+    gateway = f"test__{request.param}"
+    if gateway not in config.gateways:
+        # TODO: Once everything is fully setup we want to error if a gateway is not configured that we expect
+        pytest.skip(f"Gateway {gateway} not configured")
+    engine_adapter = config.gateways[gateway].connection.create_engine_adapter()
+    engine_adapter.DEFAULT_BATCH_SIZE = 1
+    schema = normalize_identifiers(
+        exp.to_identifier(TEST_SCHEMA), dialect=engine_adapter.dialect
+    ).sql(dialect=engine_adapter.dialect)
+    engine_adapter.drop_schema(schema, ignore_if_not_exists=True, cascade=True)
+    engine_adapter.create_schema(schema)
+    return engine_adapter
+
+
+def compare_dfs(
+    actual: t.Union[pd.DataFrame, exp.Expression, str],
+    expected: pd.DataFrame,
+) -> None:
+    def replace_nat_with_none(df):
+        return [
+            col if type(col) != NaTType else None
+            for row in sorted(list(df.itertuples(index=False, name=None)))
+            for col in row
+        ]
+
+    assert replace_nat_with_none(actual) == replace_nat_with_none(expected)
+
+
+def create_metadata_results(engine_adapter, schema: str = TEST_SCHEMA) -> MetadataResults:
+    return MetadataResults.from_data_objects(engine_adapter._get_data_objects(schema))
+
+
+def get_current_data(engine_adapter, table_name: exp.Table) -> pd.DataFrame:
+    return engine_adapter.fetchdf(exp.select("*").from_(table_name))
+
+
+@pytest.fixture
+def default_columns_to_types():
+    return {"id": exp.DataType.build("int"), "ds": exp.DataType.build("string")}
+
+
+def get_table(
+    table_name: str, engine_adapter: EngineAdapter, schema: str = TEST_SCHEMA
+) -> exp.Table:
+    return normalize_identifiers(
+        exp.to_table(".".join([schema, table_name]), dialect=engine_adapter.dialect),
+        dialect=engine_adapter.dialect,
+    )
+
+
+def test_temp_table(engine_adapter, test_type, default_columns_to_types):
+    formatter = Formatter(test_type, engine_adapter, default_columns_to_types)
+    input_data = pd.DataFrame(
+        [
+            {"id": 1, "ds": "2022-01-01"},
+            {"id": 2, "ds": "2022-01-02"},
+            {"id": 3, "ds": "2022-01-03"},
+        ]
+    )
+    table = formatter.table("example")
+    with engine_adapter.temp_table(
+        formatter.input_data(input_data), table.sql(dialect=engine_adapter.dialect)
+    ) as table_name:
+        results = create_metadata_results(engine_adapter)
+        assert len(results.views) == 0
+        assert len(results.tables) == 1
+        assert len(results.non_temp_tables) == 0
+        compare_dfs(get_current_data(engine_adapter, table_name), formatter.output_data(input_data))
+    results = create_metadata_results(engine_adapter)
+    assert len(results.views) == len(results.tables) == len(results.non_temp_tables) == 0
+
+
+def test_ctas(engine_adapter, test_type, default_columns_to_types):
+    formatter = Formatter(test_type, engine_adapter, default_columns_to_types)
+    table = formatter.table("test_table")
+    input_data = pd.DataFrame(
+        [
+            {"id": 1, "ds": "2022-01-01"},
+            {"id": 2, "ds": "2022-01-02"},
+            {"id": 3, "ds": "2022-01-03"},
+        ]
+    )
+    engine_adapter.ctas(table, formatter.input_data(input_data))
+    results = create_metadata_results(engine_adapter)
+    assert len(results.views) == 0
+    assert len(results.tables) == len(results.non_temp_tables) == 1
+    assert results.non_temp_tables[0] == table.name
+    compare_dfs(get_current_data(engine_adapter, table), formatter.output_data(input_data))
+
+
+def test_create_view(engine_adapter, test_type, default_columns_to_types):
+    formatter = Formatter(test_type, engine_adapter, default_columns_to_types)
+    view = formatter.table("test_view")
+    input_data = pd.DataFrame(
+        [
+            {"id": 1, "ds": "2022-01-01"},
+            {"id": 2, "ds": "2022-01-02"},
+            {"id": 3, "ds": "2022-01-03"},
+        ]
+    )
+    if engine_adapter.dialect == "redshift" and test_type == "df":
+        with pytest.raises(
+            NotImplementedError,
+            match=r"DataFrames are not supported for Redshift views because Redshift doesn't support using `VALUES` in a `CREATE VIEW` statement.",
+        ):
+            engine_adapter.create_view(view, formatter.input_data(input_data))
+        return
+    engine_adapter.create_view(view, formatter.input_data(input_data))
+    results = create_metadata_results(engine_adapter)
+    assert len(results.tables) == 0
+    assert len(results.views) == 1
+    assert results.views[0] == view.name
+    compare_dfs(get_current_data(engine_adapter, view), formatter.output_data(input_data))
+
+
+def test_replace_query(engine_adapter, test_type, default_columns_to_types):
+    # Replace query doesn't support batched queries so we enforce that here
+    engine_adapter.DEFAULT_BATCH_SIZE = sys.maxsize
+    formatter = Formatter(test_type, engine_adapter, default_columns_to_types)
+    table = formatter.table("test_table")
+    # Initial Load
+    input_data = pd.DataFrame(
+        [
+            {"id": 1, "ds": "2022-01-01"},
+            {"id": 2, "ds": "2022-01-02"},
+            {"id": 3, "ds": "2022-01-03"},
+        ]
+    )
+    engine_adapter.create_table(table, formatter.columns_to_types)
+    engine_adapter.replace_query(
+        table,
+        formatter.input_data(input_data),
+        # Spark based engines do a create table -> insert overwrite instead of replace. If columns to types aren't
+        # provided then it checks the table itself for types. This is fine within SQLMesh since we always know the tables
+        # exist prior to evaluation but when running these tests that isn't the case. As a result we just pass in
+        # columns_to_types for these two engines so we can still test inference on the other ones
+        columns_to_types=formatter.columns_to_types
+        if engine_adapter.dialect in ["spark", "databricks"]
+        else None,
+    )
+    results = create_metadata_results(engine_adapter)
+    assert len(results.views) == 0
+    assert len(results.tables) == len(results.non_temp_tables) == 1
+    assert results.non_temp_tables[0] == table.name
+    compare_dfs(get_current_data(engine_adapter, table), formatter.output_data(input_data))
+
+    # Replace that we only need to run once
+    if type == "df":
+        replace_data = pd.DataFrame(
+            [
+                {"id": 4, "ds": "2022-01-04"},
+                {"id": 5, "ds": "2022-01-05"},
+                {"id": 6, "ds": "2022-01-06"},
+            ]
+        )
+        engine_adapter.replace_query(
+            table,
+            formatter.input_data(replace_data),
+            columns_to_types=formatter.columns_to_types
+            if engine_adapter.dialect in ["spark", "databricks"] and test_type == "query"
+            else None,
+        )
+        results = create_metadata_results(engine_adapter)
+        assert len(results.views) == 0
+        assert len(results.tables) == len(results.non_temp_tables) == 1
+        assert results.non_temp_tables[0] == table.name
+        compare_dfs(get_current_data(engine_adapter, table), formatter.output_data(replace_data))
+
+
+def test_insert_append(engine_adapter, test_type, default_columns_to_types):
+    formatter = Formatter(test_type, engine_adapter, default_columns_to_types)
+    table = formatter.table("test_table")
+    engine_adapter.create_table(table, default_columns_to_types)
+    # Initial Load
+    input_data = pd.DataFrame(
+        [
+            {"id": 1, "ds": "2022-01-01"},
+            {"id": 2, "ds": "2022-01-02"},
+            {"id": 3, "ds": "2022-01-03"},
+        ]
+    )
+    engine_adapter.insert_append(table, formatter.input_data(input_data))
+    results = create_metadata_results(engine_adapter)
+    assert len(results.views) == 0
+    assert len(results.tables) == len(results.non_temp_tables) == 1
+    assert results.non_temp_tables[0] == table.name
+    compare_dfs(get_current_data(engine_adapter, table), formatter.output_data(input_data))
+
+    # Replace that we only need to run once
+    if type == "df":
+        append_data = pd.DataFrame(
+            [
+                {"id": 4, "ds": "2022-01-04"},
+                {"id": 5, "ds": "2022-01-05"},
+                {"id": 6, "ds": "2022-01-06"},
+            ]
+        )
+        engine_adapter.insert_append(table, formatter.input_data(append_data))
+        results = create_metadata_results(engine_adapter)
+        assert len(results.views) == 0
+        assert len(results.tables) in [1, 2, 3]
+        assert len(results.non_temp_tables) == 1
+        assert results.non_temp_tables[0] == table.name
+        compare_dfs(
+            get_current_data(engine_adapter, table),
+            formatter.output_data(pd.concat([input_data, append_data])),
+        )
+
+
+def test_insert_overwrite_by_time_partition(engine_adapter, test_type, default_columns_to_types):
+    ds_type = "timestamp" if engine_adapter.dialect == "bigquery" else "string"
+    formatter = Formatter(test_type, engine_adapter, columns_to_types={"id": "int", "ds": ds_type})
+    table = formatter.table("test_table")
+    if engine_adapter.dialect == "bigquery":
+        partitioned_by = ["DATE(ds)"]
+    else:
+        partitioned_by = formatter.partitioned_by
+    engine_adapter.create_table(
+        table,
+        formatter.columns_to_types,
+        partitioned_by=partitioned_by,
+        partition_interval_unit="DAY",
+    )
+    input_data = pd.DataFrame(
+        [
+            {"id": 1, formatter.time_column: "2022-01-01"},
+            {"id": 2, formatter.time_column: "2022-01-02"},
+            {"id": 3, formatter.time_column: "2022-01-03"},
+        ]
+    )
+    engine_adapter.insert_overwrite_by_time_partition(
+        table,
+        formatter.input_data(input_data),
+        start="2022-01-02",
+        end="2022-01-03",
+        time_formatter=formatter.time_formatter,
+        time_column=formatter.time_column,
+        columns_to_types=formatter.columns_to_types,
+    )
+    results = create_metadata_results(engine_adapter)
+    assert len(results.views) == 0
+    assert len(results.tables) == len(results.non_temp_tables) == 1
+    assert len(results.non_temp_tables) == 1
+    assert results.non_temp_tables[0] == table.name
+    compare_dfs(get_current_data(engine_adapter, table), formatter.output_data(input_data.iloc[1:]))
+
+    if test_type == "df":
+        overwrite_data = pd.DataFrame(
+            [
+                {"id": 10, formatter.time_column: "2022-01-03"},
+                {"id": 4, formatter.time_column: "2022-01-04"},
+                {"id": 5, formatter.time_column: "2022-01-05"},
+            ]
+        )
+        engine_adapter.insert_overwrite_by_time_partition(
+            table,
+            formatter.input_data(overwrite_data),
+            start="2022-01-03",
+            end="2022-01-05",
+            time_formatter=formatter.time_formatter,
+            time_column=formatter.time_column,
+            columns_to_types=formatter.columns_to_types,
+        )
+        results = create_metadata_results(engine_adapter)
+        assert len(results.views) == 0
+        assert len(results.tables) == len(results.non_temp_tables) == 1
+        assert results.non_temp_tables[0] == table.name
+        compare_dfs(
+            get_current_data(engine_adapter, table),
+            formatter.output_data(
+                pd.DataFrame(
+                    [
+                        {"id": 2, formatter.time_column: "2022-01-02"},
+                        {"id": 10, formatter.time_column: "2022-01-03"},
+                        {"id": 4, formatter.time_column: "2022-01-04"},
+                        {"id": 5, formatter.time_column: "2022-01-05"},
+                    ]
+                )
+            ),
+        )
+
+
+def test_merge(engine_adapter, test_type, default_columns_to_types):
+    if engine_adapter.dialect == "redshift":
+        pytest.skip("Redshift currently doesn't support `MERGE`")
+    formatter = Formatter(test_type, engine_adapter, default_columns_to_types)
+    table = formatter.table("test_table")
+    engine_adapter.create_table(table, formatter.columns_to_types)
+    input_data = pd.DataFrame(
+        [
+            {"id": 1, "ds": "2022-01-01"},
+            {"id": 2, "ds": "2022-01-02"},
+            {"id": 3, "ds": "2022-01-03"},
+        ]
+    )
+    engine_adapter.merge(
+        table,
+        formatter.input_data(input_data),
+        columns_to_types=None,
+        unique_key=["id"],
+    )
+    results = create_metadata_results(engine_adapter)
+    assert len(results.views) == 0
+    assert len(results.tables) == len(results.non_temp_tables) == 1
+    assert len(results.non_temp_tables) == 1
+    assert results.non_temp_tables[0] == table.name
+    compare_dfs(get_current_data(engine_adapter, table), formatter.output_data(input_data))
+
+    if test_type == "df":
+        merge_data = pd.DataFrame(
+            [
+                {"id": 2, "ds": "2022-01-10"},
+                {"id": 4, "ds": "2022-01-04"},
+                {"id": 5, "ds": "2022-01-05"},
+            ]
+        )
+        engine_adapter.merge(
+            table,
+            formatter.input_data(merge_data),
+            columns_to_types=None,
+            unique_key=["id"],
+        )
+        results = create_metadata_results(engine_adapter)
+        assert len(results.views) == 0
+        assert len(results.tables) == len(results.non_temp_tables) == 1
+        assert results.non_temp_tables[0] == table.name
+        compare_dfs(
+            get_current_data(engine_adapter, table),
+            formatter.output_data(
+                pd.DataFrame(
+                    [
+                        {"id": 1, "ds": "2022-01-01"},
+                        {"id": 2, "ds": "2022-01-10"},
+                        {"id": 3, "ds": "2022-01-03"},
+                        {"id": 4, "ds": "2022-01-04"},
+                        {"id": 5, "ds": "2022-01-05"},
+                    ]
+                )
+            ),
+        )
+
+
+def test_scd_type_2(engine_adapter, test_type):
+    formatter = Formatter(
+        test_type,
+        engine_adapter,
+        columns_to_types={
+            "id": "int",
+            "name": "string",
+            "updated_at": "timestamp",
+            "valid_from": "timestamp",
+            "valid_to": "timestamp",
+        },
+    )
+    table = formatter.table("test_table")
+    input_schema = {
+        k: v for k, v in formatter.columns_to_types.items() if k not in ("valid_from", "valid_to")
+    }
+    engine_adapter.create_table(table, formatter.columns_to_types)
+    input_data = pd.DataFrame(
+        [
+            {"id": 1, "name": "a", "updated_at": "2022-01-01 00:00:00"},
+            {"id": 2, "name": "b", "updated_at": "2022-01-02 00:00:00"},
+            {"id": 3, "name": "c", "updated_at": "2022-01-03 00:00:00"},
+        ]
+    )
+    engine_adapter.scd_type_2(
+        table,
+        formatter.input_data(input_data, input_schema),
+        unique_key=["id"],
+        valid_from_name="valid_from",
+        valid_to_name="valid_to",
+        updated_at_name="updated_at",
+        execution_time="2023-01-01",
+        columns_to_types=input_schema,
+    )
+    results = create_metadata_results(engine_adapter)
+    assert len(results.views) == 0
+    assert len(results.tables) == len(results.non_temp_tables) == 1
+    assert len(results.non_temp_tables) == 1
+    assert results.non_temp_tables[0] == table.name
+    compare_dfs(
+        get_current_data(engine_adapter, table),
+        formatter.output_data(
+            pd.DataFrame(
+                [
+                    {
+                        "id": 1,
+                        "name": "a",
+                        "updated_at": "2022-01-01 00:00:00",
+                        "valid_from": "1970-01-01 00:00:00",
+                        "valid_to": pd.NaT,
+                    },
+                    {
+                        "id": 2,
+                        "name": "b",
+                        "updated_at": "2022-01-02 00:00:00",
+                        "valid_from": "1970-01-01 00:00:00",
+                        "valid_to": pd.NaT,
+                    },
+                    {
+                        "id": 3,
+                        "name": "c",
+                        "updated_at": "2022-01-03 00:00:00",
+                        "valid_from": "1970-01-01 00:00:00",
+                        "valid_to": pd.NaT,
+                    },
+                ]
+            )
+        ),
+    )
+
+    if test_type == "query":
+        return
+    current_data = pd.DataFrame(
+        [
+            # Change `a` to `x`
+            {"id": 1, "name": "x", "updated_at": "2022-01-04 00:00:00"},
+            # Delete
+            # {"id": 2, "name": "b", "updated_at": "2022-01-02 00:00:00"},
+            # No change
+            {"id": 3, "name": "c", "updated_at": "2022-01-03 00:00:00"},
+            # Add
+            {"id": 4, "name": "d", "updated_at": "2022-01-04 00:00:00"},
+        ]
+    )
+    engine_adapter.scd_type_2(
+        table,
+        formatter.input_data(current_data, input_schema),
+        unique_key=["id"],
+        valid_from_name="valid_from",
+        valid_to_name="valid_to",
+        updated_at_name="updated_at",
+        execution_time="2023-01-05",
+        columns_to_types=input_schema,
+    )
+    results = create_metadata_results(engine_adapter)
+    assert len(results.views) == 0
+    assert len(results.tables) == len(results.non_temp_tables) == 1
+    assert results.non_temp_tables[0] == table.name
+    compare_dfs(
+        get_current_data(engine_adapter, table),
+        formatter.output_data(
+            pd.DataFrame(
+                [
+                    {
+                        "id": 1,
+                        "name": "a",
+                        "updated_at": "2022-01-01 00:00:00",
+                        "valid_from": "1970-01-01 00:00:00",
+                        "valid_to": "2022-01-04 00:00:00",
+                    },
+                    {
+                        "id": 1,
+                        "name": "x",
+                        "updated_at": "2022-01-04 00:00:00",
+                        "valid_from": "2022-01-04 00:00:00",
+                        "valid_to": pd.NaT,
+                    },
+                    {
+                        "id": 2,
+                        "name": "b",
+                        "updated_at": "2022-01-02 00:00:00",
+                        "valid_from": "1970-01-01 00:00:00",
+                        "valid_to": "2023-01-05 00:00:00",
+                    },
+                    {
+                        "id": 3,
+                        "name": "c",
+                        "updated_at": "2022-01-03 00:00:00",
+                        "valid_from": "1970-01-01 00:00:00",
+                        "valid_to": pd.NaT,
+                    },
+                    {
+                        "id": 4,
+                        "name": "d",
+                        "updated_at": "2022-01-04 00:00:00",
+                        "valid_from": "1970-01-01 00:00:00",
+                        "valid_to": pd.NaT,
+                    },
+                ]
+            )
+        ),
+    )

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -181,13 +181,13 @@ def config() -> Config:
 
 @pytest.fixture(
     params=[
-        # "duckdb",
-        # pytest.param("postgres", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
-        # pytest.param("mysql", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
-        # pytest.param("bigquery", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
+        "duckdb",
+        pytest.param("postgres", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
+        pytest.param("mysql", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
+        pytest.param("bigquery", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
         pytest.param("databricks", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
-        # pytest.param("redshift", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
-        # pytest.param("snowflake", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
+        pytest.param("redshift", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
+        pytest.param("snowflake", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
     ]
 )
 def engine_adapter(request, config) -> EngineAdapter:

--- a/tests/core/engine_adapter/test_mixins.py
+++ b/tests/core/engine_adapter/test_mixins.py
@@ -1,5 +1,6 @@
 # type: ignore
 import typing as t
+import uuid
 from unittest.mock import call
 
 from pytest_mock.plugin import MockerFixture
@@ -49,6 +50,43 @@ def test_logical_replace_query_does_not_exist(
     adapter.cursor.execute.assert_called_once_with(
         'CREATE TABLE "db"."table" AS SELECT "col" FROM "db"."other_table"'
     )
+
+
+def test_logical_replace_self_reference(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+):
+    adapter = make_mocked_engine_adapter(LogicalReplaceQueryMixin, "postgres")
+    adapter.cursor.fetchone.return_value = (1,)
+    temp_table_uuid = uuid.uuid4()
+    uuid4_mock = mocker.patch("uuid.uuid4")
+    uuid4_mock.return_value = temp_table_uuid
+
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.postgres.LogicalReplaceQueryMixin.table_exists",
+        return_value=True,
+    )
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.postgres.LogicalReplaceQueryMixin.columns",
+        return_value={"col": exp.DataType(this=exp.DataType.Type.INT)},
+    )
+
+    adapter.replace_query("db.table", parse_one("SELECT col + 1 FROM db.table"))
+
+    assert to_sql_calls(adapter) == [
+        f'CREATE SCHEMA IF NOT EXISTS "db"',
+        f'CREATE TABLE IF NOT EXISTS "db"."__temp_table_{temp_table_uuid.hex}" AS SELECT "col" FROM "db"."table"',
+        'TRUNCATE "db"."table"',
+        f'INSERT INTO "db"."table" ("col") SELECT "col" + 1 FROM "db"."__temp_table_{temp_table_uuid.hex}"',
+        f'DROP TABLE IF EXISTS "db"."__temp_table_{temp_table_uuid.hex}"',
+    ]
+
+
+# ['CREATE TABLE IF NOT EXISTS '
+#  '"__temp_replace_temp_d5e58eb32e0949e4b02604e868934277" AS SELECT "col" FROM '
+#  '"db"."table"',
+#  'TRUNCATE "db"."table"',
+#  'INSERT INTO "db"."table" ("col") SELECT "col" + 1 FROM "db"."table"',
+#  'DROP TABL
 
 
 def test_logical_merge(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):

--- a/tests/core/engine_adapter/test_mixins.py
+++ b/tests/core/engine_adapter/test_mixins.py
@@ -81,14 +81,6 @@ def test_logical_replace_self_reference(
     ]
 
 
-# ['CREATE TABLE IF NOT EXISTS '
-#  '"__temp_replace_temp_d5e58eb32e0949e4b02604e868934277" AS SELECT "col" FROM '
-#  '"db"."table"',
-#  'TRUNCATE "db"."table"',
-#  'INSERT INTO "db"."table" ("col") SELECT "col" + 1 FROM "db"."table"',
-#  'DROP TABL
-
-
 def test_logical_merge(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(LogicalMergeMixin, "duckdb")
     temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.base.EngineAdapter._get_temp_table")

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -60,7 +60,7 @@ def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas(
     )
 
     assert to_sql_calls(adapter) == [
-        f'CREATE TABLE IF NOT EXISTS "__temp_test_table_{temp_table_uuid.hex}" ("a" INTEGER, "ds" TEXT)',
+        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table_{temp_table_uuid.hex}') EXEC('CREATE TABLE "__temp_test_table_{temp_table_uuid.hex}" ("a" INTEGER, "ds" TEXT)')""",
         f"""MERGE INTO "test_table" AS "__MERGE_TARGET__" USING (SELECT * FROM (SELECT "a", "ds" FROM "__temp_test_table_{temp_table_uuid.hex}") AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02') AS "__MERGE_SOURCE__" ON 1 = 2 WHEN NOT MATCHED BY SOURCE AND "ds" BETWEEN '2022-01-01' AND '2022-01-02' THEN DELETE WHEN NOT MATCHED THEN INSERT ("a", "ds") VALUES ("a", "ds")""",
         f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_uuid.hex}"',
     ]
@@ -96,7 +96,7 @@ def test_insert_overwrite_by_time_partition_replace_where_pandas(
     )
 
     assert to_sql_calls(adapter) == [
-        f'CREATE TABLE IF NOT EXISTS "__temp_test_table_{temp_table_uuid.hex}" ("a" INTEGER, "ds" TEXT)',
+        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table_{temp_table_uuid.hex}') EXEC('CREATE TABLE "__temp_test_table_{temp_table_uuid.hex}" ("a" INTEGER, "ds" TEXT)')""",
         f"""MERGE INTO "test_table" AS "__MERGE_TARGET__" USING (SELECT * FROM (SELECT "a", "ds" FROM "__temp_test_table_{temp_table_uuid.hex}") AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02') AS "__MERGE_SOURCE__" ON 1 = 2 WHEN NOT MATCHED BY SOURCE AND "ds" BETWEEN '2022-01-01' AND '2022-01-02' THEN DELETE WHEN NOT MATCHED THEN INSERT ("a", "ds") VALUES ("a", "ds")""",
         f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_uuid.hex}"',
     ]
@@ -128,7 +128,7 @@ def test_insert_append_pandas(make_mocked_engine_adapter: t.Callable, mocker: Mo
     )
 
     assert to_sql_calls(adapter) == [
-        f'CREATE TABLE IF NOT EXISTS "__temp_test_table_{temp_table_uuid.hex}" ("a" INTEGER, "b" INTEGER)',
+        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table_{temp_table_uuid.hex}') EXEC('CREATE TABLE "__temp_test_table_{temp_table_uuid.hex}" ("a" INTEGER, "b" INTEGER)')""",
         f'INSERT INTO "test_table" ("a", "b") SELECT "a", "b" FROM "__temp_test_table_{temp_table_uuid.hex}"',
         f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_uuid.hex}"',
     ]
@@ -195,7 +195,7 @@ def test_merge_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixt
     )
 
     assert to_sql_calls(adapter) == [
-        f'CREATE TABLE IF NOT EXISTS "__temp_target_{temp_table_uuid.hex}" ("id" INTEGER, "ts" DATETIME2, "val" INTEGER)',
+        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_target_{temp_table_uuid.hex}') EXEC('CREATE TABLE "__temp_target_{temp_table_uuid.hex}" ("id" INTEGER, "ts" DATETIME2, "val" INTEGER)')""",
         f'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT "id", "ts", "val" FROM "__temp_target_{temp_table_uuid.hex}") AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val")',
         f'DROP TABLE IF EXISTS "__temp_target_{temp_table_uuid.hex}"',
     ]
@@ -222,7 +222,7 @@ def test_merge_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixt
     )
 
     assert to_sql_calls(adapter) == [
-        f'CREATE TABLE IF NOT EXISTS "__temp_target_{temp_table_uuid.hex}" ("id" INTEGER, "ts" DATETIME2, "val" INTEGER)',
+        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_target_{temp_table_uuid.hex}') EXEC('CREATE TABLE "__temp_target_{temp_table_uuid.hex}" ("id" INTEGER, "ts" DATETIME2, "val" INTEGER)')""",
         f'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT "id", "ts", "val" FROM "__temp_target_{temp_table_uuid.hex}") AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" AND "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts" WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val")',
         f'DROP TABLE IF EXISTS "__temp_target_{temp_table_uuid.hex}"',
     ]
@@ -263,7 +263,7 @@ def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable, mocker: Mo
     assert to_sql_calls(adapter) == [
         """SELECT 1 FROM "master"."information_schema"."tables" WHERE "table_name" = 'test_table'""",
         'TRUNCATE "test_table"',
-        f"""CREATE TABLE IF NOT EXISTS "__temp_test_table_{temp_table_uuid.hex}" ("a" int, "b" int)""",
+        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table_{temp_table_uuid.hex}') EXEC('CREATE TABLE "__temp_test_table_{temp_table_uuid.hex}" ("a" int, "b" int)')""",
         f'INSERT INTO "test_table" ("a", "b") SELECT "a", "b" FROM "__temp_test_table_{temp_table_uuid.hex}"',
         f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_uuid.hex}"',
     ]

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -1,16 +1,17 @@
 # type: ignore
 import typing as t
+import uuid
 from unittest.mock import call
 
 import pandas as pd
-import pytest
 from pytest_mock.plugin import MockerFixture
 from sqlglot import expressions as exp
 from sqlglot import parse_one
 
 from sqlmesh.core.engine_adapter.base import InsertOverwriteStrategy
 from sqlmesh.core.engine_adapter.mssql import MSSQLEngineAdapter
-from sqlmesh.core.schema_diff import SchemaDiffer, TableAlterOperation
+from sqlmesh.utils.date import to_ds
+from tests.core.engine_adapter import to_sql_calls
 
 
 def test_table_exists(make_mocked_engine_adapter: t.Callable):
@@ -30,108 +31,83 @@ def test_table_exists(make_mocked_engine_adapter: t.Callable):
 
 
 def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas(
-    make_mocked_engine_adapter: t.Callable,
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
 ):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
     adapter.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
+
+    temp_table_uuid = uuid.uuid4()
+    uuid4_mock = mocker.patch("uuid.uuid4")
+    uuid4_mock.return_value = temp_table_uuid
+
     df = pd.DataFrame({"a": [1, 2], "ds": ["2022-01-01", "2022-01-02"]})
-    adapter._insert_overwrite_by_condition(
+    adapter.insert_overwrite_by_time_partition(
         "test_table",
         df,
-        where=parse_one("ds BETWEEN '2022-01-01' and '2022-01-02'"),
+        start="2022-01-01",
+        end="2022-01-02",
+        time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
+        time_column="ds",
         columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
     )
+    adapter._connection_pool.get().assert_has_calls(
+        [
+            call.bulk_copy(
+                f"__temp_test_table_{temp_table_uuid.hex}",
+                [(1, "2022-01-01"), (2, "2022-01-02")],
+            )
+        ]
+    )
 
-    # Check for the important parts of these queries
-    expected_queries: t.List[t.List[str]] = [
-        [
-            "IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table",
-            """EXEC('CREATE TABLE "__temp_test_table""",
-            """("a" BIGINT, "ds" TEXT)""",
-        ],
-        [
-            'INSERT INTO "__temp_test_table_',
-            """" ("a", "ds") SELECT CAST("a" AS BIGINT) AS "a", CAST("ds" AS TEXT) AS "ds" FROM (VALUES (1, '2022-01-01'), (2, '2022-01-02')) AS "t"("a", "ds")""",
-        ],
-        [
-            'MERGE INTO "test_table" AS "__MERGE_TARGET__" USING (SELECT * FROM (SELECT "a", "ds" FROM "__temp_test_table_',
-            """") AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02') AS "__MERGE_SOURCE__" ON 1 = 2 WHEN NOT MATCHED BY SOURCE AND "ds" BETWEEN '2022-01-01' AND '2022-01-02' THEN DELETE WHEN NOT MATCHED THEN INSERT ("a", "ds") VALUES ("a", "ds")""",
-        ],
-        ['DROP TABLE IF EXISTS "__temp_test_table_'],
+    assert to_sql_calls(adapter) == [
+        f'CREATE TABLE IF NOT EXISTS "__temp_test_table_{temp_table_uuid.hex}" ("a" INTEGER, "ds" TEXT)',
+        f"""MERGE INTO "test_table" AS "__MERGE_TARGET__" USING (SELECT * FROM (SELECT "a", "ds" FROM "__temp_test_table_{temp_table_uuid.hex}") AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02') AS "__MERGE_SOURCE__" ON 1 = 2 WHEN NOT MATCHED BY SOURCE AND "ds" BETWEEN '2022-01-01' AND '2022-01-02' THEN DELETE WHEN NOT MATCHED THEN INSERT ("a", "ds") VALUES ("a", "ds")""",
+        f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_uuid.hex}"',
     ]
-    # call can be Tuple[Tuple, Dict] or Tuple[str, Tuple, Dict], per docs
-    # we're after the nested tuple, which contains call args
-    # https://docs.python.org/3.7/library/unittest.mock.html#calls-as-tuples
-    call_list: t.List[str] = [
-        c[0][0] if isinstance(c[0], tuple) else c[1][0]
-        for c in adapter.cursor.execute.call_args_list
-    ]
-    test_results: t.List[bool] = [
-        # any call can match one of the expected queries
-        any(
-            [  # all pieces of the query should be found in the call
-                all([q in c for q in e]) for e in expected_queries
-            ]
-        )
-        for c in call_list
-    ]
-
-    assert all(test_results)
 
 
 def test_insert_overwrite_by_time_partition_replace_where_pandas(
-    make_mocked_engine_adapter: t.Callable,
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
 ):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
-
     adapter.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.REPLACE_WHERE
+
+    temp_table_uuid = uuid.uuid4()
+    uuid4_mock = mocker.patch("uuid.uuid4")
+    uuid4_mock.return_value = temp_table_uuid
+
     df = pd.DataFrame({"a": [1, 2], "ds": ["2022-01-01", "2022-01-02"]})
-    adapter._insert_overwrite_by_condition(
+    adapter.insert_overwrite_by_time_partition(
         "test_table",
         df,
-        where=parse_one("CAST(CAST(ds AS VARCHAR) AS DATE) BETWEEN '2022-01-01' and '2022-01-02'"),
-        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("TEXT")},
+        start="2022-01-01",
+        end="2022-01-02",
+        time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
+        time_column="ds",
+        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+    )
+    adapter._connection_pool.get().assert_has_calls(
+        [
+            call.bulk_copy(
+                f"__temp_test_table_{temp_table_uuid.hex}",
+                [(1, "2022-01-01"), (2, "2022-01-02")],
+            )
+        ]
     )
 
-    # Check for the important parts of these queries
-    expected_queries: t.List[t.List[str]] = [
-        [
-            "IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table",
-            """EXEC('CREATE TABLE "__temp_test_table""",
-            """("a" BIGINT, "ds" TEXT)""",
-        ],
-        [
-            'INSERT INTO "__temp_test_table_',
-            """" ("a", "ds") SELECT CAST("a" AS BIGINT) AS "a", CAST("ds" AS TEXT) AS "ds" FROM (VALUES (1, '2022-01-01'), (2, '2022-01-02')) AS "t"("a", "ds")""",
-        ],
-        [
-            'MERGE INTO "test_table" AS "__MERGE_TARGET__" USING (SELECT * FROM (SELECT "a", "ds" FROM "__temp_test_table_',
-            """") AS "_subquery" WHERE CAST(CAST("ds" AS VARCHAR) AS DATE) BETWEEN '2022-01-01' AND '2022-01-02') AS "__MERGE_SOURCE__" ON 1 = 2 WHEN NOT MATCHED BY SOURCE AND CAST(CAST("ds" AS VARCHAR) AS DATE) BETWEEN '2022-01-01' AND '2022-01-02' THEN DELETE WHEN NOT MATCHED THEN INSERT ("a", "ds") VALUES ("a", "ds")""",
-        ],
-        ['DROP TABLE IF EXISTS "__temp_test_table_'],
-    ]
-    # call can be Tuple[Tuple, Dict] or Tuple[str, Tuple, Dict], per docs
-    # we're after the nested tuple, which contains call args
-    # https://docs.python.org/3.7/library/unittest.mock.html#calls-as-tuples
-    call_list: t.List[str] = [
-        c[0][0] if isinstance(c[0], tuple) else c[1][0]
-        for c in adapter.cursor.execute.call_args_list
-    ]
-    test_results: t.List[bool] = [
-        # any call can match one of the expected queries
-        any(
-            [  # all pieces of the query should be found in the call
-                all([q in c for q in e]) for e in expected_queries
-            ]
-        )
-        for c in call_list
+    assert to_sql_calls(adapter) == [
+        f'CREATE TABLE IF NOT EXISTS "__temp_test_table_{temp_table_uuid.hex}" ("a" INTEGER, "ds" TEXT)',
+        f"""MERGE INTO "test_table" AS "__MERGE_TARGET__" USING (SELECT * FROM (SELECT "a", "ds" FROM "__temp_test_table_{temp_table_uuid.hex}") AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02') AS "__MERGE_SOURCE__" ON 1 = 2 WHEN NOT MATCHED BY SOURCE AND "ds" BETWEEN '2022-01-01' AND '2022-01-02' THEN DELETE WHEN NOT MATCHED THEN INSERT ("a", "ds") VALUES ("a", "ds")""",
+        f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_uuid.hex}"',
     ]
 
-    assert all(test_results)
 
-
-def test_insert_append_pandas(make_mocked_engine_adapter: t.Callable):
+def test_insert_append_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
+
+    temp_table_uuid = uuid.uuid4()
+    uuid4_mock = mocker.patch("uuid.uuid4")
+    uuid4_mock.return_value = temp_table_uuid
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.insert_append(
@@ -142,17 +118,20 @@ def test_insert_append_pandas(make_mocked_engine_adapter: t.Callable):
             "b": exp.DataType.build("INT"),
         },
     )
-
-    adapter.cursor.begin.assert_called_once()
-    adapter.cursor.commit.assert_called_once()
-
-    adapter.cursor.execute.assert_has_calls(
+    adapter._connection_pool.get().assert_has_calls(
         [
-            call(
-                'INSERT INTO "test_table" ("a", "b") SELECT CAST("a" AS INTEGER) AS "a", CAST("b" AS INTEGER) AS "b" FROM (VALUES (1, 4), (2, 5), (3, 6)) AS "t"("a", "b")',
-            ),
+            call.bulk_copy(
+                f"__temp_test_table_{temp_table_uuid.hex}",
+                [(1, 4), (2, 5), (3, 6)],
+            )
         ]
     )
+
+    assert to_sql_calls(adapter) == [
+        f'CREATE TABLE IF NOT EXISTS "__temp_test_table_{temp_table_uuid.hex}" ("a" INTEGER, "b" INTEGER)',
+        f'INSERT INTO "test_table" ("a", "b") SELECT "a", "b" FROM "__temp_test_table_{temp_table_uuid.hex}"',
+        f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_uuid.hex}"',
+    ]
 
 
 def test_create_table(make_mocked_engine_adapter: t.Callable):
@@ -188,411 +167,65 @@ def test_create_table_properties(make_mocked_engine_adapter: t.Callable):
     )
 
 
-@pytest.mark.parametrize(
-    "schema_differ_config, current_table, target_table, expected_final_structure, expected",
-    [
-        (
-            {
-                "support_positional_add": True,
-                "support_nested_operations": True,
-                "array_element_selector": "element",
-            },
-            {
-                "a": "INT",
-                "b": "TEXT",
-                "c": "INT",
-                "d": "INT",
-                "nested": "STRUCT<nested_a INT, nested_c INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_c INT>>",
-            },
-            {
-                "f": "VARCHAR(100)",
-                "a": "INT",
-                "e": "TEXT",
-                "b": "TEXT",
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_c INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_c INT>>",
-            },
-            {
-                "f": "VARCHAR(100)",
-                "a": "INT",
-                "e": "TEXT",
-                "b": "TEXT",
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_c INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_c INT>>",
-            },
-            [
-                'ALTER TABLE "test_table" DROP COLUMN "c"',
-                'ALTER TABLE "test_table" DROP COLUMN "d"',
-                'ALTER TABLE "test_table" ADD "f" VARCHAR(100) FIRST',
-                'ALTER TABLE "test_table" ADD "e" TEXT AFTER "a"',
-                'ALTER TABLE "test_table" ADD "nested"."nested_b" INTEGER AFTER "nested_a"',
-                'ALTER TABLE "test_table" ADD "array_col"."element"."array_b" INTEGER AFTER "array_a"',
-            ],
-        ),
-        (
-            {
-                "support_nested_operations": True,
-                "array_element_selector": "element",
-            },
-            {
-                "a": "INT",
-                "b": "TEXT",
-                "c": "INT",
-                "d": "INT",
-                "nested": "STRUCT<nested_a INT, nested_c INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_c INT>>",
-            },
-            {
-                "f": "VARCHAR(100)",
-                "a": "INT",
-                "e": "TEXT",
-                "b": "TEXT",
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_c INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_c INT>>",
-            },
-            {
-                "a": "INT",
-                "b": "TEXT",
-                "nested": "STRUCT<nested_a INT, nested_c INT, nested_b INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_c INT, array_b INT>>",
-                "f": "VARCHAR(100)",
-                "e": "TEXT",
-            },
-            [
-                'ALTER TABLE "test_table" DROP COLUMN "c"',
-                'ALTER TABLE "test_table" DROP COLUMN "d"',
-                'ALTER TABLE "test_table" ADD "f" VARCHAR(100)',
-                'ALTER TABLE "test_table" ADD "e" TEXT',
-                'ALTER TABLE "test_table" ADD "nested"."nested_b" INTEGER',
-                'ALTER TABLE "test_table" ADD "array_col"."element"."array_b" INTEGER',
-            ],
-        ),
-        (
-            {
-                "array_element_selector": "element",
-            },
-            {
-                "a": "INT",
-                "b": "TEXT",
-                "c": "INT",
-                "d": "INT",
-                "nested": "STRUCT<nested_a INT, nested_c INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_c INT>>",
-            },
-            {
-                "f": "VARCHAR(100)",
-                "a": "INT",
-                "e": "TEXT",
-                "b": "TEXT",
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_c INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_c INT>>",
-            },
-            {
-                "a": "INT",
-                "b": "TEXT",
-                "f": "VARCHAR(100)",
-                "e": "TEXT",
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_c INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_c INT>>",
-            },
-            [
-                'ALTER TABLE "test_table" DROP COLUMN "c"',
-                'ALTER TABLE "test_table" DROP COLUMN "d"',
-                'ALTER TABLE "test_table" ADD "f" VARCHAR(100)',
-                'ALTER TABLE "test_table" ADD "e" TEXT',
-                'ALTER TABLE "test_table" DROP COLUMN "nested"',
-                'ALTER TABLE "test_table" ADD "nested" STRUCT<"nested_a" INTEGER, "nested_b" INTEGER, "nested_c" INTEGER>',
-                'ALTER TABLE "test_table" DROP COLUMN "array_col"',
-                'ALTER TABLE "test_table" ADD "array_col" ARRAY<STRUCT<"array_a" INTEGER, "array_b" INTEGER, "array_c" INTEGER>>',
-            ],
-        ),
-        (
-            {
-                "array_element_selector": "element",
-            },
-            {
-                "a": "INT",
-                "b": "TEXT",
-                "c": "INT",
-                "d": "INT",
-                "nested": "STRUCT<nested_a INT, nested_c INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_c INT>>",
-            },
-            {
-                "f": "VARCHAR(100)",
-                "a": "INT",
-                "e": "TEXT",
-                "b": "TEXT",
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_c INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_c INT>>",
-            },
-            {
-                "a": "INT",
-                "b": "TEXT",
-                "f": "VARCHAR(100)",
-                "e": "TEXT",
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_c INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_c INT>>",
-            },
-            [
-                'ALTER TABLE "test_table" DROP COLUMN "c"',
-                'ALTER TABLE "test_table" DROP COLUMN "d"',
-                'ALTER TABLE "test_table" ADD "f" VARCHAR(100)',
-                'ALTER TABLE "test_table" ADD "e" TEXT',
-                'ALTER TABLE "test_table" DROP COLUMN "nested"',
-                'ALTER TABLE "test_table" ADD "nested" STRUCT<"nested_a" INTEGER, "nested_b" INTEGER, "nested_c" INTEGER>',
-                'ALTER TABLE "test_table" DROP COLUMN "array_col"',
-                'ALTER TABLE "test_table" ADD "array_col" ARRAY<STRUCT<"array_a" INTEGER, "array_b" INTEGER, "array_c" INTEGER>>',
-            ],
-        ),
-        # Test multiple operations on a column with positional and nested features enabled
-        (
-            {
-                "support_positional_add": True,
-                "support_nested_operations": True,
-                "array_element_selector": "element",
-            },
-            {
-                "nested": """STRUCT<nested_a INT, "nested_c" INT, nested_e INT>""",
-                "array_col": """ARRAY<STRUCT<array_a INT, "array_c" INT, array_e INT>>""",
-            },
-            {
-                "nested": """STRUCT<nested_a INT, "nested_b" INT, nested_d INT, nested_e INT>""",
-                "array_col": """ARRAY<STRUCT<array_a INT, "array_b" INT, array_d INT, array_e INT>>""",
-            },
-            {
-                "nested": """STRUCT<nested_a INT, "nested_b" INT, nested_d INT, nested_e INT>""",
-                "array_col": """ARRAY<STRUCT<array_a INT, "array_b" INT, array_d INT, array_e INT>>""",
-            },
-            [
-                'ALTER TABLE "test_table" DROP COLUMN "nested"."nested_c"',
-                'ALTER TABLE "test_table" ADD "nested"."nested_b" INTEGER AFTER "nested_a"',
-                'ALTER TABLE "test_table" ADD "nested"."nested_d" INTEGER AFTER "nested_b"',
-                'ALTER TABLE "test_table" DROP COLUMN "array_col"."element"."array_c"',
-                'ALTER TABLE "test_table" ADD "array_col"."element"."array_b" INTEGER AFTER "array_a"',
-                'ALTER TABLE "test_table" ADD "array_col"."element"."array_d" INTEGER AFTER "array_b"',
-            ],
-        ),
-        # Test multiple operations on a column with positional and nested features enabled and that when adding
-        # last we don't include position since it is not needed
-        (
-            {
-                "support_positional_add": True,
-                "support_nested_operations": True,
-                "array_element_selector": "element",
-            },
-            {
-                "nested": "STRUCT<nested_a INT, nested_c INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_c INT>>",
-            },
-            {
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_d INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_d INT>>",
-            },
-            {
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_d INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_d INT>>",
-            },
-            [
-                'ALTER TABLE "test_table" DROP COLUMN "nested"."nested_c"',
-                # Position is not included since we are adding to last so we don't need to specify position
-                'ALTER TABLE "test_table" ADD "nested"."nested_b" INTEGER',
-                'ALTER TABLE "test_table" ADD "nested"."nested_d" INTEGER',
-                'ALTER TABLE "test_table" DROP COLUMN "array_col"."element"."array_c"',
-                'ALTER TABLE "test_table" ADD "array_col"."element"."array_b" INTEGER',
-                'ALTER TABLE "test_table" ADD "array_col"."element"."array_d" INTEGER',
-            ],
-        ),
-        # Test multiple operations on a column with positional and no nested features enabled
-        (
-            {
-                "support_positional_add": True,
-                "array_element_selector": "element",
-            },
-            {
-                "nested": "STRUCT<nested_a INT, nested_c INT, nested_e INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_c INT, array_e INT>>",
-                "col_c": "INT",
-            },
-            {
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_d INT, nested_e INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_d INT, array_e INT>>",
-                "col_c": "INT",
-            },
-            {
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_d INT, nested_e INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_d INT, array_e INT>>",
-                "col_c": "INT",
-            },
-            [
-                'ALTER TABLE "test_table" DROP COLUMN "nested"',
-                'ALTER TABLE "test_table" ADD "nested" STRUCT<"nested_a" INTEGER, "nested_b" INTEGER, "nested_d" INTEGER, "nested_e" INTEGER> FIRST',
-                'ALTER TABLE "test_table" DROP COLUMN "array_col"',
-                'ALTER TABLE "test_table" ADD "array_col" ARRAY<STRUCT<"array_a" INTEGER, "array_b" INTEGER, "array_d" INTEGER, "array_e" INTEGER>> AFTER "nested"',
-            ],
-        ),
-        # Test multiple operations on a column with no positional and nested features enabled
-        (
-            {
-                "support_nested_operations": True,
-                "array_element_selector": "element",
-            },
-            {
-                "nested": "STRUCT<nested_a INT, nested_c INT, nested_e INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_c INT, nested_e INT>>",
-                "col_c": "INT",
-            },
-            {
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_d INT, nested_e INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_d INT, nested_e INT>>",
-                "col_c": "INT",
-            },
-            {
-                "nested": "STRUCT<nested_a INT, nested_e INT, nested_b INT, nested_d INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, nested_e INT, array_b INT, array_d INT>>",
-                "col_c": "INT",
-            },
-            [
-                'ALTER TABLE "test_table" DROP COLUMN "nested"."nested_c"',
-                'ALTER TABLE "test_table" ADD "nested"."nested_b" INTEGER',
-                'ALTER TABLE "test_table" ADD "nested"."nested_d" INTEGER',
-                'ALTER TABLE "test_table" DROP COLUMN "array_col"."element"."array_c"',
-                'ALTER TABLE "test_table" ADD "array_col"."element"."array_b" INTEGER',
-                'ALTER TABLE "test_table" ADD "array_col"."element"."array_d" INTEGER',
-            ],
-        ),
-        # Test multiple operations on a column with no positional or nested features enabled
-        (
-            {
-                "array_element_selector": "element",
-            },
-            {
-                "nested": "STRUCT<nested_a INT, nested_c INT, nested_e INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_c INT, array_e INT>>",
-                "col_c": "INT",
-            },
-            {
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_d INT, nested_e INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_d INT, array_e INT>>",
-                "col_c": "INT",
-            },
-            {
-                "col_c": "INT",
-                "nested": "STRUCT<nested_a INT, nested_b INT, nested_d INT, nested_e INT>",
-                "array_col": "ARRAY<STRUCT<array_a INT, array_b INT, array_d INT, array_e INT>>",
-            },
-            [
-                'ALTER TABLE "test_table" DROP COLUMN "nested"',
-                'ALTER TABLE "test_table" ADD "nested" STRUCT<"nested_a" INTEGER, "nested_b" INTEGER, "nested_d" INTEGER, "nested_e" INTEGER>',
-                'ALTER TABLE "test_table" DROP COLUMN "array_col"',
-                'ALTER TABLE "test_table" ADD "array_col" ARRAY<STRUCT<"array_a" INTEGER, "array_b" INTEGER, "array_d" INTEGER, "array_e" INTEGER>>',
-            ],
-        ),
-        # Test deeply nested structures
-        (
-            {
-                "support_nested_operations": True,
-                "array_element_selector": "element",
-            },
-            {
-                "nested": """STRUCT<nested_1_a STRUCT<"nested_2_a" ARRAY<STRUCT<nested_3_a STRUCT<nested_4_a ARRAY<STRUCT<"nested_5_a" ARRAY<STRUCT<nested_6_a INT>>>>>>>>>""",
-            },
-            {
-                "nested": """STRUCT<nested_1_a STRUCT<"nested_2_a" ARRAY<STRUCT<nested_3_a STRUCT<nested_4_a ARRAY<STRUCT<"nested_5_a" ARRAY<STRUCT<nested_6_a INT, nested_6_b INT>>>>>>>>>""",
-            },
-            {
-                "nested": """STRUCT<nested_1_a STRUCT<"nested_2_a" ARRAY<STRUCT<nested_3_a STRUCT<nested_4_a ARRAY<STRUCT<"nested_5_a" ARRAY<STRUCT<nested_6_a INT, nested_6_b INT>>>>>>>>>""",
-            },
-            [
-                'ALTER TABLE "test_table" ADD "nested"."nested_1_a"."nested_2_a"."element"."nested_3_a"."nested_4_a"."element"."nested_5_a"."element"."nested_6_b" INTEGER',
-            ],
-        ),
-    ],
-)
-def test_alter_table(
-    make_mocked_engine_adapter: t.Callable,
-    mocker: MockerFixture,
-    schema_differ_config: t.Dict[str, t.Any],
-    current_table: t.Dict[str, str],
-    target_table: t.Dict[str, str],
-    expected_final_structure: t.Dict[str, str],
-    expected: t.List[str],
-):
+def test_merge_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
 
-    adapter.SCHEMA_DIFFER = SchemaDiffer(**schema_differ_config)
-    original_from_structs = adapter.SCHEMA_DIFFER._from_structs
-
-    def _from_structs(
-        current_struct: exp.DataType, new_struct: exp.DataType
-    ) -> t.List[TableAlterOperation]:
-        operations = original_from_structs(current_struct, new_struct)
-        assert (
-            operations[-1].expected_table_struct.sql()
-            == SchemaDiffer._dict_to_struct(expected_final_structure).sql()
-        )
-        return operations
-
-    mocker.patch.object(SchemaDiffer, "_from_structs", side_effect=_from_structs)
-
-    current_table_name = "test_table"
-    target_table_name = "target_table"
-
-    def table_columns(table_name: str) -> t.Dict[str, exp.DataType]:
-        if table_name == current_table_name:
-            return {k: exp.DataType.build(v) for k, v in current_table.items()}
-        else:
-            return {k: exp.DataType.build(v) for k, v in target_table.items()}
-
-    adapter.columns = table_columns
-
-    adapter.alter_table(
-        current_table_name,
-        target_table_name,
-    )
-
-    adapter.cursor.begin.assert_called_once()
-    adapter.cursor.commit.assert_called_once()
-    adapter.cursor.execute.assert_has_calls([call(x) for x in expected])
-
-
-def test_merge_pandas(make_mocked_engine_adapter: t.Callable):
-    adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
+    temp_table_uuid = uuid.uuid4()
+    uuid4_mock = mocker.patch("uuid.uuid4")
+    uuid4_mock.return_value = temp_table_uuid
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.merge(
         target_table="target",
         source_table=df,
         columns_to_types={
-            "id": exp.DataType.Type.INT,
-            "ts": exp.DataType.Type.TIMESTAMP,
-            "val": exp.DataType.Type.INT,
+            "id": exp.DataType.build("int"),
+            "ts": exp.DataType.build("TIMESTAMP"),
+            "val": exp.DataType.build("int"),
         },
         unique_key=["id"],
     )
-    adapter.cursor.execute.assert_called_once_with(
-        'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT CAST("id" AS INTEGER) AS "id", CAST("ts" AS DATETIME2) AS "ts", CAST("val" AS INTEGER) AS "val" FROM (VALUES (1, 4), (2, 5), (3, 6)) AS "t"("id", "ts", "val")) AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" '
-        'WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" '
-        'WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val")'
+    adapter._connection_pool.get().assert_has_calls(
+        [
+            call.bulk_copy(
+                f"__temp_target_{temp_table_uuid.hex}",
+                [(1, 4), (2, 5), (3, 6)],
+            )
+        ]
     )
 
+    assert to_sql_calls(adapter) == [
+        f'CREATE TABLE IF NOT EXISTS "__temp_target_{temp_table_uuid.hex}" ("id" INTEGER, "ts" DATETIME2, "val" INTEGER)',
+        f'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT "id", "ts", "val" FROM "__temp_target_{temp_table_uuid.hex}") AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val")',
+        f'DROP TABLE IF EXISTS "__temp_target_{temp_table_uuid.hex}"',
+    ]
+
     adapter.cursor.reset_mock()
+    adapter._connection_pool.get().reset_mock()
     adapter.merge(
         target_table="target",
         source_table=df,
         columns_to_types={
-            "id": exp.DataType.Type.INT,
-            "ts": exp.DataType.Type.TIMESTAMP,
-            "val": exp.DataType.Type.INT,
+            "id": exp.DataType.build("int"),
+            "ts": exp.DataType.build("TIMESTAMP"),
+            "val": exp.DataType.build("int"),
         },
         unique_key=["id", "ts"],
     )
-    adapter.cursor.execute.assert_called_once_with(
-        'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT CAST("id" AS INTEGER) AS "id", CAST("ts" AS DATETIME2) AS "ts", CAST("val" AS INTEGER) AS "val" FROM (VALUES (1, 4), (2, 5), (3, 6)) AS "t"("id", "ts", "val")) AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" AND "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts" '
-        'WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" '
-        'WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val")'
+    adapter._connection_pool.get().assert_has_calls(
+        [
+            call.bulk_copy(
+                f"__temp_target_{temp_table_uuid.hex}",
+                [(1, 4), (2, 5), (3, 6)],
+            )
+        ]
     )
+
+    assert to_sql_calls(adapter) == [
+        f'CREATE TABLE IF NOT EXISTS "__temp_target_{temp_table_uuid.hex}" ("id" INTEGER, "ts" DATETIME2, "val" INTEGER)',
+        f'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT "id", "ts", "val" FROM "__temp_target_{temp_table_uuid.hex}") AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" AND "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts" WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val")',
+        f'DROP TABLE IF EXISTS "__temp_target_{temp_table_uuid.hex}"',
+    ]
 
 
 def test_replace_query(make_mocked_engine_adapter: t.Callable):
@@ -600,41 +233,40 @@ def test_replace_query(make_mocked_engine_adapter: t.Callable):
     adapter.cursor.fetchone.return_value = (1,)
     adapter.replace_query("test_table", parse_one("SELECT a FROM tbl"), {"a": "int"})
 
-    adapter.cursor.execute.assert_has_calls(
-        [
-            call(
-                """SELECT 1 """
-                """FROM "master"."information_schema"."tables" """
-                """WHERE "table_name" = 'test_table'"""
-            ),
-            call('TRUNCATE "test_table"'),
-            call('INSERT INTO "test_table" ("a") SELECT "a" FROM "tbl"'),
-        ]
-    )
+    assert to_sql_calls(adapter) == [
+        """SELECT 1 FROM "master"."information_schema"."tables" WHERE "table_name" = 'test_table'""",
+        'TRUNCATE "test_table"',
+        'INSERT INTO "test_table" ("a") SELECT "a" FROM "tbl"',
+    ]
 
 
-def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable):
+def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
     adapter.cursor.fetchone.return_value = (1,)
+
+    temp_table_uuid = uuid.uuid4()
+    uuid4_mock = mocker.patch("uuid.uuid4")
+    uuid4_mock.return_value = temp_table_uuid
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.replace_query("test_table", df, {"a": "int", "b": "int"})
 
-    adapter.cursor.execute.assert_has_calls(
+    adapter._connection_pool.get().assert_has_calls(
         [
-            call(
-                """SELECT 1 FROM "master"."information_schema"."tables" WHERE "table_name" = 'test_table'"""
-            ),
-            call('TRUNCATE "test_table"'),
-            call(
-                'INSERT INTO "test_table" ("a", "b") '
-                "SELECT "
-                'CAST("a" AS INTEGER) AS "a", '
-                'CAST("b" AS INTEGER) AS "b" '
-                'FROM (VALUES (1, 4), (2, 5), (3, 6)) AS "t"("a", "b")'
-            ),
+            call.bulk_copy(
+                f"__temp_test_table_{temp_table_uuid.hex}",
+                [(1, 4), (2, 5), (3, 6)],
+            )
         ]
     )
+
+    assert to_sql_calls(adapter) == [
+        """SELECT 1 FROM "master"."information_schema"."tables" WHERE "table_name" = 'test_table'""",
+        'TRUNCATE "test_table"',
+        f"""CREATE TABLE IF NOT EXISTS "__temp_test_table_{temp_table_uuid.hex}" ("a" int, "b" int)""",
+        f'INSERT INTO "test_table" ("a", "b") SELECT "a", "b" FROM "__temp_test_table_{temp_table_uuid.hex}"',
+        f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_uuid.hex}"',
+    ]
 
 
 def test_create_table_primary_key(make_mocked_engine_adapter: t.Callable):

--- a/tests/core/engine_adapter/test_redshift.py
+++ b/tests/core/engine_adapter/test_redshift.py
@@ -2,7 +2,6 @@
 import typing as t
 
 import pandas as pd
-import pytest
 from pytest_mock.plugin import MockerFixture
 from sqlglot import expressions as exp
 from sqlglot import parse_one
@@ -19,18 +18,6 @@ def test_columns(make_mocked_engine_adapter: t.Callable):
         """SELECT "column_name", "data_type" FROM "SVV_COLUMNS" WHERE "table_name" = 'table' AND "table_schema" = 'db'"""
     )
     assert resp == {"col": exp.DataType.build("INT")}
-
-
-def test_create_view_from_dataframe(make_mocked_engine_adapter: t.Callable):
-    adapter = make_mocked_engine_adapter(RedshiftEngineAdapter)
-    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    pytest.raises(
-        NotImplementedError,
-        adapter.create_view,
-        view_name="test_view",
-        query_or_df=df,
-        columns_to_types={"a": "int", "b": "int"},
-    )
 
 
 def test_create_table_from_query_exists_no_if_not_exists(

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -110,7 +110,7 @@ def test_replace_query(make_mocked_engine_adapter: t.Callable):
 
     assert to_sql_calls(adapter) == [
         "CREATE TABLE IF NOT EXISTS `test_table` (`a` int)",
-        "INSERT OVERWRITE TABLE `test_table` (`a`) SELECT * FROM (SELECT `a` FROM `tbl`) AS `_subquery` WHERE 1 = 1",
+        "INSERT OVERWRITE TABLE `test_table` (`a`) SELECT * FROM (SELECT `a` FROM `tbl`) AS `_subquery` WHERE TRUE",
     ]
 
 
@@ -124,7 +124,7 @@ def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable, mocker: Mo
 
     assert to_sql_calls(adapter) == [
         "CREATE TABLE IF NOT EXISTS `test_table` (`a` INT, `b` INT)",
-        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `t`(`a`, `b`)) AS `_subquery` WHERE 1 = 1",
+        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `t`(`a`, `b`)) AS `_subquery` WHERE TRUE",
     ]
 
 

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -116,10 +116,12 @@ def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable, mocker: Mo
     adapter = make_mocked_engine_adapter(SparkEngineAdapter)
     mocker.patch("sqlmesh.core.engine_adapter.spark.SparkEngineAdapter._use_spark_session", False)
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    adapter.replace_query("test_table", df, {"a": "int", "b": "int"})
+    adapter.replace_query(
+        "test_table", df, {"a": exp.DataType.build("int"), "b": exp.DataType.build("int")}
+    )
 
     adapter.cursor.execute.assert_called_once_with(
-        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `test_table`(`a`, `b`)) AS `_subquery` WHERE 1 = 1"
+        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `t`(`a`, `b`)) AS `_subquery` WHERE 1 = 1"
     )
 
 

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -10,6 +10,7 @@ from sqlglot import parse_one
 
 from sqlmesh.core.engine_adapter import SparkEngineAdapter
 from sqlmesh.utils.errors import SQLMeshError
+from tests.core.engine_adapter import to_sql_calls
 
 
 def test_create_table_properties(make_mocked_engine_adapter: t.Callable):
@@ -107,9 +108,10 @@ def test_replace_query(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(SparkEngineAdapter)
     adapter.replace_query("test_table", parse_one("SELECT a FROM tbl"), {"a": "int"})
 
-    adapter.cursor.execute.assert_called_once_with(
-        "INSERT OVERWRITE TABLE `test_table` (`a`) SELECT * FROM (SELECT `a` FROM `tbl`) AS `_subquery` WHERE 1 = 1"
-    )
+    assert to_sql_calls(adapter) == [
+        "CREATE TABLE IF NOT EXISTS `test_table` (`a` int)",
+        "INSERT OVERWRITE TABLE `test_table` (`a`) SELECT * FROM (SELECT `a` FROM `tbl`) AS `_subquery` WHERE 1 = 1",
+    ]
 
 
 def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
@@ -120,9 +122,10 @@ def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable, mocker: Mo
         "test_table", df, {"a": exp.DataType.build("int"), "b": exp.DataType.build("int")}
     )
 
-    adapter.cursor.execute.assert_called_once_with(
-        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `t`(`a`, `b`)) AS `_subquery` WHERE 1 = 1"
-    )
+    assert to_sql_calls(adapter) == [
+        "CREATE TABLE IF NOT EXISTS `test_table` (`a` INT, `b` INT)",
+        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT * FROM (SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `t`(`a`, `b`)) AS `_subquery` WHERE 1 = 1",
+    ]
 
 
 def test_create_table_table_options(make_mocked_engine_adapter: t.Callable):

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -519,7 +519,7 @@ def test_migrate_view(
     cursor_mock.execute.assert_has_calls(
         [
             call(
-                'CREATE OR REPLACE VIEW "sqlmesh__test_schema"."test_schema__test_model__1" AS SELECT "c" AS "c", "a" AS "a" FROM "tbl" AS "tbl"'
+                'CREATE OR REPLACE VIEW "sqlmesh__test_schema"."test_schema__test_model__1" ("c", "a") AS SELECT "c" AS "c", "a" AS "a" FROM "tbl" AS "tbl"'
             )
         ]
     )


### PR DESCRIPTION
The core change is to create a single method (`_df_to_source_query`) that can be overridden by any engine to take a Dataframe and create a query. They just need to return a generator that creates expressions. Since it is a generator they can also define their own setup/teardown logic around each expression. This covers all known implementations of either converting pandas to SQL, loading pandas to temp table and then reading from the table, or create a tempView out of a PySpark Dataframe. 

One known regression is that for BigQuery and Snowflake we now always load to a temp table from a Pandas Dataframe and then copy those contents into the target table when in some cases we could have loaded the target directly. Since Pandas Dataframes are smaller data I doubt this have much actual impact and can be improved in a follow-up PR.


Follow Up:
* Make `columns_to_types` required in `SourceQuery`
* Add support for testing Spark
* Add MSSQL to integration tests