### PR TITLE
Feat!: Sync Connection Catalog With Model Default Catalog

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -274,7 +274,12 @@ class Context(BaseContext):
 
         connection_config = self.config.get_connection(self.gateway)
         self.concurrent_tasks = concurrent_tasks or connection_config.concurrent_tasks
-        self._engine_adapter = engine_adapter or connection_config.create_engine_adapter()
+        self._engine_adapter = engine_adapter or connection_config.create_engine_adapter(
+            default_catalog=self.config.model_defaults.catalog
+        )
+        engine_default_catalog = connection_config.get_catalog()
+        if engine_default_catalog:
+            self.config.model_defaults.catalog = engine_default_catalog
 
         test_connection_config = self.config.get_test_connection(self.gateway)
         self._test_engine_adapter = test_connection_config.create_engine_adapter()


### PR DESCRIPTION
This PR makes sure that default catalog is synced with the connection catalog. If they say different things then an error is raised. Also if a user sets a default catalog on an engine that doesn't support catalogs then an error is raised.