### PR TITLE
chore: add local spark to integration tests

### DIFF
--- a/sqlmesh/core/engine_adapter/shared.py
+++ b/sqlmesh/core/engine_adapter/shared.py
@@ -101,7 +101,7 @@ def set_catalog(
                 exp.to_table if obj_type == "TableName" else to_schema,
             )
             expression = to_expression_func(obj.copy() if isinstance(obj, exp.Table) else obj)
-            catalog_name = expression.args.get("catalog")
+            catalog_name = expression.catalog
             if not catalog_name:
                 return func(*list_args, **kwargs)
             # If we have a catalog and this engine doesn't support catalogs then we need to error

--- a/tests/core/engine_adapter/config.yaml
+++ b/tests/core/engine_adapter/config.yaml
@@ -1,0 +1,41 @@
+gateways:
+  inttest_duckdb:
+    connection:
+      type: duckdb
+  inttest_trino:
+    connection:
+      type: trino
+      host: localhost
+      port: 8080
+      user: admin
+      catalog: datalake
+      http_scheme: http
+      retries: 20
+  inttest_spark:
+    connection:
+      type: spark
+      config:
+        spark.remote: sc://localhost
+  inttest_mssql:
+    connection:
+      type: mssql
+      host: localhost
+      user: sa
+      password: 1StrongPwd@@
+  inttest_postgres:
+    connection:
+      type: postgres
+      user: postgres
+      password: postgres
+      database: postgres
+      host: localhost
+      port: 5432
+      concurrent_tasks: 1
+  inttest_mysql:
+    connection:
+      type: mysql
+      host: localhost
+      user: root
+      password: mysql
+      port: 3306
+      charset: utf8

--- a/tests/core/engine_adapter/docker-compose.yaml
+++ b/tests/core/engine_adapter/docker-compose.yaml
@@ -1,4 +1,25 @@
 version: '3'
+
+x-hive-metastore-environments: &hive_metastore_environments
+  S3_ENDPOINT: http://minio:9000
+  S3_ACCESS_KEY: minio
+  S3_SECRET_KEY: minio123
+  S3_PATH_STYLE_ACCESS: "true"
+  REGION: ""
+  GOOGLE_CLOUD_KEY_FILE_PATH: ""
+  AZURE_ADL_CLIENT_ID: ""
+  AZURE_ADL_CREDENTIAL: ""
+  AZURE_ADL_REFRESH_URL: ""
+  AZURE_ABFS_STORAGE_ACCOUNT: ""
+  AZURE_ABFS_ACCESS_KEY: ""
+  AZURE_WASB_STORAGE_ACCOUNT: ""
+  AZURE_ABFS_OAUTH: ""
+  AZURE_ABFS_OAUTH_TOKEN_PROVIDER: ""
+  AZURE_ABFS_OAUTH_CLIENT_ID: ""
+  AZURE_ABFS_OAUTH_SECRET: ""
+  AZURE_ABFS_OAUTH_ENDPOINT: ""
+  AZURE_WASB_ACCESS_KEY: ""
+
 services:
   mysql:
     image: mysql:8.1
@@ -27,56 +48,66 @@ services:
     ports:
       - '8080:8080'
     volumes:
-      - ./catalog:/etc/trino/catalog
+      - ./trino/catalog:/etc/trino/catalog
 
-  metastore_db:
+  trino_metastore_db:
     image: postgres
-    hostname: metastore_db
-    container_name: metastore_db
-    ports:
-      - '5433:5432' # Maps to 5433 on host to avoid conflict with Postgres
+    hostname: trino_metastore_db
     environment:
       POSTGRES_USER: hive
       POSTGRES_PASSWORD: hive
       POSTGRES_DB: metastore
 
-  hive-metastore:
-    container_name: hive-metastore
+  trino-hive-metastore:
     hostname: hive-metastore
     image: 'starburstdata/hive:3.1.2-e.15'
-    ports:
-      - '9083:9083' # Metastore Thrift
     environment:
       HIVE_METASTORE_DRIVER: org.postgresql.Driver
-      HIVE_METASTORE_JDBC_URL: jdbc:postgresql://metastore_db:5432/metastore
+      HIVE_METASTORE_JDBC_URL: jdbc:postgresql://trino_metastore_db:5432/metastore
       HIVE_METASTORE_USER: hive
       HIVE_METASTORE_PASSWORD: hive
