### PR TITLE
Fix(mssql): execute within transactions to prevent hanging

### DIFF
--- a/sqlmesh/core/engine_adapter/__init__.py
+++ b/sqlmesh/core/engine_adapter/__init__.py
@@ -13,7 +13,6 @@ from sqlmesh.core.engine_adapter.mssql import MSSQLEngineAdapter
 from sqlmesh.core.engine_adapter.mysql import MySQLEngineAdapter
 from sqlmesh.core.engine_adapter.postgres import PostgresEngineAdapter
 from sqlmesh.core.engine_adapter.redshift import RedshiftEngineAdapter
-from sqlmesh.core.engine_adapter.shared import TransactionType
 from sqlmesh.core.engine_adapter.snowflake import SnowflakeEngineAdapter
 from sqlmesh.core.engine_adapter.spark import SparkEngineAdapter
 

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -117,6 +117,7 @@ class EngineAdapter:
     DEFAULT_BATCH_SIZE = 10000
     DEFAULT_SQL_GEN_KWARGS: t.Dict[str, str | bool | int] = {}
     ESCAPE_JSON = False
+    SUPPORTS_TRANSACTIONS = True
     SUPPORTS_INDEXES = False
     INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.DELETE_INSERT
     SUPPORTS_MATERIALIZED_VIEWS = False
@@ -1209,7 +1210,7 @@ class EngineAdapter:
         """A transaction context manager."""
         if (
             self._connection_pool.is_transaction_active
-            or not self.supports_transactions()
+            or not self.SUPPORTS_TRANSACTIONS
             or (condition is not None and not condition)
         ):
             yield
@@ -1222,10 +1223,6 @@ class EngineAdapter:
             raise e
         else:
             self._connection_pool.commit()
-
-    def supports_transactions(self) -> bool:
-        """Whether or not the engine adapter supports transactions."""
-        return True
 
     @contextlib.contextmanager
     def session(self) -> t.Iterator[None]:

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1262,14 +1262,15 @@ class EngineAdapter:
             {"unsupported_level": ErrorLevel.IGNORE} if ignore_unsupported_errors else {}
         )
 
