### PR TITLE
 Fix: improve detection of mocked star column 

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -22,7 +22,7 @@ from sqlglot.time import format_time
 
 from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
-from sqlmesh.core.macros import SQLMESH_MOCKED_STAR, MacroRegistry, macro
+from sqlmesh.core.macros import MacroRegistry, macro
 from sqlmesh.core.model.common import expression_validator
 from sqlmesh.core.model.kind import (
     IncrementalByTimeRangeKind,
@@ -1079,10 +1079,7 @@ class SqlModel(_SqlBasedModel):
             schema, default_schema=default_schema, default_catalog=default_catalog
         )
 
-        query = self._query_renderer.render(optimize=False)
-        if isinstance(query, exp.Subqueryable) and any(
-            name.upper() == SQLMESH_MOCKED_STAR for name in query.named_selects
-        ):
+        if self.query.meta.get("must_empty_cache"):
             # We reset the unoptimized query cache here as well to allow the model's query
             # to be re-rendered so that the MacroEvaluator can resolve columns_to_types calls
             # and get rid of the mocked star column

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -137,7 +137,7 @@ class BaseExpressionRenderer:
                 jinja_env=jinja_env,
                 schema=self.schema,
                 runtime_stage=runtime_stage,
-                expression_meta=self._expression.meta,
+                query_meta=self._expression.meta,
             )
 
             for definition in self._macro_definitions:

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -137,6 +137,7 @@ class BaseExpressionRenderer:
                 jinja_env=jinja_env,
                 schema=self.schema,
                 runtime_stage=runtime_stage,
+                expression_meta=self._expression.meta,
             )
 
             for definition in self._macro_definitions:


### PR DESCRIPTION
The previous check in `update_schema` where we rendered and then checked for a mocked star projection was insufficient. For example, if a user transforms the column names returned by `MacroEvaluator.columns_to_types`, then the equality check with `SQLMESH_MOCKED_STAR` will never hold.

This PR makes the cache clearing check more explicit, by setting special metadata & propagating it to the model when the `columns_to_types` method is invoked, instead of relying on the rendered query's form which can be anything.

cc @z3z1ma