### PR TITLE
chore: increase wait time for ci containers

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -191,7 +191,7 @@ jobs:
           command: make core_engine_it_test_docker
       - run:
           name: Make sure DBs are ready
-          command: sleep 30
+          command: sleep 60
       - run:
           name: Run tests
           command: make core_engine_it_test_local_only


### PR DESCRIPTION
Looks like we still aren't waiting long enough: https://app.circleci.com/pipelines/github/TobikoData/sqlmesh/8149/workflows/08276a54-3e95-4329-ae05-ef325d214116/jobs/56809