### PR TITLE
Feat: Support BigQuery No-Op Coerce Types

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -54,14 +54,20 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
             exp.DataType.build("INT64", dialect=DIALECT): {
                 exp.DataType.build("NUMERIC", dialect=DIALECT),
                 exp.DataType.build("FLOAT64", dialect=DIALECT),
+                exp.DataType.build("BIGNUMERIC", dialect=DIALECT),
             },
             exp.DataType.build("NUMERIC", dialect=DIALECT): {
+                exp.DataType.build("FLOAT64", dialect=DIALECT),
+                exp.DataType.build("BIGNUMERIC", dialect=DIALECT),
+            },
+            exp.DataType.build("BIGNUMERIC", dialect=DIALECT): {
                 exp.DataType.build("FLOAT64", dialect=DIALECT),
             },
             exp.DataType.build("DATE", dialect=DIALECT): {
                 exp.DataType.build("DATETIME", dialect=DIALECT),
             },
         },
+        support_coercing_compatible_types=True,
     )
 
     @property


### PR DESCRIPTION
If types are compatible (i.e: alterable) then that also means for BigQuery that the inverse relationship can be a no-operation for us. We can't alter but we can insert new values without issue. 

This can later be expanded to more engines but just focusing on BigQuery for now. 