### PR TITLE
Feat: allow omitting output columns in unit tests, add docs

### DIFF
--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -21,7 +21,7 @@ Test suites are defined using YAML format within `.yaml` files in the `tests/` f
 * [Optional] The dictionary of values for macro variables that will be set during model testing
     * There are three special macros that can be overridden, `start`, `end`, and `execution_time`. Overriding each will allow you to override the date macros in your SQL queries. For example, setting execution_time: 2022-01-01 -> execution_ds in your queries.
 
-If a column is omitted from a row (either input or output), it is implicitly added and its value is `NULL`. For example, this can be useful when specifying input data for wide tables where some columns may not be required to define a test.
+A column may be omitted from a row (either input or output), in which case it will be implicitly added with the value `NULL`. For example, this can be useful when specifying input data for wide tables where some columns may not be required to define a test.
 
 The YAML format is defined as follows:
 
@@ -105,7 +105,9 @@ test_full_model:
         num_orders: 1
 ```
 
-One may observe that since `ds` is not referenced in `full_model`, it can be omitted. Additionally, let's assume that we are only interested in testing the `num_orders` output column, i.e. we only care about the `id` input column of `sqlmesh_example.incremental_model`. Then, we could rewrite the above test more compactly as follows:
+Note that `ds` is redundant in the above test, since it is not referenced in `full_model`, so it may be omitted.
+
+Let's also assume that we are only interested in testing the `num_orders` output column, i.e. we only care about the `id` input column of `sqlmesh_example.incremental_model`. Then, we could rewrite the above test more compactly as follows:
 
 ```yaml linenums="1"
 test_full_model:
@@ -122,7 +124,7 @@ test_full_model:
       - num_orders: 3
 ```
 
-Leaving out the input column `item_id` means that it will be implicitly added and populated with `NULL` values. Thus, we expect the corresponding output column to also contain `NULL` values. This is reflected in the above test since the `item_id` column is also omitted from the `query` output, meaning that the output value is also `NULL` for this column.
+Leaving out the input column `item_id` means that it will be implicitly added in all input rows with a `NULL` value. Thus, we expect the corresponding output column to only contain `NULL` values, which is indeed reflected in the above test since the `item_id` column is also omitted from `query`'s rows.
 
 ### Testing CTEs
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -45,6 +45,17 @@ The YAML format is defined as follows:
     <macro_variable_name>: <macro_variable_value>
 ```
 
+Note: the `rows` key is optional in the above format, so the following would also be valid:
+
+```
+<unique_test_name>:
+  model: <target_model_name>
+  inputs:
+    <upstream_model_or_external_table_name>:
+      - <column_name>: <column_value>
+...
+```
+
 ### Example
 
 In this example, we'll use the `sqlmesh_example.full_model` model, which is provided as part of the `sqlmesh init` command and defined as follows:

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -21,7 +21,7 @@ Test suites are defined using YAML format within `.yaml` files in the `tests/` f
 * [Optional] The dictionary of values for macro variables that will be set during model testing
     * There are three special macros that can be overridden, `start`, `end`, and `execution_time`. Overriding each will allow you to override the date macros in your SQL queries. For example, setting execution_time: 2022-01-01 -> execution_ds in your queries.
 
-If a column is omitted in a test, it will be implicitly added and populated with `NULL` values. This can be useful when specifying input data for wide tables where some columns may not be required to define a test.
+If a column is omitted from a row (either input or output), it is implicitly added and its value is `NULL`. For example, this can be useful when specifying input data for wide tables where some columns may not be required to define a test.
 
 The YAML format is defined as follows:
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -14,12 +14,14 @@ Test suites are defined using YAML format within `.yaml` files in the `tests/` f
 * The name of the model targeted by this test
 * Test inputs, which are defined per external table or upstream model referenced by the target model. Each test input consists of the following:
     * The name of an upstream model or external table
