### PR TITLE
Chore: Wrap JSON strings with PARSE_JSON() in values

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -697,7 +697,11 @@ def select_from_values_for_batch_range(
         exp.alias_(exp.cast(column, to=kind), column, copy=False)
         for column, kind in columns_to_types.items()
     ]
-    values_exp = exp.values(values[batch_start:batch_end], alias=alias, columns=columns_to_types)
+    values_exp = exp.values(
+        [tuple(transform_values(v, columns_to_types)) for v in values[batch_start:batch_end]],
+        alias=alias,
+        columns=columns_to_types,
+    )
     return exp.select(*casted_columns).from_(values_exp, copy=False)
 
 
@@ -759,3 +763,13 @@ def find_tables(expression: exp.Expression, dialect: DialectType = None) -> t.Se
         for table in scope.tables
         if not isinstance(table.this, exp.Func) and exp.table_name(table) not in scope.cte_sources
     }
+
+
+def transform_values(
+    values: t.Tuple[t.Any, ...], columns_to_types: t.Dict[str, exp.DataType]
+) -> t.Iterator[t.Any]:
+    for value, col_type in zip(values, columns_to_types.values()):
+        if col_type == exp.DataType.build("json"):
+            yield exp.func("PARSE_JSON", f"'{value}'")
+        else:
+            yield value

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -18,6 +18,8 @@ from sqlmesh.core.constants import MAX_MODEL_DEFINITION_SIZE
 from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.pandas import columns_to_types_from_df
 
+JSON_TYPE = exp.DataType.build("json")
+
 
 class Model(exp.Expression):
     arg_types = {"expressions": True}
@@ -773,7 +775,7 @@ def transform_values(
     Currently, the only transformation is wrapping JSON columns with PARSE_JSON().
     """
     for value, col_type in zip(values, columns_to_types.values()):
-        if col_type == exp.DataType.build("json"):
+        if col_type == JSON_TYPE:
             yield exp.func("PARSE_JSON", f"'{value}'")
         else:
             yield value

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -768,6 +768,10 @@ def find_tables(expression: exp.Expression, dialect: DialectType = None) -> t.Se
 def transform_values(
     values: t.Tuple[t.Any, ...], columns_to_types: t.Dict[str, exp.DataType]
 ) -> t.Iterator[t.Any]:
+    """Perform transformations on values given columns_to_types.
+
+    Currently, the only transformation is wrapping JSON columns with PARSE_JSON().
+    """
     for value, col_type in zip(values, columns_to_types.values()):
         if col_type == exp.DataType.build("json"):
             yield exp.func("PARSE_JSON", f"'{value}'")

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -6,6 +6,7 @@ from sqlmesh.core.dialect import (
     Model,
     format_model_expressions,
     parse,
+    select_from_values_for_batch_range,
     text_diff,
 )
 
@@ -219,3 +220,18 @@ def test_seed():
     )
     assert len(expressions) == 1
     assert "../../../data/data.csv" in expressions[0].sql()
+
+
+def select_from_values_for_batch_range_json():
+    values = [(1, "2022-01-01", '{"foo":"bar"}'), (2, "2022-01-01", '{"foo":"qaz"}')]
+    columns_to_types = {
+        "id": exp.DataType.build("int"),
+        "ds": exp.DataType.build("text"),
+        "json_col": exp.DataType.build("json"),
+    }
+    assert select_from_values_for_batch_range(values, columns_to_types, 0, len(values)).sql() == (
+        """SELECT CAST(id AS INT) AS id, CAST(ds AS TEXT) AS ds, CAST(json_col AS JSON) AS json_col """
+        """FROM """
+        """(VALUES (1, '2022-01-01', PARSE_JSON('{"foo":"bar"}')), (2, '2022-01-01', PARSE_JSON('{"foo":"qaz"}'))) """
+        """AS t(id, ds, json_col)"""
+    )


### PR DESCRIPTION
Example:
```python
from sqlmesh.core.dialect import select_from_values_for_batch_range
values = [
    (1, '2022-01-01', '{"foo":"bar"}'), 
    (2, '2022-01-01', '{"foo":"qaz"}')
]
columns_to_types = {
    'id': exp.DataType.build("int"), 
    'ds': exp.DataType.build("text"), 
    'json_col': exp.DataType.build("json")
}
print(select_from_values_for_batch_range(values, columns_to_types, 0, len(values)).sql(pretty=True))
# SELECT
#   CAST(id AS INT) AS id,
#   CAST(ds AS TEXT) AS ds,
#   CAST(json_col AS JSON) AS json_col
# FROM (VALUES
#   (1, '2022-01-01', PARSE_JSON('{"foo":"bar"}')),
#   (2, '2022-01-01', PARSE_JSON('{"foo":"qaz"}'))) AS t(id, ds, json_col)
```