### PR TITLE
Feat: Use internal state instead of Airflow Variables to store Plan DAG specs

### DIFF
--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -306,7 +306,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         snapshot.updated_ts = now_timestamp()
         self.engine_adapter.update_table(
             self.snapshots_table,
-            {"snapshot": snapshot.json()},
+            {"snapshot": _snapshot_to_json(snapshot)},
             where=self._snapshot_id_filter([snapshot.snapshot_id]),
             contains_json=True,
         )
@@ -1000,7 +1000,7 @@ def _snapshots_to_df(snapshots: t.Iterable[Snapshot]) -> pd.DataFrame:
                 "name": snapshot.name,
                 "identifier": snapshot.identifier,
                 "version": snapshot.version,
-                "snapshot": snapshot.json(exclude={"intervals", "dev_intervals"}),
+                "snapshot": _snapshot_to_json(snapshot),
                 "kind_name": snapshot.model_kind_name.value if snapshot.model_kind_name else None,
             }
             for snapshot in snapshots
@@ -1033,3 +1033,7 @@ def _environment_to_df(environment: Environment) -> pd.DataFrame:
 
 def _backup_table_name(table_name: str) -> str:
     return f"{table_name}_backup"
+
+
+def _snapshot_to_json(snapshot: Snapshot) -> str:
+    return snapshot.json(exclude={"intervals", "dev_intervals"})

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -85,6 +85,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         self.environments_table = nullsafe_join(".", self.schema, "_environments")
         self.seeds_table = nullsafe_join(".", self.schema, "_seeds")
         self.intervals_table = nullsafe_join(".", self.schema, "_intervals")
+        self.plan_dags_table = nullsafe_join(".", self.schema, "_plan_dags")
         self.versions_table = nullsafe_join(".", self.schema, "_versions")
 
         self._snapshot_columns_to_types = {
@@ -726,10 +727,11 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         """Rollback to the previous migration."""
         logger.info("Starting migration rollback.")
         tables = (self.snapshots_table, self.environments_table, self.versions_table)
+        optional_tables = (self.seeds_table, self.intervals_table, self.plan_dags_table)
         versions = self.get_versions(validate=False)
         if versions.schema_version == 0:
             # Clean up state tables
-            for table in tables + (self.seeds_table, self.intervals_table):
+            for table in tables + optional_tables:
                 self.engine_adapter.drop_table(table)
         else:
             if not all(self.engine_adapter.table_exists(f"{table}_backup") for table in tables):
@@ -737,11 +739,10 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
             for table in tables:
                 self._restore_table(table, _backup_table_name(table))
 
-            if self.engine_adapter.table_exists(_backup_table_name(self.seeds_table)):
-                self._restore_table(self.seeds_table, _backup_table_name(self.seeds_table))
+            for optional_table in optional_tables:
+                if self.engine_adapter.table_exists(_backup_table_name(optional_table)):
+                    self._restore_table(optional_table, _backup_table_name(optional_table))
 
-            if self.engine_adapter.table_exists(_backup_table_name(self.intervals_table)):
-                self._restore_table(self.intervals_table, _backup_table_name(self.intervals_table))
         logger.info("Migration rollback successful.")
 
     def _backup_state(self) -> None:
@@ -751,6 +752,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
             self.versions_table,
             self.seeds_table,
             self.intervals_table,
+            self.plan_dags_table,
         ):
             if self.engine_adapter.table_exists(table):
                 with self.engine_adapter.transaction(TransactionType.DDL):

--- a/sqlmesh/migrations/v0028_add_plan_dags_table.py
+++ b/sqlmesh/migrations/v0028_add_plan_dags_table.py
@@ -1,0 +1,28 @@
+"""Creates the '_plan_dags' table if Airflow is used."""
+from sqlglot import exp
+
+from sqlmesh.utils.migration import index_text_type
+
+
+def migrate(state_sync):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    plan_dags_table = "_plan_dags"
+
+    if schema:
+        engine_adapter.create_schema(schema)
+        plan_dags_table = f"{schema}.{plan_dags_table}"
+
+    text_type = index_text_type(engine_adapter.dialect)
+
+    engine_adapter.create_state_table(
+        plan_dags_table,
+        {
+            "request_id": exp.DataType.build(text_type),
+            "dag_id": exp.DataType.build(text_type),
+            "dag_spec": exp.DataType.build("text"),
+        },
+        primary_key=("request_id",),
+    )
+
+    engine_adapter.create_index(plan_dags_table, "dag_id_idx", ("dag_id",))

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -68,17 +68,17 @@ class PlanDagSpec(PydanticModel):
     promoted_snapshots: t.List[SnapshotTableInfo]
     demoted_snapshots: t.List[SnapshotTableInfo]
     start: TimeLike
-    end: t.Optional[TimeLike]
-    unpaused_dt: t.Optional[TimeLike]
+    end: t.Optional[TimeLike] = None
+    unpaused_dt: t.Optional[TimeLike] = None
     no_gaps: bool
     plan_id: str
