### PR TITLE
Feat: allow passing config to context with expected type

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -248,13 +248,16 @@ class Context(BaseContext):
 
         self.sqlmesh_path = Path.home() / ".sqlmesh"
 
-        self.configs = self._load_configs(
-            config or "config",
-            [
-                Path(path).absolute()
-                for path in ([paths] if isinstance(paths, str) else list(paths))
-            ],
-        )
+        if isinstance(config, dict):
+            self.configs = config
+        else:
+            self.configs = self._load_configs(
+                config or "config",
+                [
+                    Path(path).absolute()
+                    for path in ([paths] if isinstance(paths, str) else list(paths))
+                ],
+            )
 
         self.dag: DAG[str] = DAG()
         self._models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -236,7 +236,7 @@ class Context(BaseContext):
         notification_targets: t.Optional[t.List[NotificationTarget]] = None,
         state_sync: t.Optional[StateSync] = None,
         paths: t.Union[str, t.Iterable[str]] = "",
-        config: t.Optional[t.Union[Config, str]] = None,
+        config: t.Optional[t.Union[Config, str, t.Dict[Path, Config]]] = None,
         gateway: t.Optional[str] = None,
         concurrent_tasks: t.Optional[int] = None,
         loader: t.Optional[t.Type[Loader]] = None,


### PR DESCRIPTION
Just a small change so that configs can be passed already in a dictionary so you do not have to go through the `_load_configs` plumbing and/or be constrained to pass in a `Config` object which is then [applied to all paths](https://github.com/z3z1ma/sqlmesh/blob/4f29e0f94c71a975f846476e38304b651b175a32/sqlmesh/core/context.py#L1436-L1437). Per path config should be doable without hacking at context if it is externally suppliable. 