### PR TITLE
Fix: Add Proper Catalog Support to Engine Adapter

### DIFF
--- a/sqlmesh/core/_typing.py
+++ b/sqlmesh/core/_typing.py
@@ -6,3 +6,4 @@ from sqlglot import exp
 
 if t.TYPE_CHECKING:
     TableName = t.Union[str, exp.Table]
+    SchemaName = t.Union[str, exp.Table]

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -839,3 +839,35 @@ def transform_values(
             yield exp.func("PARSE_JSON", f"'{value}'")
         else:
             yield value
+
+
+def to_schema(sql_path: str | exp.Table) -> exp.Table:
+    if isinstance(sql_path, exp.Table) and sql_path.this is None:
+        return sql_path
+    table = exp.to_table(sql_path.copy() if isinstance(sql_path, exp.Table) else sql_path)
+    table.set("catalog", table.args.get("db"))
+    table.set("db", table.args.get("this"))
+    table.set("this", None)
+    return table
+
+
+def schema_(
+    db: exp.Identifier | str,
+    catalog: t.Optional[exp.Identifier | str] = None,
+    quoted: t.Optional[bool] = None,
+) -> exp.Table:
+    """Build a Schema.
+
+    Args:
+        db: Database name.
+        catalog: Catalog name.
+        quoted: Whether to force quotes on the schema's identifiers.
+
+    Returns:
+        The new Schema instance.
+    """
+    return exp.Table(
+        this=None,
+        db=exp.to_identifier(db, quoted=quoted) if db else None,
+        catalog=exp.to_identifier(catalog, quoted=quoted) if catalog else None,
+    )

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -4,12 +4,12 @@ import typing as t
 
 from sqlglot import exp
 
-from sqlmesh.core.engine_adapter.mixins import EngineAdapter
+from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 from sqlmesh.utils.errors import SQLMeshError
 
 if t.TYPE_CHECKING:
-    from sqlmesh.core._typing import TableName
+    from sqlmesh.core._typing import SchemaName, TableName
     from sqlmesh.core.engine_adapter.base import QueryOrDF
 
 
@@ -92,13 +92,11 @@ class BasePostgresEngineAdapter(EngineAdapter):
                 **create_kwargs,
             )
 
-    def _get_data_objects(
-        self, schema_name: str, catalog_name: t.Optional[str] = None
-    ) -> t.List[DataObject]:
+    def _get_data_objects(self, schema_name: SchemaName) -> t.List[DataObject]:
         """
         Returns all the data objects that exist in the given schema and optionally catalog.
         """
-        catalog_name = f"'{catalog_name}'" if catalog_name else "NULL"
+        catalog_name = f"'{self.get_current_catalog()}'"
         query = f"""
             SELECT
                 {catalog_name} AS catalog_name,

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -7,10 +7,10 @@ from sqlglot import exp
 
 from sqlmesh.core.engine_adapter.base import SourceQuery
 from sqlmesh.core.engine_adapter.mixins import LogicalMergeMixin
-from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
+from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType, set_catalog
 
 if t.TYPE_CHECKING:
-    from sqlmesh.core._typing import TableName
+    from sqlmesh.core._typing import SchemaName, TableName
     from sqlmesh.core.engine_adapter._typing import DF
 
 
@@ -39,16 +39,14 @@ class DuckDBEngineAdapter(LogicalMergeMixin):
             )
         ]
 
-    def _get_data_objects(
-        self, schema_name: str, catalog_name: t.Optional[str] = None
-    ) -> t.List[DataObject]:
+    @set_catalog()
+    def _get_data_objects(self, schema_name: SchemaName) -> t.List[DataObject]:
         """
         Returns all the data objects that exist in the given schema and optionally catalog.
         """
-        catalog_name = f"'{catalog_name}'" if catalog_name else "NULL"
         query = f"""
             SELECT
