### PR TITLE
Fix: Return a column type instead of an instance of the type in Redshift dbt target

### DIFF
--- a/sqlmesh/dbt/target.py
+++ b/sqlmesh/dbt/target.py
@@ -372,7 +372,7 @@ class RedshiftConfig(TargetConfig):
 
             return RedshiftColumn
         else:
-            return super(RedshiftConfig, cls).column_class()
+            return super(RedshiftConfig, cls).column_class
 
     def to_sqlmesh(self) -> ConnectionConfig:
         return RedshiftConnectionConfig(


### PR DESCRIPTION
Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1699749136590689