### PR TITLE
Feat: show only relevant columns (as DataFrames) when unit tests fail

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -364,10 +364,27 @@ def dag(ctx: click.Context, file: str) -> None:
 @opt.match_pattern
 @opt.verbose
 @click.argument("tests", nargs=-1)
+@click.option(
+    "--no-truncate",
+    is_flag=True,
+    default=False,
+    help="Show the maximum number of mismatching columns in case of failure.",
+)
 @click.pass_obj
 @error_handler
-def test(obj: Context, k: t.List[str], verbose: bool, tests: t.List[str]) -> None:
+def test(
+    obj: Context,
+    k: t.List[str],
+    verbose: bool,
+    tests: t.List[str],
+    no_truncate: bool,
+) -> None:
     """Run model unit tests."""
+    if no_truncate:
+        import pandas as pd
+
+        pd.set_option("display.max_columns", None)
+
     # Set Python unittest verbosity level
     result = obj.test(match_patterns=k, tests=tests, verbose=verbose)
     if not result.wasSuccessful():

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -364,27 +364,10 @@ def dag(ctx: click.Context, file: str) -> None:
 @opt.match_pattern
 @opt.verbose
 @click.argument("tests", nargs=-1)
-@click.option(
-    "--no-truncate",
-    is_flag=True,
-    default=False,
-    help="Show the maximum number of mismatching columns in case of failure.",
-)
 @click.pass_obj
 @error_handler
-def test(
-    obj: Context,
-    k: t.List[str],
-    verbose: bool,
-    tests: t.List[str],
-    no_truncate: bool,
-) -> None:
+def test(obj: Context, k: t.List[str], verbose: bool, tests: t.List[str]) -> None:
     """Run model unit tests."""
-    if no_truncate:
-        import pandas as pd
-
-        pd.set_option("display.max_columns", None)
-
     # Set Python unittest verbosity level
     result = obj.test(match_patterns=k, tests=tests, verbose=verbose)
     if not result.wasSuccessful():

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1047,7 +1047,11 @@ class Context(BaseContext):
         stream: t.Optional[t.TextIO] = None,
     ) -> unittest.result.TestResult:
         """Discover and run model tests"""
-        verbosity = 2 if verbose else 1
+        if verbose:
+            pd.set_option("display.max_columns", None)
+            verbosity = 2
+        else:
+            verbosity = 1
 
         try:
             if tests:

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import difflib
 import pathlib
 import typing as t
 import unittest
@@ -111,13 +110,8 @@ class ModelTest(unittest.TestCase):
                 check_datetimelike_compat=True,
             )
         except AssertionError as e:
-            diff = "\n".join(
-                difflib.ndiff(
-                    [str(x) for x in expected.to_dict("records")],
-                    [str(x) for x in actual.to_dict("records")],
-                )
-            )
-            e.args = (f"Data differs\n{diff}",)
+            diff = expected.compare(actual).rename(columns={"self": "expected", "other": "actual"})
+            e.args = (f"Data differs\n\n{diff}",)
             raise e
 
     def runTest(self) -> None:

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -97,7 +97,9 @@ class ModelTest(unittest.TestCase):
         # Two astypes are necessary, pandas converts strings to times as NS,
         # but if the actual is US, it doesn't take effect until the 2nd try!
         actual_types = actual.dtypes.to_dict()
-        expected = expected.astype(actual_types, errors="ignore").astype(actual_types, errors="ignore")
+        expected = expected.astype(actual_types, errors="ignore").astype(
+            actual_types, errors="ignore"
+        )
 
         expected = expected.replace({np.nan: None, "nan": None})
         actual = actual.replace({np.nan: None, "nan": None})

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -94,10 +94,10 @@ class ModelTest(unittest.TestCase):
         """Compare two DataFrames"""
         self._add_missing_columns(expected, actual)
 
-        # Two astypes are necessary, pandas converts strings to times as NS, but if the actual
-        # is US, it doesn't take affect until the 2nd try!
+        # Two astypes are necessary, pandas converts strings to times as NS,
+        # but if the actual is US, it doesn't take effect until the 2nd try!
         actual_types = actual.dtypes.to_dict()
-        expected = expected.astype(actual_types).astype(actual_types)
+        expected = expected.astype(actual_types, errors="ignore").astype(actual_types, errors="ignore")
 
         expected = expected.replace({np.nan: None, "nan": None})
         actual = actual.replace({np.nan: None, "nan": None})

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -112,8 +112,8 @@ class ModelTest(unittest.TestCase):
                 check_datetimelike_compat=True,
             )
         except AssertionError as e:
-            diff = expected.compare(actual).rename(columns={"self": "expected", "other": "actual"})
-            e.args = (f"Data differs\n\n{diff}",)
+            diff = expected.compare(actual).rename(columns={"self": "exp", "other": "act"})
+            e.args = (f"Data differs (exp: expected, act: actual)\n\n{diff}",)
             raise e
 
     def runTest(self) -> None:

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -329,6 +329,30 @@ test_foo:
     assert result and result.wasSuccessful()
 
 
