### PR TITLE
Fix: Get dbt classes without all config fields present

### DIFF
--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -16,7 +16,7 @@ from ruamel.yaml import YAMLError
 
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.dbt.adapter import BaseAdapter, ParsetimeAdapter, RuntimeAdapter
-from sqlmesh.dbt.target import TargetConfig
+from sqlmesh.dbt.target import TARGET_TYPE_TO_CONFIG_CLASS
 from sqlmesh.dbt.util import DBT_VERSION
 from sqlmesh.utils import AttributeDict, yaml
 from sqlmesh.utils.errors import ConfigError, MacroEvalError
@@ -44,10 +44,10 @@ class Exceptions:
 class Api:
     def __init__(self, target: t.Optional[AttributeDict] = None) -> None:
         if target:
-            config = TargetConfig.load(target)
-            self.Relation = config.relation_class
-            self.Column = config.column_class
-            self.quote_policy = config.quote_policy
+            config_class = TARGET_TYPE_TO_CONFIG_CLASS[target["type"]]
+            self.Relation = config_class.relation_class()
+            self.Column = config_class.column_class()
+            self.quote_policy = config_class.quote_policy()
         else:
             self.Relation = BaseRelation
             self.Column = Column

--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -45,9 +45,9 @@ class Api:
     def __init__(self, target: t.Optional[AttributeDict] = None) -> None:
         if target:
             config_class = TARGET_TYPE_TO_CONFIG_CLASS[target["type"]]
-            self.Relation = config_class.relation_class()
-            self.Column = config_class.column_class()
-            self.quote_policy = config_class.quote_policy()
+            self.Relation = config_class.relation_class
+            self.Column = config_class.column_class
+            self.quote_policy = config_class.quote_policy
         else:
             self.Relation = BaseRelation
             self.Column = Column

--- a/sqlmesh/dbt/target.py
+++ b/sqlmesh/dbt/target.py
@@ -111,20 +111,20 @@ class TargetConfig(abc.ABC, DbtConfig):
         fields["target_name"] = self.name
         return AttributeDict(fields)
 
-    @property
-    def quote_policy(self) -> Policy:
+    @classmethod
+    def quote_policy(cls) -> Policy:
         return Policy()
 
     @property
     def extra(self) -> t.Set[str]:
         return self.extra_fields(set(self.dict()))
 
-    @property
-    def relation_class(self) -> t.Type[BaseRelation]:
+    @classmethod
+    def relation_class(cls) -> t.Type[BaseRelation]:
         return BaseRelation
 
-    @property
-    def column_class(self) -> t.Type[Column]:
+    @classmethod
+    def column_class(cls) -> t.Type[Column]:
         return Column
 
 
@@ -161,8 +161,8 @@ class DuckDbConfig(TargetConfig):
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "delete+insert"
 
-    @property
-    def relation_class(self) -> t.Type[BaseRelation]:
+    @classmethod
+    def relation_class(cls) -> t.Type[BaseRelation]:
         from dbt.adapters.duckdb.relation import DuckDBRelation
 
         return DuckDBRelation
@@ -223,14 +223,14 @@ class SnowflakeConfig(TargetConfig):
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "merge"
 
-    @property
-    def relation_class(self) -> t.Type[BaseRelation]:
+    @classmethod
+    def relation_class(cls) -> t.Type[BaseRelation]:
         from dbt.adapters.snowflake import SnowflakeRelation
 
         return SnowflakeRelation
 
-    @property
-    def column_class(self) -> t.Type[Column]:
+    @classmethod
+    def column_class(cls) -> t.Type[Column]:
         from dbt.adapters.snowflake import SnowflakeColumn
 
         return SnowflakeColumn
@@ -247,8 +247,8 @@ class SnowflakeConfig(TargetConfig):
             concurrent_tasks=self.threads,
         )
 
-    @property
-    def quote_policy(self) -> Policy:
+    @classmethod
+    def quote_policy(cls) -> Policy:
         return Policy(database=False, schema=False, identifier=False)
 
 