-      HIVE_METASTORE_WAREHOUSE_DIR: s3://datalake/
-      S3_ENDPOINT: http://minio:9000
-      S3_ACCESS_KEY: minio
-      S3_SECRET_KEY: minio123
-      S3_PATH_STYLE_ACCESS: "true"
-      REGION: ""
-      GOOGLE_CLOUD_KEY_FILE_PATH: ""
-      AZURE_ADL_CLIENT_ID: ""
-      AZURE_ADL_CREDENTIAL: ""
-      AZURE_ADL_REFRESH_URL: ""
-      AZURE_ABFS_STORAGE_ACCOUNT: ""
-      AZURE_ABFS_ACCESS_KEY: ""
-      AZURE_WASB_STORAGE_ACCOUNT: ""
-      AZURE_ABFS_OAUTH: ""
-      AZURE_ABFS_OAUTH_TOKEN_PROVIDER: ""
-      AZURE_ABFS_OAUTH_CLIENT_ID: ""
-      AZURE_ABFS_OAUTH_SECRET: ""
-      AZURE_ABFS_OAUTH_ENDPOINT: ""
-      AZURE_WASB_ACCESS_KEY: ""
+      HIVE_METASTORE_WAREHOUSE_DIR: s3://trino/
+      <<: *hive_metastore_environments
     depends_on:
-      - metastore_db
+      - trino_metastore_db
+  # Spark Stack
+  spark:
+    build:
+      context: ./spark
+    command: /opt/bitnami/spark/sbin/start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:3.5.0
+    ports:
+      - '15000-15100:15000-15100'
+    volumes:
+      - ./spark/conf/spark-defaults.conf:/opt/bitnami/spark/conf/spark-defaults.conf
+      - ./spark/conf/hive-site.xml:/opt/bitnami/spark/conf/hive-site.xml
+    depends_on:
+      - spark-hive-metastore
 
+  spark_metastore_db:
+    image: postgres:11
+    hostname: spark_metastore_db
+    environment:
+      POSTGRES_USER: hive
+      POSTGRES_PASSWORD: hive
+      POSTGRES_DB: metastore
+
+  spark-hive-metastore:
+    hostname: spark-hive-metastore
+    image: 'starburstdata/hive:3.1.2-e.15'
+    environment:
+      HIVE_METASTORE_DRIVER: org.postgresql.Driver
+      HIVE_METASTORE_JDBC_URL: jdbc:postgresql://spark_metastore_db:5432/metastore
+      HIVE_METASTORE_USER: hive
+      HIVE_METASTORE_PASSWORD: hive
+      HIVE_METASTORE_WAREHOUSE_DIR: s3://spark/
+      <<: *hive_metastore_environments
+    depends_on:
+      - spark_metastore_db
+
+  # Shared Spark/Truno S3 Storage
   minio:
     hostname: minio
     image: 'minio/minio:RELEASE.2022-05-26T05-48-41Z'
-    container_name: minio
     ports:
       - '9000:9000'
       - '9001:9001'
@@ -85,15 +116,16 @@ services:
       MINIO_SECRET_KEY: minio123
     command: server /data --console-address ":9001"
 
-  # This job will create the "datalake" bucket on Minio
+  # This job will create the "spark/trino" buckets and sub paths
   mc-job:
     image: 'minio/mc:RELEASE.2022-05-09T04-08-26Z'
-    container_name: mc-job
     entrypoint: |
       /bin/bash -c "
       sleep 5;
       /usr/bin/mc config --quiet host add myminio http://minio:9000 minio minio123;
-      /usr/bin/mc mb --quiet myminio/datalake
+      /usr/bin/mc mb --quiet myminio/trino/datalake
+      /usr/bin/mc mb --quiet myminio/spark/datalake;
+      /usr/bin/mc mb --quiet myminio/spark/testing
       "
     depends_on:
       - minio

--- a/tests/core/engine_adapter/docker-compose.yaml
+++ b/tests/core/engine_adapter/docker-compose.yaml
@@ -50,26 +50,47 @@ services:
     volumes:
       - ./trino/catalog:/etc/trino/catalog
 
-  trino_metastore_db:
+  trino_datalake_metastore_db:
     image: postgres
-    hostname: trino_metastore_db
+    hostname: trino_datalake_metastore_db
     environment:
       POSTGRES_USER: hive
       POSTGRES_PASSWORD: hive
       POSTGRES_DB: metastore
 