-              {catalog_name} as catalog,
+              NULL as catalog,
               table_name as name,
               table_schema as schema,
               CASE table_type

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -7,10 +7,10 @@ from sqlmesh.core.engine_adapter.mixins import (
     LogicalReplaceQueryMixin,
     PandasNativeFetchDFSupportMixin,
 )
-from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
+from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType, set_catalog
 
 if t.TYPE_CHECKING:
-    from sqlmesh.core._typing import TableName
+    from sqlmesh.core._typing import SchemaName, TableName
 
 
 class MySQLEngineAdapter(
@@ -34,19 +34,19 @@ class MySQLEngineAdapter(
         super().create_index(table_name, index_name, columns, exists=False)
 
     def drop_schema(
-        self, schema_name: str, ignore_if_not_exists: bool = True, cascade: bool = False
+        self,
+        schema_name: SchemaName,
+        ignore_if_not_exists: bool = True,
+        cascade: bool = False,
     ) -> None:
         # MySQL doesn't support CASCADE clause and drops schemas unconditionally.
         super().drop_schema(schema_name, ignore_if_not_exists=ignore_if_not_exists, cascade=False)
 
-    def _get_data_objects(
-        self, schema_name: str, catalog_name: t.Optional[str] = None
-    ) -> t.List[DataObject]:
+    @set_catalog()
+    def _get_data_objects(self, schema_name: SchemaName) -> t.List[DataObject]:
         """
         Returns all the data objects that exist in the given schema and optionally catalog.
         """
-        if catalog_name is not None:
-            raise NotImplementedError("MySQL doesn't support catalogs.")
         query = f"""
             SELECT
                 null AS catalog_name,

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -23,6 +23,12 @@ class PostgresEngineAdapter(
     DIALECT = "postgres"
     SUPPORTS_INDEXES = True
 
+    def get_current_catalog(self) -> t.Optional[str]:
+        result = self.fetchone("SELECT current_catalog")
+        if result:
+            return result[0]
+        return None
+
     def _fetch_native_df(
         self, query: t.Union[exp.Expression, str], quote_identifiers: bool = False
     ) -> DF:

--- a/sqlmesh/core/engine_adapter/shared.py
+++ b/sqlmesh/core/engine_adapter/shared.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import functools
+import inspect
 import typing as t
 from enum import Enum
 
 from pydantic import Field
+from sqlglot import exp
 
+from sqlmesh.core.dialect import to_schema
+from sqlmesh.utils.errors import UnsupportedCatalogOperationError
 from sqlmesh.utils.pydantic import PydanticModel
+
+if t.TYPE_CHECKING:
+    from sqlmesh.core.engine_adapter.base import CatalogSupport
 
 
 class DataObjectType(str, Enum):
@@ -47,3 +55,73 @@ class DataObject(PydanticModel):
     schema_name: str = Field(alias="schema")
     name: str
     type: DataObjectType
+
+
+def _get_args_pos_and_kwarg_name(
+    func: t.Callable,
+) -> t.Optional[t.Tuple[str, int, str]]:
+    spec = inspect.getfullargspec(func)
+    for i, name in enumerate(spec.args):
+        obj_type = spec.annotations.get(name)
+        if obj_type == "SchemaName":
+            return name, i, obj_type
+        if obj_type == "TableName":
+            return name, i, obj_type
+    return None
+
+
+def set_catalog(
+    *,
+    override: t.Optional[CatalogSupport] = None,
+) -> t.Callable:
+    def decorator(func: t.Callable) -> t.Callable:
+        @functools.wraps(func)
+        def wrapper(*args: t.Any, **kwargs: t.Any) -> t.Any:
+            # Need to convert args to list in order to later do assignment to the object
+            list_args = list(args)
+            engine_adapter = list_args[0]
+            catalog_support = override or engine_adapter.CATALOG_SUPPORT
+            # If there is full catalog support then we have nothing to do
+            if catalog_support.is_full_support:
+                return func(*list_args, **kwargs)
+
+            # Get the field value and the container which it came from so we can update it later
+            location = _get_args_pos_and_kwarg_name(func)
+            if location is None:
+                return func(*list_args, **kwargs)
+            name, pos, obj_type = location
+            obj, container, key = t.cast(
+                t.Tuple[t.Union[str, exp.Table], t.Union[t.Dict, t.List], t.Union[int, str]],
+                (kwargs.get(name), kwargs, name)
+                if kwargs.get(name)
+                else (list_args[pos], list_args, pos),
+            )
+            to_expression_func = t.cast(
+                t.Callable[[t.Union[str, exp.Table]], exp.Table],
+                exp.to_table if obj_type == "TableName" else to_schema,
+            )
+            expression = to_expression_func(obj.copy() if isinstance(obj, exp.Table) else obj)
+            catalog_name = expression.args.get("catalog")
+            if not catalog_name:
+                return func(*list_args, **kwargs)
+            # If we have a catalog and this engine doesn't support catalogs then we need to error
+            if catalog_support.is_unsupported:
+                raise UnsupportedCatalogOperationError(
+                    f"{engine_adapter.dialect} does not support catalogs and a catalog was provided: {catalog_name}"
+                )
+            # Remove the catalog name from the argument so the engine adapter doesn't try to use it
+            expression.set("catalog", None)
+            container[key] = expression  # type: ignore
+            # Set the catalog name on the engine adapter if needed
+            current_catalog = engine_adapter.get_current_catalog()
+            if expression.catalog != current_catalog:
+                engine_adapter.set_current_catalog(catalog_name)
+            resp = func(*list_args, **kwargs)
+            # Reset the catalog name on the engine adapter if needed
+            if expression.catalog != catalog_name:
+                engine_adapter.set_current_catalog(current_catalog)
+            return resp
+
+        return wrapper
+
+    return decorator

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -10,7 +10,7 @@ import pandas as pd
 from sqlglot import exp, parse_one
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
-from sqlmesh.core.dialect import normalize_model_name
+from sqlmesh.core.dialect import normalize_model_name, schema_
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.model import Model, PythonModel, SqlModel
 from sqlmesh.utils.errors import SQLMeshError
@@ -81,7 +81,9 @@ class ModelTest(unittest.TestCase):
             table = exp.to_table(table_name)
 
             if table.db:
-                self.engine_adapter.create_schema(table.db, catalog_name=table.catalog)
+                self.engine_adapter.create_schema(
+                    schema_(table.args["db"], table.args.get("catalog"))
+                )
 
             self.engine_adapter.create_view(_test_fixture_name(table_name), df, columns_to_types)
 

--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -9,6 +9,7 @@ from dbt.contracts.relation import Policy
 from sqlglot import exp, parse_one
 from sqlglot.helper import seq_get
 
+from sqlmesh.core.dialect import schema_
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.snapshot import Snapshot, to_table_mapping
 from sqlmesh.utils.errors import ConfigError, ParsetimeAdapterCallError
@@ -212,7 +213,7 @@ class RuntimeAdapter(BaseAdapter):
 
         assert schema_relation.schema is not None
         data_objects = self.engine_adapter._get_data_objects(
-            schema_name=schema_relation.schema, catalog_name=schema_relation.database
+            schema_(schema_relation.schema, schema_relation.database)
         )
         relations = [
             self.relation_type.create(

--- a/sqlmesh/utils/errors.py
+++ b/sqlmesh/utils/errors.py
@@ -111,6 +111,14 @@ class ParsetimeAdapterCallError(SQLMeshError):
     pass
 
 
+class EngineAdapterError(SQLMeshError):
+    pass
+
+
+class UnsupportedCatalogOperationError(EngineAdapterError):
+    pass
+
+
 def raise_config_error(
     msg: str,
     location: t.Optional[str | Path] = None,

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -35,3 +35,10 @@ def test_clone_table(make_mocked_engine_adapter: t.Callable):
     adapter.cursor.execute.assert_called_once_with(
         "CREATE TABLE `target_table` SHALLOW CLONE `source_table`"
     )
+
+
+def test_set_current_catalog(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(DatabricksEngineAdapter)
+    adapter.set_current_catalog("test_catalog")
+
+    assert to_sql_calls(adapter) == ["USE CATALOG `test_catalog`"]

--- a/tests/core/engine_adapter/test_postgres.py
+++ b/tests/core/engine_adapter/test_postgres.py
@@ -1,0 +1,59 @@
+import typing as t
+
+import pytest
+from pytest_mock import MockFixture
+from sqlglot.helper import ensure_list
+
+from sqlmesh.core.engine_adapter import PostgresEngineAdapter
+from sqlmesh.utils.errors import UnsupportedCatalogOperationError
+from tests.core.engine_adapter import to_sql_calls
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        (
+            {
+                "schema_name": "test_schema",
+            },
+            'DROP SCHEMA IF EXISTS "test_schema"',
+        ),
+        (
+            {
+                "schema_name": "test_schema",
+                "ignore_if_not_exists": False,
+            },
+            'DROP SCHEMA "test_schema"',
+        ),
+        (
+            {
+                "schema_name": "test_schema",
+                "cascade": True,
+            },
+            'DROP SCHEMA IF EXISTS "test_schema" CASCADE',
+        ),
+        (
+            {
+                "schema_name": "test_schema",
+                "cascade": True,
+                "ignore_if_not_exists": False,
+            },
+            'DROP SCHEMA "test_schema" CASCADE',
+        ),
+    ],
+)
+def test_drop_schema(kwargs, expected, make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(PostgresEngineAdapter)
+
+    adapter.drop_schema(**kwargs)
+
+    assert to_sql_calls(adapter) == ensure_list(expected)
+
+
+def test_drop_schema_with_catalog(make_mocked_engine_adapter: t.Callable, mocker: MockFixture):
+    adapter = make_mocked_engine_adapter(PostgresEngineAdapter)
+
+    adapter.get_current_catalog = mocker.MagicMock(return_value="test_catalog")
+
+    with pytest.raises(UnsupportedCatalogOperationError):
+        adapter.drop_schema("test_catalog.test_schema")

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -16,7 +16,7 @@ from sqlmesh.core.config import (
     SnowflakeConnectionConfig,
 )
 from sqlmesh.core.context import Context
-from sqlmesh.core.dialect import parse
+from sqlmesh.core.dialect import parse, schema_
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.model import load_sql_based_model
 from sqlmesh.core.plan import BuiltInPlanEvaluator, Plan
@@ -411,10 +411,13 @@ def test_janitor(sushi_context, mocker: MockerFixture) -> None:
     sushi_context._state_sync = state_sync_mock
     sushi_context._run_janitor()
     # Assert that the schemas are dropped just twice for the schema based environment
-    assert sorted(adapter_mock.drop_schema.call_args_list) == [
-        call("raw__test_environment", ignore_if_not_exists=True, cascade=True),
-        call("sushi__test_environment", ignore_if_not_exists=True, cascade=True),
-    ]
+    adapter_mock.drop_schema.assert_has_calls(
+        [
+            call(schema_("raw__test_environment"), cascade=True, ignore_if_not_exists=True),
+            call(schema_("sushi__test_environment"), cascade=True, ignore_if_not_exists=True),
+        ],
+        any_order=True,
+    )
     # Assert that the views are dropped for each snapshot just once and make sure that the name used is the
     # view name with the environment as a suffix
     # TODO: It appears we try to drop views for external models which shouldn't hurt but we should fix this

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -7,6 +7,7 @@ from sqlglot import expressions as exp
 from sqlglot import parse, parse_one, select
 
 from sqlmesh.core.audit import StandaloneAudit
+from sqlmesh.core.dialect import to_schema
 from sqlmesh.core.engine_adapter import EngineAdapter, create_engine_adapter
 from sqlmesh.core.engine_adapter.base import InsertOverwriteStrategy
 from sqlmesh.core.environment import EnvironmentNamingInfo
@@ -132,7 +133,7 @@ def test_evaluate(mocker: MockerFixture, adapter_mock, make_snapshot):
 
     adapter_mock.create_schema.assert_has_calls(
         [
-            call("sqlmesh__test_schema", catalog_name=None),
+            call(to_schema("sqlmesh__test_schema")),
         ]
     )
 
@@ -184,7 +185,7 @@ def test_promote(mocker: MockerFixture, adapter_mock, make_snapshot):
 
     evaluator.promote([snapshot], EnvironmentNamingInfo(name="test_env"))
 
-    adapter_mock.create_schema.assert_called_once_with("test_schema__test_env", catalog_name=None)
+    adapter_mock.create_schema.assert_called_once_with(to_schema("test_schema__test_env"))
     adapter_mock.create_view.assert_called_once_with(
         "test_schema__test_env.test_model",
         parse_one(
@@ -213,8 +214,8 @@ def test_promote_forward_only(mocker: MockerFixture, adapter_mock, make_snapshot
 
     adapter_mock.create_schema.assert_has_calls(
         [
-            call("test_schema__test_env", catalog_name=None),
-            call("test_schema__test_env", catalog_name=None),
+            call(to_schema("test_schema__test_env")),
+            call(to_schema("test_schema__test_env")),
         ]
     )
     adapter_mock.create_view.assert_has_calls(
@@ -482,7 +483,7 @@ def test_promote_model_info(mocker: MockerFixture, make_snapshot):
 
     evaluator.promote([snapshot], EnvironmentNamingInfo(name="test_env"))
 
-    adapter_mock.create_schema.assert_called_once_with("test_schema__test_env", catalog_name=None)
+    adapter_mock.create_schema.assert_called_once_with(to_schema("test_schema__test_env"))
     adapter_mock.create_view.assert_called_once_with(
         "test_schema__test_env.test_model",
         parse_one(f"SELECT * FROM physical_schema.test_schema__test_model__{snapshot.version}"),

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -10,7 +10,7 @@ from sqlglot import exp
 
 from sqlmesh.core import constants as c
 from sqlmesh.core.config import EnvironmentSuffixTarget
-from sqlmesh.core.dialect import parse_one
+from sqlmesh.core.dialect import parse_one, schema_
 from sqlmesh.core.engine_adapter import create_engine_adapter
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.model import (
@@ -1256,7 +1256,7 @@ def test_cleanup_expired_views(
     assert adapter.drop_schema.called
     assert adapter.drop_view.called
     assert adapter.drop_schema.call_args_list == [
-        call("default__test_environment", ignore_if_not_exists=True, cascade=True)
+        call(schema_("default__test_environment"), ignore_if_not_exists=True, cascade=True)
     ]
     assert sorted(adapter.drop_view.call_args_list) == [
         call("default.c__test_environment", ignore_if_not_exists=True),


### PR DESCRIPTION
Controversial change to highlight: Removed the field `catalog_name` and instead let callers provide a `TableName` which means it can either be a string or `exp.Table` object. 

Added engine adapter methods:
* `get_current_catalog`
* `set_current_catalog`

New Property: `CatalogSupport`
This tells the `set_catalog` decorator what level of catalog support the engine adapter has in order to set the catalog properly. 3 levels:
* Unsupported
* Requires Set Catalog
* Full Support

`Requires Set Catalog` means that operations cannot be provided with the catalog but instead they need `set_current_catalog` against the catalog and then they can provide the operation but now with the catalog dropped. This always refers to the target of the operation (ex: if drop schema, the schema being drooped) and we assume reads can happen across catalogs. For engines that don't support reads across catalogs we just consider them Unsupported (ex: Postgres). 

Follow up work:
* Have new default catalog integrate with connector default catalog if it supports it
* Add Redshift catalog support
  * The challenge with this is that Redshift doesn't allow changing the catalog from within a connection. A new connection needs to be created with the new catalog defined. This is just for creating objects across catalogs and not querying across catalogs