-    * The list of rows defined as a mapping from a column name to a value associated with it. If an input column is excluded, it will be implicitly added and populated with `NULL` values. This can be useful when specifying input data for e.g. wide tables, where some columns may not be required to define a test.
+    * The list of rows defined as a mapping from a column name to a value associated with it
 * Expected outputs, which are defined as follows:
     * The list of rows that are expected to be returned by the model's query defined as a mapping from a column name to a value associated with it
     * [Optional] The list of expected rows per each individual [Common Table Expression](glossary.md#cte) (CTE) defined in the model's query
 * [Optional] The dictionary of values for macro variables that will be set during model testing
     * There are three special macros that can be overridden, `start`, `end`, and `execution_time`. Overriding each will allow you to override the date macros in your SQL queries. For example, setting execution_time: 2022-01-01 -> execution_ds in your queries.
+
+If a column (either input or output) is omitted in the test, it will be implicitly added and populated with `NULL` values. This can be useful when specifying input data for e.g. wide tables, where some columns may not be required to define a test.
 
 The YAML format is defined as follows:
 
@@ -117,11 +119,10 @@ test_full_model:
   outputs:
     query:
       rows:
-      - item_id: null
-        num_orders: 3
+      - num_orders: 3
 ```
 
-Leaving out the input column `item_id` means that it will be implicitly added and populated with `NULL` values. Thus, we expect the corresponding output column to also contain `NULL` values, which is indeed reflected in the above test.
+Leaving out the input column `item_id` means that it will be implicitly added and populated with `NULL` values. Thus, we expect the corresponding output column to also contain `NULL` values. This is reflected in the above test since the `item_id` column is also omitted from the `query` output, meaning that the output value is also `NULL` for this column.
 
 ### Testing CTEs
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -21,7 +21,7 @@ Test suites are defined using YAML format within `.yaml` files in the `tests/` f
 * [Optional] The dictionary of values for macro variables that will be set during model testing
     * There are three special macros that can be overridden, `start`, `end`, and `execution_time`. Overriding each will allow you to override the date macros in your SQL queries. For example, setting execution_time: 2022-01-01 -> execution_ds in your queries.
 
-If a column (either input or output) is omitted in the test, it will be implicitly added and populated with `NULL` values. This can be useful when specifying input data for e.g. wide tables, where some columns may not be required to define a test.
+If a column is omitted in a test, it will be implicitly added and populated with `NULL` values. This can be useful when specifying input data for wide tables where some columns may not be required to define a test.
 
 The YAML format is defined as follows:
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -107,9 +107,7 @@ test_full_model:
     query:
       rows:
       - item_id: null
-        num_orders: 2
-      - item_id: null
-        num_orders: 1
+        num_orders: 3
 ```
 
 Leaving out the input column `item_id` means that it will be implicitly added and populated with `NULL` values. Thus, we expect the corresponding output column to also contain `NULL` values, which is indeed reflected in the above test.

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -105,7 +105,7 @@ test_full_model:
         num_orders: 1
 ```
 
-One can observe that since `ds` is not referenced in `full_model`, it can be omitted. Additionally, let's assume that we are only interested in testing the `num_orders` output column, i.e. we only care about the `id` input column of `sqlmesh_example.incremental_model`. Then, we could rewrite the above test more compactly as follows:
+One may observe that since `ds` is not referenced in `full_model`, it can be omitted. Additionally, let's assume that we are only interested in testing the `num_orders` output column, i.e. we only care about the `id` input column of `sqlmesh_example.incremental_model`. Then, we could rewrite the above test more compactly as follows:
 
 ```yaml linenums="1"
 test_full_model:

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -289,7 +289,10 @@ def test_partial_inputs(sushi_context: Context) -> None:
                         kind FULL
                     );
 
-                    SELECT id, name FROM sushi.waiter_names;
+                    WITH source AS (
+                        SELECT id, name FROM sushi.waiter_names
+                    )
+                    SELECT id, name FROM source;
                     """,
                 ),
             ),
@@ -303,11 +306,24 @@ test_foo:
   inputs:
     sushi.waiter_names:
       - id: 1
+      - id: 2
+        name: null
+      - id: 3
+        name: 'bob'
   outputs:
+    ctes:
+      source:
+        - id: 1
+        - id: 2
+          name: null
+        - id: 3
+          name: 'bob'
     query:
       - id: 1
-        name: null
-            """
+      - id: 2
+      - id: 3
+        name: 'bob'
+        """
     )
     result = _create_test(body, "test_foo", model, sushi_context).run()
     assert result and result.wasSuccessful()


### PR DESCRIPTION
Extends the previous [implementation](https://github.com/TobikoData/sqlmesh/pull/1714) of item 1 in #1637 to also allow omitting output columns.