### PR TITLE
fix: init duckdb catalogs at connection level

### DIFF
--- a/examples/sushi/config.py
+++ b/examples/sushi/config.py
@@ -113,3 +113,14 @@ environment_suffix_config = Config(
     model_defaults=ModelDefaultsConfig(dialect="duckdb"),
     environment_suffix_target=EnvironmentSuffixTarget.TABLE,
 )
+
+CATALOGS = {
+    "in_memory": ":memory:",
+    "other_catalog": f":memory:",
+}
+
+local_catalogs = Config(
+    default_connection=DuckDBConnectionConfig(catalogs=CATALOGS),
+    default_test_connection=DuckDBConnectionConfig(catalogs=CATALOGS),
+    model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,6 +178,13 @@ def sushi_test_dbt_context(mocker: MockerFixture) -> Context:
     return context
 
 
+@pytest.fixture()
+def sushi_default_catalog(mocker: MockerFixture) -> Context:
+    context, plan = init_and_plan_context("examples/sushi", mocker, "local_catalogs")
+    context.apply(plan)
+    return context
+
+
 def init_and_plan_context(
     paths: str | t.List[str],
     mocker: MockerFixture,

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -418,7 +418,8 @@ def test_plan_set_choice_is_reflected_in_missing_intervals(mocker: MockerFixture
 @pytest.mark.integration
 @pytest.mark.core_integration
 @pytest.mark.parametrize(
-    "context_fixture", ["sushi_context", "sushi_dbt_context", "sushi_test_dbt_context"]
+    "context_fixture",
+    ["sushi_context", "sushi_dbt_context", "sushi_test_dbt_context", "sushi_default_catalog"],
 )
 def test_model_add(context_fixture: Context, request):
     initial_add(request.getfixturevalue(context_fixture), "dev")


### PR DESCRIPTION
Prior approach didn't take into account that a connection could be closed (like after running tests) and once re-opened it wouldn't have the catalogs applied. Therefore we now create the catalogs as part of the connection factory to ensure every connection has them defined. 