@@ -359,20 +359,20 @@ class RedshiftConfig(TargetConfig):
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "append"
 
-    @property
-    def relation_class(self) -> t.Type[BaseRelation]:
+    @classmethod
+    def relation_class(cls) -> t.Type[BaseRelation]:
         from dbt.adapters.redshift import RedshiftRelation
 
         return RedshiftRelation
 
-    @property
-    def column_class(self) -> t.Type[Column]:
+    @classmethod
+    def column_class(cls) -> t.Type[Column]:
         if DBT_VERSION < (1, 6):
             from dbt.adapters.redshift import RedshiftColumn  # type: ignore
 
             return RedshiftColumn
         else:
-            return super().column_class
+            return super(RedshiftConfig, cls).column_class()
 
     def to_sqlmesh(self) -> ConnectionConfig:
         return RedshiftConnectionConfig(
@@ -409,14 +409,14 @@ class DatabricksConfig(TargetConfig):
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "merge"
 
-    @property
-    def relation_class(self) -> t.Type[BaseRelation]:
+    @classmethod
+    def relation_class(cls) -> t.Type[BaseRelation]:
         from dbt.adapters.databricks.relation import DatabricksRelation
 
         return DatabricksRelation
 
-    @property
-    def column_class(self) -> t.Type[Column]:
+    @classmethod
+    def column_class(cls) -> t.Type[Column]:
         from dbt.adapters.databricks.column import DatabricksColumn
 
         return DatabricksColumn
@@ -491,14 +491,14 @@ class BigQueryConfig(TargetConfig):
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "merge"
 
-    @property
-    def relation_class(self) -> t.Type[BaseRelation]:
+    @classmethod
+    def relation_class(cls) -> t.Type[BaseRelation]:
         from dbt.adapters.bigquery.relation import BigQueryRelation
 
         return BigQueryRelation
 
-    @property
-    def column_class(self) -> t.Type[Column]:
+    @classmethod
+    def column_class(cls) -> t.Type[Column]:
         from dbt.adapters.bigquery import BigQueryColumn
 
         return BigQueryColumn
@@ -529,3 +529,13 @@ class BigQueryConfig(TargetConfig):
             priority=self.priority,
             maximum_bytes_billed=self.maximum_bytes_billed,
         )
+
+
+TARGET_TYPE_TO_CONFIG_CLASS: t.Dict[str, t.Type[TargetConfig]] = {
+    "databricks": DatabricksConfig,
+    "duckdb": DuckDbConfig,
+    "postgres": PostgresConfig,
+    "redshift": RedshiftConfig,
+    "snowflake": SnowflakeConfig,
+    "bigquery": BigQueryConfig,
+}

--- a/sqlmesh/dbt/target.py
+++ b/sqlmesh/dbt/target.py
@@ -27,7 +27,7 @@ from sqlmesh.core.model import (
 )
 from sqlmesh.dbt.common import DbtConfig
 from sqlmesh.dbt.util import DBT_VERSION
-from sqlmesh.utils import AttributeDict
+from sqlmesh.utils import AttributeDict, classproperty
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.pydantic import field_validator, model_validator
 
@@ -111,7 +111,7 @@ class TargetConfig(abc.ABC, DbtConfig):
         fields["target_name"] = self.name
         return AttributeDict(fields)
 
-    @classmethod
+    @classproperty
     def quote_policy(cls) -> Policy:
         return Policy()
 
@@ -119,11 +119,11 @@ class TargetConfig(abc.ABC, DbtConfig):
     def extra(self) -> t.Set[str]:
         return self.extra_fields(set(self.dict()))
 
-    @classmethod
+    @classproperty
     def relation_class(cls) -> t.Type[BaseRelation]:
         return BaseRelation
 
-    @classmethod
+    @classproperty
     def column_class(cls) -> t.Type[Column]:
         return Column
 
@@ -161,7 +161,7 @@ class DuckDbConfig(TargetConfig):
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "delete+insert"
 
-    @classmethod
+    @classproperty
     def relation_class(cls) -> t.Type[BaseRelation]:
         from dbt.adapters.duckdb.relation import DuckDBRelation
 
