### PR TITLE
Fix: Improve error reporting when validating the connection config

### DIFF
--- a/sqlmesh/core/config/gateway.py
+++ b/sqlmesh/core/config/gateway.py
@@ -4,7 +4,7 @@ import typing as t
 
 from sqlmesh.core import constants as c
 from sqlmesh.core.config.base import BaseConfig
-from sqlmesh.core.config.connection import ConnectionConfig
+from sqlmesh.core.config.connection import ConnectionConfig, connection_config_validator
 from sqlmesh.core.config.scheduler import SchedulerConfig
 
 
@@ -27,3 +27,5 @@ class GatewayConfig(BaseConfig):
     test_connection: t.Optional[ConnectionConfig] = None
     scheduler: t.Optional[SchedulerConfig] = None
     state_schema: t.Optional[str] = c.SQLMESH
+
+    _connection_config_validator = connection_config_validator

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -8,7 +8,11 @@ from sqlmesh.core import constants as c
 from sqlmesh.core.config import EnvironmentSuffixTarget
 from sqlmesh.core.config.base import BaseConfig, UpdateStrategy
 from sqlmesh.core.config.categorizer import CategorizerConfig
-from sqlmesh.core.config.connection import ConnectionConfig, DuckDBConnectionConfig
+from sqlmesh.core.config.connection import (
+    ConnectionConfig,
+    DuckDBConnectionConfig,
+    connection_config_validator,
+)
 from sqlmesh.core.config.gateway import GatewayConfig
 from sqlmesh.core.config.model import ModelDefaultsConfig
 from sqlmesh.core.config.scheduler import BuiltInSchedulerConfig, SchedulerConfig
@@ -85,6 +89,8 @@ class Config(BaseConfig):
         "pinned_environments": UpdateStrategy.EXTEND,
         "physical_schema_override": UpdateStrategy.KEY_UPDATE,
     }
+
+    _connection_config_validator = connection_config_validator
 
     @field_validator("gateways", mode="before", always=True)
     @classmethod

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -1,14 +1,16 @@
-import pydantic
 import pytest
 
-from sqlmesh.core.config.connection import ConnectionConfig, SnowflakeConnectionConfig
+from sqlmesh.core.config.connection import (
+    SnowflakeConnectionConfig,
+    _connection_config_validator,
+)
 from sqlmesh.utils.errors import ConfigError
 
 
 def test_snowflake_auth():
     # Authenticator and user/password is fine
