### PR TITLE
Fix: Property Override Pydantic 2

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -676,7 +676,10 @@ class MySQLConnectionConfig(ConnectionConfig):
 
     type_: Literal["mysql"] = Field(alias="type", default="mysql")
 
-    _cursor_kwargs = {"buffered": True}
+    @property
+    def _cursor_kwargs(self) -> t.Optional[t.Dict[str, t.Any]]:
+        """Key-value arguments that will be passed during cursor construction."""
+        return {"buffered": True}
 
     @property
     def _connection_kwargs_keys(self) -> t.Set[str]:


### PR DESCRIPTION
Repro (Pydantic 2 only) showing the issue:
```
class Parent:
    @property
    def _test_prop(self) -> str:
        return "original_val"

    @property
    def test_prop(self) -> str:
        return self._test_prop


class Child(Parent):
    _test_prop = "new_val"


assert Child().test_prop == "new_val"


class ParentPydantic(PydanticModel):
    @property
    def _test_prop(self) -> str:
        return "original_val"

    @property
    def test_prop(self) -> str:
        return self._test_prop


class ChildPydantic(ParentPydantic):
    _test_prop = "new_val"


assert ChildPydantic().test_prop == "original_val"
```