### PR TITLE
Fix: preserve Array macro vars instead of converting them to Tuple

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -169,7 +169,8 @@ class MacroEvaluator:
 
                     return node
 
-                return exp.convert(_norm_env_value(self.locals[node.name]))
+                value = self.locals[node.name]
+                return exp.convert(tuple(value) if isinstance(value, list) else value)
             if node.is_string:
                 text = node.this
                 if has_jinja(text):
@@ -419,11 +420,7 @@ def _norm_var_arg_lambda(
 
 
 def _norm_env_value(value: t.Any) -> t.Any:
-    if isinstance(value, list):
-        return tuple(value)
-    if isinstance(value, exp.Array):
-        return exp.Tuple(expressions=value.expressions)
-    return value
+    return tuple(value) if isinstance(value, list) else value
 
 
 @macro()

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -29,15 +29,19 @@ class model(registry_decorator):
         self.is_sql = is_sql
         self.kwargs = kwargs
 
-        # Make sure that argument values are expressions in order to
-        # pass validation in ModelMeta.
+        # Make sure that argument values are expressions in order to pass validation in ModelMeta.
         calls = self.kwargs.pop("audits", [])
         self.kwargs["audits"] = [
             (call, {})
             if isinstance(call, str)
             else (
                 call[0],
-                {arg_key: exp.convert(arg_value) for arg_key, arg_value in call[1].items()},
+                {
+                    arg_key: exp.convert(
+                        tuple(arg_value) if isinstance(arg_value, list) else arg_value
+                    )
+                    for arg_key, arg_value in call[1].items()
+                },
             )
             for call in calls
         ]

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1060,6 +1060,22 @@ def test_render_query(assert_exp_eq, sushi_context):
         """,
     )
 
+    expressions = d.parse(
+        """
+        MODEL (
+          name dummy.model,
+          kind FULL,
+          dialect duckdb
+        );
+
+        @DEF(x, ['1', '2', '3']);
+
+        SELECT @x AS "x"
+        """
+    )
+    model = load_sql_based_model(expressions, dialect="duckdb")
+    assert model.render_query().sql("duckdb") == '''SELECT ['1', '2', '3'] AS "x"'''
+
 
 def test_time_column():
     expressions = d.parse(


### PR DESCRIPTION
This fixes the following bug: let's assume we add a `@DEF(cols, ['1', '2', '3', '4']);` in the example full model and include it in the projection list. Then, without this PR we have:

```
➜  sqlmesh render sqlmesh_example.full_model
SELECT
  "incremental_model"."item_id" AS "item_id",
  COUNT(DISTINCT "incremental_model"."id") AS "num_orders",
  ('1', '2', '3', '4') AS "_col_2"  -- Invalid DuckDB, we need an array here
FROM "sqlmesh__sqlmesh_example"."sqlmesh_example__incremental_model__3958293195" AS "incremental_model"
GROUP BY
  "incremental_model"."item_id"
ORDER BY
  "item_id"
```

Including the PR we get:

```
➜  sqlmesh render sqlmesh_example.full_model
SELECT
  "incremental_model"."item_id" AS "item_id",
  COUNT(DISTINCT "incremental_model"."id") AS "num_orders",
  ['1', '2', '3', '4'] AS "_col_2"
FROM "sqlmesh__sqlmesh_example"."sqlmesh_example__incremental_model__3958293195" AS "incremental_model"
GROUP BY
  "incremental_model"."item_id"
ORDER BY
  "item_id"
```

This may or may not be related to #1768, cc @eakmanrq if you take a look into it.