-    previous_plan_id: t.Optional[str]
+    previous_plan_id: t.Optional[str] = None
     notification_targets: t.List[NotificationTarget]
     backfill_concurrent_tasks: int
     ddl_concurrent_tasks: int
     users: t.List[User]
     is_dev: bool
-    forward_only: t.Optional[bool]
+    forward_only: t.Optional[bool] = None
     environment_expiration_ts: t.Optional[int] = None
     dag_start_ts: t.Optional[int] = None
 
@@ -141,10 +141,6 @@ def dag_id_for_name_version(name: str, version: str) -> str:
 
 def plan_application_dag_id(environment: str, request_id: str) -> str:
     return f"sqlmesh_plan_application__{environment}__{request_id}"
-
-
-def environment_key(env: str) -> str:
-    return f"{ENV_KEY_PREFIX}__{env}"
 
 
 def plan_dag_spec_key(request_id: str) -> str:

--- a/sqlmesh/schedulers/airflow/mwaa_client.py
+++ b/sqlmesh/schedulers/airflow/mwaa_client.py
@@ -21,19 +21,6 @@ class MWAAClient(BaseAirflowClient):
             {"Authorization": f"Bearer {auth_token}", "Content-Type": "text/plain"}
         )
 
-    def set_variable(self, key: str, value: str) -> t.Tuple[str, str]:
-        """Sets the Airflow variable.
-
-        Args:
-            key: The name of the variable.
-            value: The value of the variable.
-
-        Returns:
-            A tuple of stdout and stderr from the MWAA CLI.
-        """
-        value = value.replace("\\", "\\\\").replace('"', '\\"')
-        return self._post(f'variables set {key} "{value}"')
-
     def get_first_dag_run_id(self, dag_id: str) -> t.Optional[str]:
         dag_runs = self._list_dag_runs(dag_id)
         if dag_runs:

--- a/sqlmesh/schedulers/airflow/operators/hwm_sensor.py
+++ b/sqlmesh/schedulers/airflow/operators/hwm_sensor.py
@@ -60,6 +60,6 @@ class HighWaterMarkSensor(BaseSensorOperator):
         self, dag_run: DagRun, target_snapshot: Snapshot
     ) -> datetime:
         target_date = to_datetime(dag_run.data_interval_end)
-        target_prev = to_datetime(target_snapshot.model.cron_floor(target_date))
-        this_prev = to_datetime(self.this_snapshot.model.cron_floor(target_date))
+        target_prev = to_datetime(target_snapshot.node.cron_floor(target_date))
+        this_prev = to_datetime(self.this_snapshot.node.cron_floor(target_date))
         return min(target_prev, this_prev)

--- a/sqlmesh/schedulers/airflow/plan.py
+++ b/sqlmesh/schedulers/airflow/plan.py
@@ -2,14 +2,84 @@ from __future__ import annotations
 
 import typing as t
 
+import pandas as pd
+from sqlglot import exp
+
 from sqlmesh.core import scheduler
+from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.plan import can_evaluate_before_promote
 from sqlmesh.core.snapshot import SnapshotTableInfo
-from sqlmesh.core.state_sync import StateSync
+from sqlmesh.core.state_sync import EngineAdapterStateSync, StateSync
+from sqlmesh.core.state_sync.base import DelegatingStateSync
 from sqlmesh.schedulers.airflow import common
+from sqlmesh.utils import nullsafe_join
 from sqlmesh.utils.date import now, now_timestamp
 from sqlmesh.utils.errors import SQLMeshError
