### PR TITLE
fix: cicd chunk up comments and check runs

### DIFF
--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -345,6 +345,20 @@ update_sqlmesh_comment_info_params = [
         "**SQLMesh Bot Info**\ntest2",
         None,
     ),
+    (
+        "Ensure comments are truncated if they are too long",
+        [
+            MockIssueComment(body="**SQLMesh Bot Info**\ntest1"),
+        ],
+        # Making sure that although we will be under the character limit of `65535` we will still truncate
+        # because the byte size of this character is 3 and therefore we will be over the limit since it is based
+        # on bytes on not characters (despite what the error message may say)
+        "桜" * 65000,
+        None,
+        # ((Max Byte Length) - (Length of "**SQLMesh Bot Info**\ntest1\n")) / (Length of "桜")
+        "**SQLMesh Bot Info**\ntest1\n" + ("桜" * int((65535 - 27) / 3)),
+        None,
+    ),
 ]
 
 


### PR DESCRIPTION
Previously just check run updated were chunked up but now this will chunk up comments too. Note that like before this chunking does not respect markdown formatting so the final output can be messy. Ideally each caller has a way to compact output if needed that still provides a full formatted result but this at least ensures we don't error and captures as much as we can. 