### PR TITLE
chore: ci only run local engine integration tests

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -173,7 +173,7 @@ jobs:
       - store_artifacts:
           path: /tmp/airflow_logs
 
-  engine_adapter_integration_tests:
+  engine_adapter_integration_local_only_tests:
     machine:
       image: ubuntu-2204:2022.10.2
       docker_layer_caching: true
@@ -194,7 +194,7 @@ jobs:
           command: sleep 10
       - run:
           name: Run tests
-          command: make core_engine_it_test
+          command: make core_engine_it_test_local_only
           no_output_timeout: 15m
 
 workflows:
@@ -214,7 +214,7 @@ workflows:
             branches:
               only:
                 - main
-      - engine_adapter_integration_tests:
+      - engine_adapter_integration_local_only_tests:
           context: engine_adapter_integration
           requires:
             - style_and_unit_tests

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ core-it-test:
 core_engine_it_test:
 	pytest -m "engine_integration"
 
+core_engine_it_test_local_only:
+	pytest -m "engine_integration_local"
+
 core_engine_it_test_docker:
 	docker-compose -f ./tests/core/engine_adapter/docker-compose.yaml up -d
 

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -195,14 +195,42 @@ def config() -> Config:
 @pytest.fixture(
     params=[
         "duckdb",
-        pytest.param("postgres", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
-        pytest.param("mysql", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
+        pytest.param(
+            "postgres",
+            marks=[
+                pytest.mark.integration,
+                pytest.mark.engine_integration,
+                pytest.mark.engine_integration_local,
+            ],
+        ),
+        pytest.param(
+            "mysql",
+            marks=[
+                pytest.mark.integration,
+                pytest.mark.engine_integration,
+                pytest.mark.engine_integration_local,
+            ],
+        ),
+        pytest.param(
+            "mssql",
+            marks=[
+                pytest.mark.integration,
+                pytest.mark.engine_integration,
+                pytest.mark.engine_integration_local,
+            ],
+        ),
+        pytest.param(
+            "trino",
+            marks=[
+                pytest.mark.integration,
+                pytest.mark.engine_integration,
+                pytest.mark.engine_integration_local,
+            ],
+        ),
         pytest.param("bigquery", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
         pytest.param("databricks", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
         pytest.param("redshift", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
         pytest.param("snowflake", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
-        pytest.param("mssql", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
-        pytest.param("trino", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
     ]
 )
 def engine_adapter(request, config) -> EngineAdapter:


### PR DESCRIPTION
Doing this to make CI less flaky on main. We should do two things in order to re-enable remote tests:

* Make sure the remote tests read/write to isolated path (in case someone else is running tests locally)
* Add retry to all adapters in order to deal with network blips (Redshift seems to have the most issues with this)

Until then we need to make sure to run these manually when making engine adapter changes. 