### PR TITLE
Fix: Set file extension for created file based on top level parent

### DIFF
--- a/web/client/src/library/components/fileExplorer/context.tsx
+++ b/web/client/src/library/components/fileExplorer/context.tsx
@@ -36,7 +36,7 @@ interface FileExplorer {
   setArtifactRename: (artifact?: ModelArtifact) => void
   selectArtifactsInRange: (to: ModelArtifact) => void
   createDirectory: (parent: ModelDirectory) => void
-  createFile: (parent: ModelDirectory) => void
+  createFile: (parent: ModelDirectory, extension?: string) => void
   renameArtifact: (artifact: ModelArtifact, newName?: string) => void
   removeArtifacts: (artifacts: ModelArtifact[]) => void
   removeArtifactWithConfirmation: (artifact: ModelArtifact) => void
@@ -125,8 +125,18 @@ export default function FileExplorerProvider({
       })
   }
 
-  function createFile(parent: ModelDirectory, extension = '.py'): void {
+  function createFile(parent: ModelDirectory, extension?: string): void {
     if (isLoading) return
+
+    if (isNil(extension)) {
+      if (parent.isModels) {
+        extension = '.sql'
+      } else if (parent.isTests) {
+        extension = '.yaml'
+      } else {
+        extension = '.py'
+      }
+    }
 
     setIsLoading(true)
 

--- a/web/client/src/models/directory.ts
+++ b/web/client/src/models/directory.ts
@@ -110,6 +110,10 @@ export class ModelDirectory extends ModelArtifact<InitialDirectory> {
     return this.path.startsWith('models')
   }
 
+  get isTests(): boolean {
+    return this.path.startsWith('tests')
+  }
+
   open(): void {
     this._isOpen = true
 


### PR DESCRIPTION
Set default extension for models to `sql` by and for tests to `yaml`