### PR TITLE
fix: don't check for dialects when they are already known

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -579,7 +579,7 @@ class ChunkType(Enum):
 
 
 def parse_one(sql: str, dialect: t.Optional[str] = None) -> exp.Expression:
-    expressions = parse(sql, default_dialect=dialect)
+    expressions = parse(sql, default_dialect=dialect, match_dialect=False)
     if not expressions:
         raise SQLMeshError(f"No expressions found in '{sql}'")
     elif len(expressions) > 1:
@@ -587,7 +587,9 @@ def parse_one(sql: str, dialect: t.Optional[str] = None) -> exp.Expression:
     return expressions[0]
 
 
-def parse(sql: str, default_dialect: t.Optional[str] = None) -> t.List[exp.Expression]:
+def parse(
+    sql: str, default_dialect: t.Optional[str] = None, match_dialect: bool = True
+) -> t.List[exp.Expression]:
     """Parse a sql string.
 
     Supports parsing model definition.
@@ -600,7 +602,7 @@ def parse(sql: str, default_dialect: t.Optional[str] = None) -> t.List[exp.Expre
     Returns:
         A list of the parsed expressions: [Model, *Statements, Query, *Statements]
     """
-    match = DIALECT_PATTERN.search(sql[:MAX_MODEL_DEFINITION_SIZE])
+    match = match_dialect and DIALECT_PATTERN.search(sql[:MAX_MODEL_DEFINITION_SIZE])
     dialect = Dialect.get_or_raise(match.group(2) if match else default_dialect)()
 
     tokens = dialect.tokenizer.tokenize(sql)

--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import typing as t
 
 from sqlglot import exp
-from sqlglot.helper import ensure_list, seq_get
+from sqlglot.helper import ensure_list
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
-from sqlmesh.core.dialect import parse, parse_one
+from sqlmesh.core.dialect import parse_one
 from sqlmesh.utils import str_to_bool
 from sqlmesh.utils.errors import ConfigError, SQLMeshError
 from sqlmesh.utils.pydantic import field_validator, field_validator_v1_args
@@ -29,16 +29,11 @@ def parse_expression(
 
     if isinstance(v, list):
         return [
-            e
-            for expressions in (
-                parse(i, default_dialect=dialect) if not isinstance(i, exp.Expression) else [i]
-                for i in v
-            )
-            for e in expressions
+            parse_one(e, dialect=dialect) if not isinstance(e, exp.Expression) else e for e in v
         ]
 
     if isinstance(v, str):
-        return seq_get(parse(v, default_dialect=dialect), 0)
+        return parse_one(v, dialect=dialect)
 
     if not v:
         raise ConfigError(f"Could not parse {v}")

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1786,7 +1786,7 @@ def _create_model(
     return t.cast(Model, model)
 
 
-INSERT_SEED_MACRO_CALL = d.parse("@INSERT_SEED()")[0]
+INSERT_SEED_MACRO_CALL = d.parse_one("@INSERT_SEED()")
 
 
 def _split_sql_model_statements(


### PR DESCRIPTION
before this change, dialect.parse always does a regex to find the model dialect override. this is expensive and not necessary when the dialect is known ahead of time like in serialization.