+
+
+class PlanDagState:
+    def __init__(self, engine_adapter: EngineAdapter, schema: t.Optional[str]):
+        self.engine_adapter = engine_adapter
+
+        self._plan_dags_table = nullsafe_join(".", schema, "_plan_dags")
+        self._plan_dag_columns_to_types = {
+            "request_id": exp.DataType.build("text"),
+            "dag_id": exp.DataType.build("text"),
+            "dag_spec": exp.DataType.build("text"),
+        }
+
+    @classmethod
+    def from_state_sync(cls, state_sync: StateSync) -> PlanDagState:
+        while isinstance(state_sync, DelegatingStateSync):
+            state_sync = state_sync.state_sync
+        if not isinstance(state_sync, EngineAdapterStateSync):
+            raise SQLMeshError(f"Unsupported state sync {state_sync.__class__.__name__}")
+        return cls(state_sync.engine_adapter, state_sync.schema)
+
+    def add_dag_spec(self, spec: common.PlanDagSpec) -> None:
+        """Adds a new DAG spec to the state.
+
+        Args:
+            spec: the plan DAG spec to add.
+        """
+        df = pd.DataFrame(
+            [
+                {
+                    "request_id": spec.request_id,
+                    "dag_id": common.plan_application_dag_id(
+                        spec.environment_naming_info.name, spec.request_id
+                    ),
+                    "dag_spec": spec.json(),
+                }
+            ]
+        )
+        self.engine_adapter.insert_append(
+            self._plan_dags_table,
+            df,
+            columns_to_types=self._plan_dag_columns_to_types,
+            contains_json=True,
+        )
+
+    def get_dag_specs(self) -> t.List[common.PlanDagSpec]:
+        """Returns all DAG specs in the state."""
+        query = exp.select("dag_spec").from_(self._plan_dags_table)
+        return [
+            common.PlanDagSpec.parse_raw(row[0])
+            for row in self.engine_adapter.fetchall(
+                query, ignore_unsupported_errors=True, quote_identifiers=True
+            )
+        ]
+
+    def delete_dag_specs(self, dag_ids: t.Iterable[str]) -> None:
+        """Deletes the DAG specs with the given DAG IDs."""
+        dag_ids = list(dag_ids)
+        if not dag_ids:
+            return
+        self.engine_adapter.delete_from(
+            self._plan_dags_table,
+            where=exp.column("dag_id").isin(*dag_ids),
+        )
 
 
 def create_plan_dag_spec(

--- a/sqlmesh/schedulers/airflow/plan.py
+++ b/sqlmesh/schedulers/airflow/plan.py
@@ -13,16 +13,15 @@ from sqlmesh.core.snapshot import SnapshotTableInfo
 from sqlmesh.core.state_sync import EngineAdapterStateSync, StateSync
 from sqlmesh.core.state_sync.base import DelegatingStateSync
 from sqlmesh.schedulers.airflow import common
-from sqlmesh.utils import nullsafe_join
 from sqlmesh.utils.date import now, now_timestamp
 from sqlmesh.utils.errors import SQLMeshError
 
 
 class PlanDagState:
-    def __init__(self, engine_adapter: EngineAdapter, schema: t.Optional[str]):
+    def __init__(self, engine_adapter: EngineAdapter, plan_dags_table: str):
         self.engine_adapter = engine_adapter
 
-        self._plan_dags_table = nullsafe_join(".", schema, "_plan_dags")
+        self._plan_dags_table = plan_dags_table
         self._plan_dag_columns_to_types = {
             "request_id": exp.DataType.build("text"),
             "dag_id": exp.DataType.build("text"),
@@ -35,7 +34,7 @@ class PlanDagState:
             state_sync = state_sync.state_sync
         if not isinstance(state_sync, EngineAdapterStateSync):
             raise SQLMeshError(f"Unsupported state sync {state_sync.__class__.__name__}")
-        return cls(state_sync.engine_adapter, state_sync.schema)
+        return cls(state_sync.engine_adapter, state_sync.plan_dags_table)
 
     def add_dag_spec(self, spec: common.PlanDagSpec) -> None:
         """Adds a new DAG spec to the state.

--- a/sqlmesh/schedulers/airflow/plan.py
+++ b/sqlmesh/schedulers/airflow/plan.py
@@ -71,9 +71,8 @@ class PlanDagState:
             )
         ]
 
-    def delete_dag_specs(self, dag_ids: t.Iterable[str]) -> None:
+    def delete_dag_specs(self, dag_ids: t.Collection[str]) -> None:
         """Deletes the DAG specs with the given DAG IDs."""
-        dag_ids = list(dag_ids)
         if not dag_ids:
             return
         self.engine_adapter.delete_from(

--- a/tests/schedulers/airflow/test_mwaa_client.py
+++ b/tests/schedulers/airflow/test_mwaa_client.py
@@ -6,26 +6,6 @@ from pytest_mock.plugin import MockerFixture
 from sqlmesh.schedulers.airflow.mwaa_client import MWAAClient
 
 
-def test_set_variable(mocker: MockerFixture):
-    set_variable_response_mock = mocker.Mock()
-    set_variable_response_mock.json.return_value = {
-        "stdout": "",
-        "stderr": "",
-    }
-    set_variable_response_mock.status_code = 200
-    set_variable_mock = mocker.patch("requests.Session.post")
-    set_variable_mock.return_value = set_variable_response_mock
-
-    client = MWAAClient("https://test_airflow_host", "test_token")
-
-    client.set_variable("test_key", "test_value")
-
-    set_variable_mock.assert_called_once_with(
-        "https://test_airflow_host/aws_mwaa/cli",
-        data='variables set test_key "test_value"',
-    )
-
-
 def test_get_first_dag_run_id(mocker: MockerFixture):
     list_runs_response_mock = mocker.Mock()
     list_runs_response_mock.json.return_value = {


### PR DESCRIPTION
MWAA relies on shell / bash to set variables in Airflow and bash has limit on a number of characters that can be passed in. 

With this update we no longer rely on Airflow to store our Plan Application DAG specs and instead use our own internal state.  The additional `_plan_dags` table is added to our state to support this.