### PR TITLE
Fix: Create schemas sequentially when evaluating or promoting snapshots

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -167,12 +167,13 @@ class QualifiedViewName(PydanticModel, frozen=True):
     table: str
 
     def for_environment(self, environment_naming_info: EnvironmentNamingInfo) -> str:
-        return exp.table_name(
-            exp.table_(
-                self.table_for_environment(environment_naming_info),
-                db=self.schema_for_environment(environment_naming_info),
-                catalog=self.catalog,
-            )
+        return exp.table_name(self.table_for_environment(environment_naming_info))
+
+    def table_for_environment(self, environment_naming_info: EnvironmentNamingInfo) -> exp.Table:
+        return exp.table_(
+            self.table_name_for_environment(environment_naming_info),
+            db=self.schema_for_environment(environment_naming_info),
+            catalog=self.catalog,
         )
 
     def schema_for_environment(self, environment_naming_info: EnvironmentNamingInfo) -> str:
@@ -184,7 +185,7 @@ class QualifiedViewName(PydanticModel, frozen=True):
             schema = f"{schema}__{environment_naming_info.name}"
         return schema
 
-    def table_for_environment(self, environment_naming_info: EnvironmentNamingInfo) -> str:
+    def table_name_for_environment(self, environment_naming_info: EnvironmentNamingInfo) -> str:
         table = self.table
         if (
             environment_naming_info.name.lower() != c.PROD

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -231,7 +231,7 @@ class SnapshotEvaluator:
             [
                 s.qualified_view_name.table_for_environment(environment_naming_info)
                 for s in target_snapshots
-                if not s.is_symbolic
+                if s.is_model and not s.is_symbolic
             ]
         )
         with self.concurrent_context():
@@ -274,7 +274,9 @@ class SnapshotEvaluator:
             snapshots: Mapping of snapshot ID to snapshot.
             on_complete: A callback to call on each successfully created snapshot.
         """
-        self._create_schemas([s.table_name() for s in target_snapshots if not s.is_symbolic])
+        self._create_schemas(
+            [s.table_name() for s in target_snapshots if s.is_model and not s.is_symbolic]
+        )
         with self.concurrent_context():
             concurrent_apply_to_snapshots(
                 target_snapshots,

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -227,6 +227,13 @@ class SnapshotEvaluator:
                 tables / table clones should be used where applicable.
             on_complete: A callback to call on each successfully promoted snapshot.
         """
+        self._create_schemas(
+            [
+                s.qualified_view_name.table_for_environment(environment_naming_info)
+                for s in target_snapshots
+                if not s.is_symbolic
+            ]
+        )
         with self.concurrent_context():
             concurrent_apply_to_snapshots(
                 target_snapshots,
@@ -267,6 +274,7 @@ class SnapshotEvaluator:
             snapshots: Mapping of snapshot ID to snapshot.
             on_complete: A callback to call on each successfully created snapshot.
         """
+        self._create_schemas([s.table_name() for s in target_snapshots if not s.is_symbolic])
         with self.concurrent_context():
             concurrent_apply_to_snapshots(
                 target_snapshots,
@@ -567,6 +575,15 @@ class SnapshotEvaluator:
             query=query,
         )
 
+    def _create_schemas(self, tables: t.Iterable[t.Union[exp.Table, str]]) -> None:
+        table_exprs = [exp.to_table(t) for t in tables]
+        unique_schemas = {(t.db, t.args.get("catalog")) for t in table_exprs if t and t.db}
+        # Create schemas sequentially, since some engines (eg. Postgres) may not support concurrent creation
+        # of schemas with the same name.
+        for schema, catalog in unique_schemas:
+            logger.info("Creating schema '%s'", schema)
+            self.adapter.create_schema(schema, catalog_name=catalog)
+
 
 def _evaluation_strategy(snapshot: SnapshotInfoLike, adapter: EngineAdapter) -> EvaluationStrategy:
     klass: t.Type
@@ -788,10 +805,6 @@ class PromotableStrategy(EvaluationStrategy):
         table_name: str,
         snapshot: Snapshot,
     ) -> None:
-        schema = view_name.schema_for_environment(environment_naming_info=environment_naming_info)
-        if schema is not None:
-            self.adapter.create_schema(schema, catalog_name=view_name.catalog)
-
         target_name = view_name.for_environment(environment_naming_info)
         logger.info("Updating view '%s' to point at table '%s'", target_name, table_name)
         self.adapter.create_view(
@@ -828,9 +841,6 @@ class MaterializableStrategy(PromotableStrategy):
         **render_kwargs: t.Any,
     ) -> None:
         model = snapshot.model
-        table = exp.to_table(name)
-        self.adapter.create_schema(table.db, catalog_name=table.catalog)
-
         ctas_query = model.ctas_query(**render_kwargs)
 
         logger.info("Creating table '%s'", name)
@@ -1066,9 +1076,6 @@ class ViewStrategy(PromotableStrategy):
         **render_kwargs: t.Any,
     ) -> None:
         model = snapshot.model
-
-        table = exp.to_table(name)
-        self.adapter.create_schema(table.db, catalog_name=table.catalog)
 
         logger.info("Creating view '%s'", name)
         self.adapter.create_view(

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -131,7 +131,7 @@ def test_evaluate(mocker: MockerFixture, adapter_mock, make_snapshot):
 
     adapter_mock.create_schema.assert_has_calls(
         [
-            call("sqlmesh__test_schema", catalog_name=""),
+            call("sqlmesh__test_schema", catalog_name=None),
         ]
     )
 


### PR DESCRIPTION
Some engines fail or behave unexpectedly when we attempt to create the same schema concurrently. 

Additionally, this update reduces the number of redundant `CREATE SCHEMA` statements.