### PR TITLE
Fix: start dates of models are now relative to cron

### DIFF
--- a/sqlmesh/core/node.py
+++ b/sqlmesh/core/node.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing as t
+from datetime import datetime
 from enum import Enum
 
 from pydantic import Field
@@ -95,7 +96,7 @@ class IntervalUnit(str, Enum):
     def croniter(self, value: TimeLike) -> CroniterCache:
         return CroniterCache(self._cron_expr, value)
 
-    def cron_next(self, value: TimeLike) -> TimeLike:
+    def cron_next(self, value: TimeLike) -> datetime:
         """
         Get the next timestamp given a time-like value for this interval unit.
 
@@ -107,7 +108,7 @@ class IntervalUnit(str, Enum):
         """
         return self.croniter(value).get_next()
 
-    def cron_prev(self, value: TimeLike) -> TimeLike:
+    def cron_prev(self, value: TimeLike) -> datetime:
         """
         Get the previous timestamp given a time-like value for this interval unit.
 
@@ -119,7 +120,7 @@ class IntervalUnit(str, Enum):
         """
         return self.croniter(value).get_prev()
 
-    def cron_floor(self, value: TimeLike) -> TimeLike:
+    def cron_floor(self, value: TimeLike) -> datetime:
         """
         Get the floor timestamp given a time-like value for this interval unit.
 
@@ -283,7 +284,7 @@ class _Node(PydanticModel):
             self._croniter.curr = to_datetime(value)
         return self._croniter
 
-    def cron_next(self, value: TimeLike) -> TimeLike:
+    def cron_next(self, value: TimeLike) -> datetime:
         """
         Get the next timestamp given a time-like value and the node's cron.
 
@@ -295,7 +296,7 @@ class _Node(PydanticModel):
         """
         return self.croniter(value).get_next()
 
-    def cron_prev(self, value: TimeLike) -> TimeLike:
+    def cron_prev(self, value: TimeLike) -> datetime:
         """
         Get the previous timestamp given a time-like value and the node's cron.
 
@@ -307,7 +308,7 @@ class _Node(PydanticModel):
         """
         return self.croniter(value).get_prev()
 
-    def cron_floor(self, value: TimeLike) -> TimeLike:
+    def cron_floor(self, value: TimeLike) -> datetime:
         """
         Get the floor timestamp given a time-like value and the node's cron.
 

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -66,7 +66,7 @@ def test_forward_only_plan_with_effective_date(mocker: MockerFixture):
 
     model_name = "sushi.waiter_revenue_by_day"
     model = context.models[model_name]
-    context.upsert_model(add_projection_to_model(t.cast(SqlModel, model)))
+    context.upsert_model(add_projection_to_model(t.cast(SqlModel, model)), start="2023-01-01")
 
     plan = context.plan("dev", no_prompts=True, skip_tests=True, forward_only=True)
     assert len(plan.new_snapshots) == 2

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -68,11 +68,11 @@ def test_interval_params_missing(scheduler: Scheduler, sushi_context_fixed_date:
 
     start_ds = "2022-01-01"
     end_ds = "2022-03-01"
-    assert compute_interval_params([waiters], start=start_ds, end=end_ds, is_dev=False) == {
-        waiters: [
-            (to_datetime(start_ds), to_datetime("2022-03-02")),
-        ]
-    }
+    assert compute_interval_params(
+        sushi_context_fixed_date.snapshots.values(), start=start_ds, end=end_ds, is_dev=False
+    )[waiters] == [
+        (to_datetime(start_ds), to_datetime("2022-03-02")),
+    ]
 
 
 def test_run(sushi_context_fixed_date: Context, scheduler: Scheduler):

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -1323,6 +1323,4 @@ def test_earliest_start_date(sushi_context: Context):
 
     cache: t.Dict[str, datetime] = {}
     earliest_start_date(sushi_context.snapshots.values(), cache)
-
-    # Make sure that the default value for a snapshot with a missing start is not cached.
-    assert model_name not in cache
+    assert cache[model_name] == to_datetime("yesterday")

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -630,7 +630,7 @@ def test_promote_snapshots_no_gaps(state_sync: EngineAdapterStateSync, make_snap
         name="a",
         query=parse_one("select 1, ds"),
         kind=IncrementalByTimeRangeKind(time_column="ds"),
-        cron="@daily",
+        start="2022-01-01",
     )
 
     snapshot = make_snapshot(model, version="a")

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -36,6 +36,7 @@ def snapshot(make_snapshot, random_name) -> Snapshot:
             random_name(),
             parse_one("SELECT 1, ds"),
             kind=IncrementalByTimeRangeKind(time_column="ds"),
+            start="2022-01-01",
         ),
     )
     result.categorize_as(SnapshotChangeCategory.BREAKING)
@@ -50,6 +51,7 @@ def depends_on_past_snapshot(make_snapshot, random_name) -> Snapshot:
             name,
             parse_one(f"SELECT 1, ds FROM {name}"),
             kind=IncrementalByTimeRangeKind(time_column="ds", batch_size=1),
+            start="2022-01-01",
         ),
     )
     result.categorize_as(SnapshotChangeCategory.BREAKING)


### PR DESCRIPTION
if a project does not have a start date set, models with monthly cron would never run because the default start date was yesterday.