### PR TITLE
Fix: Clear timeoutId and callback to avoid zombie timeouts

### DIFF
--- a/web/client/openapi.json
+++ b/web/client/openapi.json
@@ -1189,6 +1189,7 @@
           "INCREMENTAL_BY_UNIQUE_KEY",
           "INCREMENTAL_UNMANAGED",
           "FULL",
+          "SCD_TYPE_2",
           "VIEW",
           "EMBEDDED",
           "SEED",

--- a/web/client/src/api/index.ts
+++ b/web/client/src/api/index.ts
@@ -450,10 +450,10 @@ function useQueryWithTimeout<
     console.log(`[REQUEST CANCELED] ${key} at ${Date.now()}`)
   }
 
-  function onError(err: TError): void {
+  function onError(err: TError & { name?: string }): void {
     timeoutClear()
 
-    if (isCancelledError(err)) {
+    if (isCancelledError(err) || err.name === 'AbortError') {
       console.log(
         `[REQUEST ABORTED] ${key} aborted by React Query at ${Date.now()}`,
       )

--- a/web/client/src/library/components/plan/Plan.tsx
+++ b/web/client/src/library/components/plan/Plan.tsx
@@ -254,6 +254,7 @@ function Plan({
           setPlanState(EnumPlanState.Finished)
         }
       })
+      .catch(console.log)
       .finally(() => {
         elTaskProgress?.current?.scrollIntoView({
           behavior: 'smooth',

--- a/web/client/src/library/pages/ide/RunPlan.tsx
+++ b/web/client/src/library/pages/ide/RunPlan.tsx
@@ -252,7 +252,7 @@ function PlanChanges({
               <ChangesPreview
                 headline="Direct Changes"
                 type={EnumPlanChangeType.Direct}
-                changes={plan!.changes!.modified.direct!.map(
+                changes={plan!.changes!.modified.direct.map(
                   ({ model_name }) => model_name,
                 )}
               />
@@ -261,7 +261,7 @@ function PlanChanges({
               <ChangesPreview
                 headline="Indirectly Modified"
                 type={EnumPlanChangeType.Indirect}
-                changes={plan!.changes!.modified.indirect!.map(
+                changes={plan!.changes!.modified.indirect.map(
                   ci => ci.model_name,
                 )}
               />


### PR DESCRIPTION
Also increased delay to be 1min. Timeout only should send an error if server is not `500` but request taking longer then `delay` to return response. Mainly when server is unresponsive (an unexpected error occurred on server). Another potential case is when calling `context.load()` from `_get_loaded_context`  triggered  and takes too long.