### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate, Azure Models - using LiteLLM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
         "llm": [
             "langchain",
             "openai",
+            "litellm",
         ],
         "mssql": [
             "pymssql",

--- a/sqlmesh/integrations/llm.py
+++ b/sqlmesh/integrations/llm.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 
 from langchain import LLMChain, PromptTemplate
-from langchain.chat_models import ChatOpenAI
+from langchain.chat_models import ChatLiteLLM
 
 from sqlmesh.core.model import Model
 
@@ -30,7 +30,7 @@ class LLMIntegration:
         query_prompt_template = PromptTemplate.from_template(_QUERY_PROMPT_TEMPLATE).partial(
             dialect=dialect, table_info=_to_table_info(models)
         )
-        llm = ChatOpenAI(temperature=temperature)  # type: ignore
+        llm = ChatLiteLLM(temperature=temperature)  # type: ignore
         self._query_chain = LLMChain(llm=llm, prompt=query_prompt_template, verbose=verbose)
 
     def query(self, prompt: str) -> str:


### PR DESCRIPTION
This PR adds support for 50+ models with a standard I/O interface using: https://github.com/BerriAI/litellm/

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the `ChatOpenAI` I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```