### PR TITLE
Fix(mysql): use 8-character random ID for temp table names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install-dev:
 	pip3 install -e ".[dev,web,slack]"
 
 install-engine-integration:
-	pip3 install -e ".[dev,web,slack,mysql,postgres,databricks,redshift,bigquery,snowflake]"
+	pip3 install -e ".[dev,web,slack,mysql,postgres,databricks,redshift,bigquery,snowflake,trino]"
 
 install-pre-commit:
 	pre-commit install

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -14,7 +14,6 @@ import logging
 import sys
 import types
 import typing as t
-import uuid
 from datetime import datetime, timezone
 from enum import Enum
 from functools import partial
@@ -34,7 +33,7 @@ from sqlmesh.core.dialect import (
 from sqlmesh.core.engine_adapter.shared import DataObject, set_catalog
 from sqlmesh.core.model.kind import TimeColumn
 from sqlmesh.core.schema_diff import SchemaDiffer
-from sqlmesh.utils import double_escape
+from sqlmesh.utils import double_escape, random_id
 from sqlmesh.utils.connection_pool import create_connection_pool
 from sqlmesh.utils.date import TimeLike, make_inclusive, to_ts
 from sqlmesh.utils.errors import SQLMeshError, UnsupportedCatalogOperationError
@@ -1431,7 +1430,7 @@ class EngineAdapter:
         Returns the name of the temp table that should be used for the given table name.
         """
         table = t.cast(exp.Table, exp.to_table(table).copy())
-        table.set("this", exp.to_identifier(f"__temp_{table.name}_{uuid.uuid4().hex}"))
+        table.set("this", exp.to_identifier(f"__temp_{table.name}_{random_id(short=True)}"))
 
         if table_only:
             table.set("db", None)

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import copy
 import importlib
 import os
+import random
 import re
+import string
 import sys
 import time
 import traceback
@@ -47,7 +49,10 @@ def unique(iterable: t.Iterable[T], by: t.Callable[[T], t.Any] = lambda i: i) ->
     return list({by(i): None for i in iterable})
 
 
-def random_id() -> str:
+def random_id(short: bool = False) -> str:
+    if short:
+        return "".join(random.choices(string.ascii_letters + string.digits, k=8))
+
     return uuid.uuid4().hex
 
 

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -24,6 +24,8 @@ KEY = t.TypeVar("KEY", bound=t.Hashable)
 VALUE = t.TypeVar("VALUE")
 DECORATOR_RETURN_TYPE = t.TypeVar("DECORATOR_RETURN_TYPE")
 
+ALPHANUMERIC = string.ascii_lowercase + string.digits
+
 
 def optional_import(name: str) -> t.Optional[types.ModuleType]:
     """Optionally import a module.
@@ -51,7 +53,7 @@ def unique(iterable: t.Iterable[T], by: t.Callable[[T], t.Any] = lambda i: i) ->
 
 def random_id(short: bool = False) -> str:
     if short:
-        return "".join(random.choices(string.ascii_letters + string.digits, k=8))
+        return "".join(random.choices(ALPHANUMERIC, k=8))
 
     return uuid.uuid4().hex
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,3 +260,13 @@ def delete_cache(project_paths: str | t.List[str]) -> None:
             rmtree(path + "/.cache")
         except FileNotFoundError:
             pass
+
+
+@pytest.fixture
+def make_temp_table_name(mocker: MockerFixture) -> t.Callable:
+    def _make_function(table_name: str, random_id: str) -> exp.Table:
+        temp_table = t.cast(exp.Table, exp.to_table(table_name))
+        temp_table.set("this", exp.to_identifier(f"__temp_{temp_table.name}_{random_id}"))
+        return temp_table
+
+    return _make_function

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -265,7 +265,7 @@ def delete_cache(project_paths: str | t.List[str]) -> None:
 @pytest.fixture
 def make_temp_table_name(mocker: MockerFixture) -> t.Callable:
     def _make_function(table_name: str, random_id: str) -> exp.Table:
-        temp_table = t.cast(exp.Table, exp.to_table(table_name))
+        temp_table = exp.to_table(table_name)
         temp_table.set("this", exp.to_identifier(f"__temp_{temp_table.name}_{random_id}"))
         return temp_table
 

--- a/tests/core/engine_adapter/__init__.py
+++ b/tests/core/engine_adapter/__init__.py
@@ -17,3 +17,9 @@ def to_sql_calls(adapter: EngineAdapter, identify: bool = True) -> t.List[str]:
         )
         output.append(sql)
     return output
