### PR TITLE
Fix(mssql, snowflake): convert datetime64 with timezone

### DIFF
--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import typing as t
 
 import pandas as pd
-from pandas.api.types import is_datetime64_dtype  # type: ignore
+from pandas.api.types import is_datetime64_any_dtype  # type: ignore
 from sqlglot import exp
 from sqlglot.optimizer.qualify_columns import quote_identifiers
 
@@ -185,9 +185,12 @@ class MSSQLEngineAdapter(
             # pymssql doesn't convert Pandas Timestamp (datetime64) types
             # - this code is based on snowflake adapter implementation
             for column, kind in (columns_to_types or {}).items():
-                if kind.is_type("date") and is_datetime64_dtype(df.dtypes[column]):  # type: ignore
+                if kind.is_type("date") and is_datetime64_any_dtype(df.dtypes[column]):  # type: ignore
                     df[column] = pd.to_datetime(df[column]).dt.strftime("%Y-%m-%d")  # type: ignore
-                elif is_datetime64_dtype(df.dtypes[column]):  # type: ignore
+                elif is_datetime64_any_dtype(df.dtypes[column]) and getattr(df.dtypes[column], "tz", None) is not None:  # type: ignore
+                    # MSSQL requires a colon in the offset (+00:00) so we use isoformat() instead of strftime()
+                    df[column] = pd.to_datetime(df[column]).map(lambda x: x.isoformat(" "))  # type: ignore
+                elif is_datetime64_any_dtype(df.dtypes[column]):  # type: ignore
                     df[column] = pd.to_datetime(df[column]).dt.strftime("%Y-%m-%d %H:%M:%S.%f")  # type: ignore
 
             self.create_table(temp_table, columns_to_types)


### PR DESCRIPTION
The MSSQL and Snowflake connector libraries do not handle pandas datetime64 columns correctly, so we convert them to strings and let the engine convert to the proper table data type when inserting the data.

The current implementation uses `is_datetime64_dtype()` to detect datetime64 columns, but it returns `False` for datetime64 columns with a time zone. 

This PR replaces it with the more general `is_datetime64_any_dtype()` to detect columns and includes the time zone UTC offset in the string when the column has a timezone specified.