@@ -223,13 +223,13 @@ class SnowflakeConfig(TargetConfig):
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "merge"
 
-    @classmethod
+    @classproperty
     def relation_class(cls) -> t.Type[BaseRelation]:
         from dbt.adapters.snowflake import SnowflakeRelation
 
         return SnowflakeRelation
 
-    @classmethod
+    @classproperty
     def column_class(cls) -> t.Type[Column]:
         from dbt.adapters.snowflake import SnowflakeColumn
 
@@ -247,7 +247,7 @@ class SnowflakeConfig(TargetConfig):
             concurrent_tasks=self.threads,
         )
 
-    @classmethod
+    @classproperty
     def quote_policy(cls) -> Policy:
         return Policy(database=False, schema=False, identifier=False)
 
@@ -359,13 +359,13 @@ class RedshiftConfig(TargetConfig):
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "append"
 
-    @classmethod
+    @classproperty
     def relation_class(cls) -> t.Type[BaseRelation]:
         from dbt.adapters.redshift import RedshiftRelation
 
         return RedshiftRelation
 
-    @classmethod
+    @classproperty
     def column_class(cls) -> t.Type[Column]:
         if DBT_VERSION < (1, 6):
             from dbt.adapters.redshift import RedshiftColumn  # type: ignore
@@ -409,13 +409,13 @@ class DatabricksConfig(TargetConfig):
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "merge"
 
-    @classmethod
+    @classproperty
     def relation_class(cls) -> t.Type[BaseRelation]:
         from dbt.adapters.databricks.relation import DatabricksRelation
 
         return DatabricksRelation
 
-    @classmethod
+    @classproperty
     def column_class(cls) -> t.Type[Column]:
         from dbt.adapters.databricks.column import DatabricksColumn
 
@@ -491,13 +491,13 @@ class BigQueryConfig(TargetConfig):
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "merge"
 
-    @classmethod
+    @classproperty
     def relation_class(cls) -> t.Type[BaseRelation]:
         from dbt.adapters.bigquery.relation import BigQueryRelation
 
         return BigQueryRelation
 
-    @classmethod
+    @classproperty
     def column_class(cls) -> t.Type[Column]:
         from dbt.adapters.bigquery import BigQueryColumn
 

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -2,7 +2,9 @@ import typing as t
 from pathlib import Path
 
 import pytest
-from dbt.adapters.base import BaseRelation
+from dbt.adapters.base import BaseRelation, Column
+from dbt.adapters.duckdb.relation import DuckDBRelation
+from dbt.contracts.relation import Policy
 
 from sqlmesh.core.dialect import jinja_query
 from sqlmesh.core.model import SqlModel
@@ -12,6 +14,7 @@ from sqlmesh.dbt.model import IncrementalByUniqueKeyKind, Materialization, Model
 from sqlmesh.dbt.project import Project
 from sqlmesh.dbt.source import SourceConfig
 from sqlmesh.dbt.target import (
+    TARGET_TYPE_TO_CONFIG_CLASS,
     BigQueryConfig,
     DatabricksConfig,
     DuckDbConfig,
@@ -512,3 +515,15 @@ def test_quoting_config():
     assert QuotingConfig.parse_obj(
         {"database": True, "identifier": True, "schema": True}
     ) == QuotingConfig(database=True, identifier=True, schema=True)
+
+
+def test_db_type_to_relation_class():
+    assert (TARGET_TYPE_TO_CONFIG_CLASS["duckdb"].relation_class) == DuckDBRelation
+
+
+def test_db_type_to_column_class():
+    assert (TARGET_TYPE_TO_CONFIG_CLASS["duckdb"].column_class) == Column
+
+
+def test_db_type_to_quote_policy():
+    assert isinstance(TARGET_TYPE_TO_CONFIG_CLASS["duckdb"].quote_policy, Policy)


### PR DESCRIPTION
Now that we don't store all target config fields in the snapshot, we need to be able to get the dbt classes (relation, column, and quote_policy) without instantiating the TargetConfig class.