### PR TITLE
Fix: force no color when using github markdown console

### DIFF
--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
       - name: Checkout PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.issue.pull_request && github.event.issue.number || github.event.pull_request.number  }}/merge
       - name: Install SQLMesh + Dependencies
@@ -230,7 +230,7 @@ jobs:
   sqlmesh:
     steps:
     - name: Checkout PR branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       # Add if statement so we don't checkout merged PR but instead main branch
       if: github.event.pull_request.merged == false
       with:
@@ -404,7 +404,7 @@ jobs:
         with:
           python-version: '3.9'
       - name: Checkout PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.issue.pull_request && github.event.issue.number || github.event.pull_request.number  }}/merge
       - name: Install Dependencies

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -13,6 +13,7 @@ from typing import List
 
 import requests
 from hyperscript import Element, h
+from rich.console import Console
 from sqlglot.helper import seq_get
 
 from sqlmesh.core import constants as c
@@ -288,7 +289,7 @@ class GithubController:
         self._prod_plan: t.Optional[Plan] = None
         self._prod_plan_with_gaps: t.Optional[Plan] = None
         self._check_run_mapping: t.Dict[str, CheckRun] = {}
-        self._console = MarkdownConsole()
+        self._console = MarkdownConsole(console=Console(no_color=True))
         self._client: Github = client or Github(
             base_url=os.environ["GITHUB_API_URL"],
             login_or_token=self._token,


### PR DESCRIPTION
Prior to this we were rely on rich console's inference of the environment to not include color in the output text. This now forces that behavior. 

Also includes a documentation fix for the CI/CD bot. 