### PR TITLE
Chore: test python model table properties inline

### DIFF
--- a/examples/sushi/models/items.py
+++ b/examples/sushi/models/items.py
@@ -63,12 +63,6 @@ ITEMS = [
         ("not_null", {"columns": [to_column("name"), to_column("price")]}),
         ("assert_items_price_exceeds_threshold", {"price": 0}),
     ],
-    table_properties={
-        "format": "PARQUET",
-        "bucket_count": 0,
-        "orc_bloom_filter_fpp": 0.05,
-        "auto_purge": False,
-    },
     session_properties={
         "string_prop": "some_value",
         "int_prop": 1,

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1985,12 +1985,12 @@ def test_model_table_properties() -> None:
     def my_model(context, **kwargs):
         pass
 
-    m = model.get_registry()["my_model"].model(
+    python_model = model.get_registry()["my_model"].model(
         module_path=Path("."),
         path=Path("."),
     )
 
-    assert m.table_properties == {
+    assert python_model.table_properties == {
         "format": exp.Literal.string("PARQUET"),
         "bucket_count": exp.Literal.number(0),
         "orc_bloom_filter_fpp": exp.Literal.number(0.05),

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1969,16 +1969,36 @@ def test_custom_interval_unit():
         )
 
 
-def test_model_table_properties(sushi_context):
-    # # Validate python model table properties
-    assert sushi_context.models["sushi.items"].table_properties == {
+def test_model_table_properties() -> None:
+    # Validate python model table properties
+    @model(
+        "my_model",
+        kind="full",
+        columns={"id": "int"},
+        table_properties={
+            "format": "PARQUET",
+            "bucket_count": 0,
+            "orc_bloom_filter_fpp": 0.05,
+            "auto_purge": False,
+        },
+    )
+    def my_model(context, **kwargs):
+        pass
+
+    m = model.get_registry()["my_model"].model(
+        module_path=Path("."),
+        path=Path("."),
+    )
+
+    assert m.table_properties == {
         "format": exp.Literal.string("PARQUET"),
         "bucket_count": exp.Literal.number(0),
         "orc_bloom_filter_fpp": exp.Literal.number(0.05),
         "auto_purge": exp.false(),
     }
+
     # Validate a tuple.
-    model = load_sql_based_model(
+    sql_model = load_sql_based_model(
         d.parse(
             """
         MODEL (
@@ -1994,18 +2014,18 @@ def test_model_table_properties(sushi_context):
         """
         )
     )
-    assert model.table_properties == {
+    assert sql_model.table_properties == {
         "key_a": exp.convert("value_a"),
         "key_b": exp.convert(1),
         "key_c": exp.convert(True),
         "key_d": exp.convert(2.0),
     }
-    assert model.table_properties_ == d.parse_one(
+    assert sql_model.table_properties_ == d.parse_one(
         """(key_a = 'value_a', 'key_b' = 1, key_c = TRUE, "key_d" = 2.0)"""
     )
 
     # Validate a tuple with one item.
-    model = load_sql_based_model(
+    sql_model = load_sql_based_model(
         d.parse(
             """
             MODEL (
@@ -2016,14 +2036,14 @@ def test_model_table_properties(sushi_context):
             """
         )
     )
-    assert model.table_properties == {"key_a": exp.convert("value_a")}
+    assert sql_model.table_properties == {"key_a": exp.convert("value_a")}
     assert (
-        model.table_properties_.sql()
+        sql_model.table_properties_.sql()  # type: ignore
         == exp.Tuple(expressions=[d.parse_one("key_a = 'value_a'")]).sql()
     )
 
     # Validate an array.
-    model = load_sql_based_model(
+    sql_model = load_sql_based_model(
         d.parse(
             """
         MODEL (
@@ -2037,14 +2057,14 @@ def test_model_table_properties(sushi_context):
         """
         )
     )
-    assert model.table_properties == {
+    assert sql_model.table_properties == {
         "key_a": exp.convert("value_a"),
         "key_b": exp.convert(1),
     }
-    assert model.table_properties_ == d.parse_one("""(key_a = 'value_a', 'key_b' = 1)""")
+    assert sql_model.table_properties_ == d.parse_one("""(key_a = 'value_a', 'key_b' = 1)""")
 
     # Validate empty.
-    model = load_sql_based_model(
+    sql_model = load_sql_based_model(
         d.parse(
             """
         MODEL (
@@ -2054,11 +2074,11 @@ def test_model_table_properties(sushi_context):
         """
         )
     )
-    assert model.table_properties == {}
-    assert model.table_properties_ is None
+    assert sql_model.table_properties == {}
+    assert sql_model.table_properties_ is None
 
     # Validate sql expression.
-    model = load_sql_based_model(
+    sql_model = load_sql_based_model(
         d.parse(
             """
         MODEL (
@@ -2071,11 +2091,11 @@ def test_model_table_properties(sushi_context):
         """
         )
     )
-    assert model.table_properties == {"key": d.parse_one("['value']")}
-    assert model.table_properties_ == exp.Tuple(expressions=[d.parse_one("key = ['value']")])
+    assert sql_model.table_properties == {"key": d.parse_one("['value']")}
+    assert sql_model.table_properties_ == exp.Tuple(expressions=[d.parse_one("key = ['value']")])
 
     # Validate dict parsing.
-    model = create_sql_model(
+    sql_model = create_sql_model(
         name="test_schema.test_model",
         query=d.parse_one("SELECT a FROM tbl"),
         table_properties={
@@ -2085,13 +2105,13 @@ def test_model_table_properties(sushi_context):
             "key_d": exp.Literal.number(2.0),
         },
     )
-    assert model.table_properties == {
+    assert sql_model.table_properties == {
         "key_a": exp.convert("value_a"),
         "key_b": exp.convert(1),
         "key_c": exp.convert(True),
         "key_d": exp.convert(2.0),
     }
-    assert model.table_properties_ == d.parse_one(
+    assert sql_model.table_properties_ == d.parse_one(
         """('key_a' = 'value_a', 'key_b' = 1, 'key_c' = TRUE, 'key_d' = 2.0)"""
     )
 


### PR DESCRIPTION
Some engines only allow specific table properties