### PR TITLE
Chore: improve error message when cycle is detected in model graph

### DIFF
--- a/sqlmesh/utils/dag.py
+++ b/sqlmesh/utils/dag.py
@@ -100,9 +100,10 @@ class DAG(t.Generic[T]):
                 next_nodes = {node for node, deps in unprocessed_nodes.items() if not deps}
 
                 if not next_nodes:
+                    # Sort cycle candidates to make the order deterministic
                     cycle_candidates_msg = (
                         "\nPossible candidates to check for circular references: "
-                        + ", ".join(str(node) for node in cycle_candidates)
+                        + ", ".join(str(node) for node in sorted(cycle_candidates))
                     )
 
                     if last_processed_nodes:
@@ -129,12 +130,12 @@ class DAG(t.Generic[T]):
                     if deps_before_subtraction == deps:
                         nodes_with_unaffected_deps.add(node)
 
-                last_processed_nodes = next_nodes
                 cycle_candidates = nodes_with_unaffected_deps or unprocessed_nodes
 
                 # Sort to make the order deterministic
                 # TODO: Make protocol that makes the type var both hashable and sortable once we are on Python 3.8+
-                self._sorted.extend(sorted(next_nodes))  # type: ignore
+                last_processed_nodes = sorted(next_nodes)  # type: ignore
+                self._sorted.extend(last_processed_nodes)
 
         return self._sorted
 


### PR DESCRIPTION
This is with the changes introduced in this PR:

```
➜  cat models/a.sql
model (name a, kind full);

select id from b
➜ cat models/b.sql
model (name b, kind full);

select id from a
➜  cat models/normal.sql
model (name normal, kind full);

select 1 as a%
➜  sqlmesh info
Error: Detected a cycle in the DAG. Please make sure there are no circular references between models.
Last models added to the DAG: normal
Possible model candidates to check for circular references: b, a
```

If I get rid of the `normal.sql` model, then the error message becomes:
```
➜  sqlmesh info
Error: Detected a cycle in the DAG. Please make sure there are no circular references between models.
Possible model candidates to check for circular references: b, a
```