### PR TITLE
Fix!: Make interval unit a part of the data hash

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -699,6 +699,7 @@ class _Model(ModelMeta, frozen=True):
             *(self.clustered_by or []),
             self.stamp,
             self.physical_schema,
+            str(self.interval_unit_) if self.interval_unit_ is not None else None,
         ]
 
         for column_name, column_type in (self.columns_to_types_ or {}).items():
@@ -741,7 +742,6 @@ class _Model(ModelMeta, frozen=True):
             *sorted(ref.json(sort_keys=True) for ref in self.all_references),
             str(self.forward_only),
             str(self.disable_restatement),
-            str(self.interval_unit_) if self.interval_unit_ is not None else None,
             self.project,
         ]
 

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -395,8 +395,8 @@ def test_fingerprint(model: Model, parent_model: Model):
     fingerprint = fingerprint_from_node(model, nodes={})
 
     original_fingerprint = SnapshotFingerprint(
-        data_hash="1116890341",
-        metadata_hash="1312958471",
+        data_hash="3811098861",
+        metadata_hash="1237394431",
     )
 
     assert fingerprint == original_fingerprint
@@ -442,8 +442,8 @@ def test_fingerprint_seed_model():
     )
 
     expected_fingerprint = SnapshotFingerprint(
-        data_hash="1421766360",
-        metadata_hash="1617581697",
+        data_hash="3270932819",
+        metadata_hash="3585221762",
     )
 
     model = load_sql_based_model(expressions, path=Path("./examples/sushi/models/test_model.sql"))
@@ -482,8 +482,8 @@ def test_fingerprint_jinja_macros(model: Model):
         }
     )
     original_fingerprint = SnapshotFingerprint(
-        data_hash="4053778362",
-        metadata_hash="1312958471",
+        data_hash="2864998504",
+        metadata_hash="1237394431",
     )
 
     fingerprint = fingerprint_from_node(model, nodes={})
@@ -605,7 +605,7 @@ def test_table_name(snapshot: Snapshot, make_snapshot: t.Callable):
     fully_qualified_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
     assert (
         fully_qualified_snapshot.table_name(is_dev=False, for_read=False)
-        == '"my-catalog".sqlmesh__db.my_catalog__db__table__2528031000'
+        == '"my-catalog".sqlmesh__db.my_catalog__db__table__1271801991'
     )
 
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -442,7 +442,7 @@ def test_promote_model_info(mocker: MockerFixture, make_snapshot):
     adapter_mock.create_schema.assert_called_once_with("test_schema__test_env", catalog_name=None)
     adapter_mock.create_view.assert_called_once_with(
         "test_schema__test_env.test_model",
-        parse_one("SELECT * FROM physical_schema.test_schema__test_model__3512709882"),
+        parse_one(f"SELECT * FROM physical_schema.test_schema__test_model__{snapshot.version}"),
     )
 
 

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -133,7 +133,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
             "promoted_snapshot_ids": [
                 {
                     "name": "test_model",
-                    "identifier": "3474928511",
+                    "identifier": "4130255842",
                 }
             ],
             "suffix_target": "schema",


### PR DESCRIPTION
As it turns out the interval unit may impact a partitioning scheme of the created table and hence should be a part of the data hash and not the metadata hash.