-        for e in ensure_list(expressions):
-            sql = (
-                self._to_sql(e, quote=quote_identifiers, **to_sql_kwargs)
-                if isinstance(e, exp.Expression)
-                else e
-            )
-            logger.debug(f"Executing SQL:\n{sql}")
-            self.cursor.execute(sql, **kwargs)
+        with self.transaction():
+            for e in ensure_list(expressions):
+                sql = (
+                    self._to_sql(e, quote=quote_identifiers, **to_sql_kwargs)
+                    if isinstance(e, exp.Expression)
+                    else e
+                )
+                logger.debug(f"Executing SQL:\n{sql}")
+                self.cursor.execute(sql, **kwargs)
 
     @contextlib.contextmanager
     def temp_table(

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -4,12 +4,8 @@ import typing as t
 
 from sqlglot import exp
 
-from sqlmesh.core.engine_adapter.mixins import CommitOnExecuteMixin
-from sqlmesh.core.engine_adapter.shared import (
-    DataObject,
-    DataObjectType,
-    TransactionType,
-)
+from sqlmesh.core.engine_adapter.mixins import EngineAdapter
+from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 from sqlmesh.utils.errors import SQLMeshError
 
 if t.TYPE_CHECKING:
@@ -17,7 +13,7 @@ if t.TYPE_CHECKING:
     from sqlmesh.core.engine_adapter.base import QueryOrDF
 
 
-class BasePostgresEngineAdapter(CommitOnExecuteMixin):
+class BasePostgresEngineAdapter(EngineAdapter):
     COLUMNS_TABLE = "information_schema.columns"
 
     def columns(
@@ -85,7 +81,7 @@ class BasePostgresEngineAdapter(CommitOnExecuteMixin):
 
         Reference: https://www.postgresql.org/docs/current/sql-createview.html
         """
-        with self.transaction(TransactionType.DDL):
+        with self.transaction():
             if replace:
                 self.drop_view(view_name, materialized=materialized)
             super().create_view(

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -11,11 +11,7 @@ from sqlglot.transforms import remove_precision_parameterized_types
 
 from sqlmesh.core.engine_adapter.base import SourceQuery
 from sqlmesh.core.engine_adapter.mixins import InsertOverwriteWithMergeMixin
-from sqlmesh.core.engine_adapter.shared import (
-    DataObject,
-    DataObjectType,
-    TransactionType,
-)
+from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 from sqlmesh.core.node import IntervalUnit
 from sqlmesh.core.schema_diff import SchemaDiffer
 from sqlmesh.utils.date import to_datetime
@@ -478,7 +474,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
             columns_to_types,
         )
 
-    def supports_transactions(self, transaction_type: TransactionType) -> bool:
+    def supports_transactions(self) -> bool:
         return False
 
     def _db_call(self, func: t.Callable[..., t.Any], *args: t.Any, **kwargs: t.Any) -> t.Any:

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -41,6 +41,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
     DIALECT = "bigquery"
     DEFAULT_BATCH_SIZE = 1000
     ESCAPE_JSON = True
+    SUPPORTS_TRANSACTIONS = False
     SUPPORTS_MATERIALIZED_VIEWS = True
     SUPPORTS_CLONING = True
 
@@ -473,9 +474,6 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
             table_name,
             columns_to_types,
         )
-
-    def supports_transactions(self) -> bool:
-        return False
 
     def _db_call(self, func: t.Callable[..., t.Any], *args: t.Any, **kwargs: t.Any) -> t.Any:
         return func(

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -16,6 +16,7 @@ if t.TYPE_CHECKING:
 
 class DuckDBEngineAdapter(LogicalMergeMixin):
     DIALECT = "duckdb"
+    SUPPORTS_TRANSACTIONS = False
 
     def _df_to_source_queries(
         self,

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -6,7 +6,7 @@ import typing as t
 from sqlglot import exp
 from sqlglot.optimizer.qualify_columns import quote_identifiers
 
-from sqlmesh.core.engine_adapter.base import EngineAdapter, SourceQuery, TransactionType
+from sqlmesh.core.engine_adapter.base import EngineAdapter, SourceQuery
 from sqlmesh.utils.errors import SQLMeshError
 
 if t.TYPE_CHECKING:
@@ -42,7 +42,7 @@ class LogicalMergeMixin(EngineAdapter):
         unique_exp = exp.func("CONCAT_WS", "'__SQLMESH_DELIM__'", *unique_key)
         column_names = list(columns_to_types or [])
 
-        with self.transaction(TransactionType.DML):
+        with self.transaction():
             self.ctas(temp_table, source_table, columns_to_types=columns_to_types, exists=False)
             self.execute(
                 exp.delete(target_table).where(
@@ -77,7 +77,7 @@ class LogicalReplaceQueryMixin(EngineAdapter):
 
         if not self.table_exists(table_name):
             return self.ctas(table_name, query_or_df, columns_to_types, exists=False, **kwargs)
-        with self.transaction(TransactionType.DDL):
+        with self.transaction():
             # TODO: remove quote_identifiers when sqlglot has an expression to represent TRUNCATE
             source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
                 query_or_df, columns_to_types, table_name
@@ -123,30 +123,6 @@ class PandasNativeFetchDFSupportMixin(EngineAdapter):
         )
         logger.debug(f"Executing SQL:\n{sql}")
         return read_sql_query(sql, self._connection_pool.get())
-
-
-class CommitOnExecuteMixin(EngineAdapter):
-    def execute(
-        self,
-        expressions: t.Union[str, exp.Expression, t.Sequence[exp.Expression]],
-        ignore_unsupported_errors: bool = False,
-        quote_identifiers: bool = True,
-        **kwargs: t.Any,
-    ) -> None:
-        """
-        To make sure that inserts and updates take effect we need to commit explicitly unless the
-        statement is executed as part of an active transaction.
-
-        Reference: https://www.psycopg.org/psycopg3/docs/basic/transactions.html
-        """
-        super().execute(
-            expressions,
-            ignore_unsupported_errors=ignore_unsupported_errors,
-            quote_identifiers=quote_identifiers,
-            **kwargs,
-        )
-        if not self._connection_pool.is_transaction_active:
-            self._connection_pool.commit()
 
 
 class InsertOverwriteWithMergeMixin(EngineAdapter):

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import typing as t
 
 from sqlmesh.core.engine_adapter.mixins import (
-    CommitOnExecuteMixin,
     LogicalMergeMixin,
     LogicalReplaceQueryMixin,
     PandasNativeFetchDFSupportMixin,
@@ -15,7 +14,6 @@ if t.TYPE_CHECKING:
 
 
 class MySQLEngineAdapter(
-    CommitOnExecuteMixin,
     LogicalMergeMixin,
     LogicalReplaceQueryMixin,
     PandasNativeFetchDFSupportMixin,
@@ -54,8 +52,8 @@ class MySQLEngineAdapter(
                 null AS catalog_name,
                 table_name AS name,
                 table_schema AS schema_name,
-                CASE 
-                    WHEN table_type = 'BASE TABLE' THEN 'table' 
+                CASE
+                    WHEN table_type = 'BASE TABLE' THEN 'table'
                     WHEN table_type = 'VIEW' THEN 'view'
                     ELSE table_type
                 END AS type

--- a/sqlmesh/core/engine_adapter/shared.py
+++ b/sqlmesh/core/engine_adapter/shared.py
@@ -8,19 +8,6 @@ from pydantic import Field
 from sqlmesh.utils.pydantic import PydanticModel
 
 
-class TransactionType(str, Enum):
-    DDL = "DDL"
-    DML = "DML"
-
-    @property
-    def is_ddl(self) -> bool:
-        return self == TransactionType.DDL
-
-    @property
-    def is_dml(self) -> bool:
-        return self == TransactionType.DML
-
-
 class DataObjectType(str, Enum):
     UNKNOWN = "unknown"
     TABLE = "table"

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 class SparkEngineAdapter(EngineAdapter):
     DIALECT = "spark"
     ESCAPE_JSON = True
+    SUPPORTS_TRANSACTIONS = False
     INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
 
     @property
@@ -397,6 +398,3 @@ class SparkEngineAdapter(EngineAdapter):
         return [
             exp.Property(this=key, value=value.copy()) for key, value in table_properties.items()
         ]
-
-    def supports_transactions(self) -> bool:
-        return False

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -12,11 +12,7 @@ from sqlmesh.core.engine_adapter.base import (
     InsertOverwriteStrategy,
     SourceQuery,
 )
-from sqlmesh.core.engine_adapter.shared import (
-    DataObject,
-    DataObjectType,
-    TransactionType,
-)
+from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 from sqlmesh.utils import classproperty, nullsafe_join
 from sqlmesh.utils.errors import SQLMeshError
 
@@ -402,5 +398,5 @@ class SparkEngineAdapter(EngineAdapter):
             exp.Property(this=key, value=value.copy()) for key, value in table_properties.items()
         ]
 
-    def supports_transactions(self, transaction_type: TransactionType) -> bool:
+    def supports_transactions(self) -> bool:
         return False

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -32,7 +32,7 @@ from sqlglot import exp, select
 from sqlglot.executor import execute
 
 from sqlmesh.core.audit import Audit, AuditResult
-from sqlmesh.core.engine_adapter import EngineAdapter, TransactionType
+from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.engine_adapter.base import InsertOverwriteStrategy
 from sqlmesh.core.model import IncrementalUnmanagedKind, Model, SCDType2Kind, ViewKind
 from sqlmesh.core.snapshot import (
@@ -160,11 +160,7 @@ class SnapshotEvaluator:
             **common_render_kwargs,
         )
 
-        with self.adapter.transaction(
-            transaction_type=TransactionType.DDL
-            if model.kind.is_view or model.kind.is_full
-            else TransactionType.DML
-        ), self.adapter.session():
+        with self.adapter.transaction(), self.adapter.session():
             if not limit:
                 self.adapter.execute(model.render_pre_statements(**render_statements_kwargs))
 
@@ -418,7 +414,7 @@ class SnapshotEvaluator:
 
         evaluation_strategy = _evaluation_strategy(snapshot, self.adapter)
 
-        with self.adapter.transaction(TransactionType.DDL), self.adapter.session():
+        with self.adapter.transaction(), self.adapter.session():
             self.adapter.execute(snapshot.model.render_pre_statements(**render_kwargs))
 
             if is_dev and not snapshot.previous_versions:

--- a/sqlmesh/core/state_sync/common.py
+++ b/sqlmesh/core/state_sync/common.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from datetime import datetime
 from functools import wraps
 
-from sqlmesh.core.engine_adapter.shared import TransactionType
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.snapshot import (
     Snapshot,
@@ -50,16 +49,14 @@ def cleanup_expired_views(adapter: EngineAdapter, environments: t.List[Environme
         adapter.drop_view(expired_view, ignore_if_not_exists=True)
 
 
-def transactional(
-    transaction_type: TransactionType = TransactionType.DML,
-) -> t.Callable[[t.Callable], t.Callable]:
+def transactional() -> t.Callable[[t.Callable], t.Callable]:
     def decorator(func: t.Callable) -> t.Callable:
         @wraps(func)
         def wrapper(self: t.Any, *args: t.Any, **kwargs: t.Any) -> t.Any:
             if not hasattr(self, "_transaction"):
                 return func(self, *args, **kwargs)
 
-            with self._transaction(transaction_type):
+            with self._transaction():
                 return func(self, *args, **kwargs)
 
         return wrapper

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -948,7 +948,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
             )
 
     @contextlib.contextmanager
-    def _transaction(self) -> t.Generator[None, None, None]:
+    def _transaction(self) -> t.Iterator[None]:
         with self.engine_adapter.transaction():
             yield
 

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -29,7 +29,7 @@ from sqlglot import exp
 from sqlmesh.core import constants as c
 from sqlmesh.core.audit import ModelAudit
 from sqlmesh.core.console import Console, get_console
-from sqlmesh.core.engine_adapter import EngineAdapter, TransactionType
+from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.model import ModelKindName, SeedModel
 from sqlmesh.core.snapshot import (
@@ -752,7 +752,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
             self.intervals_table,
         ):
             if self.engine_adapter.table_exists(table):
-                with self.engine_adapter.transaction(TransactionType.DDL):
+                with self.engine_adapter.transaction():
                     backup_name = _backup_table_name(table)
                     self.engine_adapter.drop_table(backup_name)
                     self.engine_adapter.ctas(
@@ -947,8 +947,8 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
             )
 
     @contextlib.contextmanager
-    def _transaction(self, transaction_type: TransactionType) -> t.Generator[None, None, None]:
-        with self.engine_adapter.transaction(transaction_type=transaction_type):
+    def _transaction(self) -> t.Generator[None, None, None]:
+        with self.engine_adapter.transaction():
             yield
 
 

--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -9,7 +9,7 @@ from dbt.contracts.relation import Policy
 from sqlglot import exp, parse_one
 from sqlglot.helper import seq_get
 
-from sqlmesh.core.engine_adapter import EngineAdapter, TransactionType
+from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.snapshot import Snapshot, to_table_mapping
 from sqlmesh.utils.errors import ConfigError, ParsetimeAdapterCallError
 from sqlmesh.utils.jinja import JinjaMacroRegistry, MacroReference
@@ -282,7 +282,7 @@ class RuntimeAdapter(BaseAdapter):
 
         if auto_begin:
             # TODO: This could be a bug. I think dbt leaves the transaction open while we close immediately.
-            with self.engine_adapter.transaction(TransactionType.DML):
+            with self.engine_adapter.transaction():
                 resp = exec_func(expression)
         else:
             resp = exec_func(expression)

--- a/tests/core/engine_adapter/test_duckdb.py
+++ b/tests/core/engine_adapter/test_duckdb.py
@@ -61,19 +61,3 @@ def test_replace_query_pandas(adapter: EngineAdapter, duck_conn):
         "test_table", df, {"a": exp.DataType.build("long"), "b": exp.DataType.build("long")}
     )
     pd.testing.assert_frame_equal(adapter.fetchdf("SELECT * FROM test_table"), df)
-
-
-def test_transaction(adapter: EngineAdapter, duck_conn):
-    adapter.create_table("test_table", {"a": exp.DataType.build("int")})
-    with adapter.transaction():
-        adapter.execute("INSERT INTO test_table (a) VALUES (1)")
-    assert duck_conn.execute("SELECT * FROM test_table").fetchall() == [(1,)]
-
-    # Assert transaction was rolled back if an exception was raised
-    try:
-        with adapter.transaction():
-            adapter.execute("INSERT INTO test_table (a) VALUES (1)")
-            raise Exception
-    except Exception:
-        pass
-    assert duck_conn.execute("SELECT * FROM test_table").fetchall() == [(1,)]


### PR DESCRIPTION
The pymssql library [always begins transactions](https://github.com/pymssql/pymssql/issues/460) - "pymssql opens transaction on connection start with 'BEGIN TRAN' and after conn.commit() it commits already opened transaction and then open new one again."

In some cases we did not explicitly close them, leading to hung sessions.

The fix wraps calls to `cursor.execute()` in a transaction **in the base engine_adapter**, ensuring they are properly closed. 

Some engines do not support transactions or handle them idiosyncratically, such that this approach does not work. Engine adapters are now given a flag that determines whether their executions occur within transactions. 

At this time, BigQuery, DuckDB, and Spark have the flag set to False.