### PR TITLE
Fix: use test engine adapter to compute output query in test gen

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1063,6 +1063,7 @@ class Context(BaseContext):
             input_queries=input_queries,
             models=self._models,
             engine_adapter=self._engine_adapter,
+            test_engine_adapter=self._test_engine_adapter,
             project_path=self.path,
             overwrite=overwrite,
             variables=variables,

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -307,6 +307,7 @@ def generate_test(
     input_queries: t.Dict[str, str],
     models: t.Dict[str, Model],
     engine_adapter: EngineAdapter,
+    test_engine_adapter: EngineAdapter,
     project_path: Path,
     overwrite: bool = False,
     variables: t.Optional[t.Dict[str, str]] = None,
@@ -321,6 +322,7 @@ def generate_test(
             will be populated in the test based on the results of the corresponding query.
         models: The context's models.
         engine_adapter: The target engine adapter.
+        test_engine_adapter: The test engine adapter.
         project_path: The path pointing to the project's root directory.
         overwrite: Whether to overwrite the existing test in case of a file path collision.
             When set to False, an error will be raised if there is such a collision.
@@ -358,7 +360,7 @@ def generate_test(
         body=test_body,
         test_name=test_name,
         models=models,
-        engine_adapter=engine_adapter,
+        engine_adapter=test_engine_adapter,
         dialect=model.dialect,
         path=fixture_path,
     )
@@ -369,7 +371,7 @@ def generate_test(
         mapping = {name: _test_fixture_name(name) for name in models.keys() | inputs.keys()}
         model_query = model.render_query_or_raise(
             **t.cast(t.Dict[str, t.Any], variables),
-            engine_adapter=engine_adapter,
+            engine_adapter=test_engine_adapter,
             table_mapping=mapping,
         )
         output = t.cast(SqlModelTest, test)._execute(model_query)


### PR DESCRIPTION
We previously used the project's adapter in order to create the necessary database objects and compute the expected output data based on the input data computed by the supplied queries. This ensures we use the test adapter instead.