-    config = pydantic.parse_obj_as(
-        ConnectionConfig,
+    config = _connection_config_validator(
+        None,
         dict(
             type="snowflake",
             account="test",
@@ -19,24 +21,44 @@ def test_snowflake_auth():
     )
     assert isinstance(config, SnowflakeConnectionConfig)
     # Auth with no user/password is fine
-    config = pydantic.parse_obj_as(
-        ConnectionConfig, dict(type="snowflake", account="test", authenticator="externalbrowser")
+    config = _connection_config_validator(
+        None, dict(type="snowflake", account="test", authenticator="externalbrowser")
     )
     assert isinstance(config, SnowflakeConnectionConfig)
     # No auth and no user raises
     with pytest.raises(
         ConfigError, match="User and password must be provided if using default authentication"
     ):
-        pydantic.parse_obj_as(
-            ConnectionConfig, dict(type="snowflake", account="test", password="test")
-        )
+        _connection_config_validator(None, dict(type="snowflake", account="test", password="test"))
     # No auth and no password raises
     with pytest.raises(
         ConfigError, match="User and password must be provided if using default authentication"
     ):
-        pydantic.parse_obj_as(ConnectionConfig, dict(type="snowflake", account="test", user="test"))
+        _connection_config_validator(None, dict(type="snowflake", account="test", user="test"))
     # No auth and no user/password raises
     with pytest.raises(
         ConfigError, match="User and password must be provided if using default authentication"
     ):
-        pydantic.parse_obj_as(ConnectionConfig, dict(type="snowflake", account="test"))
+        _connection_config_validator(None, dict(type="snowflake", account="test"))
+
+
+def test_validator():
+    assert _connection_config_validator(None, None) is None
+
+    snowflake_config = SnowflakeConnectionConfig(account="test", authenticator="externalbrowser")
+    assert _connection_config_validator(None, snowflake_config) == snowflake_config
+
+    assert (
+        _connection_config_validator(
+            None, dict(type="snowflake", account="test", authenticator="externalbrowser")
+        )
+        == snowflake_config
+    )
+
+    with pytest.raises(ConfigError, match="Missing connection type."):
+        _connection_config_validator(None, dict(account="test", authenticator="externalbrowser"))
+
+    with pytest.raises(ConfigError, match="Unknown connection type 'invalid'."):
+        _connection_config_validator(
+            None, dict(type="invalid", account="test", authenticator="externalbrowser")
+        )


### PR DESCRIPTION
Instead of relying on Pydantic's union discriminator for connection config deserialization we now use our own custom validator which produces clear validation errors instead of garbage returned previously.

Before:
```
$ sqlmesh info
Error: 25 validation errors for Config
gateways -> local -> connection -> type
  unexpected value; permitted: 'bigquery' (type=value_error.const; given=databricks; permitted=('bigquery',))
gateways -> local -> connection -> instance_connection_string
  field required (type=value_error.missing)
gateways -> local -> connection -> user
  field required (type=value_error.missing)
gateways -> local -> connection -> db
  field required (type=value_error.missing)
gateways -> local -> connection -> type
  unexpected value; permitted: 'gcp_postgres' (type=value_error.const; given=databricks; permitted=('gcp_postgres',))
gateways -> local -> connection -> __root__
  `server_hostname`, `http_path`, and `access_token` are required for Databricks connections when not running in a notebook (type=value_error)
gateways -> local -> connection -> type
  unexpected value; permitted: 'duckdb' (type=value_error.const; given=databricks; permitted=('duckdb',))
gateways -> local -> connection -> host
  field required (type=value_error.missing)
gateways -> local -> connection -> user
  field required (type=value_error.missing)
gateways -> local -> connection -> password
  field required (type=value_error.missing)
gateways -> local -> connection -> type
  unexpected value; permitted: 'mssql' (type=value_error.const; given=databricks; permitted=('mssql',))
gateways -> local -> connection -> host
  field required (type=value_error.missing)
gateways -> local -> connection -> user
  field required (type=value_error.missing)
gateways -> local -> connection -> password
  field required (type=value_error.missing)
gateways -> local -> connection -> type
  unexpected value; permitted: 'mysql' (type=value_error.const; given=databricks; permitted=('mysql',))
gateways -> local -> connection -> host
  field required (type=value_error.missing)
gateways -> local -> connection -> user
  field required (type=value_error.missing)
gateways -> local -> connection -> password
  field required (type=value_error.missing)
gateways -> local -> connection -> port
  field required (type=value_error.missing)
gateways -> local -> connection -> database
  field required (type=value_error.missing)
gateways -> local -> connection -> type
  unexpected value; permitted: 'postgres' (type=value_error.const; given=databricks; permitted=('postgres',))
gateways -> local -> connection -> type
  unexpected value; permitted: 'redshift' (type=value_error.const; given=databricks; permitted=('redshift',))
gateways -> local -> connection -> account
  field required (type=value_error.missing)
gateways -> local -> connection -> type
  unexpected value; permitted: 'snowflake' (type=value_error.const; given=databricks; permitted=('snowflake',))
gateways -> local -> connection -> type
  unexpected value; permitted: 'spark' (type=value_error.const; given=databricks; permitted=('spark',))
  ```
  
  After:
  ```
  $ sqlmesh info
Error: 1 validation error for Config
gateways -> local -> connection -> __root__
  `server_hostname`, `http_path`, and `access_token` are required for Databricks connections when not running in a notebook (type=value_error)
  ```