### PR TITLE
fix: github cicd support uncategorized snapshots

### DIFF
--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -272,27 +272,32 @@ class Plan:
         return self._restatements
 
     @property
-    def loaded_snapshot_intervals(self) -> t.List[LoadedSnapshotIntervals]:
+    def loaded_snapshot_intervals(
+        self,
+    ) -> t.Tuple[t.List[LoadedSnapshotIntervals], t.List[Snapshot]]:
         loaded_snapshots = []
+        unloaded_snapshots = []
         for snapshot in self.directly_modified:
-            if not snapshot.change_category:
-                logger.debug(
-                    f"Got a directly modified snapshot without a change category so now including it in loaded snapshot intervals. Snapshot: {snapshot.name}"
-                )
-                continue
-            loaded_snapshots.append(LoadedSnapshotIntervals.from_snapshot(snapshot))
+            if snapshot.change_category:
+                loaded_snapshots.append(LoadedSnapshotIntervals.from_snapshot(snapshot))
+            else:
+                logger.debug(f"Got an unloaded snapshot. Snapshot: {snapshot.name}")
+                unloaded_snapshots.append(snapshot)
             for downstream_indirect in self.indirectly_modified.get(snapshot.name, set()):
                 downstream_snapshot = self._snapshot_mapping[downstream_indirect]
-                if not downstream_snapshot.change_category:
-                    logger.debug(
-                        f"Got an indirectly-modified snapshot without a change category so now including it in loaded snapshot intervals. Snapshot: {downstream_snapshot.name}"
-                    )
-                    continue
                 # We don't want to display indirect non-breaking since to users these are effectively no-op changes
                 if downstream_snapshot.is_indirect_non_breaking:
                     continue
-                loaded_snapshots.append(LoadedSnapshotIntervals.from_snapshot(downstream_snapshot))
-        return loaded_snapshots
+                if downstream_snapshot.change_category:
+                    loaded_snapshots.append(
+                        LoadedSnapshotIntervals.from_snapshot(downstream_snapshot)
+                    )
+                else:
+                    logger.debug(
+                        f"Got an unloaded indirectly-modified snapshot. Snapshot: {downstream_snapshot.name}"
+                    )
+                    unloaded_snapshots.append(downstream_snapshot)
+        return loaded_snapshots, unloaded_snapshots
 
     @property
     def has_changes(self) -> bool:

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -276,10 +276,18 @@ class Plan:
         loaded_snapshots = []
         for snapshot in self.directly_modified:
             if not snapshot.change_category:
+                logger.debug(
+                    f"Got a directly modified snapshot without a change category so now including it in loaded snapshot intervals. Snapshot: {snapshot.name}"
+                )
                 continue
             loaded_snapshots.append(LoadedSnapshotIntervals.from_snapshot(snapshot))
             for downstream_indirect in self.indirectly_modified.get(snapshot.name, set()):
                 downstream_snapshot = self._snapshot_mapping[downstream_indirect]
+                if not downstream_snapshot.change_category:
+                    logger.debug(
+                        f"Got an indirectly-modified snapshot without a change category so now including it in loaded snapshot intervals. Snapshot: {downstream_snapshot.name}"
+                    )
+                    continue
                 # We don't want to display indirect non-breaking since to users these are effectively no-op changes
                 if downstream_snapshot.is_indirect_non_breaking:
                     continue

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -22,6 +22,7 @@ from sqlmesh.core.console import MarkdownConsole
 from sqlmesh.core.context import Context
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.plan import LoadedSnapshotIntervals, Plan
+from sqlmesh.core.snapshot.definition import Snapshot
 from sqlmesh.core.user import User
 from sqlmesh.integrations.github.cicd.config import GithubCICDBotConfig
 from sqlmesh.utils.concurrency import NodeExecutionFailedError
@@ -547,12 +548,9 @@ class GithubController:
         if self.bot_config.invalidate_environment_after_deploy:
             self._context.invalidate_environment(self.pr_environment_name)
 
-    def get_loaded_snapshot_intervals(self) -> t.List[LoadedSnapshotIntervals]:
-        """
-        Note: It is possible that the prod plan with gaps can be run against a prod which is different then the prod
-        that was used to create the PR environment. Therefore, we can have new uncateogrized snapshots that
-        will not be included in the loaded snapshot intervals.
-        """
+    def get_loaded_snapshot_intervals(
+        self,
+    ) -> t.Tuple[t.List[LoadedSnapshotIntervals], t.List[Snapshot]]:
         return self.prod_plan_with_gaps.loaded_snapshot_intervals
 
     def _update_check(
@@ -734,8 +732,8 @@ class GithubController:
             conclusion: GithubCheckConclusion, exception: t.Optional[Exception]
         ) -> t.Tuple[GithubCheckConclusion, str, t.Optional[str]]:
             if conclusion.is_success:
-                pr_affected_models = self.get_loaded_snapshot_intervals()
-                if not pr_affected_models:
+                loaded_snapshots, unloaded_snapshots = self.get_loaded_snapshot_intervals()
+                if not loaded_snapshots and not unloaded_snapshots:
                     summary = "No models were modified in this PR.\n"
                 else:
                     header_rows = [
@@ -747,16 +745,24 @@ class GithubController:
                         ],
                     ]
                     body_rows: List[Element | List[Element]] = []
-                    for affected_model in pr_affected_models:
+                    for loaded_snapshot in loaded_snapshots:
                         model_rows = [
-                            h("td", affected_model.node_name),
-                            h("td", affected_model.change_category_str),
+                            h("td", loaded_snapshot.node_name),
+                            h("td", loaded_snapshot.change_category_str),
                         ]
-                        if affected_model.intervals:
-                            model_rows.append(h("td", affected_model.format_intervals()))
+                        if loaded_snapshot.intervals:
+                            model_rows.append(h("td", loaded_snapshot.format_intervals()))
                         else:
                             model_rows.append(h("td", "N/A"))
                         body_rows.append(model_rows)
+                    for unloaded_snapshot in unloaded_snapshots:
+                        body_rows.append(
+                            [
+                                h("td", unloaded_snapshot.name),
+                                h("td", "Uncategorized"),
+                                h("td", "N/A"),
+                            ]
+                        )
                     table_header = h("thead", [h("tr", row) for row in header_rows])
                     table_body = h("tbody", [h("tr", row) for row in body_rows])
                     summary = str(h("table", [table_header, table_body]))

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -548,6 +548,11 @@ class GithubController:
             self._context.invalidate_environment(self.pr_environment_name)
 
     def get_loaded_snapshot_intervals(self) -> t.List[LoadedSnapshotIntervals]:
+        """
+        Note: It is possible that the prod plan with gaps can be run against a prod which is different then the prod
+        that was used to create the PR environment. Therefore, we can have new uncateogrized snapshots that
+        will not be included in the loaded snapshot intervals.
+        """
         return self.prod_plan_with_gaps.loaded_snapshot_intervals
 
     def _update_check(


### PR DESCRIPTION
I believe the way this happens is if a PR environment is created and then we go to report what was loaded compared to prod and prod has changed. If that is the case then when we diff we could get new snapshots that have not been categorized. This change allows those to flow through and just get reported as uncategorized snapshots. 