### PR TITLE
fix: redshift dbt connection timeout none

### DIFF
--- a/sqlmesh/dbt/target.py
+++ b/sqlmesh/dbt/target.py
@@ -353,8 +353,7 @@ class RedshiftConfig(TargetConfig):
     password: str
     port: int
     dbname: str
-    keepalives_idle: int = 240
-    connect_timeout: int = 10
+    connect_timeout: t.Optional[int] = None
     ra3_node: bool = True
     search_path: t.Optional[str] = None
     sslmode: t.Optional[str] = None


### PR DESCRIPTION
This now matches what is in dbt: https://github.com/dbt-labs/dbt-redshift/blob/e88a48331f05b7024cadc191d554500de4cad2da/dbt/adapters/redshift/connections.py#L119

It looks like before we implemented it to match Postgres: https://github.com/dbt-labs/dbt-core/blob/5488dfb9926c3f81e6a80bd0d8b01fe7f0ac7a60/plugins/postgres/dbt/adapters/postgres/connections.py#L29

Also removed `keepalives_idle` since that wasn't used/isn't supported (also come over from Postgres). 