### PR TITLE
Fix: Trino Remove Password from Connection Kwargs

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -986,7 +986,6 @@ class TrinoConnectionConfig(ConnectionConfig):
             "host",
             "port",
             "catalog",
-            "password",
             "roles",
             "http_scheme",
             "http_headers",


### PR DESCRIPTION
I double checked and the rest of the ones listed are valid so the bug was just password. 

Resolves: https://github.com/TobikoData/sqlmesh/issues/1753