### PR TITLE
Feat: Support When Matched Expression for Merge

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "requests",
         "rich",
         "ruamel.yaml",
-        "sqlglot~=18.12.0",
+        "sqlglot~=18.13.0",
     ],
     extras_require={
         "bigquery": [

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -294,15 +294,17 @@ def _parse_props(self: Parser) -> t.Optional[exp.Expression]:
     if not key:
         return None
 
-    if self._match(TokenType.L_PAREN):
-        value: t.Optional[exp.Expression] = self.expression(
+    name = key.name.lower()
+    if name == "when_matched":
+        value: t.Optional[exp.Expression] = self._parse_when_matched()[0]
+    elif self._match(TokenType.L_PAREN):
+        value = self.expression(
             exp.Tuple, expressions=self._parse_csv(lambda: _parse_prop_value(self))
         )
         self._match_r_paren()
     else:
         value = self._parse_bracket(self._parse_field(any_token=True))
 
-    name = key.name.lower()
     if name == "path" and value:
         # Make sure if we get a windows path that it is converted to posix
         value = exp.Literal.string(value.this.replace("\\", "/"))

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1159,6 +1159,7 @@ class EngineAdapter:
         source_table: QueryOrDF,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
+        when_matched: t.Optional[exp.When] = None,
     ) -> None:
         source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
             source_table, columns_to_types, target_table=target_table
@@ -1170,16 +1171,17 @@ class EngineAdapter:
                 for part in unique_key
             )
         )
-        when_matched = exp.When(
-            matched=True,
-            source=False,
-            then=exp.Update(
-                expressions=[
-                    exp.column(col, MERGE_TARGET_ALIAS).eq(exp.column(col, MERGE_SOURCE_ALIAS))
-                    for col in columns_to_types
-                ],
-            ),
-        )
+        if not when_matched:
+            when_matched = exp.When(
+                matched=True,
+                source=False,
+                then=exp.Update(
+                    expressions=[
+                        exp.column(col, MERGE_TARGET_ALIAS).eq(exp.column(col, MERGE_SOURCE_ALIAS))
+                        for col in columns_to_types
+                    ],
+                ),
+            )
         when_not_matched = exp.When(
             matched=False,
             source=False,

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -24,6 +24,7 @@ class LogicalMergeMixin(EngineAdapter):
         source_table: QueryOrDF,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
+        when_matched: t.Optional[exp.When] = None,
     ) -> None:
         """
         Merge implementation for engine adapters that do not support merge natively.
@@ -35,6 +36,10 @@ class LogicalMergeMixin(EngineAdapter):
            within the temporary table are ommitted.
         4. Drop the temporary table.
         """
+        if when_matched:
+            raise SQLMeshError(
+                "This engine does not support MERGE expressions and therefore `when_matched` is not supported."
+            )
         if columns_to_types is None:
             columns_to_types = self.columns(target_table)
 

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -354,3 +354,9 @@ class ModelMeta(_Node, extra="allow"):
     @property
     def managed_columns(self) -> t.Dict[str, exp.DataType]:
         return getattr(self.kind, "managed_columns", {})
+
+    @property
+    def when_matched(self) -> t.Optional[exp.When]:
+        if isinstance(self.kind, IncrementalByUniqueKeyKind):
+            return self.kind.when_matched
+        return None

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -925,6 +925,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
             query_or_df,
             columns_to_types=model.columns_to_types,
             unique_key=model.unique_key,
+            when_matched=model.when_matched,
         )
 
     def append(
@@ -942,6 +943,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
             query_or_df,
             columns_to_types=model.columns_to_types,
             unique_key=model.unique_key,
+            when_matched=model.when_matched,
         )
 
 


### PR DESCRIPTION
Users can now override the when matched logic for `INCREMENTAL_BY_UNQIUE_KEY` model kind. Note that macros are not supported in this PR. 