### PR TITLE
Chore: refactor the detection of SQLMESH_MOCKED_STAR

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -273,7 +273,7 @@ class MacroEvaluator:
 
         columns_to_types = self._schema.find(exp.to_table(model_name))
         if columns_to_types is None:
-            raise SQLMeshError(f"Model '{model_name}' not found in the macro evaluator's context.")
+            raise SQLMeshError(f"Schema for model '{model_name}' can't be statically determined.")
 
         return columns_to_types  # type: ignore
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -17,7 +17,6 @@ from pydantic import Field
 from sqlglot import diff, exp
 from sqlglot.diff import Insert, Keep
 from sqlglot.helper import ensure_list
-from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 from sqlglot.schema import MappingSchema, nested_set
 from sqlglot.time import format_time
 
@@ -1028,8 +1027,10 @@ class SqlModel(_SqlBasedModel):
             schema, default_schema=default_schema, default_catalog=default_catalog
         )
 
-        mocked_star = normalize_identifiers(SQLMESH_MOCKED_STAR, dialect=self.dialect)
-        if mocked_star.name in (self.columns_to_types or {}):
+        query = self._query_renderer.render(optimize=False)
+        if isinstance(query, exp.Expression) and any(
+            select.output_name.upper() == SQLMESH_MOCKED_STAR for select in query.selects
+        ):
             # We reset the unoptimized query cache here as well to allow the model's query
             # to be re-rendered so that the MacroEvaluator can resolve columns_to_types calls
             # and get rid of the mocked star column

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1028,8 +1028,8 @@ class SqlModel(_SqlBasedModel):
         )
 
         query = self._query_renderer.render(optimize=False)
-        if isinstance(query, exp.Expression) and any(
-            select.output_name.upper() == SQLMESH_MOCKED_STAR for select in query.selects
+        if isinstance(query, exp.Subqueryable) and any(
+            name.upper() == SQLMESH_MOCKED_STAR for name in query.named_selects
         ):
             # We reset the unoptimized query cache here as well to allow the model's query
             # to be re-rendered so that the MacroEvaluator can resolve columns_to_types calls


### PR DESCRIPTION
Apparently this part:

```python
if mocked_star.name in (self.columns_to_types or {}):
```

was causing `self.columns_to_types` to render the query in `optimize=True` mode and so we would get a warning pre-evaluation time for the sushi project because the mocked column was unresolved. I think this PR makes it a little bit cleaner, it mimics what we do to detect actual star projections.