### PR TITLE
Fix: handle empty list in select_from_values_for_batch_range

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -759,7 +759,7 @@ def select_from_values_for_batch_range(
     if not values:
         # Ensures we don't generate an empty VALUES clause & forces a zero-row output
         where = exp.false()
-        expressions = [tuple(exp.cast(exp.null(), to=kind) for _, kind in columns_to_types.items())]
+        expressions = [tuple(exp.cast(exp.null(), to=kind) for kind in columns_to_types.values())]
     else:
         where = None
         expressions = [

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -759,7 +759,7 @@ def select_from_values_for_batch_range(
     if not values:
         # Ensures we don't generate an empty VALUES clause & forces a zero-row output
         where = exp.false()
-        expressions =  [(exp.null(),) * len(columns_to_types)]
+        expressions = [(exp.null(),) * len(columns_to_types)]
     else:
         where = None
         expressions = [

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -759,7 +759,7 @@ def select_from_values_for_batch_range(
     if not values:
         # Ensures we don't generate an empty VALUES clause & forces a zero-row output
         where = exp.false()
-        expressions = [(exp.null(),) * len(columns_to_types)]
+        expressions = [tuple(exp.cast(exp.null(), to=kind) for _, kind in columns_to_types.items())]
     else:
         where = None
         expressions = [

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -114,7 +114,7 @@ class ModelTest(unittest.TestCase):
                 check_datetimelike_compat=True,
             )
         except AssertionError as e:
-            if expected.empty and actual.empty and expected.columns == actual.columns:
+            if expected.empty and actual.empty and all(expected.columns == actual.columns):
                 # Only the index differs, so we treat the two DataFrames as equivalent in this case
                 return
 

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -72,7 +72,7 @@ class ModelTest(unittest.TestCase):
             if table_name in self.models:
                 columns_to_types = self.models[table_name].columns_to_types or {}
 
-            if not columns_to_types:
+            if not columns_to_types and rows:
                 for i, v in rows[0].items():
                     # convert ruamel into python
                     v = v.real if hasattr(v, "real") else v
@@ -114,6 +114,10 @@ class ModelTest(unittest.TestCase):
                 check_datetimelike_compat=True,
             )
         except AssertionError as e:
+            if expected.empty and actual.empty and expected.columns == actual.columns:
+                # Only the index differs, so we treat the two DataFrames as equivalent in this case
+                return
+
             diff = expected.compare(actual).rename(columns={"self": "exp", "other": "act"})
             e.args = (f"Data differs (exp: expected, act: actual)\n\n{diff}",)
             raise e
@@ -175,7 +179,7 @@ class ModelTest(unittest.TestCase):
         """Normalizes all identifiers in this test according to the given dialect."""
 
         def _normalize_rows(rows: t.List[Row] | t.Dict[str, t.List[Row]]) -> t.List[Row]:
-            if isinstance(rows, dict):
+            if isinstance(rows, dict) and rows:
                 if "rows" not in rows:
                     _raise_error("Incomplete test, missing row data for table", self.path)
                 rows = rows["rows"]
@@ -183,7 +187,7 @@ class ModelTest(unittest.TestCase):
             return [
                 {
                     normalize_identifiers(column, dialect=dialect).name: value
-                    for column, value in row.items()
+                    for column, value in t.cast(Row, row).items()
                 }
                 for row in rows
             ]

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -239,5 +239,5 @@ def test_select_from_values_for_batch_range_json():
 
     assert select_from_values_for_batch_range([], columns_to_types, 0, 0).sql() == (
         "SELECT CAST(id AS INT) AS id, CAST(ds AS TEXT) AS ds, CAST(json_col AS JSON) AS json_col "
-        "FROM (VALUES (NULL, NULL, NULL)) AS t(id, ds, json_col) WHERE FALSE"
+        "FROM (VALUES (CAST(NULL AS INT), CAST(NULL AS TEXT), CAST(NULL AS JSON))) AS t(id, ds, json_col) WHERE FALSE"
     )

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -222,7 +222,7 @@ def test_seed():
     assert "../../../data/data.csv" in expressions[0].sql()
 
 
-def select_from_values_for_batch_range_json():
+def test_select_from_values_for_batch_range_json():
     values = [(1, "2022-01-01", '{"foo":"bar"}'), (2, "2022-01-01", '{"foo":"qaz"}')]
     columns_to_types = {
         "id": exp.DataType.build("int"),
@@ -238,5 +238,6 @@ def select_from_values_for_batch_range_json():
     )
 
     assert select_from_values_for_batch_range([], columns_to_types, 0, 0).sql() == (
-        "SELECT 1 AS id, 1 AS ds, 1 AS json_col WHERE FALSE"
+        "SELECT CAST(id AS INT) AS id, CAST(ds AS TEXT) AS ds, CAST(json_col AS JSON) AS json_col "
+        "FROM (VALUES (NULL, NULL, NULL)) AS t(id, ds, json_col) WHERE FALSE"
     )

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -229,9 +229,14 @@ def select_from_values_for_batch_range_json():
         "ds": exp.DataType.build("text"),
         "json_col": exp.DataType.build("json"),
     }
+
     assert select_from_values_for_batch_range(values, columns_to_types, 0, len(values)).sql() == (
         """SELECT CAST(id AS INT) AS id, CAST(ds AS TEXT) AS ds, CAST(json_col AS JSON) AS json_col """
         """FROM """
         """(VALUES (1, '2022-01-01', PARSE_JSON('{"foo":"bar"}')), (2, '2022-01-01', PARSE_JSON('{"foo":"qaz"}'))) """
         """AS t(id, ds, json_col)"""
+    )
+
+    assert select_from_values_for_batch_range([], columns_to_types, 0, 0).sql() == (
+        "SELECT 1 AS id, 1 AS ds, 1 AS json_col WHERE FALSE"
     )

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -357,6 +357,38 @@ test_foo:
     assert expected_msg in result.failures[0][1]
 
 
+def test_empty_rows(sushi_context: Context) -> None:
+    model = t.cast(
+        SqlModel,
+        sushi_context.upsert_model(
+            load_sql_based_model(
+                parse(
+                    """
+                    MODEL (
+                        name sushi.foo,
+                        kind FULL,
+                    );
+
+                    SELECT id FROM sushi.items;
+                    """,
+                ),
+            )
+        ),
+    )
+    body = load_yaml(
+        """
+test_foo:
+  model: sushi.foo
+  inputs:
+    sushi.items: []
+  outputs:
+    query: []
+            """
+    )
+    result = _create_test(body, "test_foo", model, sushi_context).run()
+    assert result and result.wasSuccessful()
+
+
 @pytest.mark.parametrize("full_model_without_ctes", ["snowflake"], indirect=True)
 def test_normalization(full_model_without_ctes: SqlModel) -> None:
     body = load_yaml(


### PR DESCRIPTION
The current implementation of select_from_values_for_batch_range constructs an empty VALUES () clause in case it's passed an empty list for its 'values' argument, which is usually a syntax error.

This commit makes it so we instead return a dummy query that's guaranteed to not return any rows (using a WHERE FALSE filter).

Additionally, it fixes a few bugs in the unit test module related to test cases that contain empty input / output rows.