-  trino-hive-metastore:
-    hostname: hive-metastore
+  trino-datalake-hive-metastore:
+    hostname: trino-datalake-hive-metastore
     image: 'starburstdata/hive:3.1.2-e.15'
     environment:
       HIVE_METASTORE_DRIVER: org.postgresql.Driver
-      HIVE_METASTORE_JDBC_URL: jdbc:postgresql://trino_metastore_db:5432/metastore
+      HIVE_METASTORE_JDBC_URL: jdbc:postgresql://trino_datalake_metastore_db:5432/metastore
       HIVE_METASTORE_USER: hive
       HIVE_METASTORE_PASSWORD: hive
-      HIVE_METASTORE_WAREHOUSE_DIR: s3://trino/
+      HIVE_METASTORE_WAREHOUSE_DIR: s3://trino/datalake
       <<: *hive_metastore_environments
     depends_on:
-      - trino_metastore_db
+      - trino_datalake_metastore_db
+
+  trino_testing_metastore_db:
+    image: postgres
+    hostname: trino_testing_metastore_db
+    environment:
+      POSTGRES_USER: hive
+      POSTGRES_PASSWORD: hive
+      POSTGRES_DB: metastore
+
+  trino-testing-hive-metastore:
+    hostname: trino-testing-hive-metastore
+    image: 'starburstdata/hive:3.1.2-e.15'
+    environment:
+      HIVE_METASTORE_DRIVER: org.postgresql.Driver
+      HIVE_METASTORE_JDBC_URL: jdbc:postgresql://trino_testing_metastore_db:5432/metastore
+      HIVE_METASTORE_USER: hive
+      HIVE_METASTORE_PASSWORD: hive
+      HIVE_METASTORE_WAREHOUSE_DIR: s3://trino/testing
+      <<: *hive_metastore_environments
+    depends_on:
+      - trino_testing_metastore_db
   # Spark Stack
   spark:
     build:
@@ -123,7 +144,8 @@ services:
       /bin/bash -c "
       sleep 5;
       /usr/bin/mc config --quiet host add myminio http://minio:9000 minio minio123;
-      /usr/bin/mc mb --quiet myminio/trino/datalake
+      /usr/bin/mc mb --quiet myminio/trino/datalake;
+      /usr/bin/mc mb --quiet myminio/trino/testing;
       /usr/bin/mc mb --quiet myminio/spark/datalake;
       /usr/bin/mc mb --quiet myminio/spark/testing
       "

--- a/tests/core/engine_adapter/spark/Dockerfile
+++ b/tests/core/engine_adapter/spark/Dockerfile
@@ -1,0 +1,7 @@
+FROM docker.io/bitnami/spark:3.5
+USER root
+RUN install_packages curl
+USER 1001
+RUN curl https://jdbc.postgresql.org/download/postgresql-42.5.0.jar -o /opt/bitnami/spark/jars/postgresql-42.5.0.jar
+RUN curl https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.704/aws-java-sdk-bundle-1.11.704.jar -o /opt/bitnami/spark/jars/aws-java-sdk-bundle-1.11.704.jar
+RUN curl https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/1.4.1/iceberg-spark-runtime-3.5_2.12-1.4.1.jar -o /opt/bitnami/spark/jars/iceberg-spark-runtime-3.5_2.12-1.4.1.jar

--- a/tests/core/engine_adapter/spark/conf/hive-site.xml
+++ b/tests/core/engine_adapter/spark/conf/hive-site.xml
@@ -1,0 +1,45 @@
+<configuration>
+    <property>
+        <name>metastore.thrift.uris</name>
+        <value>thrift://spark-hive-metastore:9083</value>
+    </property>
+    <property>
+        <name>hive.metastore.uris</name>
+        <value>thrift://spark-hive-metastore:9083</value>
+    </property>
+    <property>
+        <name>metastore.task.threads.always</name>
+        <value>org.apache.hadoop.hive.metastore.events.EventCleanerTask,org.apache.hadoop.hive.metastore.MaterializationsCacheCleanerTask</value>
+    </property>
+    <property>
+        <name>metastore.expression.proxy</name>
+        <value>org.apache.hadoop.hive.metastore.DefaultPartitionExpressionProxy</value>
+    </property>
+    <property>
+        <name>metastore.warehouse.dir</name>
+        <value>s3://spark/</value>
+    </property>
+
+    <property>
+        <name>fs.s3a.access.key</name>
+        <value>minio</value>
+    </property>
+    <property>
+        <name>fs.s3a.secret.key</name>
+        <value>minio123</value>
+    </property>
+    <property>
+        <name>fs.s3a.endpoint</name>
+        <value>http://minio:9000</value>
+    </property>
+    <property>
+        <name>fs.s3a.path.style.access</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hive.default.fileformat</name>
+        <value>Parquet</value>
+    </property>
+
+</configuration>

