### PR TITLE
Fix(postgres): view model support

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -714,7 +714,7 @@ class EngineAdapter:
         )
 
     def drop_view(
-        self, view_name: TableName, ignore_if_not_exists: bool = True, materialized: bool = False
+        self, view_name: TableName, ignore_if_not_exists: bool = True, materialized: bool = False, cascade: bool = False
     ) -> None:
         """Drop a view."""
         self.execute(
@@ -722,6 +722,7 @@ class EngineAdapter:
                 this=exp.to_table(view_name),
                 exists=ignore_if_not_exists,
                 materialized=materialized,
+                cascade=cascade,
                 kind="VIEW",
             )
         )

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -714,7 +714,11 @@ class EngineAdapter:
         )
 
     def drop_view(
-        self, view_name: TableName, ignore_if_not_exists: bool = True, materialized: bool = False, cascade: bool = False
+        self,
+        view_name: TableName,
+        ignore_if_not_exists: bool = True,
+        materialized: bool = False,
+        cascade: bool = False,
     ) -> None:
         """Drop a view."""
         self.execute(

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -86,7 +86,7 @@ class BasePostgresEngineAdapter(EngineAdapter):
         """
         with self.transaction():
             if replace:
-                self.drop_view(view_name, materialized=materialized)
+                self.drop_view(view_name, materialized=materialized, cascade=True)
             super().create_view(
                 view_name,
                 query_or_df,

--- a/tests/core/engine_adapter/test_base_postgres.py
+++ b/tests/core/engine_adapter/test_base_postgres.py
@@ -41,7 +41,7 @@ def test_create_view(make_mocked_engine_adapter: t.Callable):
     adapter.cursor.execute.assert_has_calls(
         [
             # 1st call
-            call('DROP VIEW IF EXISTS "db"."view"'),
+            call('DROP VIEW IF EXISTS "db"."view" CASCADE'),
             call('CREATE VIEW "db"."view" AS SELECT 1'),
             # 2nd call
             call('CREATE VIEW "db"."view" AS SELECT 1'),


### PR DESCRIPTION
Steps to recreate:
1. Create a project with `sqlmesh init postgres`
2. Change default gateway to postgres database
3. Delete full_model and its test
4. Change incremental_model to `kind VIEW` and set `allow_partials true`
5. Run `sqlmesh plan` twice

Error:
```
======================================================================
Successfully Ran 0 tests against postgres
----------------------------------------------------------------------
No differences when compared to `prod`
Models needing backfill (missing dates):
└── sqlmesh_example.view_model: 2023-11-15 - 2023-11-15
Apply - Backfill Tables [y/n]: y
Evaluating models ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.0% • 1/1 • 0:00:00

FAILED processing snapshot name='sqlmesh_example.view_model' fingerprint=SnapshotFingerprint(data_hash='1253059017', 
metadata_hash='2648156034', parent_data_hash='2794386484', parent_metadata_hash='2849308837') physical_schema_=None node=Model<name: 
sqlmesh_example.view_model, query: SELECT id, item_id, ds FROM sq> parents=(SnapshotId(name='sqlmesh_example.seed_model', 
identifier='628156117'),) audits=() intervals=[(1577836800000, 1700006400000)] dev_intervals=[] created_ts=1700070401988 
updated_ts=1700070403939 ttl='in 1 week' previous_versions=() indirect_versions={} version='2177036638' temp_version=None 
change_category=<SnapshotChangeCategory.BREAKING: 1> unpaused_ts=1700006400000 effective_from=None migrated=False unrestorable=False
Traceback (most recent call last):
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\utils\concurrency.py", line 67, in _process_node
    self.fn(node)
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\scheduler.py", line 273, in evaluate_node
    self.evaluate(snapshot, start, end, execution_time, deployability_index)
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\scheduler.py", line 160, in evaluate
    self.snapshot_evaluator.evaluate(
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\snapshot\evaluator.py", line 209, in evaluate
    apply(query_or_df, index)
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\snapshot\evaluator.py", line 140, in apply
    evaluation_strategy.insert(
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\snapshot\evaluator.py", line 1088, in insert
    self.adapter.create_view(
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\engine_adapter\base_postgres.py", line 89, in create_view
    self.drop_view(view_name, materialized=materialized, cascade=True)
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\engine_adapter\base.py", line 720, in drop_view
    self.execute(
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\engine_adapter\base.py", line 1353, in execute
    self.cursor.execute(sql, **kwargs)
psycopg2.errors.DependentObjectsStillExist: cannot drop view sqlmesh__sqlmesh_example.sqlmesh_example__view_model__2177036638 because other    
objects depend on it
DETAIL:  view sqlmesh_example.view_model depends on view sqlmesh__sqlmesh_example.sqlmesh_example__view_model__2177036638
HINT:  Use DROP ... CASCADE to drop the dependent objects too.


Traceback (most recent call last):
  File "C:\Users\deschman\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\deschman\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Git\transformer\.venv\Scripts\sqlmesh.exe\__main__.py", line 7, in <module>
  File "C:\Git\transformer\.venv\lib\site-packages\click\core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "C:\Git\transformer\.venv\lib\site-packages\click\core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "C:\Git\transformer\.venv\lib\site-packages\click\core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Git\transformer\.venv\lib\site-packages\click\core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Git\transformer\.venv\lib\site-packages\click\core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "C:\Git\transformer\.venv\lib\site-packages\click\decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\cli\__init__.py", line 24, in wrapper
    return handler(lambda: func(*args, **kwargs))
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\cli\__init__.py", line 43, in _debug_exception_handler
    return func()
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\cli\__init__.py", line 24, in <lambda>
    return handler(lambda: func(*args, **kwargs))
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\cli\main.py", line 309, in plan
    context.plan(
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\context.py", line 908, in plan
    self.console.plan(plan, auto_apply, no_diff=no_diff)
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\console.py", line 478, in plan
    self._show_options_after_categorization(plan, auto_apply)
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\console.py", line 573, in _show_options_after_categorization
    self._prompt_backfill(plan, auto_apply)
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\console.py", line 682, in _prompt_backfill
    plan.apply()
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\plan\definition.py", line 338, in apply
    self._apply(self)
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\context.py", line 941, in apply
    raise e
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\context.py", line 935, in apply
    self._scheduler.create_plan_evaluator(self).evaluate(plan)
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\plan\evaluator.py", line 103, in evaluate
    self._backfill(plan, before_promote_snapshots, deployability_index)
  File "C:\Git\transformer\.venv\lib\site-packages\sqlmesh\core\plan\evaluator.py", line 144, in _backfill
    raise SQLMeshError("Plan application failed.")
sqlmesh.utils.errors.SQLMeshError: Plan application failed.
```


Tested this changed in one of our postgres projects with 16 models of varying types. Let me know if I need to account for anything else here! 