+def test_missing_column_failure(sushi_context: Context, full_model_without_ctes: SqlModel) -> None:
+    model = t.cast(SqlModel, sushi_context.upsert_model(full_model_without_ctes))
+    body = load_yaml(
+        """
+test_foo:
+  model: sushi.foo
+  inputs:
+    raw:
+      - id: 1
+        value: 2
+        ds: 3
+  outputs:
+    query:
+      - id: 1
+        value: null
+            """
+    )
+    result = _create_test(body, "test_foo", model, sushi_context).run()
+    assert result and not result.wasSuccessful()
+
+    expected_msg = "AssertionError: Data differs\n\n     value              ds       \n  expected actual expected actual\n0     None      2     None      3\n"
+    assert expected_msg in result.failures[0][1]
+
+
 @pytest.mark.parametrize("full_model_without_ctes", ["snowflake"], indirect=True)
 def test_normalization(full_model_without_ctes: SqlModel) -> None:
     body = load_yaml(

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -349,7 +349,7 @@ test_foo:
     result = _create_test(body, "test_foo", model, sushi_context).run()
     assert result and not result.wasSuccessful()
 
-    expected_msg = "AssertionError: Data differs\n\n     value              ds       \n  expected actual expected actual\n0     None      2     None      3\n"
+    expected_msg = "AssertionError: Data differs (exp: expected, act: actual)\n\n  value        ds    \n    exp act   exp act\n0  None   2  None   3\n"
     assert expected_msg in result.failures[0][1]
 
 

--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -603,13 +603,6 @@ def test_test_failure(project_context: Context) -> None:
         {
             "name": "test_foo",
             "path": "tests/test_foo.yaml",
-            "tb": """AssertionError: Data differs
-- {'ds': 2}
-?        ^
-
-+ {'ds': 1}
-?        ^
-
-""",
+            "tb": "AssertionError: Data differs\n\n        ds       \n  expected actual\n0        2      1\n",
         }
     ]

--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -603,6 +603,6 @@ def test_test_failure(project_context: Context) -> None:
         {
             "name": "test_foo",
             "path": "tests/test_foo.yaml",
-            "tb": "AssertionError: Data differs\n\n        ds       \n  expected actual\n0        2      1\n",
+            "tb": "AssertionError: Data differs (exp: expected, act: actual)\n\n   ds    \n  exp act\n0   2   1\n",
         }
     ]


### PR DESCRIPTION
Addresses the second item in https://github.com/TobikoData/sqlmesh/issues/1637. Below I've shared some examples to demonstrate how this looks, both in the CLI and the UI.

TL;DR instead of `difflib.ndiff` the diff will now be produced with `DataFrame.compare`.

EDIT: check out https://github.com/TobikoData/sqlmesh/pull/1741#issuecomment-1821065762 for updated views of the error reporting.

<details>
<summary>A single column in a single row is incorrect (outdated)</summary>

CLI:
```
➜  tests sqlmesh test
F
======================================================================
FAIL: test_example_full_model (tests/test_full_model.yaml)
----------------------------------------------------------------------
AssertionError: Data differs

  num_orders
    expected actual
0        5.0    2.0

----------------------------------------------------------------------
Ran 1 test in 0.013s

FAILED (failures=1)
```

UI:

<img width="544" alt="Screenshot 2023-11-20 at 8 26 14 PM" src="https://github.com/TobikoData/sqlmesh/assets/46752250/ef8770a0-daaa-48ba-b7c4-bdd99d8712bf">
</details>

<details>
<summary>Two columns in a single row are incorrect (outdated)</summary>

CLI:
```
➜  tests sqlmesh test
F
======================================================================
FAIL: test_example_full_model (tests/test_full_model.yaml)
----------------------------------------------------------------------
AssertionError: Data differs

   item_id        num_orders
  expected actual   expected actual
0      5.0    1.0        5.0    2.0

----------------------------------------------------------------------
Ran 1 test in 0.013s

FAILED (failures=1)
```

UI:

<img width="538" alt="Screenshot 2023-11-20 at 8 35 05 PM" src="https://github.com/TobikoData/sqlmesh/assets/46752250/055c35b9-0efa-42a5-b618-0e6245f07f2f">
</details>

<details>
<summary>Two columns in two different rows are incorrect (outdated)</summary>

CLI:
```
➜  tests sqlmesh test
F
======================================================================
FAIL: test_example_full_model (tests/test_full_model.yaml)
----------------------------------------------------------------------
AssertionError: Data differs

   item_id        num_orders
  expected actual   expected actual
0      NaN    NaN        5.0    2.0
1      5.0    2.0        NaN    NaN

----------------------------------------------------------------------
Ran 1 test in 0.013s

FAILED (failures=1)
```

UI:

<img width="503" alt="Screenshot 2023-11-20 at 9 27 44 PM" src="https://github.com/TobikoData/sqlmesh/assets/46752250/76816e45-bf33-42c4-9762-4bee30504d74">
</details>

<details>
<summary>Five columns in a single row are incorrect (outdated)</summary>

CLI:
```
➜  sushi git:(jo/improve_test_failure_msg) ✗ sqlmesh test
F.
======================================================================
FAIL: test_order_items (sushi/tests/test_order_items.yaml)
----------------------------------------------------------------------
AssertionError: Data differs

        id        order_id         item_id        quantity                 ds
  expected actual expected actual expected actual expected actual    expected      actual
0     10.0    1.0     10.0    1.0     10.0    2.0     10.0    4.0  2022-01-06  2022-01-01

----------------------------------------------------------------------
Ran 2 tests in 0.048s

FAILED (failures=1)
```

UI:

<img width="875" alt="Screenshot 2023-11-20 at 9 31 42 PM" src="https://github.com/TobikoData/sqlmesh/assets/46752250/c6dae6e5-acb8-42d0-a9b6-621e93df5e71">
</details>

References:
- https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.compare.html
- https://pandas.pydata.org/docs/user_guide/advanced.html#renaming-names-of-an-index-or-multiindex