### PR TITLE
Fix: allow parsing functions as property values in model meta

### DIFF
--- a/docs/concepts/models/model_kinds.md
+++ b/docs/concepts/models/model_kinds.md
@@ -164,7 +164,7 @@ The `unique_key` values can either be column names or SQL expressions. For examp
 MODEL (
   name db.employees,
   kind INCREMENTAL_BY_UNIQUE_KEY (
-    unique_key (COALESCE("ds", ''))
+    unique_key COALESCE("ds", '')
   )
 );
 ```

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -281,14 +281,6 @@ def _parse_order(
     return macro
 
 
-def _parse_prop_value(self: Parser) -> t.Optional[exp.Expression]:
-    this = self._parse_string() or self._parse_function() or self._parse_id_var()
-    if self._match(TokenType.EQ):
-        this = exp.EQ(this=this, expression=self._parse_string() or self._parse_id_var())
-
-    return this
-
-
 def _parse_props(self: Parser) -> t.Optional[exp.Expression]:
     key = self._parse_id_var(any_token=True)
     if not key:
@@ -298,9 +290,7 @@ def _parse_props(self: Parser) -> t.Optional[exp.Expression]:
     if name == "when_matched":
         value: t.Optional[exp.Expression] = self._parse_when_matched()[0]
     elif self._match(TokenType.L_PAREN):
-        value = self.expression(
-            exp.Tuple, expressions=self._parse_csv(lambda: _parse_prop_value(self))
-        )
+        value = self.expression(exp.Tuple, expressions=self._parse_csv(self._parse_equality))
         self._match_r_paren()
     else:
         value = self._parse_bracket(self._parse_field(any_token=True))

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -282,7 +282,7 @@ def _parse_order(
 
 
 def _parse_prop_value(self: Parser) -> t.Optional[exp.Expression]:
-    this = self._parse_string() or self._parse_id_var()
+    this = self._parse_string() or self._parse_function() or self._parse_id_var()
     if self._match(TokenType.EQ):
         this = exp.EQ(this=this, expression=self._parse_string() or self._parse_id_var())
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2311,6 +2311,24 @@ def test_scd_type_2_defaults():
     assert scd_type_2_model.kind.forward_only
     assert scd_type_2_model.kind.disable_restatement
 
+    # Checks we can parse coalesced key with or without parentheses
+    for coalesced_id in ("""COALESCE("id", '')""", """(COALESCE("id", ''))"""):
+        model = load_sql_based_model(
+            d.parse(
+                f"""
+                MODEL (
+                    name db.table,
+                    kind SCD_TYPE_2 (
+                        unique_key {coalesced_id},
+                    ),
+                );
+
+                SELECT 1 AS "id"
+                """
+            )
+        )
+        assert model.unique_key == [exp.func("COALESCE", exp.column("id", quoted=True), "''")]
+
 
 def test_scd_type_2_overrides():
     view_model_expressions = d.parse(


### PR DESCRIPTION
- Updates documentation to get rid of redundant parentheses in coalesced unique key
- Makes the parser more lenient so it can recognize parenthesized coalesced unique keys