### PR TITLE
Chore: Unpin pandas

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "hyperscript",
         "ipywidgets",
         "jinja2",
-        "pandas<2.1.0",
+        "pandas",
         "pydantic[email]>=1.10.7,<2.0.0",
         "requests",
         "rich[jupyter]",


### PR DESCRIPTION
Previously, DuckDB 0.8.1 and pandas 2.1.0 weren't compatible.