### PR TITLE
Fix: treat Snowflake's staged file paths as MacroVars

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -140,7 +140,7 @@ class MacroEvaluator:
                 changed = True
                 if node.name not in self.locals:
                     if not isinstance(node.parent, StagedFilePath):
-                        raise SQLMeshError(f"Macro variable '{node.name}' does not exist.")
+                        raise SQLMeshError(f"Macro variable '{node.name}' is undefined.")
 
                     return node
 

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -17,6 +17,7 @@ from sqlmesh.core.dialect import (
     MacroSQL,
     MacroStrReplace,
     MacroVar,
+    StagedFilePath,
 )
 from sqlmesh.utils import DECORATOR_RETURN_TYPE, UniqueKeyDict, registry_decorator
 from sqlmesh.utils.errors import MacroEvalError, SQLMeshError
@@ -137,6 +138,12 @@ class MacroEvaluator:
 
             if isinstance(node, MacroVar):
                 changed = True
+                if node.name not in self.locals:
+                    if not isinstance(node.parent, StagedFilePath):
+                        raise SQLMeshError(f"Macro variable '{node.name}' does not exist.")
+
+                    return node
+
                 return exp.convert(_norm_env_value(self.locals[node.name]))
             if node.is_string:
                 text = node.this

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -87,7 +87,7 @@ def test_macro_var(macro_evaluator):
     with pytest.raises(SQLMeshError) as ex:
         macro_evaluator.transform(parse_one("SELECT @y"))
 
-    assert "Macro variable 'y' does not exist." in str(ex.value)
+    assert "Macro variable 'y' is undefined." in str(ex.value)
 
 
 def test_macro_str_replace(macro_evaluator):


### PR DESCRIPTION
This fixes an issue inadvertently introduced in https://github.com/tobymao/sqlglot/commit/8af4054d4e96b62309b1543d51548728bdba520f (later updated [here](https://github.com/tobymao/sqlglot/commit/17e39d04916e3e406307ed8922cb2597b4a6998a)). Snowflake allows `@foo` to appear in `FROM` clauses, which clashes with our macro variable syntax and hence the parsing was off, causing errors in e.g. audits because they reference `@this_model` in the `FROM` clause.

Verified that with this branch I can successfully run `sqlmesh plan` for the example project using the Snowflake dialect.