### PR TITLE
Feat: Spark Schema to SQLGlot Schema Support

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -90,12 +90,10 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
     def _df_to_source_queries(
         self,
         df: DF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        columns_to_types: t.Dict[str, exp.DataType],
         batch_size: int,
         target_table: TableName,
     ) -> t.List[SourceQuery]:
-        if not columns_to_types:
-            raise SQLMeshError("columns_to_types is required when using a dataframe.")
         temp_bq_table = self.__get_temp_bq_table(
             self._get_temp_table(target_table or "pandas"), columns_to_types
         )
@@ -108,7 +106,6 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
         def query_factory() -> Query:
             # Make mypy happy
             assert isinstance(df, pd.DataFrame)
-            assert columns_to_types
             self._db_call(self.client.create_table, table=temp_bq_table, exists_ok=False)
             result = self.__load_pandas_to_table(temp_bq_table, df, columns_to_types, replace=False)
             if result.errors:

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -9,7 +9,6 @@ from sqlglot import exp
 from sqlmesh.core.engine_adapter.base import EngineAdapter, SourceQuery
 from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 from sqlmesh.utils import nullsafe_join
-from sqlmesh.utils.pandas import columns_to_types_from_df
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import TableName
@@ -26,14 +25,11 @@ class SnowflakeEngineAdapter(EngineAdapter):
     def _df_to_source_queries(
         self,
         df: DF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        columns_to_types: t.Dict[str, exp.DataType],
         batch_size: int,
         target_table: TableName,
     ) -> t.List[SourceQuery]:
         assert isinstance(df, pd.DataFrame)
-        full_columns_to_types: t.Dict[
-            str, exp.DataType
-        ] = columns_to_types or columns_to_types_from_df(df)
         temp_table = self._get_temp_table(target_table or "pandas")
 
         def query_factory() -> Query:
@@ -46,13 +42,13 @@ class SnowflakeEngineAdapter(EngineAdapter):
             self.cursor.execute(f'USE SCHEMA "{temp_table.db}"')
 
             # See: https://stackoverflow.com/a/75627721
-            for column, kind in (full_columns_to_types or {}).items():
+            for column, kind in columns_to_types.items():
                 if kind.is_type("date") and is_datetime64_dtype(df.dtypes[column]):  # type: ignore
                     df[column] = pd.to_datetime(df[column]).dt.date  # type: ignore
                 # https://github.com/snowflakedb/snowflake-connector-python/issues/1677
                 elif is_datetime64_dtype(df.dtypes[column]):  # type: ignore
                     df[column] = pd.to_datetime(df[column]).dt.strftime("%Y-%m-%d %H:%M:%S.%f")  # type: ignore
-            self.create_table(temp_table, full_columns_to_types, exists=False)
+            self.create_table(temp_table, columns_to_types, exists=False)
             write_pandas(
                 self._connection_pool.get(),
                 df,
@@ -60,7 +56,7 @@ class SnowflakeEngineAdapter(EngineAdapter):
                 schema=temp_table.db,
                 chunk_size=self.DEFAULT_BATCH_SIZE,
             )
-            return exp.select(*full_columns_to_types).from_(temp_table)
+            return exp.select(*self._casted_columns(columns_to_types)).from_(temp_table)
 
         return [
             SourceQuery(


### PR DESCRIPTION
Currently if a user provides a PySpark DataFrame then we don't infer the `columns_to_types` from that DataFrame and instead rely on them to provide it (or try to process without it). This change makes it so that we will determine the SQLGlot schema from the provided PySpark DataFrame schema. This means that we now know the `columns_to_types` for both Pandas and PySpark DataFrames and therefore we can assume in code where we are explicitly handling DataFrames that we can get the `columns_to_types`. 

Also added the ability to convert a SQLGlot schema to PySpark schema. This is used when creating a DataFrame from Pandas and we want to enforce the provided schema is applied to the resulting PySpark DataFrame. 