### PR TITLE
Fix: omit materialized view schema in dialects that don't support it

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -120,6 +120,7 @@ class EngineAdapter:
     SUPPORTS_INDEXES = False
     INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.DELETE_INSERT
     SUPPORTS_MATERIALIZED_VIEWS = False
+    SUPPORTS_MATERIALIZED_VIEW_SCHEMA = False
     SUPPORTS_CLONING = False
     SCHEMA_DIFFER = SchemaDiffer()
 
@@ -577,23 +578,29 @@ class EngineAdapter:
                 batch_start=0,
                 batch_end=len(values),
             )
+
         source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
             query_or_df, columns_to_types, batch_size=0, target_table=view_name
         )
         if len(source_queries) != 1:
             raise SQLMeshError("Only one source query is supported for creating views")
+
         schema: t.Union[exp.Table, exp.Schema] = exp.to_table(view_name)
         if columns_to_types:
             schema = exp.Schema(
                 this=exp.to_table(view_name),
                 expressions=[exp.column(column) for column in columns_to_types],
             )
+
         properties = create_kwargs.pop("properties", None)
         if not properties:
             properties = exp.Properties(expressions=[])
 
         if materialized and self.SUPPORTS_MATERIALIZED_VIEWS:
             properties.append("expressions", exp.MaterializedProperty())
+
+            if not self.SUPPORTS_MATERIALIZED_VIEW_SCHEMA:
+                schema = schema.this
 
         create_view_properties = self._create_view_properties(
             create_kwargs.pop("table_properties", None)
@@ -604,6 +611,7 @@ class EngineAdapter:
 
         if properties.expressions:
             create_kwargs["properties"] = properties
+
         with source_queries[0] as query:
             self.execute(
                 exp.Create(

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -20,6 +20,7 @@ if t.TYPE_CHECKING:
 class BasePostgresEngineAdapter(CommitOnExecuteMixin):
     COLUMNS_TABLE = "information_schema.columns"
     SUPPORTS_MATERIALIZED_VIEWS = True
+    SUPPORTS_MATERIALIZED_VIEW_SCHEMA = True
 
     def columns(
         self, table_name: TableName, include_pseudo_columns: bool = False

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -23,6 +23,8 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
     DIALECT = "databricks"
     INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
     SUPPORTS_CLONING = True
+    SUPPORTS_MATERIALIZED_VIEWS = True
+    SUPPORTS_MATERIALIZED_VIEW_SCHEMA = True
     SCHEMA_DIFFER = SchemaDiffer(
         support_positional_add=True,
         support_nested_operations=True,

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -40,6 +40,7 @@ class MSSQLEngineAdapter(
 
     DIALECT: str = "tsql"
     FALSE_PREDICATE = exp.condition("1=2")
+    SUPPORTS_MATERIALIZED_VIEWS = True
 
     def table_exists(self, table_name: TableName) -> bool:
         """

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -22,6 +22,7 @@ class RedshiftEngineAdapter(BasePostgresEngineAdapter, LogicalReplaceQueryMixin,
     DEFAULT_BATCH_SIZE = 1000
     ESCAPE_JSON = True
     COLUMNS_TABLE = "SVV_COLUMNS"  # Includes late-binding views
+    SUPPORTS_MATERIALIZED_VIEW_SCHEMA = False
 
     @property
     def cursor(self) -> t.Any:

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -20,6 +20,7 @@ class SnowflakeEngineAdapter(EngineAdapter):
     DIALECT = "snowflake"
     ESCAPE_JSON = True
     SUPPORTS_MATERIALIZED_VIEWS = True
+    SUPPORTS_MATERIALIZED_VIEW_SCHEMA = True
     SUPPORTS_CLONING = True
 
     def _df_to_source_queries(

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -54,15 +54,39 @@ def test_create_view_pandas(make_mocked_engine_adapter: t.Callable):
 def test_create_materialized_view(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(EngineAdapter)
     adapter.SUPPORTS_MATERIALIZED_VIEWS = True
-    adapter.create_view("test_view", parse_one("SELECT a FROM tbl"), materialized=True)
     adapter.create_view(
-        "test_view", parse_one("SELECT a FROM tbl"), replace=False, materialized=True
+        "test_view",
+        parse_one("SELECT a FROM tbl"),
+        materialized=True,
+        columns_to_types={"a": exp.DataType.build("INT")},
+    )
+    adapter.create_view(
+        "test_view",
+        parse_one("SELECT a FROM tbl"),
+        replace=False,
+        materialized=True,
+        columns_to_types={"a": exp.DataType.build("INT")},
     )
 
     adapter.cursor.execute.assert_has_calls(
         [
             call('CREATE OR REPLACE MATERIALIZED VIEW "test_view" AS SELECT "a" FROM "tbl"'),
             call('CREATE MATERIALIZED VIEW "test_view" AS SELECT "a" FROM "tbl"'),
+        ]
+    )
+
+    adapter.SUPPORTS_MATERIALIZED_VIEW_SCHEMA = True
+    adapter.create_view(
+        "test_view",
+        parse_one("SELECT a, b FROM tbl"),
+        replace=False,
+        materialized=True,
+        columns_to_types={"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
+    )
+
+    adapter.cursor.execute.assert_has_calls(
+        [
+            call('CREATE MATERIALIZED VIEW "test_view" ("a", "b") AS SELECT "a", "b" FROM "tbl"'),
         ]
     )
 


### PR DESCRIPTION
| Engine  | Supports materialized views | Allows column schema in `CREATE MATERIALIZED VIEW` DDL |
| ------------- | ------------- | ------------- |
| [Postgres](https://www.postgresql.org/docs/current/sql-creatematerializedview.html)  | Yes  | Yes  |
| [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_materialized_view_statement)  | Yes  | No  |
| [Databricks](https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-create-materialized-view.html)  | Yes  | Yes  |
| [DuckDB](https://github.com/duckdb/duckdb/discussions/3638)  | No  | No  |
| [Snowflake](https://docs.snowflake.com/en/sql-reference/sql/create-materialized-view#syntax)  | Yes  | Yes  |
| [SQL Server](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-materialized-view-as-select-transact-sql?view=azure-sqldw-latest)  | Yes  | No  |
| [MySQL](https://linuxhint.com/materialized-views-mysql/)  | No  | No  |
| [Redshift](https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-create-sql-command.html)  | Yes  | No  |
| [Spark](https://issues.apache.org/jira/browse/SPARK-29038) | No  | No  |

