### PR TITLE
docs: add kestra integration link

### DIFF
--- a/docs/integrations/overview.md
+++ b/docs/integrations/overview.md
@@ -6,6 +6,7 @@ SQLMesh supports integrations with the following tools:
 * [Airflow](airflow.md)
 * [dbt](dbt.md)
 * [GitHub Actions](github.md)
+* [Kestra](https://kestra.io/plugins/plugin-sqlmesh/tasks/cli/io.kestra.plugin.sqlmesh.cli.sqlmeshcli)
 
 ## Execution engines
 SQLMesh supports the following execution engines for running SQLMesh projects:


### PR DESCRIPTION
This PR adds a link to the [Kestra integration](https://kestra.io/).