### PR TITLE
Feat: Optionally disable formatting of model sql in render

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -143,9 +143,7 @@ def init(
     type=str,
     help="The SQL dialect to render the query as.",
 )
-@click.option(
-    "--no-pretty-print", is_flag=True, help="Disable pretty printing of the query."
-)
+@click.option("--no-pretty-print", is_flag=True, help="Disable pretty printing of the query.")
 @click.pass_context
 @error_handler
 def render(

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -143,7 +143,7 @@ def init(
     type=str,
     help="The SQL dialect to render the query as.",
 )
-@click.option("--no-pretty-print", is_flag=True, help="Disable pretty printing of the query.")
+@click.option("--no-format", is_flag=True, help="Disable fancy formatting of the query.")
 @click.pass_context
 @error_handler
 def render(
@@ -154,7 +154,7 @@ def render(
     execution_time: t.Optional[TimeLike] = None,
     expand: t.Optional[t.Union[bool, t.Iterable[str]]] = None,
     dialect: t.Optional[str] = None,
-    no_pretty_print: bool = False,
+    no_format: bool = False,
 ) -> None:
     """Renders a model's query, optionally expanding referenced models."""
     rendered = ctx.obj.render(
@@ -166,7 +166,7 @@ def render(
     )
 
     sql = rendered.sql(pretty=True, dialect=ctx.obj.config.dialect if dialect is None else dialect)
-    if no_pretty_print:
+    if no_format:
         print(sql)
     else:
         ctx.obj.console.show_sql(sql)

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -143,6 +143,9 @@ def init(
     type=str,
     help="The SQL dialect to render the query as.",
 )
+@click.option(
+    "--no-pretty-print", is_flag=True, help="Disable pretty printing of the query."
+)
 @click.pass_context
 @error_handler
 def render(
@@ -153,6 +156,7 @@ def render(
     execution_time: t.Optional[TimeLike] = None,
     expand: t.Optional[t.Union[bool, t.Iterable[str]]] = None,
     dialect: t.Optional[str] = None,
+    no_pretty_print: bool = False,
 ) -> None:
     """Renders a model's query, optionally expanding referenced models."""
     rendered = ctx.obj.render(
@@ -164,7 +168,10 @@ def render(
     )
 
     sql = rendered.sql(pretty=True, dialect=ctx.obj.config.dialect if dialect is None else dialect)
-    ctx.obj.console.show_sql(sql)
+    if no_pretty_print:
+        print(sql)
+    else:
+        ctx.obj.console.show_sql(sql)
 
 
 @cli.command("evaluate")


### PR DESCRIPTION
**Problem:**

This has bugged me for awhile, but current way `sqlmesh render` works has a lot of issues if your SQL is wider than console length. It automatically wraps and insert new lines which breaks usage in scripts and even copy paste. Furthermore it pads the end of line all the way out to the terminal width. Which is also really annoying. Lastly, and I don't know if this is consistent -- I get truncated text sometimes too. 

**Solution:**

Let people just dump the output as is to stdout, so we can use it in our vimscripts and so on. Or even so its cleaner to yank. 

Add `--no-pretty-print` to render command which just uses simple print stmt