### PR TITLE
Fix: ensure external macros are resolved correctly

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -105,10 +105,14 @@ class MacroEvaluator:
         self.python_env = python_env or {}
         self._jinja_env: t.Optional[Environment] = jinja_env
         self.macros = {normalize_macro_name(k): v.func for k, v in macro.get_registry().items()}
+
         prepare_env(self.python_env, self.env)
         for k, v in self.python_env.items():
             if v.is_definition:
                 self.macros[normalize_macro_name(k)] = self.env[v.name or k]
+            elif v.is_import and getattr(self.env.get(k), "__wrapped__", None):
+                # External macros that are serialized as imports will have __wrapped__ set
+                self.macros[normalize_macro_name(k)] = self.env[k]
 
     def send(
         self, name: str, *args: t.Any

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -110,7 +110,7 @@ class MacroEvaluator:
         for k, v in self.python_env.items():
             if v.is_definition:
                 self.macros[normalize_macro_name(k)] = self.env[v.name or k]
-            elif v.is_import and getattr(self.env.get(k), "sqlmesh_macro", None):
+            elif v.is_import and getattr(self.env.get(k), "__sqlmesh_macro__", None):
                 self.macros[normalize_macro_name(k)] = self.env[k]
 
     def send(
@@ -277,7 +277,7 @@ class macro(registry_decorator):
         wrapper = super().__call__(func)
 
         # This is useful to identify macros at runtime
-        setattr(wrapper, "sqlmesh_macro", True)
+        setattr(wrapper, "__sqlmesh_macro__", True)
         return wrapper
 
 

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -110,7 +110,7 @@ class MacroEvaluator:
         for k, v in self.python_env.items():
             if v.is_definition:
                 self.macros[normalize_macro_name(k)] = self.env[v.name or k]
-            elif v.is_import and getattr(self.env.get(k), "is_macro", None):
+            elif v.is_import and getattr(self.env.get(k), "sqlmesh_macro", None):
                 self.macros[normalize_macro_name(k)] = self.env[k]
 
     def send(
@@ -277,7 +277,7 @@ class macro(registry_decorator):
         wrapper = super().__call__(func)
 
         # This is useful to identify macros at runtime
-        setattr(wrapper, "is_macro", True)
+        setattr(wrapper, "sqlmesh_macro", True)
         return wrapper
 
 

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -18,7 +18,7 @@ from sqlmesh.core.dialect import (
     MacroStrReplace,
     MacroVar,
 )
-from sqlmesh.utils import UniqueKeyDict, registry_decorator
+from sqlmesh.utils import DECORATOR_RETURN_TYPE, UniqueKeyDict, registry_decorator
 from sqlmesh.utils.errors import MacroEvalError, SQLMeshError
 from sqlmesh.utils.jinja import JinjaMacroRegistry, has_jinja
 from sqlmesh.utils.metaprogramming import Executable, prepare_env, print_exception
@@ -110,8 +110,7 @@ class MacroEvaluator:
         for k, v in self.python_env.items():
             if v.is_definition:
                 self.macros[normalize_macro_name(k)] = self.env[v.name or k]
-            elif v.is_import and getattr(self.env.get(k), "__wrapped__", None):
-                # External macros that are serialized as imports will have __wrapped__ set
+            elif v.is_import and getattr(self.env.get(k), "is_macro", None):
                 self.macros[normalize_macro_name(k)] = self.env[k]
 
     def send(
@@ -271,6 +270,15 @@ class macro(registry_decorator):
     """
 
     registry_name = "macros"
+
+    def __call__(
+        self, func: t.Callable[..., DECORATOR_RETURN_TYPE]
+    ) -> t.Callable[..., DECORATOR_RETURN_TYPE]:
+        wrapper = super().__call__(func)
+
+        # This is useful to identify macros at runtime
+        setattr(wrapper, "is_macro", True)
+        return wrapper
 
 
 ExecutableOrMacro = t.Union[Executable, macro]

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -278,7 +278,7 @@ def build_env(
     if name not in env:
         # We only need to add the undecorated code of @macro() functions in env, which
         # is accessible through the `__wrapped__` attribute added by functools.wraps
-        env[name] = obj.__wrapped__ if getattr(obj, "sqlmesh_macro", None) else obj
+        env[name] = obj.__wrapped__ if getattr(obj, "__sqlmesh_macro__", None) else obj
 
         if obj_module and _is_relative_to(obj_module.__file__, path):
             walk(env[name])

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -278,7 +278,8 @@ def build_env(
     if name not in env:
         # We only need to add the undecorated code of @macro() functions in env, which
         # is accessible through the `__wrapped__` attribute added by functools.wraps
-        env[name] = getattr(obj, "__wrapped__", obj)
+        env[name] = obj.__wrapped__ if getattr(obj, "is_macro", None) else obj
+
         if obj_module and _is_relative_to(obj_module.__file__, path):
             walk(env[name])
     elif env[name] != obj:

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -278,7 +278,7 @@ def build_env(
     if name not in env:
         # We only need to add the undecorated code of @macro() functions in env, which
         # is accessible through the `__wrapped__` attribute added by functools.wraps
-        env[name] = obj.__wrapped__ if getattr(obj, "is_macro", None) else obj
+        env[name] = obj.__wrapped__ if getattr(obj, "sqlmesh_macro", None) else obj
 
         if obj_module and _is_relative_to(obj_module.__file__, path):
             walk(env[name])

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -1,10 +1,12 @@
+import sys
 import typing as t
+from unittest import mock
 
 import pytest
 from sqlglot import exp, parse_one
 
 from sqlmesh.core.macros import MacroEvaluator, macro
-from sqlmesh.utils.metaprogramming import Executable
+from sqlmesh.utils.metaprogramming import Executable, ExecutableKind
 
 
 @macro()
@@ -34,6 +36,32 @@ def macro_evaluator() -> MacroEvaluator:
 
 def test_case():
     assert macro.get_registry()["upper"]
+
+
+def test_external_macro() -> None:
+    def foo(evaluator: MacroEvaluator) -> str:
+        return "foo"
+
+    # Mimic a SQLMesh macro definition by setting the func's metadata appropriately
+    setattr(foo, "__wrapped__", foo)
+    setattr(foo, "__sqlmesh_macro__", True)
+
+    sys.modules["pkg"] = mock.Mock()
+    with mock.patch("pkg.foo", foo):
+        evaluator = MacroEvaluator(
+            python_env={
+                "foo": Executable(
+                    payload="from pkg import foo",
+                    kind=ExecutableKind.IMPORT,
+                    name=None,
+                    path=None,
+                    alias=None,
+                )
+            }
+        )
+
+        assert "@FOO" in evaluator.macros
+        assert evaluator.macros["@FOO"](evaluator) == "foo"
 
 
 def test_macro_var(macro_evaluator):


### PR DESCRIPTION
Let's say we have a third-party package `foo`, which contains the following macro definition:

```python
# foo/test_macro.py
from sqlmesh.core.macros import macro

@macro()
def test_macro(evaluator):
    return "test_macro"
```

There's currently a bug where if one tries to expose this macro to their models by importing it in `macros/__init__.py`, it's not correctly resolved and will ultimately result in the following error @ runtime:

```python
SQLMeshError: Macro 'test_macro' does not exist
```

This PR aims to solve this issue by handling `Executable`s that are `IMPORT`s in `MacroEvaluator`'s constructor. Before, we'd just ignore them and nothing would be added to the evaluator's `macros` attribute, whereas now we map the macro's name to the corresponding function object after verifying that the import indeed corresponds to a SQLMesh macro.

TODO:
- [x] Add tests
- [ ] Check airflow works as expected