### PR TITLE
Fix!: remove auto expansion in render of unpushed snapshots

### DIFF
--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -132,7 +132,7 @@ def test_render(sushi_context, assert_exp_eq):
         """,
     )
 
-    # unpushed render still works
+    # unpushed render should not expand
     unpushed = Context(paths="examples/sushi")
     assert_exp_eq(
         unpushed.render(snapshot.name),
@@ -141,37 +141,10 @@ def test_render(sushi_context, assert_exp_eq):
           CAST("o"."waiter_id" AS INT) AS "waiter_id", /* Waiter id */
           CAST(SUM("oi"."quantity" * "i"."price") AS DOUBLE) AS "revenue", /* Revenue from orders taken by this waiter */
           CAST("o"."ds" AS TEXT) AS "ds" /* Date */
-        FROM (
-          SELECT
-            CAST(NULL AS INT) AS "id",
-            CAST(NULL AS INT) AS "customer_id",
-            CAST(NULL AS INT) AS "waiter_id",
-            CAST(NULL AS INT) AS "start_ts",
-            CAST(NULL AS INT) AS "end_ts",
-            CAST(NULL AS TEXT) AS "ds"
-          FROM (VALUES
-            (1)) AS "t"("dummy")
-        ) AS "o"
-        LEFT JOIN (
-          SELECT
-            CAST(NULL AS INT) AS "id",
-            CAST(NULL AS INT) AS "order_id",
-            CAST(NULL AS INT) AS "item_id",
-            CAST(NULL AS INT) AS "quantity",
-            CAST(NULL AS TEXT) AS "ds"
-          FROM (VALUES
-            (1)) AS "t"("dummy")
-        ) AS "oi"
+        FROM "sushi"."orders" AS "o"
+        LEFT JOIN "sushi"."order_items" AS "oi"
           ON "o"."ds" = "oi"."ds" AND "o"."id" = "oi"."order_id"
-        LEFT JOIN (
-          SELECT
-            CAST(NULL AS INT) AS "id",
-            CAST(NULL AS TEXT) AS "name",
-            CAST(NULL AS DOUBLE) AS "price",
-            CAST(NULL AS TEXT) AS "ds"
-          FROM (VALUES
-            (1)) AS "t"("dummy")
-        ) AS "i"
+        LEFT JOIN "sushi"."items" AS "i"
           ON "oi"."ds" = "i"."ds" AND "oi"."item_id" = "i"."id"
         WHERE
           "o"."ds" <= '1970-01-01' AND "o"."ds" >= '1970-01-01'

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1374,7 +1374,7 @@ def test_python_models_returning_sql(assert_exp_eq) -> None:
     assert isinstance(model2.query, d.MacroFunc)
     assert model2.depends_on == {"MODEL1"}
     assert_exp_eq(
-        context.render("model2"),
+        context.render("model2", expand=["model1"]),
         """
         SELECT
           "MODEL1"."X" AS "X",
@@ -1441,7 +1441,7 @@ def test_star_expansion(assert_exp_eq) -> None:
     context.upsert_model(model3)
 
     assert_exp_eq(
-        context.render("db.model2"),
+        context.render("db.model2", expand=["db.model1"]),
         """
         SELECT
           "model1"."id" AS "id",
@@ -1465,7 +1465,7 @@ def test_star_expansion(assert_exp_eq) -> None:
         """,
     )
     assert_exp_eq(
-        context.render("db.model3"),
+        context.render("db.model3", expand=["db.model1", "db.model2"]),
         """
         SELECT
           "model2"."id" AS "id",


### PR DESCRIPTION
prior to this commit, render a model would auto expand any snapshot that did not have a version (uncommitted). this way the render query would always generate a runnable sql query. however, with large projects, expansion is extremely expensive and makes the default render unusable.