### PR TITLE
feat: Add Single Catalog Support to Postgres Engines

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -87,12 +87,17 @@ class InsertOverwriteStrategy(Enum):
 
 class CatalogSupport(Enum):
     UNSUPPORTED = 1
-    REQUIRES_SET_CATALOG = 2
-    FULL_SUPPORT = 3
+    SINGLE_CATALOG_ONLY = 2
+    REQUIRES_SET_CATALOG = 3
+    FULL_SUPPORT = 4
 
     @property
     def is_unsupported(self) -> bool:
         return self == CatalogSupport.UNSUPPORTED
+
+    @property
+    def is_single_catalog_only(self) -> bool:
+        return self == CatalogSupport.SINGLE_CATALOG_ONLY
 
     @property
     def is_requires_set_catalog(self) -> bool:
@@ -165,6 +170,7 @@ class EngineAdapter:
         multithreaded: bool = False,
         cursor_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
         cursor_init: t.Optional[t.Callable[[t.Any], None]] = None,
+        default_catalog: t.Optional[str] = None,
         **kwargs: t.Any,
     ):
         self.dialect = dialect.lower() or self.DIALECT
@@ -172,6 +178,7 @@ class EngineAdapter:
             connection_factory, multithreaded, cursor_kwargs=cursor_kwargs, cursor_init=cursor_init
         )
         self.sql_gen_kwargs = sql_gen_kwargs or {}
+        self.default_catalog = default_catalog
         self._extra_config = kwargs
 
     @property

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -5,17 +5,19 @@ import typing as t
 from sqlglot import exp
 
 from sqlmesh.core.engine_adapter import EngineAdapter
+from sqlmesh.core.engine_adapter.base import CatalogSupport
 from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 from sqlmesh.utils.errors import SQLMeshError
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import SchemaName, TableName
-    from sqlmesh.core.engine_adapter.base import QueryOrDF
+    from sqlmesh.core.engine_adapter._typing import QueryOrDF
 
 
 class BasePostgresEngineAdapter(EngineAdapter):
     DEFAULT_BATCH_SIZE = 1000
     COLUMNS_TABLE = "information_schema.columns"
+    CATALOG_SUPPORT = CatalogSupport.SINGLE_CATALOG_ONLY
 
     def columns(
         self, table_name: TableName, include_pseudo_columns: bool = False

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -4,7 +4,7 @@ import logging
 import typing as t
 
 import pandas as pd
-from sqlglot import Dialect, exp
+from sqlglot import exp
 
 from sqlmesh.core.engine_adapter.base import CatalogSupport, InsertOverwriteStrategy
 from sqlmesh.core.engine_adapter.mixins import GetCurrentCatalogFromFunctionMixin
@@ -34,25 +34,8 @@ class DatabricksEngineAdapter(GetCurrentCatalogFromFunctionMixin, SparkEngineAda
     CATALOG_SUPPORT = CatalogSupport.FULL_SUPPORT
     CURRENT_CATALOG_FUNCTION = "current_catalog()"
 
-    def __init__(
-        self,
-        connection_factory: t.Callable[[], t.Any],
-        dialect: str = "",
-        sql_gen_kwargs: t.Optional[t.Dict[str, Dialect | bool | str]] = None,
-        multithreaded: bool = False,
-        cursor_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
-        cursor_init: t.Optional[t.Callable[[t.Any], None]] = None,
-        **kwargs: t.Any,
-    ):
-        super().__init__(
-            connection_factory,
-            dialect,
-            sql_gen_kwargs,
-            multithreaded,
-            cursor_kwargs,
-            cursor_init,
-            **kwargs,
-        )
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
+        super().__init__(*args, **kwargs)
         self._spark: t.Optional[PySparkSession] = None
 
     @classproperty

--- a/sqlmesh/core/engine_adapter/shared.py
+++ b/sqlmesh/core/engine_adapter/shared.py
@@ -112,6 +112,12 @@ def set_catalog(
             # Remove the catalog name from the argument so the engine adapter doesn't try to use it
             expression.set("catalog", None)
             container[key] = expression  # type: ignore
+            if catalog_support.is_single_catalog_only:
+                if catalog_name != engine_adapter.default_catalog:
+                    raise UnsupportedCatalogOperationError(
+                        f"{engine_adapter.dialect} requires that all catalog operations be against a single catalog: {engine_adapter.default_catalog}"
+                    )
+                return func(*list_args, **kwargs)
             # Set the catalog name on the engine adapter if needed
             current_catalog = engine_adapter.get_current_catalog()
             if expression.catalog != current_catalog:

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -22,7 +22,7 @@ def make_config() -> t.Callable:
     return _make_function
 
 
-def test_snowflake_auth(make_config):
+def test_snowflake(make_config):
     # Authenticator and user/password is fine
     config = make_config(
         type="snowflake",
@@ -88,6 +88,16 @@ def test_snowflake_auth(make_config):
             user="test",
             authenticator="externalbrowser",
         )
+    config = make_config(
+        type="snowflake",
+        account="test",
+        user="test",
+        password="test",
+        authenticator="externalbrowser",
+        database="test_catalog",
+    )
+    assert isinstance(config, SnowflakeConnectionConfig)
+    assert config.get_catalog() == "test_catalog"
 
 
 def test_validator():
@@ -127,6 +137,7 @@ def test_trino(make_config):
     assert config.catalog == "catalog"
     assert config.http_scheme == "https"
     assert config.port == 443
+    assert config.get_catalog() == "catalog"
 
     # Validate Basic Auth
     config = make_config(method="basic", password="password", **required_kwargs)


### PR DESCRIPTION
Postgres engines allow only creating objects within the catalog assigned in the connection itself. Therefore they do support catalogs but only creating objects within the connection catalog. This change will make sure that the catalog being targeted matches the connection catalog and if so it will remove the catalog and perform the operation.

Redshift allows querying across catalogs (not creating objects) but this distinction does not matter for the `set_catalog` decorator since it is focused on the objects actually being created and not the expressions being used. 