### PR TITLE
Fix MWAA client's set_variable

### DIFF
--- a/sqlmesh/schedulers/airflow/mwaa_client.py
+++ b/sqlmesh/schedulers/airflow/mwaa_client.py
@@ -31,7 +31,7 @@ class MWAAClient(BaseAirflowClient):
         Returns:
             A tuple of stdout and stderr from the MWAA CLI.
         """
-        value=value.replace('\\', '\\\\').replace('"', '\\"')
+        value = value.replace('\\', '\\\\').replace('"', '\\"')
         return self._post(f'variables set {key} "{value}"')
 
     def get_first_dag_run_id(self, dag_id: str) -> t.Optional[str]:

--- a/sqlmesh/schedulers/airflow/mwaa_client.py
+++ b/sqlmesh/schedulers/airflow/mwaa_client.py
@@ -31,7 +31,7 @@ class MWAAClient(BaseAirflowClient):
         Returns:
             A tuple of stdout and stderr from the MWAA CLI.
         """
-        value = value.replace('\\', '\\\\').replace('"', '\\"')
+        value = value.replace("\\", "\\\\").replace('"', '\\"')
         return self._post(f'variables set {key} "{value}"')
 
     def get_first_dag_run_id(self, dag_id: str) -> t.Optional[str]:

--- a/sqlmesh/schedulers/airflow/mwaa_client.py
+++ b/sqlmesh/schedulers/airflow/mwaa_client.py
@@ -31,7 +31,8 @@ class MWAAClient(BaseAirflowClient):
         Returns:
             A tuple of stdout and stderr from the MWAA CLI.
         """
-        return self._post(f"variables set {key} '{value}'")
+        value=value.replace('\\', '\\\\').replace('"', '\\"')
+        return self._post(f'variables set {key} "{value}"')
 
     def get_first_dag_run_id(self, dag_id: str) -> t.Optional[str]:
         dag_runs = self._list_dag_runs(dag_id)

--- a/tests/schedulers/airflow/test_mwaa_client.py
+++ b/tests/schedulers/airflow/test_mwaa_client.py
@@ -22,7 +22,7 @@ def test_set_variable(mocker: MockerFixture):
 
     set_variable_mock.assert_called_once_with(
         "https://test_airflow_host/aws_mwaa/cli",
-        data="variables set test_key 'test_value'",
+        data='variables set test_key "test_value"',
     )
 
 


### PR DESCRIPTION
We need to escape quotes and escape sequences within the value of this function so Airflow can recognize the string

Additionally, when we try to quote (and escape) with single quotes, Airflow returns a 500 error. We guess this is because Airflow is using escaped single quotes as part of its internal functioning