### PR TITLE
Fix(MSSQL): fix results fetching

### DIFF
--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -190,13 +190,13 @@ class MSSQLEngineAdapter(
             FROM {catalog_name}.INFORMATION_SCHEMA.TABLES
             WHERE TABLE_SCHEMA LIKE '%{schema_name}%'
         """
-        results = self.fetchall(query)
+        results = self.fetchall(query, quote_identifiers=True)
         return [
             DataObject(
-                catalog=row[0],  # type: ignore
-                schema=row[2],  # type: ignore
-                name=row[1],  # type: ignore
-                type=DataObjectType.from_str(row[3]),  # type: ignore
+                catalog=row[0],
+                schema=row[2],
+                name=row[1],
+                type=DataObjectType.from_str(row[3]),
             )
             for row in results
         ]

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 
 import logging
 import typing as t
-from typing import Literal, overload
+from typing import overload
 
 import pandas as pd
 from pandas.api.types import is_datetime64_dtype  # type: ignore
 from sqlglot import exp
 from sqlglot.errors import ErrorLevel
 from sqlglot.optimizer.qualify_columns import quote_identifiers
+from typing_extensions import Literal
 
 from sqlmesh.core.engine_adapter.base import EngineAdapterWithIndexSupport, SourceQuery
 from sqlmesh.core.engine_adapter.mixins import (

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -213,7 +213,7 @@ class MSSQLEngineAdapter(
     def execute_and_fetch(
         self,
         expression: t.Union[str, exp.Expression],
-        fetch: Literal["all"] = ...,
+        fetch_one: Literal[False] = ...,
         ignore_unsupported_errors: bool = False,
         quote_identifiers: bool = True,
         **kwargs: t.Any,
@@ -224,7 +224,7 @@ class MSSQLEngineAdapter(
     def execute_and_fetch(
         self,
         expression: t.Union[str, exp.Expression],
-        fetch: Literal["one"],
+        fetch_one: Literal[True],
         ignore_unsupported_errors: bool = False,
         quote_identifiers: bool = True,
         **kwargs: t.Any,
@@ -234,7 +234,7 @@ class MSSQLEngineAdapter(
     def execute_and_fetch(
         self,
         expression: t.Union[str, exp.Expression],
-        fetch: str = "all",
+        fetch_one: bool = False,
         ignore_unsupported_errors: bool = False,
         quote_identifiers: bool = True,
         **kwargs: t.Any,
@@ -253,7 +253,7 @@ class MSSQLEngineAdapter(
             logger.debug(f"Executing SQL:\n{sql}")
             self.cursor.execute(sql, **kwargs)
 
-            if fetch == "one":
+            if fetch_one:
                 return self.cursor.fetchone()
 
             return self.cursor.fetchall()
@@ -269,7 +269,7 @@ class MSSQLEngineAdapter(
             query,
             ignore_unsupported_errors=ignore_unsupported_errors,
             quote_identifiers=quote_identifiers,
-            fetch="one",
+            fetch_one=True,
         )
 
     def fetchall(
@@ -283,5 +283,5 @@ class MSSQLEngineAdapter(
             query,
             ignore_unsupported_errors=ignore_unsupported_errors,
             quote_identifiers=quote_identifiers,
-            fetch="all",
+            fetch_one=False,
         )

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -700,3 +700,26 @@ def test_scd_type_2(ctx: TestContext):
             ]
         ),
     )
+
+
+def test_fetch(ctx: TestContext):
+    ctx.init()
+    table = ctx.table("test_table")
+    input_data = pd.DataFrame(
+        [
+            {"id": 1, "ds": "2022-01-01"},
+            {"id": 2, "ds": "2022-01-02"},
+            {"id": 3, "ds": "2022-01-03"},
+        ]
+    )
+    ctx.engine_adapter.ctas(table, ctx.input_data(input_data))
+
+    assert ctx.engine_adapter.fetchone(exp.select("*").from_(table)) == (1, "2022-01-01")
+    assert ctx.engine_adapter.fetchall(exp.select("*").from_(table)) == [
+        (1, "2022-01-01"),
+        (2, "2022-01-02"),
+        (3, "2022-01-03"),
+    ]
+    ctx._compare_dfs(
+        ctx.engine_adapter.fetchdf(exp.select("*").from_(table)), ctx.output_data(input_data)
+    )


### PR DESCRIPTION
Background:
- pymssql automatically opens transactions, causing hung sessions on some CREATE statements
- #1532 fixed this by wrapping all `execute` calls in a transaction to ensure transactions would be closed

Current issue:
- The transaction wrapping in #1532 closes the pymssql transaction after executing the query, such that query results are not available to be fetched by the `fetchone` or `fetchall` methods

This PR:
- Creates a new MSSQL method `execute_and_fetch` that both executes a query and fetches its results. The method copies the base engine adapter `execute` code because we must fetch the results from inside the transaction context manager.
- Overrides the base engine adapter `fetchone` and `fetchall` methods.