### PR TITLE
Fix: be more lenient when registering duplicate functions

### DIFF
--- a/examples/sushi/macros/macros.py
+++ b/examples/sushi/macros/macros.py
@@ -1,14 +1,6 @@
+from macros.utils import between  # type: ignore
+
 from sqlmesh import macro
-
-
-@macro()
-def add_one(evaluator, column):
-    return f"{column} + 1"
-
-
-@macro()
-def between(evaluator, value, start, end):
-    return value.between(start, end)
 
 
 @macro()

--- a/examples/sushi/macros/utils.py
+++ b/examples/sushi/macros/utils.py
@@ -1,0 +1,11 @@
+from sqlmesh import macro
+
+
+@macro()
+def add_one(evaluator, column):
+    return f"{column} + 1"
+
+
+@macro()
+def between(evaluator, value, start, end):
+    return value.between(start, end)

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -117,12 +117,14 @@ class registry_decorator:
     ) -> t.Callable[..., DECORATOR_RETURN_TYPE]:
         self.func = func
 
+        registry = self.registry()
+        func_name = (self.name or func.__name__).lower()
+
         try:
-            func_name = (self.name or func.__name__).lower()
-            self.registry()[func_name] = self
+            registry[func_name] = self
         except ValueError:
             # No need to raise due to duplicate key if the functions are identical
-            if func.__code__.co_code != self.registry()[func_name].func.__code__.co_code:
+            if func.__code__.co_code != registry[func_name].func.__code__.co_code:
                 raise
 
         @wraps(func)

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -116,7 +116,14 @@ class registry_decorator:
         self, func: t.Callable[..., DECORATOR_RETURN_TYPE]
     ) -> t.Callable[..., DECORATOR_RETURN_TYPE]:
         self.func = func
-        self.registry()[(self.name or func.__name__).lower()] = self
+
+        try:
+            func_name = (self.name or func.__name__).lower()
+            self.registry()[func_name] = self
+        except ValueError:
+            # No need to raise due to duplicate key if the functions are identical
+            if func.__code__.co_code != self.registry()[func_name].func.__code__.co_code:
+                raise
 
         @wraps(func)
         def wrapper(*args: t.Any, **kwargs: t.Any) -> DECORATOR_RETURN_TYPE:

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -473,9 +473,9 @@ def print_exception(
 
 
 def import_python_file(path: Path, relative_base: Path = Path()) -> types.ModuleType:
-    module_name = str(
-        path.absolute().relative_to(relative_base.absolute()).with_suffix("")
-    ).replace(os.path.sep, ".")
+    relative_path = path.absolute().relative_to(relative_base.absolute())
+    module_name = str(relative_path.with_suffix("")).replace(os.path.sep, ".")
+
     # remove the entire module hierarchy in case they were already loaded
     parts = module_name.split(".")
     for i in range(len(parts)):


### PR DESCRIPTION
This aims to fix the bug demonstrated below:

```
➜  cat models/test.sql
model (name test, kind full);

select @bar()
➜  cat macros/macro_a.py
from sqlmesh.core.macros import macro

@macro()
def foo(evaluator):
    return "'foo'"
➜  cat macros/macro_b.py
from macros.macro_a import foo
from sqlmesh.core.macros import macro

@macro()
def bar(evaluator):
    return f"{foo(evaluator)} AS foo"
➜  sqlmesh render test
Error: Duplicate key 'foo' found in UniqueKeyDict<macros>. Call dict.update(...) if this is intentional.
```

It also gets rid of a duplicate implementation of the python file importer method defined under `Loader`, which might need to be double-checked to ensure it's equivalent to the definition under `metaprogramming.py` that took its place.

