### PR TITLE
Fix: external model schema was using generic model name the key. sqlg…

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1797,7 +1797,9 @@ def _create_model(
                 "jinja_macros": jinja_macros,
                 "dialect": dialect,
                 "depends_on": depends_on,
-                "physical_schema_override": physical_schema_override.get(exp.to_table(name).db),
+                "physical_schema_override": physical_schema_override.get(
+                    exp.to_table(name, dialect=dialect).db
+                ),
                 **kwargs,
             },
         )

--- a/sqlmesh/core/schema_loader.py
+++ b/sqlmesh/core/schema_loader.py
@@ -5,6 +5,7 @@ import typing as t
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+from sqlglot import exp
 from sqlglot.dialects.dialect import DialectType
 
 from sqlmesh.core.engine_adapter import EngineAdapter
@@ -63,7 +64,7 @@ def create_schema_file(
 
         schemas = [
             {
-                "name": table,
+                "name": exp.to_table(table).sql(dialect=dialect),
                 "columns": {c: t.sql(dialect=dialect) for c, t in columns.items()},
             }
             for table, columns in sorted(


### PR DESCRIPTION
…lot is lenient enough to accept double quotes instead of backticks for dialects like bigquery, but this makes the schema.yaml more consistent