### PR TITLE
Fix: Remove Distinct On from scd type 2

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -811,9 +811,9 @@ class EngineAdapter:
             exp.Select()  # type: ignore
             .with_(
                 "source",
-                exp.select(*unmanaged_columns)
-                .distinct(*unique_key)
-                .from_(source_table.subquery("raw_source")),  # type: ignore
+                exp.select(*unmanaged_columns).from_(
+                    source_table.subquery("raw_source")  # type: ignore
+                ),
             )
             # Historical Records that Do Not Change
             .with_(
@@ -1099,6 +1099,8 @@ class EngineAdapter:
                 if isinstance(e, exp.Expression)
                 else e
             )
+            logger.error("THE SQL: %s", sql)
+            print(sql)
             logger.debug(f"Executing SQL:\n{sql}")
             self.cursor.execute(sql, **kwargs)
 

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -732,7 +732,7 @@ def test_scd_type_2(make_mocked_engine_adapter: t.Callable):
             """
 CREATE OR REPLACE TABLE "target" AS
 WITH "source" AS (
-  SELECT DISTINCT ON ("id")
+  SELECT
     "id",
     "name",
     "price",
@@ -884,7 +884,7 @@ def test_merge_scd_type_2_pandas(make_mocked_engine_adapter: t.Callable):
             """
 CREATE OR REPLACE TABLE "target" AS
 WITH "source" AS (
-  SELECT DISTINCT ON ("id1", "id2")
+  SELECT
     "id1",
     "id2",
     "name",


### PR DESCRIPTION
The transpilation to spark is invalid. Error:
```
Window function row_number() requires window to be ordered, please add ORDER BY clause. For example SELECT row_number()(value_expr) OVER (PARTITION BY window_partition ORDER BY window_ordering) from table.
```

Going to hotfix by removing this entirely (user should be ensuring that their source is unique on the column they claim it to be) but open to adding it back in later if we think the cost is worth it. This was an undocumented aspect of the code so documentation does not need to be changed. 