### PR TITLE
Fix: Add check for key in migration 0023

### DIFF
--- a/sqlmesh/migrations/v0023_fix_added_models_with_forward_only_parents.py
+++ b/sqlmesh/migrations/v0023_fix_added_models_with_forward_only_parents.py
@@ -36,6 +36,8 @@ def migrate(state_sync: t.Any) -> None:
     snapshots_to_delete = set()
 
     for snapshot_id in dag:
+        if snapshot_id not in snapshot_mapping:
+            continue
         parsed_snapshot = snapshot_mapping[snapshot_id]
         is_breaking = parsed_snapshot.get("change_category") == 1
         has_previous_versions = bool(parsed_snapshot.get("previous_versions", []))


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/.../sqlmesh/core/state_sync/engine_adapter.py", line 655, in migrate
    migration.migrate(self)
  File "/.../sqlmesh/migrations/v0023_fix_added_models_with_forward_only_parents.py", line 39, in migrate
    parsed_snapshot = snapshot_mapping[snapshot_id]
KeyError: ('analytics.fct_sales__account_module_unit', '2775306648')
```

Its possible for a migration to fail here. Added a check.