### PR TITLE
Feat: automate unit test generation

### DIFF
--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -183,7 +183,7 @@ test_example_full_model:
         num_orders: 2
 ```
 
-## Automatically generate tests
+## Automatic test generation
 
 Creating tests manually is a cumbersome process, especially as the number of rows and columns of the involved models grows. To address this, SQLMesh provides the [`create_test`](../reference/cli.md#create_test) command, which can be used to automatically create tests for a given a model.
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -185,7 +185,7 @@ test_example_full_model:
 
 ## Automatic test generation
 
-Creating tests manually is a cumbersome and, ironically, error-prone process, especially as the number of rows and columns of the involved models grows. To address this, SQLMesh provides the [`create_test` command](../reference/cli.md#create_test), which can be used to automatically create tests for a given a model.
+Creating tests manually is a cumbersome and, ironically, error-prone process, especially as the number of rows and columns of the involved models grows. To address this, SQLMesh provides the [`create_test` command](../reference/cli.md#create_test), which can be used to automatically create tests for a given model.
 
 ### Example
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -185,7 +185,7 @@ test_example_full_model:
 
 ## Automatic test generation
 
-Creating tests manually is a cumbersome process, especially as the number of rows and columns of the involved models grows. To address this, SQLMesh provides the [`create_test`](../reference/cli.md#create_test) command, which can be used to automatically create tests for a given a model.
+Creating tests manually is a cumbersome process, especially as the number of rows and columns of the involved models grows. To address this, SQLMesh provides the [`create_test` command](../reference/cli.md#create_test), which can be used to automatically create tests for a given a model.
 
 ### Example
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -228,7 +228,7 @@ However, notice that `sqlmesh_example.incremental_model` also contains a filter 
 SELECT * FROM sqlmesh_example.seed_model WHERE ds BETWEEN '2020-01-01' AND '2020-01-04' LIMIT 3
 ```
 
-We also need to define these variables in the test, so that the filter of `sqlmesh_example.incremental_model` will match that range after it's been rendered.
+We will also define these variables in the test, so that the filter of `sqlmesh_example.incremental_model` matches that range after it's been rendered.
 
 Finally, we don't have to specify the output `query` attribute, since we can compute its values given the input data produced by the above query.
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -185,7 +185,7 @@ test_example_full_model:
 
 ## Automatically generate tests
 
