### PR TITLE
fix(redshift): ctas now uses false limit 0 instead of from false prop…

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -417,11 +417,13 @@ class _Model(ModelMeta, frozen=True):
         Return:
             The mocked out ctas query.
         """
-        query = self.render_query_or_raise(**render_kwarg)
         # the query is expanded so it's been copied, it's safe to mutate.
-        for select in query.find_all(exp.Select):
-            if select.args.get("from"):
-                select.where(exp.false(), copy=False)
+        query = (
+            self.render_query_or_raise(**render_kwarg)
+            .limit(0, copy=False)
+            .where(exp.false(), copy=False, append=False)
+        )
+
         if self.managed_columns:
             query.select(
                 *[

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1307,6 +1307,7 @@ FROM (VALUES
   (1)) AS t(dummy)
 WHERE
   FALSE
+LIMIT 0
 	""",
     )
 
@@ -1625,13 +1626,13 @@ def test_model_ctas_query():
     expressions = d.parse(
         """
         MODEL (name `a-b-c.table`, kind FULL, dialect bigquery);
-        SELECT 1 as a
+        SELECT 1 as a WHERE TRUE LIMIT 2
     """
     )
 
     assert (
         load_sql_based_model(expressions, dialect="bigquery").ctas_query().sql()
-        == 'SELECT 1 AS "a"'
+        == 'SELECT 1 AS "a" WHERE FALSE LIMIT 0'
     )
 
     expressions = d.parse(
@@ -1643,7 +1644,7 @@ def test_model_ctas_query():
 
     assert (
         load_sql_based_model(expressions).ctas_query().sql()
-        == 'SELECT 1 AS "a" FROM "b" AS "b" WHERE FALSE'
+        == 'SELECT 1 AS "a" FROM "b" AS "b" WHERE FALSE LIMIT 0'
     )
 
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -1007,7 +1007,7 @@ def test_create_ctas_scd_type_2(mocker: MockerFixture, adapter_mock, make_snapsh
     evaluator.create([snapshot], {})
 
     query = parse_one(
-        """SELECT *, CAST(NULL AS TIMESTAMP) AS valid_from, CAST(NULL AS TIMESTAMP) AS valid_to FROM "tbl" AS "tbl" WHERE FALSE"""
+        """SELECT *, CAST(NULL AS TIMESTAMP) AS valid_from, CAST(NULL AS TIMESTAMP) AS valid_to FROM "tbl" AS "tbl" WHERE FALSE LIMIT 0"""
     )
 
     # Verify that managed columns are included in CTAS with types


### PR DESCRIPTION
…ogation

in redshift, there's a bug where false propogation to from statements with md5(...) was resulting in varchar(1) types instead of varchar(32).

it seems like where false limit 0 is safe in most engines.