### PR TITLE
Fix(MSSQL): wrap fetches in transaction

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1167,12 +1167,13 @@ class EngineAdapter:
         ignore_unsupported_errors: bool = False,
         quote_identifiers: bool = False,
     ) -> t.Tuple:
-        self.execute(
-            query,
-            ignore_unsupported_errors=ignore_unsupported_errors,
-            quote_identifiers=quote_identifiers,
-        )
-        return self.cursor.fetchone()
+        with self.transaction():
+            self.execute(
+                query,
+                ignore_unsupported_errors=ignore_unsupported_errors,
+                quote_identifiers=quote_identifiers,
+            )
+            return self.cursor.fetchone()
 
     def fetchall(
         self,
@@ -1180,19 +1181,21 @@ class EngineAdapter:
         ignore_unsupported_errors: bool = False,
         quote_identifiers: bool = False,
     ) -> t.List[t.Tuple]:
-        self.execute(
-            query,
-            ignore_unsupported_errors=ignore_unsupported_errors,
-            quote_identifiers=quote_identifiers,
-        )
-        return self.cursor.fetchall()
+        with self.transaction():
+            self.execute(
+                query,
+                ignore_unsupported_errors=ignore_unsupported_errors,
+                quote_identifiers=quote_identifiers,
+            )
+            return self.cursor.fetchall()
 
     def _fetch_native_df(
         self, query: t.Union[exp.Expression, str], quote_identifiers: bool = False
     ) -> DF:
         """Fetches a DataFrame that can be either Pandas or PySpark from the cursor"""
-        self.execute(query, quote_identifiers=quote_identifiers)
-        return self.cursor.fetchdf()
+        with self.transaction():
+            self.execute(query, quote_identifiers=quote_identifiers)
+            return self.cursor.fetchdf()
 
     def fetchdf(
         self, query: t.Union[exp.Expression, str], quote_identifiers: bool = False

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -61,15 +61,14 @@ class MSSQLEngineAdapter(
                 "numeric_precision",
                 "numeric_scale",
             )
-            .from_(f"information_schema.columns")
+            .from_("information_schema.columns")
             .where(f"table_name = '{table.name}'")
         )
         database_name = table.db
         if database_name:
             sql = sql.where(f"table_schema = '{database_name}'")
 
-        self.execute(sql)
-        columns_raw = self.cursor.fetchall()
+        columns_raw = self.fetchall(sql, quote_identifiers=True)
 
         def build_var_length_col(row: tuple) -> tuple:
             var_len_chars = ("binary", "varbinary", "char", "varchar", "nchar", "nvarchar")
@@ -100,16 +99,14 @@ class MSSQLEngineAdapter(
 
         sql = (
             exp.select("1")
-            .from_(f"information_schema.tables")
+            .from_("information_schema.tables")
             .where(f"table_name = '{table.alias_or_name}'")
         )
         database_name = table.db
         if database_name:
             sql = sql.where(f"table_schema = '{database_name}'")
 
-        self.execute(sql)
-
-        result = self.cursor.fetchone()
+        result = self.fetchone(sql, quote_identifiers=True)
 
         return result[0] == 1 if result else False
 


### PR DESCRIPTION
This PR wraps `fetchone`, `fetchall`, and `fetchdf` in transactions to ensure query results are still available for fetching after we return from `execute`.