-Creating tests manually is a cumbersome process, especially as the number of rows and columns of the involved models grows. For this reason, SQLMesh provides the [`create_test`](../reference/cli.md#create_test) command, which can be used to automatically create tests for a given a model.
+Creating tests manually is a cumbersome process, especially as the number of rows and columns of the involved models grows. To address this, SQLMesh provides the [`create_test`](../reference/cli.md#create_test) command, which can be used to automatically create tests for a given a model.
 
 ### Example
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -189,7 +189,7 @@ Creating tests manually is a cumbersome process, especially as the number of row
 
 ### Example
 
-Since we already have a test for `sqlmesh_example.full_model`, in this example we'll show how to create a test for `sqlmesh_example.incremental_model`, which is provided as part of the `sqlmesh init` command and defined as follows:
+Since we already have a test for `sqlmesh_example.full_model`, in this example we'll show how to generate a test for `sqlmesh_example.incremental_model`, which is provided as part of the `sqlmesh init` command and defined as follows:
 
 ```sql linenums="1"
 MODEL (
@@ -213,7 +213,7 @@ WHERE
 
 ```
 
-As one may expect, we need to start by specifying what the input data are for `sqlmesh_example.seed_model`. The `create_test` command achieves this by executing a user-supplied query against the default target warehouse of the SQLMesh project and treating its result as the input rows for the aforementioned model.
+As one may expect, we need to start by specifying what the input data are for `sqlmesh_example.seed_model`. The `create_test` command achieves this by executing a user-supplied query against the default target warehouse of the SQLMesh project and treating its result as the input rows of the aforementioned model.
 
 Let's assume that we're only interested in specifying three input rows for `sqlmesh_example.seed_model`. One way to do that is by executing the following query:
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -281,7 +281,7 @@ Ran 2 tests in 0.024s
 OK
 ```
 
-Note: since the `sqlmesh create_test` command executes queries directly in the target warehouse, the tables of the involved models must exist in it, otherwise the queries will fail.
+Note: since the `sqlmesh create_test` command executes queries directly in the target warehouse, the tables of the involved models must be built first, otherwise the queries will fail.
 
 ## Running tests
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -183,6 +183,106 @@ test_example_full_model:
         num_orders: 2
 ```
 
+## Automatically generate tests
+
+Creating tests manually is a cumbersome process, especially as the number of rows and columns of the involved models grows. For this reason, SQLMesh provides the [`create_test`](../reference/cli.md#create_test) command, which can be used to automatically create tests for a given a model.
+
+### Example
+
+Since we already have a test for `sqlmesh_example.full_model`, in this example we'll show how to create a test for `sqlmesh_example.incremental_model`, which is provided as part of the `sqlmesh init` command and defined as follows:
+
+```sql linenums="1"
+MODEL (
+    name sqlmesh_example.incremental_model,
+    kind INCREMENTAL_BY_TIME_RANGE (
+        time_column ds
+    ),
+    start '2020-01-01',
+    cron '@daily',
+    grain [id, ds]
+);
+
+SELECT
+    id,
+    item_id,
+    ds,
+FROM
+    sqlmesh_example.seed_model
+WHERE
+    ds between @start_ds and @end_ds
+
+```
+
+As one may expect, we need to start by specifying what the input data are for `sqlmesh_example.seed_model`. The `create_test` command achieves this by executing a user-supplied query against the default target warehouse of the SQLMesh project and treating its result as the input rows for the aforementioned model.
+
+Let's assume that we're only interested in specifying three input rows for `sqlmesh_example.seed_model`. One way to do that is by executing the following query:
+
+```sql linenums="1"
+SELECT * FROM sqlmesh_example.seed_model LIMIT 3
+```
+
+However, notice that `sqlmesh_example.incremental_model` also contains a filter which references the `@start_ds` and `@end_ds` [macro variables](macros/macro_variables.md). To ensure that the produced test will always pass, we modify the above query to constrain the value range of the `ds` column:
+
+```sql linenums="1"
+-- The dates '2020-01-01' and '2020-01-04' have been picked arbitrarily
+SELECT * FROM sqlmesh_example.seed_model WHERE ds BETWEEN '2020-01-01' AND '2020-01-04' LIMIT 3
+```
+
+We also need to define these variables in the test, so that the filter of `sqlmesh_example.incremental_model` will match that range after it's been rendered.
+
+Finally, we don't have to specify the output `query` attribute, since we can compute its values given the input data produced by the above query.
+
+The following command captures all of the above:
+
+```bash
+$ sqlmesh create_test sqlmesh_example.incremental_model --query sqlmesh_example.seed_model "select * from sqlmesh_example.seed_model where ds between '2020-01-01' and '2020-01-04' limit 3" --var start '2020-01-01' --var end '2020-01-04'
+```
+
+Running this command produces the following new test, which is located at `tests/test_incremental_model.yaml`:
+
+```yaml linenums="1" hl_lines="16-22"
+test_incremental_model:
+  model: sqlmesh_example.incremental_model
+  inputs:
+    sqlmesh_example.seed_model:
+    - id: 1
+      item_id: 2
+      ds: '2020-01-01'
+    - id: 2
+      item_id: 1
+      ds: '2020-01-01'
+    - id: 3
+      item_id: 3
+      ds: '2020-01-03'
+  outputs:
+    query:
+    - id: 1
+      item_id: 2
+      ds: '2020-01-01'
+    - id: 2
+      item_id: 1
+      ds: '2020-01-01'
+    - id: 3
+      item_id: 3
+      ds: '2020-01-03'
+  vars:
+    start: '2020-01-01'
+    end: '2020-01-04'
+```
+
+As shown below, we now have two passing tests:
+
+```bash
+$ sqlmesh test
+.
+----------------------------------------------------------------------
+Ran 2 tests in 0.024s
+
+OK
+```
+
+Note: since the `sqlmesh create_test` command executes queries directly in the target warehouse, the tables of the involved models must exist in it, otherwise the queries will fail.
+
 ## Running tests
 
 ### Automatic testing with plan

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -213,7 +213,7 @@ WHERE
 
 ```
 
-As one may expect, we need to start by specifying what the input data are for `sqlmesh_example.seed_model`. The `create_test` command achieves this by executing a user-supplied query against the default target warehouse of the SQLMesh project and treating its result as the input rows of the aforementioned model.
+As one may expect, we need to start by specifying what the input data are for `sqlmesh_example.seed_model`. The `create_test` command achieves this by executing a user-supplied query against the target warehouse of the SQLMesh project to produce the input rows of the aforementioned model.
 
 Let's assume that we're only interested in specifying three input rows for `sqlmesh_example.seed_model`. One way to do that is by executing the following query:
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -185,7 +185,7 @@ test_example_full_model:
 
 ## Automatic test generation
 
-Creating tests manually is a cumbersome process, especially as the number of rows and columns of the involved models grows. To address this, SQLMesh provides the [`create_test` command](../reference/cli.md#create_test), which can be used to automatically create tests for a given a model.
+Creating tests manually is a cumbersome and, ironically, error-prone process, especially as the number of rows and columns of the involved models grows. To address this, SQLMesh provides the [`create_test` command](../reference/cli.md#create_test), which can be used to automatically create tests for a given a model.
 
 ### Example
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -58,6 +58,28 @@ Usage: sqlmesh create_external_models [OPTIONS]
   Create a schema file containing external model schemas.
 ```
 
+## create_test
+```
+Usage: sqlmesh create_test [OPTIONS] MODEL
+
+  Generate a unit test fixture for a given model.
+
+Options:
+  -q, --query <TEXT TEXT>...  Queries that will be used to generate data for
+                              the model's dependencies.  [required]
+  -o, --overwrite             When true, the fixture file will be overwritten
+                              in case it already exists.
+  -v, --var <TEXT TEXT>...    Key-value pairs that will define variables
+                              needed by the model.
+  -p, --path TEXT             The file path corresponding to the fixture,
+                              relative to the test directory. By default, the
+                              fixture will be created under the test directory
+                              and the file name will be inferred based on the
+                              test's name.
+  -n, --name TEXT             The name of the test that will be created.
+  --help                      Show this message and exit.
+```
+
 ## dag
 ```
 Usage: sqlmesh dag [OPTIONS]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -76,7 +76,9 @@ Options:
                               fixture will be created under the test directory
                               and the file name will be inferred based on the
                               test's name.
-  -n, --name TEXT             The name of the test that will be created.
+  -n, --name TEXT             The name of the test that will be created. By
+                              default, it's inferred based on the model's
+                              name.
   --help                      Show this message and exit.
 ```
 

--- a/sqlmesh/cli/example_project.py
+++ b/sqlmesh/cli/example_project.py
@@ -133,16 +133,16 @@ EXAMPLE_TEST = f"""test_example_full_model:
   model: {EXAMPLE_FULL_MODEL_NAME}
   inputs:
     {EXAMPLE_INCREMENTAL_MODEL_NAME}:
-        rows:
-        - id: 1
-          item_id: 1
-          ds: '2020-01-01'
-        - id: 2
-          item_id: 1
-          ds: '2020-01-02'
-        - id: 3
-          item_id: 2
-          ds: '2020-01-03'
+      rows:
+      - id: 1
+        item_id: 1
+        ds: '2020-01-01'
+      - id: 2
+        item_id: 1
+        ds: '2020-01-02'
+      - id: 3
+        item_id: 2
+        ds: '2020-01-03'
   outputs:
     query:
       rows:

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -405,7 +405,7 @@ def create_test(
     name: t.Optional[str] = None,
     path: t.Optional[str] = None,
 ) -> None:
-    """Automatically create a new unit test for a given model."""
+    """Generate a unit test fixture for a given model."""
     obj.create_test(model, input_queries=dict(queries), overwrite=overwrite, name=name, path=path)
 
 

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -363,18 +363,50 @@ def dag(ctx: click.Context, file: str) -> None:
 @cli.command("create_test")
 @click.argument("model")
 @click.option(
-    "--query",
     "-q",
+    "--query",
     "queries",
     type=(str, str),
     multiple=True,
+    required=True,
     help="Queries that will be used to generate data for the model's dependencies.",
+)
+@click.option(
+    "-o",
+    "--overwrite",
+    "overwrite",
+    is_flag=True,
+    default=False,
+    help="When true, the fixture file will be overwritten in case it already exists.",
+)
+@click.option(
+    "-p",
+    "--path",
+    "path",
+    help=(
+        "The file path corresponding to the fixture, relative to the test directory. "
+        "By default, the fixture will be created under the test directory and the file "
+        "name will be inferred based on the test's name."
+    ),
+)
+@click.option(
+    "-n",
+    "--name",
+    "name",
+    help="The name of the test that will be created.",
 )
 @click.pass_obj
 @error_handler
-def create_test(obj: Context, model: str, queries: t.List[t.Tuple[str, str]]) -> None:
+def create_test(
+    obj: Context,
+    model: str,
+    queries: t.List[t.Tuple[str, str]],
+    overwrite: bool = False,
+    name: t.Optional[str] = None,
+    path: t.Optional[str] = None,
+) -> None:
     """Automatically create a new unit test for a given model."""
-    obj.create_test(model, input_queries=dict(queries))
+    obj.create_test(model, input_queries=dict(queries), overwrite=overwrite, name=name, path=path)
 
 
 @cli.command("test")

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -380,6 +380,14 @@ def dag(ctx: click.Context, file: str) -> None:
     help="When true, the fixture file will be overwritten in case it already exists.",
 )
 @click.option(
+    "-v",
+    "--var",
+    "variables",
+    type=(str, str),
+    multiple=True,
+    help="Key-value pairs that will define variables needed by the model.",
+)
+@click.option(
     "-p",
     "--path",
     "path",
@@ -402,11 +410,19 @@ def create_test(
     model: str,
     queries: t.List[t.Tuple[str, str]],
     overwrite: bool = False,
+    variables: t.Optional[t.List[t.Tuple[str, str]]] = None,
     name: t.Optional[str] = None,
     path: t.Optional[str] = None,
 ) -> None:
     """Generate a unit test fixture for a given model."""
-    obj.create_test(model, input_queries=dict(queries), overwrite=overwrite, name=name, path=path)
+    obj.create_test(
+        model,
+        input_queries=dict(queries),
+        overwrite=overwrite,
+        variables=variables and dict(variables),
+        name=name,
+        path=path,
+    )
 
 
 @cli.command("test")

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -360,6 +360,23 @@ def dag(ctx: click.Context, file: str) -> None:
         ctx.obj.console.log_success(f"Generated the dag to {rendered_dag_path}")
 
 
+@cli.command("create_test")
+@click.argument("model")
+@click.option(
+    "--query",
+    "-q",
+    "queries",
+    type=(str, str),
+    multiple=True,
+    help="Queries that will be used to generate data for the model's dependencies.",
+)
+@click.pass_obj
+@error_handler
+def create_test(obj: Context, model: str, queries: t.List[t.Tuple[str, str]]) -> None:
+    """Automatically create a new unit test for a given model."""
+    obj.create_test(model, input_queries=dict(queries))
+
+
 @cli.command("test")
 @opt.match_pattern
 @opt.verbose

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -419,7 +419,7 @@ def create_test(
         model,
         input_queries=dict(queries),
         overwrite=overwrite,
-        variables=variables and dict(variables),
+        variables=dict(variables) if variables else None,
         name=name,
         path=path,
     )

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -401,7 +401,7 @@ def dag(ctx: click.Context, file: str) -> None:
     "-n",
     "--name",
     "name",
-    help="The name of the test that will be created.",
+    help="The name of the test that will be created. By default, it's inferred based on the model's name.",
 )
 @click.pass_obj
 @error_handler

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -94,7 +94,7 @@ from sqlmesh.core.state_sync import (
     cleanup_expired_views,
 )
 from sqlmesh.core.table_diff import TableDiff
-from sqlmesh.core.test import get_all_model_tests, run_model_tests, run_tests
+from sqlmesh.core.test import ModelTest, get_all_model_tests, run_model_tests, run_tests
 from sqlmesh.core.user import User
 from sqlmesh.utils import UniqueKeyDict, env_vars, sys_path
 from sqlmesh.utils.dag import DAG
@@ -1041,6 +1041,22 @@ class Context(BaseContext):
             raise MissingDependencyError(
                 "Graphviz is pip-installed but the system install is missing. Instructions: https://graphviz.org/download/"
             ) from e
+
+    def create_test(self, model: str, input_queries: t.Dict[str, str]) -> None:
+        """Automatically create a new unit test for a given model.
+
+        Args:
+            model: The model to test.
+            input_queries: Mapping of model names to queries. Each model included in this mapping
+                will be populated in the test based on the results of the corresponding query.
+        """
+        # TODO: this should be prohibited if the DB hasn't been populated with model data yet
+        ModelTest.generate_test(
+            model=self.get_model(model, raise_if_missing=True),
+            input_queries=input_queries,
+            models=self._models,
+            engine_adapter=self._engine_adapter,
+        )
 
     def test(
         self,

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1068,9 +1068,6 @@ class Context(BaseContext):
                 will be inferred from the test's name.
             name: The name of the test. This is inferred from the model name by default.
         """
-        # TODO: this command shouldn't be allowed if the models haven't been created, otherwise the
-        # queries will crash when they are executed to fetch the data needed to populate the fixture
-
         input_queries = {
             # The get_model here has two purposes: return normalized names & check for missing deps
             self.get_model(dep, raise_if_missing=True).name: query

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1052,6 +1052,7 @@ class Context(BaseContext):
         model: str,
         input_queries: t.Dict[str, str],
         overwrite: bool = False,
+        variables: t.Optional[t.Dict[str, str]] = None,
         path: t.Optional[str] = None,
         name: t.Optional[str] = None,
     ) -> None:
@@ -1063,6 +1064,7 @@ class Context(BaseContext):
                 will be populated in the test based on the results of the corresponding query.
             overwrite: Whether to overwrite the existing test in case of a file path collision.
                 When set to False, an error will be raised if there is such a collision.
+            variables: Key-value pairs that will define variables needed by the model.
             path: The file path corresponding to the fixture, relative to the test directory.
                 By default, the fixture will be created under the test directory and the file name
                 will be inferred from the test's name.
@@ -1079,7 +1081,9 @@ class Context(BaseContext):
             input_queries=input_queries,
             models=self._models,
             engine_adapter=self._engine_adapter,
+            project_path=self.path,
             overwrite=overwrite,
+            variables=variables,
             path=path,
             name=name,
         )

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1055,7 +1055,7 @@ class Context(BaseContext):
         path: t.Optional[str] = None,
         name: t.Optional[str] = None,
     ) -> None:
-        """Automatically create a new unit test for a given model.
+        """Generate a unit test fixture for a given model.
 
         Args:
             model: The model to test.

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -94,7 +94,12 @@ from sqlmesh.core.state_sync import (
     cleanup_expired_views,
 )
 from sqlmesh.core.table_diff import TableDiff
-from sqlmesh.core.test import ModelTest, get_all_model_tests, run_model_tests, run_tests
+from sqlmesh.core.test import (
+    generate_test,
+    get_all_model_tests,
+    run_model_tests,
+    run_tests,
+)
 from sqlmesh.core.user import User
 from sqlmesh.utils import UniqueKeyDict, env_vars, sys_path
 from sqlmesh.utils.dag import DAG
@@ -1051,7 +1056,7 @@ class Context(BaseContext):
                 will be populated in the test based on the results of the corresponding query.
         """
         # TODO: this should be prohibited if the DB hasn't been populated with model data yet
-        ModelTest.generate_test(
+        generate_test(
             model=self.get_model(model, raise_if_missing=True),
             input_queries=input_queries,
             models=self._models,

--- a/sqlmesh/core/test/__init__.py
+++ b/sqlmesh/core/test/__init__.py
@@ -6,7 +6,7 @@ import unittest
 
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.model import Model
-from sqlmesh.core.test.definition import ModelTest
+from sqlmesh.core.test.definition import ModelTest, generate_test
 from sqlmesh.core.test.discovery import (
     ModelTestMetadata,
     filter_tests_by_patterns,

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -125,12 +125,6 @@ class ModelTest(unittest.TestCase):
         """Compute a version of this test's path relative to the `other` path"""
         return self.path.relative_to(other) if self.path else None
 
-    def _add_missing_columns(self, df: pd.DataFrame, columns: t.Iterable) -> None:
-        """Add missing columns to a given dataframe with None values."""
-        for index, column in enumerate(columns):
-            if column not in df:
-                df.insert(index, column, None)  # type: ignore
-
     @staticmethod
     def create_test(
         body: t.Dict[str, t.Any],
@@ -170,6 +164,12 @@ class ModelTest(unittest.TestCase):
 
     def __str__(self) -> str:
         return f"{self.test_name} ({self.path})"
+
+    def _add_missing_columns(self, df: pd.DataFrame, columns: t.Iterable) -> None:
+        """Add missing columns to a given dataframe with None values."""
+        for index, column in enumerate(columns):
+            if column not in df:
+                df.insert(index, column, None)  # type: ignore
 
     def _normalize_test(self, dialect: str | None) -> None:
         """Normalizes all identifiers in this test according to the given dialect."""

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -361,7 +361,9 @@ def generate_test(
     if isinstance(model, SqlModel):
         mapping = {name: _test_fixture_name(name) for name in models.keys() | inputs.keys()}
         model_query = model.render_query_or_raise(
-            **variables, engine_adapter=engine_adapter, table_mapping=mapping
+            **t.cast(t.Dict[str, t.Any], variables),
+            engine_adapter=engine_adapter,
+            table_mapping=mapping,
         )
         output = t.cast(SqlModelTest, test)._execute(model_query)
     else:

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -307,7 +307,7 @@ def generate_test(
     path: t.Optional[str] = None,
     name: t.Optional[str] = None,
 ) -> None:
-    """Automatically create a new unit test for a given model.
+    """Generate a unit test fixture for a given model.
 
     Args:
         model: The model to test.

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import typing as t
 import unittest
 from pathlib import Path

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -345,7 +345,10 @@ def generate_test(
     }
     outputs: t.Dict[str, t.Any] = {"query": {}}
     variables = variables or {}
-    test_body = {"model": model.name, "inputs": inputs, "outputs": outputs, "vars": variables}
+    test_body = {"model": model.name, "inputs": inputs, "outputs": outputs}
+
+    if variables:
+        test_body["vars"] = variables
 
     test = ModelTest.create_test(
         body=test_body,

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -284,7 +284,7 @@ class PythonModelTest(ModelTest):
         )
 
     def _execute_model(self) -> pd.DataFrame:
-        """Evaluates the python model and returns a DataFrame."""
+        """Executes the python model and returns a DataFrame."""
         return t.cast(
             pd.DataFrame,
             next(self.model.render(context=self.context, **self.body.get("vars", {}))),

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 import unittest
 from pathlib import Path

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 import datetime
 import typing as t
+from pathlib import Path
 
 import pytest
 
+from sqlmesh.cli.example_project import init_example_project
 from sqlmesh.core import constants as c
 from sqlmesh.core.config import Config, DuckDBConnectionConfig, ModelDefaultsConfig
 from sqlmesh.core.context import Context
 from sqlmesh.core.dialect import parse
 from sqlmesh.core.model import SqlModel, load_sql_based_model
-from sqlmesh.core.test import load_model_test_file
 from sqlmesh.core.test.definition import SqlModelTest
-from sqlmesh.cli.example_project import init_example_project
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.yaml import load as load_yaml
 
@@ -405,7 +405,7 @@ def test_test_generation(tmp_path: Path) -> None:
         model_defaults=ModelDefaultsConfig(dialect="duckdb"),
     )
 
-    context = Context(paths=[tmp_path], config=config)
+    context = Context(paths=[str(tmp_path)], config=config)
     context.plan(auto_apply=True)
 
     input_queries = {
@@ -438,7 +438,7 @@ def test_test_generation(tmp_path: Path) -> None:
     assert len(test) == 1
     assert "test_full_model" in test
     assert "vars" in test["test_full_model"]
-    assert test["test_full_model"]["vars"] == {'start': '2020-01-01', 'end': '2024-01-01'}
+    assert test["test_full_model"]["vars"] == {"start": "2020-01-01", "end": "2024-01-01"}
 
     result = context.test()
     assert result and result.wasSuccessful()


### PR DESCRIPTION
This PR introduces a way to automate the generation of unit tests for a given model, by specifying how its dependencies should be populated with data. This is achieved through user-supplied queries which are executed against the default warehouse, but the interface can certainly be improved over time.

Currently, the CLI command looks like this:

```
$ sqlmesh create_test model_to_test -q dep1 'SELECT ...' -q dep2 'SELECT ...' ...
```

To be addressed in a future PR:
- Update other interfaces to add support for this command (Notebooks, UI)
- Add an "append" mode which updates an existing test, see https://github.com/TobikoData/sqlmesh/pull/1756#discussion_r1406937195

Notes:
- Updated some type hints for consistency, e.g. `dict[...]` to `t.Dict[...]`
- Updated the example project's `inputs` indentation for consistency
- Fixed a bug in `test/definition.py`:

```diff
    def tearDown(self) -> None:
-        """Drop all input tables"""
+        """Drop all fixture tables."""
        for table in self.body.get("inputs", {}):
-            self.engine_adapter.drop_view(table)
+            self.engine_adapter.drop_view(_test_fixture_name(table))
```

In the context of this PR, this was important because we would previously try to drop the actual model views instead of the fixtures.

Implements the third feature in https://github.com/TobikoData/sqlmesh/issues/1637.