### PR TITLE
Feature/add model to audit log

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1050,14 +1050,15 @@ class Context(BaseContext):
                 snapshots=self.snapshots,
                 raise_exception=False,
             ):
+                audit_id = f"{audit_result.model.name}:{audit_result.audit.name}"
                 if audit_result.skipped:
-                    self.console.log_status_update(f"{audit_result.audit.name} SKIPPED.")
+                    self.console.log_status_update(f"{audit_id} SKIPPED.")
                     skipped_count += 1
                 elif audit_result.count:
                     errors.append(audit_result)
-                    self.console.log_status_update(f"{audit_result.audit.name} FAIL.")
+                    self.console.log_status_update(f"{audit_id} FAIL.")
                 else:
-                    self.console.log_status_update(f"{audit_result.audit.name} PASS.")
+                    self.console.log_status_update(f"{audit_id} PASS.")
 
         self.console.log_status_update(
             f"\nFinished with {len(errors)} audit error{'' if len(errors) == 1 else 's'} "

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1050,13 +1050,15 @@ class Context(BaseContext):
                 snapshots=self.snapshots,
                 raise_exception=False,
             ):
-                audit_id = f"{audit_result.model.name}:{audit_result.audit.name}"
+                audit_id = f"{audit_result.audit.name}"
+                if audit_result.model:
+                    audit_id += f" on model {audit_result.model.name}"
                 if audit_result.skipped:
                     self.console.log_status_update(f"{audit_id} SKIPPED.")
                     skipped_count += 1
                 elif audit_result.count:
                     errors.append(audit_result)
-                    self.console.log_status_update(f"{audit_id} FAIL.")
+                    self.console.log_status_update(f"{audit_id} FAIL [{audit_result.count}].")
                 else:
                     self.console.log_status_update(f"{audit_id} PASS.")
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1050,7 +1050,10 @@ class Context(BaseContext):
                 snapshots=self.snapshots,
                 raise_exception=False,
             ):
-                
+                audit_id = f"{audit_result.audit.name}"
+                if audit_result.model:
+                    audit_id += f" on model {audit_result.model.name}"
+
                 if audit_result.skipped:
                     self.console.log_status_update(f"{audit_id} ⏸️ SKIPPED.")
                     skipped_count += 1

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1051,18 +1051,16 @@ class Context(BaseContext):
                 raise_exception=False,
             ):
                 
-                if audit_result.model:
-                    audit_id += f" on model {audit_result.model.name}"
                 if audit_result.skipped:
-                    self.console.log_status_update(f"{audit_id} SKIPPED.")
+                    self.console.log_status_update(f"{audit_id} ⏸️ SKIPPED.")
                     skipped_count += 1
                 elif audit_result.count:
                     errors.append(audit_result)
                     self.console.log_status_update(
-                        f"{audit_id} FAIL [{audit_result.count}] [{audit_result.count}]."
+                        f"{audit_id} ❌ [red]FAIL [{audit_result.count}][/red]."
                     )
                 else:
-                    self.console.log_status_update(f"{audit_id} PASS.")
+                    self.console.log_status_update(f"{audit_id} ✅ [green]PASS[/green].")
 
         self.console.log_status_update(
             f"\nFinished with {len(errors)} audit error{'' if len(errors) == 1 else 's'} "

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1050,7 +1050,7 @@ class Context(BaseContext):
                 snapshots=self.snapshots,
                 raise_exception=False,
             ):
-                audit_id = f"{audit_result.audit.name}"
+                
                 if audit_result.model:
                     audit_id += f" on model {audit_result.model.name}"
                 if audit_result.skipped:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1058,7 +1058,9 @@ class Context(BaseContext):
                     skipped_count += 1
                 elif audit_result.count:
                     errors.append(audit_result)
-                    self.console.log_status_update(f"{audit_id} FAIL [{audit_result.count}].")
+                    self.console.log_status_update(
+                        f"{audit_id} FAIL [{audit_result.count}] [{audit_result.count}]."
+                    )
                 else:
                     self.console.log_status_update(f"{audit_id} PASS.")
 


### PR DESCRIPTION
- Adding model name into the audit log
- Adding count if FAILED

Current v30:
```
(.env) $>sqlmesh audit
Found 21 audit(s).
assert_positive_order_ids PASS.
```

After merged
```
(.env) $>sqlmesh audit
Found 21 audit(s).
assert_positive_order_ids on model sqlmesh_example.full_model ✅ PASS.
assert_positive_order_ids on model sqlmesh_example.full_model  ❌ FAIL [100].
assert_positive_order_ids on model sqlmesh_example.full_model  ⏸️ SKIPPED.
```