### PR TITLE
Fix!: show proper pip install command when sqlmesh schema version is behind

### DIFF
--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -171,9 +171,14 @@ class StateReader(abc.ABC):
                     f"{lib} (local) is using version '{local}' which is ahead of '{remote}' (remote). "
                     "Please run a migration ('sqlmesh migrate' command)."
                 )
+
+            if remote_package_version:
+                upgrade_suggestion = f" Please upgrade {lib} ('pip install --upgrade \"{lib.lower()}=={remote_package_version}\"' command)."
+            else:
+                upgrade_suggestion = ""
+
             raise SQLMeshError(
-                f"{lib} (local) is using version '{local}' which is behind '{remote}' (remote). "
-                f"Please upgrade {lib} ('pip install --upgrade \"{lib.lower()}=={remote_package_version or remote}\"' command)."
+                f"{lib} (local) is using version '{local}' which is behind '{remote}' (remote).{upgrade_suggestion}"
             )
 
         if SCHEMA_VERSION < versions.schema_version:
@@ -185,7 +190,12 @@ class StateReader(abc.ABC):
             )
 
         if major_minor(SQLGLOT_VERSION) < major_minor(versions.sqlglot_version):
-            raise_error("SQLGlot", SQLGLOT_VERSION, versions.sqlglot_version)
+            raise_error(
+                "SQLGlot",
+                SQLGLOT_VERSION,
+                versions.sqlglot_version,
+                remote_package_version=versions.sqlglot_version,
+            )
 
         if validate:
             if SCHEMA_VERSION > versions.schema_version:

--- a/sqlmesh/migrations/v0032_add_sqlmesh_version.py
+++ b/sqlmesh/migrations/v0032_add_sqlmesh_version.py
@@ -1,6 +1,7 @@
 """Add new 'sqlmesh_version' column to the version state table."""
 from sqlglot import exp
 
+
 def migrate(state_sync):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     versions_table = "_versions"

--- a/sqlmesh/migrations/v0032_add_sqlmesh_version.py
+++ b/sqlmesh/migrations/v0032_add_sqlmesh_version.py
@@ -1,0 +1,20 @@
+"""Add new 'sqlmesh_version' column to the version state table."""
+from sqlglot import exp
+
+def migrate(state_sync):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    versions_table = "_versions"
+    if state_sync.schema:
+        versions_table = f"{state_sync.schema}.{versions_table}"
+
+    alter_table_exp = exp.AlterTable(
+        this=exp.to_table(versions_table),
+        actions=[
+            exp.ColumnDef(
+                this=exp.to_column("sqlmesh_version"),
+                kind=exp.DataType.build("text"),
+            )
+        ],
+    )
+
+    engine_adapter.execute(alter_table_exp)


### PR DESCRIPTION
Current behavior:

```
Error: SQLMesh (local) is using version '30' which is behind '31' (remote). Please upgrade SQLMesh ('pip install --upgrade "sqlmesh==31"' command).
```

The suggested command is incorrect because we're interpolating `versions.schema_version` instead of the actual SQLMesh package version. To overcome this issue I added a new column `sqlmesh_version` to the `_versions` state table which is currently only used to improve the UX when an error message is raised.