--- a/tests/core/engine_adapter/spark/conf/spark-defaults.conf
+++ b/tests/core/engine_adapter/spark/conf/spark-defaults.conf
@@ -1,0 +1,11 @@
+spark.hadoop.hive.exec.dynamic.partition true
+spark.hadoop.hive.exec.dynamic.partition.mode nonstrict
+spark.sql.sources.partitionOverwriteMode dynamic
+spark.hadoop.fs.s3.impl org.apache.hadoop.fs.s3a.S3AFileSystem
+spark.sql.warehouse.dir s3://spark/datalake/
+spark.sql.catalogImplementation hive
+spark.sql.extensions org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
+spark.sql.catalog.testing org.apache.iceberg.spark.SparkCatalog
+spark.sql.catalog.testing.type hive
+spark.sql.catalog.testing.uri thrift://spark-hive-metastore:9083
+spark.sql.catalog.testing.warehouse s3://spark/testing/

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -1,6 +1,7 @@
 # type: ignore
 from __future__ import annotations
 
+import os
 import pathlib
 import sys
 import typing as t
@@ -187,7 +188,10 @@ def test_type(request):
 @pytest.fixture(scope="session")
 def config() -> Config:
     return load_config_from_paths(
-        project_paths=[pathlib.Path("examples/wursthall/config.yaml")],
+        project_paths=[
+            pathlib.Path("examples/wursthall/config.yaml"),
+            pathlib.Path(os.path.join(os.path.dirname(__file__), "config.yaml")),
+        ],
         personal_paths=[pathlib.Path("~/.sqlmesh/config.yaml").expanduser()],
     )
 

--- a/tests/core/engine_adapter/trino/catalog/datalake.properties
+++ b/tests/core/engine_adapter/trino/catalog/datalake.properties
@@ -1,5 +1,5 @@
 connector.name=hive
-hive.metastore.uri=thrift://trino-hive-metastore:9083
+hive.metastore.uri=thrift://trino-datalake-hive-metastore:9083
 hive.s3.endpoint=http://minio:9000
 hive.s3.path-style-access=true
 hive.s3.aws-access-key=minio

--- a/tests/core/engine_adapter/trino/catalog/datalake.properties
+++ b/tests/core/engine_adapter/trino/catalog/datalake.properties
@@ -1,5 +1,5 @@
 connector.name=hive
-hive.metastore.uri=thrift://hive-metastore:9083
+hive.metastore.uri=thrift://trino-hive-metastore:9083
 hive.s3.endpoint=http://minio:9000
 hive.s3.path-style-access=true
 hive.s3.aws-access-key=minio

--- a/tests/core/engine_adapter/trino/catalog/testing.properties
+++ b/tests/core/engine_adapter/trino/catalog/testing.properties
@@ -1,5 +1,5 @@
 connector.name=hive
-hive.metastore.uri=thrift://trino-hive-metastore:9083
+hive.metastore.uri=thrift://trino-testing-hive-metastore:9083
 hive.s3.endpoint=http://minio:9000
 hive.s3.path-style-access=true
 hive.s3.aws-access-key=minio

--- a/tests/core/engine_adapter/trino/catalog/testing.properties
+++ b/tests/core/engine_adapter/trino/catalog/testing.properties
@@ -1,5 +1,5 @@
 connector.name=hive
-hive.metastore.uri=thrift://hive-metastore:9083
+hive.metastore.uri=thrift://trino-hive-metastore:9083
 hive.s3.endpoint=http://minio:9000
 hive.s3.path-style-access=true
 hive.s3.aws-access-key=minio


### PR DESCRIPTION
Adds Spark to our integration tests and since it is deployed locally it means it will be tested on all merges to main. 

I ended up adding the local config as a checked in YAML so now users just need to have connection config to external services defined locally. 

Note: Iceberg was just included because I needed a way to add a catalog and I was pulling my hair out trying to figure out how to do it when the catalog isn't a Iceberg/Delta catalog. I just eventually gave up and made it an Iceberg catalog. The tests involving creating objects or loading data are all done agains the default catalog and therefore it is reading/writing Parquet files to "S3" (Minio). 