### PR TITLE
Fix: Drop state tables during rollback when first migration fails

### DIFF
--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -725,16 +725,17 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         """Rollback to the previous migration."""
         logger.info("Starting migration rollback.")
         tables = (self.snapshots_table, self.environments_table, self.versions_table)
-        if not any(self.engine_adapter.table_exists(f"{table}_backup") for table in tables):
-            raise SQLMeshError("There are no prior migrations to roll back to.")
-        for table in tables:
-            self._restore_table(table, _backup_table_name(table))
-
-        if self.engine_adapter.table_exists(_backup_table_name(self.seeds_table)):
-            self._restore_table(self.seeds_table, _backup_table_name(self.seeds_table))
-
-        if self.engine_adapter.table_exists(_backup_table_name(self.intervals_table)):
-            self._restore_table(self.intervals_table, _backup_table_name(self.intervals_table))
+        versions = self.get_versions(validate=False)
+        if versions.schema_version == 0:
+            # Clean up state tables
+            for table in tables + (self.seeds_table, self.intervals_table):
+                self.engine_adapter.drop_table(table)
+        else:
+            if not any(self.engine_adapter.table_exists(f"{table}_backup") for table in tables):
+                raise SQLMeshError("There are no prior migrations to roll back to.")
+            for table in tables + (self.seeds_table, self.intervals_table):
+                if self.engine_adapter.table_exists(_backup_table_name(table)):
+                    self._restore_table(table, _backup_table_name(table))
         logger.info("Migration rollback successful.")
 
     def _backup_state(self) -> None:


### PR DESCRIPTION
When a project's first migration fails, state tables could be left over depending on when the failure occurs. This causes problems for future migrates. This PR drops all state tables if the first migration fails.