+
+
+def temp_table_name(table_name: str, random_id: str):
+    temp_table = t.cast(exp.Table, exp.to_table(table_name))
+    temp_table.set("this", exp.to_identifier(f"__temp_{temp_table.name}_{random_id}"))
+    return temp_table

--- a/tests/core/engine_adapter/__init__.py
+++ b/tests/core/engine_adapter/__init__.py
@@ -17,9 +17,3 @@ def to_sql_calls(adapter: EngineAdapter, identify: bool = True) -> t.List[str]:
         )
         output.append(sql)
     return output
-
-
-def temp_table_name(table_name: str, random_id: str):
-    temp_table = t.cast(exp.Table, exp.to_table(table_name))
-    temp_table.set("this", exp.to_identifier(f"__temp_{temp_table.name}_{random_id}"))
-    return temp_table

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -15,7 +15,6 @@ from sqlmesh.core.engine_adapter import BigQueryEngineAdapter
 from sqlmesh.core.engine_adapter.bigquery import select_partitions_expr
 from sqlmesh.core.node import IntervalUnit
 from sqlmesh.utils import AttributeDict
-from tests.core.engine_adapter import temp_table_name
 
 
 def test_insert_overwrite_by_time_partition_query(
@@ -44,7 +43,7 @@ def test_insert_overwrite_by_time_partition_query(
 
 
 def test_insert_overwrite_by_partition_query(
-    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture, make_temp_table_name: t.Callable
 ):
     adapter = make_mocked_engine_adapter(BigQueryEngineAdapter)
     execute_mock = mocker.patch(
@@ -54,7 +53,7 @@ def test_insert_overwrite_by_partition_query(
     temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "test_schema.test_table"
     temp_table_id = "abcdefgh"
-    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
+    temp_table_mock.return_value = make_temp_table_name(table_name, temp_table_id)
 
     adapter.insert_overwrite_by_partition(
         table_name,
@@ -79,7 +78,7 @@ def test_insert_overwrite_by_partition_query(
 
 
 def test_insert_overwrite_by_partition_query_unknown_column_types(
-    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture, make_temp_table_name: t.Callable
 ):
     adapter = make_mocked_engine_adapter(BigQueryEngineAdapter)
     execute_mock = mocker.patch(
@@ -97,7 +96,7 @@ def test_insert_overwrite_by_partition_query_unknown_column_types(
     temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "test_schema.test_table"
     temp_table_id = "abcdefgh"
-    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
+    temp_table_mock.return_value = make_temp_table_name(table_name, temp_table_id)
 
     adapter.insert_overwrite_by_partition(
         table_name,

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -51,11 +51,10 @@ def test_insert_overwrite_by_partition_query(
         "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.execute"
     )
 
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "test_schema.test_table"
     temp_table_id = "abcdefgh"
-    temp_table = temp_table_name(table_name, temp_table_id)
-    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
-    temp_table_mock.return_value = temp_table
+    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
 
     adapter.insert_overwrite_by_partition(
         table_name,
@@ -95,11 +94,10 @@ def test_insert_overwrite_by_partition_query_unknown_column_types(
         "ds": exp.DataType.build("DATETIME"),
     }
 
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "test_schema.test_table"
     temp_table_id = "abcdefgh"
-    temp_table = temp_table_name(table_name, temp_table_id)
-    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
-    temp_table_mock.return_value = temp_table
+    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
 
     adapter.insert_overwrite_by_partition(
         table_name,

--- a/tests/core/engine_adapter/test_mixins.py
+++ b/tests/core/engine_adapter/test_mixins.py
@@ -9,7 +9,7 @@ from sqlmesh.core.engine_adapter.mixins import (
     LogicalMergeMixin,
     LogicalReplaceQueryMixin,
 )
-from tests.core.engine_adapter import temp_table_name, to_sql_calls
+from tests.core.engine_adapter import to_sql_calls
 
 
 def test_logical_replace_query_already_exists(
@@ -52,7 +52,7 @@ def test_logical_replace_query_does_not_exist(
 
 
 def test_logical_replace_self_reference(
-    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture, make_temp_table_name: t.Callable
 ):
     adapter = make_mocked_engine_adapter(LogicalReplaceQueryMixin, "postgres")
     adapter.cursor.fetchone.return_value = (1,)
@@ -60,7 +60,7 @@ def test_logical_replace_self_reference(
     temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "db.table"
     temp_table_id = "abcdefgh"
-    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
+    temp_table_mock.return_value = make_temp_table_name(table_name, temp_table_id)
 
     mocker.patch(
         "sqlmesh.core.engine_adapter.postgres.LogicalReplaceQueryMixin.table_exists",

--- a/tests/core/engine_adapter/test_mixins.py
+++ b/tests/core/engine_adapter/test_mixins.py
@@ -57,11 +57,10 @@ def test_logical_replace_self_reference(
     adapter = make_mocked_engine_adapter(LogicalReplaceQueryMixin, "postgres")
     adapter.cursor.fetchone.return_value = (1,)
 
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "db.table"
     temp_table_id = "abcdefgh"
-    temp_table = temp_table_name(table_name, temp_table_id)
-    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
-    temp_table_mock.return_value = temp_table
+    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
 
     mocker.patch(
         "sqlmesh.core.engine_adapter.postgres.LogicalReplaceQueryMixin.table_exists",

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -1,6 +1,5 @@
 # type: ignore
 import typing as t
-import uuid
 from unittest import mock
 
 import pandas as pd
@@ -12,7 +11,7 @@ from sqlmesh.core.engine_adapter.base import InsertOverwriteStrategy
 from sqlmesh.core.engine_adapter.mssql import MSSQLEngineAdapter
 from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 from sqlmesh.utils.date import to_ds
-from tests.core.engine_adapter import to_sql_calls
+from tests.core.engine_adapter import temp_table_name, to_sql_calls
 
 
 def test_columns(make_mocked_engine_adapter: t.Callable):
@@ -91,13 +90,15 @@ def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas(
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
     adapter.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
 
-    temp_table_uuid = uuid.uuid4()
-    uuid4_mock = mocker.patch("uuid.uuid4")
-    uuid4_mock.return_value = temp_table_uuid
+    table_name = "test_table"
+    temp_table_id = "abcdefgh"
+    temp_table = temp_table_name(table_name, temp_table_id)
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
+    temp_table_mock.return_value = temp_table
 
     df = pd.DataFrame({"a": [1, 2], "ds": ["2022-01-01", "2022-01-02"]})
     adapter.insert_overwrite_by_time_partition(
-        "test_table",
+        table_name,
         df,
         start="2022-01-01",
         end="2022-01-02",
@@ -106,13 +107,13 @@ def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas(
         columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
     )
     adapter._connection_pool.get().bulk_copy.assert_called_with(
-        f'"__temp_test_table_{temp_table_uuid.hex}"',
+        f'"__temp_test_table_{temp_table_id}"',
         [(1, "2022-01-01"), (2, "2022-01-02")],
     )
     assert to_sql_calls(adapter) == [
-        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table_{temp_table_uuid.hex}') EXEC('CREATE TABLE "__temp_test_table_{temp_table_uuid.hex}" ("a" INTEGER, "ds" TEXT)');""",
-        f"""MERGE INTO "test_table" AS "__MERGE_TARGET__" USING (SELECT "a", "ds" FROM (SELECT "a", "ds" FROM "__temp_test_table_{temp_table_uuid.hex}") AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02') AS "__MERGE_SOURCE__" ON (1 = 0) WHEN NOT MATCHED BY SOURCE AND "ds" BETWEEN '2022-01-01' AND '2022-01-02' THEN DELETE WHEN NOT MATCHED THEN INSERT ("a", "ds") VALUES ("a", "ds");""",
-        f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_uuid.hex}";',
+        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table_{temp_table_id}') EXEC('CREATE TABLE "__temp_test_table_{temp_table_id}" ("a" INTEGER, "ds" TEXT)');""",
+        f"""MERGE INTO "test_table" AS "__MERGE_TARGET__" USING (SELECT "a", "ds" FROM (SELECT "a", "ds" FROM "__temp_test_table_{temp_table_id}") AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02') AS "__MERGE_SOURCE__" ON (1 = 0) WHEN NOT MATCHED BY SOURCE AND "ds" BETWEEN '2022-01-01' AND '2022-01-02' THEN DELETE WHEN NOT MATCHED THEN INSERT ("a", "ds") VALUES ("a", "ds");""",
+        f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_id}";',
     ]
 
 
@@ -122,13 +123,15 @@ def test_insert_overwrite_by_time_partition_replace_where_pandas(
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
     adapter.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.REPLACE_WHERE
 
-    temp_table_uuid = uuid.uuid4()
-    uuid4_mock = mocker.patch("uuid.uuid4")
-    uuid4_mock.return_value = temp_table_uuid
+    table_name = "test_table"
+    temp_table_id = "abcdefgh"
+    temp_table = temp_table_name(table_name, temp_table_id)
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
+    temp_table_mock.return_value = temp_table
 
     df = pd.DataFrame({"a": [1, 2], "ds": ["2022-01-01", "2022-01-02"]})
     adapter.insert_overwrite_by_time_partition(
-        "test_table",
+        table_name,
         df,
         start="2022-01-01",
         end="2022-01-02",
@@ -137,27 +140,29 @@ def test_insert_overwrite_by_time_partition_replace_where_pandas(
         columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
     )
     adapter._connection_pool.get().bulk_copy.assert_called_with(
-        f'"__temp_test_table_{temp_table_uuid.hex}"',
+        f'"__temp_test_table_{temp_table_id}"',
         [(1, "2022-01-01"), (2, "2022-01-02")],
     )
 
     assert to_sql_calls(adapter) == [
-        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table_{temp_table_uuid.hex}') EXEC('CREATE TABLE "__temp_test_table_{temp_table_uuid.hex}" ("a" INTEGER, "ds" TEXT)');""",
-        f"""MERGE INTO "test_table" AS "__MERGE_TARGET__" USING (SELECT "a", "ds" FROM (SELECT "a", "ds" FROM "__temp_test_table_{temp_table_uuid.hex}") AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02') AS "__MERGE_SOURCE__" ON (1 = 0) WHEN NOT MATCHED BY SOURCE AND "ds" BETWEEN '2022-01-01' AND '2022-01-02' THEN DELETE WHEN NOT MATCHED THEN INSERT ("a", "ds") VALUES ("a", "ds");""",
-        f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_uuid.hex}";',
+        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table_{temp_table_id}') EXEC('CREATE TABLE "__temp_test_table_{temp_table_id}" ("a" INTEGER, "ds" TEXT)');""",
+        f"""MERGE INTO "test_table" AS "__MERGE_TARGET__" USING (SELECT "a", "ds" FROM (SELECT "a", "ds" FROM "__temp_test_table_{temp_table_id}") AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02') AS "__MERGE_SOURCE__" ON (1 = 0) WHEN NOT MATCHED BY SOURCE AND "ds" BETWEEN '2022-01-01' AND '2022-01-02' THEN DELETE WHEN NOT MATCHED THEN INSERT ("a", "ds") VALUES ("a", "ds");""",
+        f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_id}";',
     ]
 
 
 def test_insert_append_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
 
-    temp_table_uuid = uuid.uuid4()
-    uuid4_mock = mocker.patch("uuid.uuid4")
-    uuid4_mock.return_value = temp_table_uuid
+    table_name = "test_table"
+    temp_table_id = "abcdefgh"
+    temp_table = temp_table_name(table_name, temp_table_id)
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
+    temp_table_mock.return_value = temp_table
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.insert_append(
-        "test_table",
+        table_name,
         df,
         columns_to_types={
             "a": exp.DataType.build("INT"),
@@ -165,14 +170,14 @@ def test_insert_append_pandas(make_mocked_engine_adapter: t.Callable, mocker: Mo
         },
     )
     adapter._connection_pool.get().bulk_copy.assert_called_with(
-        f'"__temp_test_table_{temp_table_uuid.hex}"',
+        f'"__temp_test_table_{temp_table_id}"',
         [(1, 4), (2, 5), (3, 6)],
     )
 
     assert to_sql_calls(adapter) == [
-        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table_{temp_table_uuid.hex}') EXEC('CREATE TABLE "__temp_test_table_{temp_table_uuid.hex}" ("a" INTEGER, "b" INTEGER)');""",
-        f'INSERT INTO "test_table" ("a", "b") SELECT "a", "b" FROM "__temp_test_table_{temp_table_uuid.hex}";',
-        f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_uuid.hex}";',
+        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table_{temp_table_id}') EXEC('CREATE TABLE "__temp_test_table_{temp_table_id}" ("a" INTEGER, "b" INTEGER)');""",
+        f'INSERT INTO "test_table" ("a", "b") SELECT "a", "b" FROM "__temp_test_table_{temp_table_id}";',
+        f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_id}";',
     ]
 
 
@@ -212,13 +217,15 @@ def test_create_table_properties(make_mocked_engine_adapter: t.Callable):
 def test_merge_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
 
-    temp_table_uuid = uuid.uuid4()
-    uuid4_mock = mocker.patch("uuid.uuid4")
-    uuid4_mock.return_value = temp_table_uuid
+    table_name = "target"
+    temp_table_id = "abcdefgh"
+    temp_table = temp_table_name(table_name, temp_table_id)
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
+    temp_table_mock.return_value = temp_table
 
     df = pd.DataFrame({"id": [1, 2, 3], "ts": [1, 2, 3], "val": [4, 5, 6]})
     adapter.merge(
-        target_table="target",
+        target_table=table_name,
         source_table=df,
         columns_to_types={
             "id": exp.DataType.build("int"),
@@ -228,20 +235,20 @@ def test_merge_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixt
         unique_key=[exp.to_identifier("id")],
     )
     adapter._connection_pool.get().bulk_copy.assert_called_with(
-        f'"__temp_target_{temp_table_uuid.hex}"',
+        f'"__temp_target_{temp_table_id}"',
         [(1, 1, 4), (2, 2, 5), (3, 3, 6)],
     )
 
     assert to_sql_calls(adapter) == [
-        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_target_{temp_table_uuid.hex}') EXEC('CREATE TABLE "__temp_target_{temp_table_uuid.hex}" ("id" INTEGER, "ts" DATETIME2, "val" INTEGER)');""",
-        f'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT "id", "ts", "val" FROM "__temp_target_{temp_table_uuid.hex}") AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val");',
-        f'DROP TABLE IF EXISTS "__temp_target_{temp_table_uuid.hex}";',
+        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_target_{temp_table_id}') EXEC('CREATE TABLE "__temp_target_{temp_table_id}" ("id" INTEGER, "ts" DATETIME2, "val" INTEGER)');""",
+        f'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT "id", "ts", "val" FROM "__temp_target_{temp_table_id}") AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val");',
+        f'DROP TABLE IF EXISTS "__temp_target_{temp_table_id}";',
     ]
 
     adapter.cursor.reset_mock()
     adapter._connection_pool.get().reset_mock()
     adapter.merge(
-        target_table="target",
+        target_table=table_name,
         source_table=df,
         columns_to_types={
             "id": exp.DataType.build("int"),
@@ -251,14 +258,14 @@ def test_merge_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixt
         unique_key=[exp.to_identifier("id"), exp.to_column("ts")],
     )
     adapter._connection_pool.get().bulk_copy.assert_called_with(
-        f'"__temp_target_{temp_table_uuid.hex}"',
+        f'"__temp_target_{temp_table_id}"',
         [(1, 1, 4), (2, 2, 5), (3, 3, 6)],
     )
 
     assert to_sql_calls(adapter) == [
-        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_target_{temp_table_uuid.hex}') EXEC('CREATE TABLE "__temp_target_{temp_table_uuid.hex}" ("id" INTEGER, "ts" DATETIME2, "val" INTEGER)');""",
-        f'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT "id", "ts", "val" FROM "__temp_target_{temp_table_uuid.hex}") AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" AND "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts" WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val");',
-        f'DROP TABLE IF EXISTS "__temp_target_{temp_table_uuid.hex}";',
+        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_target_{temp_table_id}') EXEC('CREATE TABLE "__temp_target_{temp_table_id}" ("id" INTEGER, "ts" DATETIME2, "val" INTEGER)');""",
+        f'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT "id", "ts", "val" FROM "__temp_target_{temp_table_id}") AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" AND "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts" WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val");',
+        f'DROP TABLE IF EXISTS "__temp_target_{temp_table_id}";',
     ]
 
 
@@ -278,26 +285,28 @@ def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable, mocker: Mo
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
     adapter.cursor.fetchone.return_value = (1,)
 
-    temp_table_uuid = uuid.uuid4()
-    uuid4_mock = mocker.patch("uuid.uuid4")
-    uuid4_mock.return_value = temp_table_uuid
+    table_name = "test_table"
+    temp_table_id = "abcdefgh"
+    temp_table = temp_table_name(table_name, temp_table_id)
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
+    temp_table_mock.return_value = temp_table
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.replace_query(
-        "test_table", df, {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")}
+        table_name, df, {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")}
     )
 
     adapter._connection_pool.get().bulk_copy.assert_called_with(
-        f'"__temp_test_table_{temp_table_uuid.hex}"',
+        f'"__temp_test_table_{temp_table_id}"',
         [(1, 4), (2, 5), (3, 6)],
     )
 
     assert to_sql_calls(adapter) == [
         """SELECT 1 FROM "information_schema"."tables" WHERE "table_name" = 'test_table';""",
-        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table_{temp_table_uuid.hex}') EXEC('CREATE TABLE "__temp_test_table_{temp_table_uuid.hex}" ("a" INTEGER, "b" INTEGER)');""",
+        f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = '__temp_test_table_{temp_table_id}') EXEC('CREATE TABLE "__temp_test_table_{temp_table_id}" ("a" INTEGER, "b" INTEGER)');""",
         'TRUNCATE TABLE "test_table"',
-        f'INSERT INTO "test_table" ("a", "b") SELECT "a", "b" FROM "__temp_test_table_{temp_table_uuid.hex}";',
-        f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_uuid.hex}";',
+        f'INSERT INTO "test_table" ("a", "b") SELECT "a", "b" FROM "__temp_test_table_{temp_table_id}";',
+        f'DROP TABLE IF EXISTS "__temp_test_table_{temp_table_id}";',
     ]
 
 

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -11,7 +11,7 @@ from sqlmesh.core.engine_adapter.base import InsertOverwriteStrategy
 from sqlmesh.core.engine_adapter.mssql import MSSQLEngineAdapter
 from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 from sqlmesh.utils.date import to_ds
-from tests.core.engine_adapter import temp_table_name, to_sql_calls
+from tests.core.engine_adapter import to_sql_calls
 
 
 def test_columns(make_mocked_engine_adapter: t.Callable):
@@ -85,7 +85,7 @@ def test_table_exists(make_mocked_engine_adapter: t.Callable):
 
 
 def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas(
-    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture, make_temp_table_name: t.Callable
 ):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
     adapter.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
@@ -93,7 +93,7 @@ def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas(
     temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "test_table"
     temp_table_id = "abcdefgh"
-    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
+    temp_table_mock.return_value = make_temp_table_name(table_name, temp_table_id)
 
     df = pd.DataFrame({"a": [1, 2], "ds": ["2022-01-01", "2022-01-02"]})
     adapter.insert_overwrite_by_time_partition(
@@ -117,7 +117,7 @@ def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas(
 
 
 def test_insert_overwrite_by_time_partition_replace_where_pandas(
-    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture, make_temp_table_name: t.Callable
 ):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
     adapter.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.REPLACE_WHERE
@@ -125,7 +125,7 @@ def test_insert_overwrite_by_time_partition_replace_where_pandas(
     temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "test_table"
     temp_table_id = "abcdefgh"
-    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
+    temp_table_mock.return_value = make_temp_table_name(table_name, temp_table_id)
 
     df = pd.DataFrame({"a": [1, 2], "ds": ["2022-01-01", "2022-01-02"]})
     adapter.insert_overwrite_by_time_partition(
@@ -149,13 +149,15 @@ def test_insert_overwrite_by_time_partition_replace_where_pandas(
     ]
 
 
-def test_insert_append_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+def test_insert_append_pandas(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture, make_temp_table_name: t.Callable
+):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
 
     temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "test_table"
     temp_table_id = "abcdefgh"
-    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
+    temp_table_mock.return_value = make_temp_table_name(table_name, temp_table_id)
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.insert_append(
@@ -211,13 +213,15 @@ def test_create_table_properties(make_mocked_engine_adapter: t.Callable):
     )
 
 
-def test_merge_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+def test_merge_pandas(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture, make_temp_table_name: t.Callable
+):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
 
     temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "target"
     temp_table_id = "abcdefgh"
-    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
+    temp_table_mock.return_value = make_temp_table_name(table_name, temp_table_id)
 
     df = pd.DataFrame({"id": [1, 2, 3], "ts": [1, 2, 3], "val": [4, 5, 6]})
     adapter.merge(
@@ -277,14 +281,16 @@ def test_replace_query(make_mocked_engine_adapter: t.Callable):
     ]
 
 
-def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+def test_replace_query_pandas(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture, make_temp_table_name: t.Callable
+):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
     adapter.cursor.fetchone.return_value = (1,)
 
     temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "test_table"
     temp_table_id = "abcdefgh"
-    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
+    temp_table_mock.return_value = make_temp_table_name(table_name, temp_table_id)
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.replace_query(

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -90,11 +90,10 @@ def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas(
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
     adapter.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
 
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "test_table"
     temp_table_id = "abcdefgh"
-    temp_table = temp_table_name(table_name, temp_table_id)
-    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
-    temp_table_mock.return_value = temp_table
+    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
 
     df = pd.DataFrame({"a": [1, 2], "ds": ["2022-01-01", "2022-01-02"]})
     adapter.insert_overwrite_by_time_partition(
@@ -123,11 +122,10 @@ def test_insert_overwrite_by_time_partition_replace_where_pandas(
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
     adapter.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.REPLACE_WHERE
 
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "test_table"
     temp_table_id = "abcdefgh"
-    temp_table = temp_table_name(table_name, temp_table_id)
-    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
-    temp_table_mock.return_value = temp_table
+    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
 
     df = pd.DataFrame({"a": [1, 2], "ds": ["2022-01-01", "2022-01-02"]})
     adapter.insert_overwrite_by_time_partition(
@@ -154,11 +152,10 @@ def test_insert_overwrite_by_time_partition_replace_where_pandas(
 def test_insert_append_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
 
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "test_table"
     temp_table_id = "abcdefgh"
-    temp_table = temp_table_name(table_name, temp_table_id)
-    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
-    temp_table_mock.return_value = temp_table
+    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.insert_append(
@@ -217,11 +214,10 @@ def test_create_table_properties(make_mocked_engine_adapter: t.Callable):
 def test_merge_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
 
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "target"
     temp_table_id = "abcdefgh"
-    temp_table = temp_table_name(table_name, temp_table_id)
-    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
-    temp_table_mock.return_value = temp_table
+    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
 
     df = pd.DataFrame({"id": [1, 2, 3], "ts": [1, 2, 3], "val": [4, 5, 6]})
     adapter.merge(
@@ -285,11 +281,10 @@ def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable, mocker: Mo
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
     adapter.cursor.fetchone.return_value = (1,)
 
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "test_table"
     temp_table_id = "abcdefgh"
-    temp_table = temp_table_name(table_name, temp_table_id)
-    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
-    temp_table_mock.return_value = temp_table
+    temp_table_mock.return_value = temp_table_name(table_name, temp_table_id)
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     adapter.replace_query(


### PR DESCRIPTION
MySQL table names must be <=64 characters long. 

Some SQLMesh temp table names exceed that, so this PR changes the length of the random ID embedded in the table name from a 32-character UUID4 to 8 alphanumeric characters.