### PR TITLE
Chore: Add Automated Engine Adapter Integration Tests

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -159,7 +159,6 @@ jobs:
       - run:
           name: Run Engine Adapter integration tests
           command: make engine_it_test
-          context: engine_adapter_integration
           no_output_timeout: 15m
 
   airflow_integration_tests:
@@ -206,6 +205,7 @@ workflows:
             branches:
               only:
                 - main
-      - engine_adapter_integration_tests
+      - engine_adapter_integration_tests:
+          context: engine_adapter_integration
       - ui_style
       - ui_test

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -216,5 +216,11 @@ workflows:
                 - main
       - engine_adapter_integration_tests:
           context: engine_adapter_integration
+          requires:
+            - style_and_unit_tests
+          filters:
+            branches:
+              only:
+                - main
       - ui_style
       - ui_test

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -146,21 +146,6 @@ jobs:
           name: Run Core integration tests
           command: make core-it-test
 
-  engine_adapter_integration_tests:
-    machine:
-      image: ubuntu-2204:2022.10.2
-      docker_layer_caching: true
-    resource_class: large
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: make install-dev
-      - run:
-          name: Run Engine Adapter integration tests
-          command: make engine_it_test
-          no_output_timeout: 15m
-
   airflow_integration_tests:
     machine:
       image: ubuntu-2204:2022.10.2
@@ -187,6 +172,30 @@ jobs:
           when: on_fail
       - store_artifacts:
           path: /tmp/airflow_logs
+
+  engine_adapter_integration_tests:
+    machine:
+      image: ubuntu-2204:2022.10.2
+      docker_layer_caching: true
+    resource_class: large
+    steps:
+      - checkout
+      - run:
+          name: Install pg_config
+          command: sudo apt-get update && sudo apt-get install libpq-dev
+      - run:
+          name: Install dependencies
+          command: make install-engine-integration
+      - run:
+          name: Bring up MySQL, Postgres, and MSSQL
+          command: make core_engine_it_test_docker
+      - run:
+          name: Make sure DBs are ready
+          command: sleep 10
+      - run:
+          name: Run tests
+          command: make core_engine_it_test
+          no_output_timeout: 15m
 
 workflows:
   main_pr:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -146,6 +146,22 @@ jobs:
           name: Run Core integration tests
           command: make core-it-test
 
+  engine_adapter_integration_tests:
+    machine:
+      image: ubuntu-2204:2022.10.2
+      docker_layer_caching: true
+    resource_class: large
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: make install-dev
+      - run:
+          name: Run Engine Adapter integration tests
+          command: make engine_it_test
+          context: engine_adapter_integration
+          no_output_timeout: 15m
+
   airflow_integration_tests:
     machine:
       image: ubuntu-2204:2022.10.2
@@ -184,6 +200,13 @@ workflows:
       - style_and_unit_tests_pydantic_v2
       - core_integration_tests
       - airflow_integration_tests:
+          requires:
+            - style_and_unit_tests
+          filters:
+            branches:
+              only:
+                - main
+      - engine_adapter_integration_tests:
           requires:
             - style_and_unit_tests
           filters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -209,9 +209,5 @@ workflows:
       - engine_adapter_integration_tests:
           requires:
             - style_and_unit_tests
-          filters:
-            branches:
-              only:
-                - main
       - ui_style
       - ui_test

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -206,8 +206,6 @@ workflows:
             branches:
               only:
                 - main
-      - engine_adapter_integration_tests:
-          requires:
-            - style_and_unit_tests
+      - engine_adapter_integration_tests
       - ui_style
       - ui_test

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,14 @@ doc-test:
 core-it-test:
 	pytest -m "core_integration"
 
+core_engine_it_test:
+	pytest -m "engine_integration"
+
+core_engine_it_test_docker:
+	docker-compose -f ./tests/core/engine_adapter/docker-compose.yaml up -d
+
+engine_it_test: core_engine_it_test_docker core_engine_it_test
+
 it-test: core-it-test airflow-it-test-with-env
 
 it-test-docker: core-it-test airflow-it-test-docker-with-env

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 install-dev:
 	pip3 install -e ".[dev,web,slack]"
 
+install-engine-integration:
+	pip3 install -e ".[dev,web,slack,mysql,postgres,databricks,redshift,bigquery,snowflake]"
+
 install-pre-commit:
 	pre-commit install
 

--- a/tests/core/engine_adapter/docker-compose.yaml
+++ b/tests/core/engine_adapter/docker-compose.yaml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  mysql:
+    image: mysql:8.1
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: mysql
+  postgres:
+    image: postgres
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: postgres
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    ports:
+      - 1433:1433
+    environment:
+        SA_PASSWORD: 1StrongPwd@@
+        ACCEPT_EULA: Y

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -191,12 +191,11 @@ def config() -> Config:
     ]
 )
 def engine_adapter(request, config) -> EngineAdapter:
-    gateway = f"inttest_{request.param}".upper()
-    gateways = {k.upper(): v for k, v in config.gateways.items()}
-    if gateway not in gateways:
+    gateway = f"inttest_{request.param}"
+    if gateway not in config.gateways:
         # TODO: Once everything is fully setup we want to error if a gateway is not configured that we expect
         pytest.skip(f"Gateway {gateway} not configured")
-    engine_adapter = gateways[gateway].connection.create_engine_adapter()
+    engine_adapter = config.gateways[gateway].connection.create_engine_adapter()
     engine_adapter.DEFAULT_BATCH_SIZE = 1
     return engine_adapter
 

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -191,11 +191,12 @@ def config() -> Config:
     ]
 )
 def engine_adapter(request, config) -> EngineAdapter:
-    gateway = f"inttest_{request.param}"
-    if gateway not in config.gateways:
+    gateway = f"inttest_{request.param}".upper()
+    gateways = {k.upper(): v for k, v in config.gateways.items()}
+    if gateway not in gateways:
         # TODO: Once everything is fully setup we want to error if a gateway is not configured that we expect
         pytest.skip(f"Gateway {gateway} not configured")
-    engine_adapter = config.gateways[gateway].connection.create_engine_adapter()
+    engine_adapter = gateways[gateway].connection.create_engine_adapter()
     engine_adapter.DEFAULT_BATCH_SIZE = 1
     return engine_adapter
 

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -191,7 +191,7 @@ def config() -> Config:
     ]
 )
 def engine_adapter(request, config) -> EngineAdapter:
-    gateway = f"test__{request.param}"
+    gateway = f"inttest_{request.param}"
     if gateway not in config.gateways:
         # TODO: Once everything is fully setup we want to error if a gateway is not configured that we expect
         pytest.skip(f"Gateway {gateway} not configured")


### PR DESCRIPTION
This change makes it so we will run these engine adapter integrations on main similar to Airflow integration tests. 