### PR TITLE
fix: duckdb init catalogs at cursor level

### DIFF
--- a/examples/sushi/config.py
+++ b/examples/sushi/config.py
@@ -113,3 +113,15 @@ environment_suffix_config = Config(
     model_defaults=ModelDefaultsConfig(dialect="duckdb"),
     environment_suffix_target=EnvironmentSuffixTarget.TABLE,
 )
+
+
+CATALOGS = {
+    "in_memory": ":memory:",
+    "other_catalog": f":memory:",
+}
+
+local_catalogs = Config(
+    default_connection=DuckDBConnectionConfig(catalogs=CATALOGS),
+    default_test_connection=DuckDBConnectionConfig(catalogs=CATALOGS),
+    model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+)

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -164,11 +164,12 @@ class EngineAdapter:
         sql_gen_kwargs: t.Optional[t.Dict[str, Dialect | bool | str]] = None,
         multithreaded: bool = False,
         cursor_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
+        cursor_init: t.Optional[t.Callable[[t.Any], None]] = None,
         **kwargs: t.Any,
     ):
         self.dialect = dialect.lower() or self.DIALECT
         self._connection_pool = create_connection_pool(
-            connection_factory, multithreaded, cursor_kwargs=cursor_kwargs
+            connection_factory, multithreaded, cursor_kwargs=cursor_kwargs, cursor_init=cursor_init
         )
         self.sql_gen_kwargs = sql_gen_kwargs or {}
         self._extra_config = kwargs

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -41,6 +41,7 @@ class DatabricksEngineAdapter(GetCurrentCatalogFromFunctionMixin, SparkEngineAda
         sql_gen_kwargs: t.Optional[t.Dict[str, Dialect | bool | str]] = None,
         multithreaded: bool = False,
         cursor_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
+        cursor_init: t.Optional[t.Callable[[t.Any], None]] = None,
         **kwargs: t.Any,
     ):
         super().__init__(
@@ -49,6 +50,7 @@ class DatabricksEngineAdapter(GetCurrentCatalogFromFunctionMixin, SparkEngineAda
             sql_gen_kwargs,
             multithreaded,
             cursor_kwargs,
+            cursor_init,
             **kwargs,
         )
         self._spark: t.Optional[PySparkSession] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,6 +178,13 @@ def sushi_test_dbt_context(mocker: MockerFixture) -> Context:
     return context
 
 
+@pytest.fixture()
+def sushi_default_catalog(mocker: MockerFixture) -> Context:
+    context, plan = init_and_plan_context("examples/sushi", mocker, "local_catalogs")
+    context.apply(plan)
+    return context
+
+
 def init_and_plan_context(
     paths: str | t.List[str],
     mocker: MockerFixture,

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -418,7 +418,8 @@ def test_plan_set_choice_is_reflected_in_missing_intervals(mocker: MockerFixture
 @pytest.mark.integration
 @pytest.mark.core_integration
 @pytest.mark.parametrize(
-    "context_fixture", ["sushi_context", "sushi_dbt_context", "sushi_test_dbt_context"]
+    "context_fixture",
+    ["sushi_context", "sushi_dbt_context", "sushi_test_dbt_context", "sushi_default_catalog"],
 )
 def test_model_add(context_fixture: Context, request):
     initial_add(request.getfixturevalue(context_fixture), "dev")


### PR DESCRIPTION
Prior approach didn't take into account that a connection could be closed (like after running tests) and once re-opened it wouldn't have the catalogs applied. Originally in another PR I modified the connection factory to init the catalogs but that doesn't work because the cursor object created by DuckDB is unique from the connection object from which it is created (despite them saying it is a duplicate). Therefore we need to make sure that whenever a cursor is created that it gets the catalog initialized.

This is more thoroughly tested in the default catalog PR that actually uses these catalogs and ensures the connection is configured correctly. 