### PR TITLE
Feat: Add merge support to Redshift

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "requests",
         "rich",
         "ruamel.yaml",
-        "sqlglot~=18.3.0",
+        "sqlglot~=18.4.0",
     ],
     extras_require={
         "bigquery": [

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -7,14 +7,17 @@ import pandas as pd
 from sqlglot import exp
 
 from sqlmesh.core.engine_adapter.base_postgres import BasePostgresEngineAdapter
-from sqlmesh.core.engine_adapter.mixins import LogicalReplaceQueryMixin
+from sqlmesh.core.engine_adapter.mixins import (
+    LogicalMergeMixin,
+    LogicalReplaceQueryMixin,
+)
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import TableName
     from sqlmesh.core.engine_adapter.base import QueryOrDF, SourceQuery
 
 
-class RedshiftEngineAdapter(BasePostgresEngineAdapter, LogicalReplaceQueryMixin):
+class RedshiftEngineAdapter(BasePostgresEngineAdapter, LogicalReplaceQueryMixin, LogicalMergeMixin):
     DIALECT = "redshift"
     DEFAULT_BATCH_SIZE = 1000
     ESCAPE_JSON = True
@@ -95,15 +98,6 @@ class RedshiftEngineAdapter(BasePostgresEngineAdapter, LogicalReplaceQueryMixin)
             self.rename_table(target_table, old_table)
             self.rename_table(temp_table, target_table)
             self.drop_table(old_table)
-
-    def merge(
-        self,
-        target_table: TableName,
-        source_table: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
-        unique_key: t.Sequence[str],
-    ) -> None:
-        raise NotImplementedError("Merge is not currently implemented on Redshift")
 
     def _short_hash(self) -> str:
         return uuid.uuid4().hex[:8]

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -429,8 +429,6 @@ def test_insert_overwrite_by_time_partition(ctx: TestContext):
 
 
 def test_merge(ctx: TestContext):
-    if ctx.dialect == "redshift":
-        pytest.skip("Redshift currently doesn't support `MERGE`")
     ctx.init()
     table = ctx.table("test_table")
     ctx.engine_adapter.create_table(table, ctx.columns_to_types)


### PR DESCRIPTION
Redshift recently added merge support but it has some constraints like no CTE's in the source query that we would need to workaround. As a result I went the easier route and just added merge support by using the Logical Merge Mixin. 