### PR TITLE
Feat: add support for @IF(cond, statement) macro

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -364,12 +364,10 @@ def _parse_if(self: Parser) -> t.Optional[exp.Expression]:
             self._retreat(index)
             statement = self._parse_as_command(self._curr)
 
-            # Unconsume the right parenthesis as well as omit it from the command's text
-            self._retreat(self._index - 1)
+            # Omit the right parenthesis from the command's text
             statement.set("expression", statement.expression[:-1])
 
         # Return anonymous so that _parse_macro can create a MacroFunc with this value
-        self._match_r_paren()
         return exp.Anonymous(this="IF", expressions=[cond, statement])
 
 

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -364,10 +364,12 @@ def _parse_if(self: Parser) -> t.Optional[exp.Expression]:
             self._retreat(index)
             statement = self._parse_as_command(self._curr)
 
-            # Omit the right parenthesis from the command's text
+            # Unconsume the right parenthesis as well as omit it from the command's text
+            self._retreat(self._index - 1)
             statement.set("expression", statement.expression[:-1])
 
         # Return anonymous so that _parse_macro can create a MacroFunc with this value
+        self._match_r_paren()
         return exp.Anonymous(this="IF", expressions=[cond, statement])
 
 

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -114,7 +114,7 @@ class MacroEvaluator:
     ):
         self.dialect = dialect
         self.generator = MacroDialect().generator()
-        self.locals: t.Dict[str, t.Any] = {"runtime_stage": runtime_stage}
+        self.locals: t.Dict[str, t.Any] = {"runtime_stage": runtime_stage.value}
         self.env = {**ENV, "self": self}
         self.python_env = python_env or {}
         self._jinja_env: t.Optional[Environment] = jinja_env

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -189,13 +189,10 @@ def test_runtime_stages(capsys, mocker, adapter_mock, make_snapshot):
     evaluator.evaluate(snapshot, "2020-01-01", "2020-01-02", "2020-01-02", snapshots={})
     assert f"RuntimeStage value: {RuntimeStage.EVALUATING.value}" in capsys.readouterr().out
 
-    adapter_mock.execute.assert_has_calls(
-        [
-            call([]),
-            call([]),
-            call([parse_one("ALTER TABLE test_schema.foo MODIFY COLUMN c SET MASKING POLICY p")]),
-            call([]),
-        ]
+    non_empty_calls = [c for c in adapter_mock.execute.mock_calls if c != call([])]
+    assert len(non_empty_calls) == 1
+    assert non_empty_calls[0] == call(
+        [parse_one("ALTER TABLE test_schema.foo MODIFY COLUMN c SET MASKING POLICY p")]
     )
 
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -169,11 +169,7 @@ def test_runtime_stages(capsys, mocker, adapter_mock, make_snapshot):
             );
 
             @increment_stage_counter();
-
-            @execute_if(
-                @runtime_stage = 'evaluating',
-                ALTER TABLE test_schema.foo MODIFY COLUMN c SET MASKING POLICY p
-            );
+            @if(@runtime_stage = 'evaluating', ALTER TABLE test_schema.foo MODIFY COLUMN c SET MASKING POLICY p);
 
             SELECT 1 AS a;
             """

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -189,7 +189,8 @@ def test_runtime_stages(capsys, mocker, adapter_mock, make_snapshot):
     evaluator.evaluate(snapshot, "2020-01-01", "2020-01-02", "2020-01-02", snapshots={})
     assert f"RuntimeStage value: {RuntimeStage.EVALUATING.value}" in capsys.readouterr().out
 
-    non_empty_calls = [c for c in adapter_mock.execute.mock_calls if c != call([])]
+    empty_call = call([])
+    non_empty_calls = [c for c in adapter_mock.execute.mock_calls if c != empty_call]
     assert len(non_empty_calls) == 1
     assert non_empty_calls[0] == call(
         [parse_one("ALTER TABLE test_schema.foo MODIFY COLUMN c SET MASKING POLICY p")]


### PR DESCRIPTION
This PR along with https://github.com/TobikoData/sqlmesh/commit/c637908ab859617b18dafc54335fa38dd6a08dd6 allows SQLMesh users to conditionally execute pre/post-statements based on the current runtime stage, using the good ol' `@IF` macro: `@IF(condition, statement)`.

~The reason I didn't just implement this using the good ol' `@IF(...)` macro, is that we don't account for statements / commands in normal function calls and hence we'd need to override its parser to account for them, thus making the `_parse_if` method more complex.~ Refactored to use `@IF` instead.