### PR TITLE
feat: redshift plan parsing to address ctas varchar(1) bug

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -518,6 +518,26 @@ class EngineAdapter:
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         **kwargs: t.Any,
     ) -> None:
+        self.execute(
+            self._create_table_exp(
+                table_name_or_schema,
+                expression=expression,
+                exists=exists,
+                replace=replace,
+                columns_to_types=columns_to_types,
+                **kwargs,
+            )
+        )
+
+    def _create_table_exp(
+        self,
+        table_name_or_schema: t.Union[exp.Schema, TableName],
+        expression: t.Optional[exp.Expression],
+        exists: bool = True,
+        replace: bool = False,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        **kwargs: t.Any,
+    ) -> exp.Create:
         exists = False if replace else exists
         if not isinstance(table_name_or_schema, exp.Schema):
             table_name_or_schema = exp.to_table(table_name_or_schema)
@@ -526,7 +546,7 @@ class EngineAdapter:
             if kwargs
             else None
         )
-        create = exp.Create(
+        return exp.Create(
             this=table_name_or_schema,
             kind="TABLE",
             replace=replace,
@@ -534,7 +554,6 @@ class EngineAdapter:
             expression=expression,
             properties=properties,
         )
-        self.execute(create)
 
     def create_table_like(
         self,

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -982,12 +982,12 @@ def test_dialects(ctx: TestContext):
 
     q = parse_one(
         f"""
-        WITH 
+        WITH
           "a" AS (SELECT 1 w),
           "B" AS (SELECT 1 x),
           c AS (SELECT 1 y),
           D AS (SELECT 1 z)
-    
+
           SELECT *
           FROM {a}
           CROSS JOIN {b}

--- a/tests/core/engine_adapter/test_redshift.py
+++ b/tests/core/engine_adapter/test_redshift.py
@@ -2,16 +2,24 @@
 import typing as t
 
 import pandas as pd
+import pytest
 from pytest_mock.plugin import MockerFixture
 from sqlglot import expressions as exp
 from sqlglot import parse_one
 
 from sqlmesh.core.engine_adapter import RedshiftEngineAdapter
+from sqlmesh.core.engine_adapter.redshift import parse_plan
 from tests.core.engine_adapter import to_sql_calls
 
 
-def test_columns(make_mocked_engine_adapter: t.Callable):
+@pytest.fixture
+def adapter(make_mocked_engine_adapter):
     adapter = make_mocked_engine_adapter(RedshiftEngineAdapter)
+    adapter.cursor.fetchall.return_value = []
+    return adapter
+
+
+def test_columns(adapter: t.Callable):
     adapter.cursor.fetchall.return_value = [("col", "INT")]
     resp = adapter.columns("db.table")
     adapter.cursor.execute.assert_called_once_with(
@@ -21,29 +29,57 @@ def test_columns(make_mocked_engine_adapter: t.Callable):
 
 
 def test_create_table_from_query_exists_no_if_not_exists(
-    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+    adapter: t.Callable, mocker: MockerFixture
 ):
-    adapter = make_mocked_engine_adapter(RedshiftEngineAdapter)
     mocker.patch(
         "sqlmesh.core.engine_adapter.redshift.RedshiftEngineAdapter.table_exists",
         return_value=True,
     )
 
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.redshift.parse_plan",
+        return_value={
+            "targetlist": [
+                {
+                    "name": "TARGETENTRY",
+                    "resdom": {
+                        "restype": "1043",
+                        "restypmod": "- 1",
+                    },
+                },
+                {
+                    "name": "TARGETENTRY",
+                    "resdom": {
+                        "restype": "1043",
+                        "restypmod": "64",
+                    },
+                },
+                {
+                    "name": "TARGETENTRY",
+                    "resdom": {
+                        "restype": "1043",
+                        "restypmod": "- 1",
+                    },
+                },
+            ]
+        },
+    )
+
     adapter.ctas(
         table_name="test_table",
-        query_or_df=parse_one("SELECT cola FROM table"),
+        query_or_df=parse_one("SELECT a, b, CAST(c AS VARCHAR) FROM table"),
         exists=False,
     )
 
-    adapter.cursor.execute.assert_called_once_with(
-        'CREATE TABLE "test_table" AS SELECT "cola" FROM "table"'
-    )
+    assert to_sql_calls(adapter) == [
+        'EXPLAIN VERBOSE CREATE TABLE "test_table" AS SELECT "a", "b", CAST("c" AS VARCHAR) FROM "table"',
+        'CREATE TABLE "test_table" AS SELECT CAST("a" AS VARCHAR(MAX)), "b", CAST("c" AS VARCHAR) FROM "table"',
+    ]
 
 
 def test_create_table_from_query_exists_and_if_not_exists(
-    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+    adapter: t.Callable, mocker: MockerFixture
 ):
-    adapter = make_mocked_engine_adapter(RedshiftEngineAdapter)
     mocker.patch(
         "sqlmesh.core.engine_adapter.redshift.RedshiftEngineAdapter.table_exists",
         return_value=True,
@@ -58,9 +94,8 @@ def test_create_table_from_query_exists_and_if_not_exists(
 
 
 def test_create_table_from_query_not_exists_if_not_exists(
-    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+    adapter: t.Callable, mocker: MockerFixture
 ):
-    adapter = make_mocked_engine_adapter(RedshiftEngineAdapter)
     mocker.patch(
         "sqlmesh.core.engine_adapter.redshift.RedshiftEngineAdapter.table_exists",
         return_value=False,
@@ -71,15 +106,14 @@ def test_create_table_from_query_not_exists_if_not_exists(
         exists=True,
     )
 
-    adapter.cursor.execute.assert_called_once_with(
+    adapter.cursor.execute.assert_called_with(
         'CREATE TABLE "test_table" AS SELECT "cola" FROM "table"'
     )
 
 
 def test_create_table_from_query_not_exists_no_if_not_exists(
-    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+    adapter: t.Callable, mocker: MockerFixture
 ):
-    adapter = make_mocked_engine_adapter(RedshiftEngineAdapter)
     mocker.patch(
         "sqlmesh.core.engine_adapter.redshift.RedshiftEngineAdapter.table_exists",
         return_value=False,
@@ -90,13 +124,12 @@ def test_create_table_from_query_not_exists_no_if_not_exists(
         exists=False,
     )
 
-    adapter.cursor.execute.assert_called_once_with(
+    adapter.cursor.execute.assert_called_with(
         'CREATE TABLE "test_table" AS SELECT "cola" FROM "table"'
     )
 
 
-def test_values_to_sql(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
-    adapter = make_mocked_engine_adapter(RedshiftEngineAdapter)
+def test_values_to_sql(adapter: t.Callable, mocker: MockerFixture):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     result = adapter._values_to_sql(
         values=list(df.itertuples(index=False, name=None)),
@@ -111,8 +144,7 @@ def test_values_to_sql(make_mocked_engine_adapter: t.Callable, mocker: MockerFix
     )
 
 
-def test_replace_query_with_query(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
-    adapter = make_mocked_engine_adapter(RedshiftEngineAdapter)
+def test_replace_query_with_query(adapter: t.Callable, mocker: MockerFixture):
     mocker.patch(
         "sqlmesh.core.engine_adapter.redshift.RedshiftEngineAdapter.table_exists",
         return_value=False,
@@ -125,14 +157,12 @@ def test_replace_query_with_query(make_mocked_engine_adapter: t.Callable, mocker
     adapter.replace_query(table_name="test_table", query_or_df=parse_one("SELECT cola FROM table"))
 
     assert to_sql_calls(adapter) == [
+        'EXPLAIN VERBOSE CREATE TABLE "test_table" AS SELECT "cola" FROM "table"',
         'CREATE TABLE "test_table" AS SELECT "cola" FROM "table"',
     ]
 
 
-def test_replace_query_with_df_table_exists(
-    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
-):
-    adapter = make_mocked_engine_adapter(RedshiftEngineAdapter)
+def test_replace_query_with_df_table_exists(adapter: t.Callable, mocker: MockerFixture):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     mocker.patch(
         "sqlmesh.core.engine_adapter.redshift.RedshiftEngineAdapter.table_exists",
@@ -163,10 +193,7 @@ def test_replace_query_with_df_table_exists(
     ]
 
 
-def test_replace_query_with_df_table_not_exists(
-    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
-):
-    adapter = make_mocked_engine_adapter(RedshiftEngineAdapter)
+def test_replace_query_with_df_table_not_exists(adapter: t.Callable, mocker: MockerFixture):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     mocker.patch(
         "sqlmesh.core.engine_adapter.redshift.RedshiftEngineAdapter.table_exists",
@@ -182,6 +209,7 @@ def test_replace_query_with_df_table_not_exists(
     )
 
     assert to_sql_calls(adapter) == [
+        'EXPLAIN VERBOSE CREATE TABLE "test_table" AS SELECT CAST("a" AS INTEGER) AS "a", CAST("b" AS INTEGER) AS "b" FROM (SELECT 1 AS "a", 4 AS "b" UNION ALL SELECT 2, 5 UNION ALL SELECT 3, 6) AS "t"',
         'CREATE TABLE "test_table" AS SELECT CAST("a" AS INTEGER) AS "a", CAST("b" AS INTEGER) AS "b" FROM (SELECT 1 AS "a", 4 AS "b" UNION ALL SELECT 2, 5 UNION ALL SELECT 3, 6) AS "t"',
     ]
 
@@ -214,8 +242,7 @@ def test_table_exists_table_only(mocker: MockerFixture):
     )
 
 
-def test_create_view(make_mocked_engine_adapter: t.Callable):
-    adapter = make_mocked_engine_adapter(RedshiftEngineAdapter)
+def test_create_view(adapter: t.Callable):
     adapter.create_view(
         view_name="test_view",
         query_or_df=parse_one("SELECT cola FROM table"),
@@ -228,4 +255,569 @@ def test_create_view(make_mocked_engine_adapter: t.Callable):
     assert to_sql_calls(adapter) == [
         'DROP VIEW IF EXISTS "test_view" CASCADE',
         'CREATE VIEW "test_view" ("a", "b") AS SELECT "cola" FROM "table" WITH NO SCHEMA BINDING',
+    ]
+
+
+def test_parse_plan():
+    plan = parse_plan(
+        """
+{ RESULT
+  :startup_cost 0.00
+  :total_cost 0.07
+  :plan_rows 2
+  :node_id 1
+  :parent_id 0
+  :plan_width 32
+  :best_pathkeys <>
+  :dist_info.dist_strategy DS_DIST_NONE
+  :dist_info.dist_keys <>
+  :dist_info.seqscan_is_distributed false
+  :dist_info.topology 1966505242
+  :phys_properties <>
+  :reqd_phys_properties <>
+  :targetlist (
+    { TARGETENTRY
+    :resdom
+      { RESDOM
+      :resno 1
+      :restype 25
+      :restypmod 36
+      :resname cola
+      :ressortgroupref 0
+      :resorigtbl 0
+      :resorigcol 0
+      :resjunk false
+      }
+    :expr
+      { FUNCEXPR
+      :funcid 2311
+      :funcresulttype 25
+      :funcretset false
+      :funcformat 0
+      :args (
+        { RELABELTYPE
+        :arg
+          { VAR
+          :varno 65001
+          :varattno 1
+          :vartype 1043
+          :vartypmod -1
+          :varlevelsup 0
+          :varnoold 2
+          :varoattno 1
+          }
+        :resulttype 25
+        :resulttypmod -1
+        :relabelformat 0
+        }
+      )
+      }
+    }
+  )
+  :non_null_target (b)
+  :qual <>
+  :lefttree
+    { SUBQUERYSCAN
+    :startup_cost 0.00
+    :total_cost 0.06
+    :plan_rows 2
+    :node_id 2
+    :parent_id 1
+    :plan_width 32
+    :best_pathkeys <>
+    :dist_info.dist_strategy DS_DIST_ERR
+    :dist_info.dist_keys <>
+    :dist_info.seqscan_is_distributed false
+    :dist_info.topology 1966505242
+    :phys_properties <>
+    :reqd_phys_properties <>
+    :targetlist (
+      { TARGETENTRY
+      :resdom
+        { RESDOM
+        :resno 1
+        :restype 1043
+        :restypmod -1
+        :resname <>
+        :ressortgroupref 0
+        :resorigtbl 0
+        :resorigcol 0
+        :resjunk false
+        }
+      :expr
+        { VAR
+        :varno 2
+        :varattno 1
+        :vartype 1043
+        :vartypmod -1
+        :varlevelsup 0
+        :varnoold 2
+        :varoattno 1
+        }
+      }
+    )
+    :non_null_target (b)
+    :qual <>
+    :lefttree <>
+    :righttree <>
+    :initPlan <>
+    :extParam (b)
+    :allParam (b)
+    :nParamExec 0
+    :scanrelid 2
+    :tuples 0
+    :subplan
+      { APPEND
+      :startup_cost 0.00
+      :total_cost 0.04
+      :plan_rows 2
+      :node_id 3
+      :parent_id 2
+      :plan_width 0
+      :best_pathkeys <>
+      :dist_info.dist_strategy DS_DIST_ERR
+      :dist_info.dist_keys <>
+      :dist_info.seqscan_is_distributed false
+      :dist_info.topology 1966505242
+      :phys_properties <>
+      :reqd_phys_properties <>
+      :targetlist (
+        { TARGETENTRY
+        :resdom
+          { RESDOM
+          :resno 1
+          :restype 1043
+          :restypmod 5
+          :resname cola
+          :ressortgroupref 0
+          :resorigtbl 0
+          :resorigcol 0
+          :resjunk false
+          }
+        :expr
+          { VAR
+          :varno 0
+          :varattno 1
+          :vartype 1043
+          :vartypmod 5
+          :varlevelsup 0
+          :varnoold 0
+          :varoattno 1
+          }
+        }
+      )
+      :non_null_target (b)
+      :qual <>
+      :lefttree <>
+      :righttree <>
+      :initPlan <>
+      :extParam (b)
+      :allParam (b)
+      :nParamExec 0
+      :appendplans (
+        { NETWORK
+        :startup_cost 0.00
+        :total_cost 0.02
+        :plan_rows 1
+        :node_id 4
+        :parent_id 3
+        :plan_width 0
+        :best_pathkeys <>
+        :dist_info.dist_strategy DS_DIST_ERR
+        :dist_info.dist_keys <>
+        :dist_info.seqscan_is_distributed false
+        :dist_info.topology 1966505242
+        :phys_properties <>
+        :reqd_phys_properties <>
+        :targetlist (
+          { TARGETENTRY
+          :resdom
+            { RESDOM
+            :resno 1
+            :restype 1043
+            :restypmod 5
+            :resname cola
+            :ressortgroupref 0
+            :resorigtbl 0
+            :resorigcol 0
+            :resjunk false
+            }
+          :expr
+            { CONST
+            :consttype 1043
+            :constlen -1
+            :constbyval false
+            :constisnull false
+            :constvalue 5 [ 5 0 0 0 49 ]
+            }
+          }
+        )
+        :non_null_target (b)
+        :qual <>
+        :lefttree
+          { SUBQUERYSCAN
+          :startup_cost 0.00
+          :total_cost 0.02
+          :plan_rows 1
+          :node_id 5
+          :parent_id 4
+          :plan_width 0
+          :best_pathkeys <>
+          :dist_info.dist_strategy DS_DIST_ERR
+          :dist_info.dist_keys <>
+          :dist_info.seqscan_is_distributed false
+          :dist_info.topology 1966505242
+          :phys_properties <>
+          :reqd_phys_properties <>
+          :targetlist (
+            { TARGETENTRY
+            :resdom
+              { RESDOM
+              :resno 1
+              :restype 1043
+              :restypmod 5
+              :resname cola
+              :ressortgroupref 0
+              :resorigtbl 0
+              :resorigcol 0
+              :resjunk false
+              }
+            :expr
+              { FUNCEXPR
+              :funcid 669
+              :funcresulttype 1043
+              :funcretset false
+              :funcformat 2
+              :args (
+                { CONST
+                :consttype 1043
+                :constlen -1
+                :constbyval false
+                :constisnull false
+                :constvalue 5 [ 5 0 0 0 49 ]
+                }
+                { CONST
+                :consttype 23
+                :constlen 4
+                :constbyval true
+                :constisnull false
+                :constvalue 4 [ 5 0 0 0 0 0 0 0 ]
+                }
+                { CONST
+                :consttype 16
+                :constlen 1
+                :constbyval true
+                :constisnull false
+                :constvalue 1 [ 0 0 0 0 0 0 0 0 ]
+                }
+              )
+              }
+            }
+          )
+          :non_null_target (b)
+          :qual <>
+          :lefttree <>
+          :righttree <>
+          :initPlan <>
+          :extParam (b)
+          :allParam (b)
+          :nParamExec 0
+          :scanrelid 1
+          :tuples 0
+          :subplan
+            { RESULT
+            :startup_cost 0.00
+            :total_cost 0.01
+            :plan_rows 1
+            :node_id 6
+            :parent_id 5
+            :plan_width 0
+            :best_pathkeys <>
+            :dist_info.dist_strategy DS_DIST_NONE
+            :dist_info.dist_keys <>
+            :dist_info.seqscan_is_distributed false
+            :dist_info.topology 1966505242
+            :phys_properties <>
+            :reqd_phys_properties <>
+            :targetlist (
+              { TARGETENTRY
+              :resdom
+                { RESDOM
+                :resno 1
+                :restype 1043
+                :restypmod 204
+                :resname cola
+                :ressortgroupref 0
+                :resorigtbl 0
+                :resorigcol 0
+                :resjunk false
+                }
+              :expr
+                { CONST
+                :consttype 1043
+                :constlen -1
+                :constbyval false
+                :constisnull false
+                :constvalue 5 [ 5 0 0 0 49 ]
+                }
+              }
+            )
+            :non_null_target (b)
+            :qual <>
+            :lefttree <>
+            :righttree <>
+            :initPlan <>
+            :extParam (b)
+            :allParam (b)
+            :nParamExec 0
+            :resconstantqual <>
+            :scanrelid 0
+            :values_lists <>
+            }
+          }
+        :righttree <>
+        :initPlan <>
+        :extParam (b)
+        :allParam (b)
+        :nParamExec 0
+        :dataMovement Distribute
+        }
+        { NETWORK
+        :startup_cost 0.00
+        :total_cost 0.02
+        :plan_rows 1
+        :node_id 7
+        :parent_id 3
+        :plan_width 0
+        :best_pathkeys <>
+        :dist_info.dist_strategy DS_DIST_ERR
+        :dist_info.dist_keys <>
+        :dist_info.seqscan_is_distributed false
+        :dist_info.topology 1966505242
+        :phys_properties <>
+        :reqd_phys_properties <>
+        :targetlist (
+          { TARGETENTRY
+          :resdom
+            { RESDOM
+            :resno 1
+            :restype 1043
+            :restypmod 5
+            :resname cola
+            :ressortgroupref 0
+            :resorigtbl 0
+            :resorigcol 0
+            :resjunk false
+            }
+          :expr
+            { CONST
+            :consttype 1043
+            :constlen -1
+            :constbyval false
+            :constisnull false
+            :constvalue 5 [ 5 0 0 0 51 ]
+            }
+          }
+        )
+        :non_null_target (b)
+        :qual <>
+        :lefttree
+          { SUBQUERYSCAN
+          :startup_cost 0.00
+          :total_cost 0.02
+          :plan_rows 1
+          :node_id 8
+          :parent_id 7
+          :plan_width 0
+          :best_pathkeys <>
+          :dist_info.dist_strategy DS_DIST_ERR
+          :dist_info.dist_keys <>
+          :dist_info.seqscan_is_distributed false
+          :dist_info.topology 1966505242
+          :phys_properties <>
+          :reqd_phys_properties <>
+          :targetlist (
+            { TARGETENTRY
+            :resdom
+              { RESDOM
+              :resno 1
+              :restype 1043
+              :restypmod 5
+              :resname cola
+              :ressortgroupref 0
+              :resorigtbl 0
+              :resorigcol 0
+              :resjunk false
+              }
+            :expr
+              { FUNCEXPR
+              :funcid 669
+              :funcresulttype 1043
+              :funcretset false
+              :funcformat 2
+              :args (
+                { CONST
+                :consttype 1043
+                :constlen -1
+                :constbyval false
+                :constisnull false
+                :constvalue 5 [ 5 0 0 0 51 ]
+                }
+                { CONST
+                :consttype 23
+                :constlen 4
+                :constbyval true
+                :constisnull false
+                :constvalue 4 [ 5 0 0 0 0 0 0 0 ]
+                }
+                { CONST
+                :consttype 16
+                :constlen 1
+                :constbyval true
+                :constisnull false
+                :constvalue 1 [ 0 0 0 0 0 0 0 0 ]
+                }
+              )
+              }
+            }
+          )
+          :non_null_target (b)
+          :qual <>
+          :lefttree <>
+          :righttree <>
+          :initPlan <>
+          :extParam (b)
+          :allParam (b)
+          :nParamExec 0
+          :scanrelid 2
+          :tuples 0
+          :subplan
+            { RESULT
+            :startup_cost 0.00
+            :total_cost 0.01
+            :plan_rows 1
+            :node_id 9
+            :parent_id 8
+            :plan_width 0
+            :best_pathkeys <>
+            :dist_info.dist_strategy DS_DIST_NONE
+            :dist_info.dist_keys <>
+            :dist_info.seqscan_is_distributed false
+            :dist_info.topology 1966505242
+            :phys_properties <>
+            :reqd_phys_properties <>
+            :targetlist (
+              { TARGETENTRY
+              :resdom
+                { RESDOM
+                :resno 1
+                :restype 1043
+                :restypmod 204
+                :resname varchar
+                :ressortgroupref 0
+                :resorigtbl 0
+                :resorigcol 0
+                :resjunk false
+                }
+              :expr
+                { CONST
+                :consttype 1043
+                :constlen -1
+                :constbyval false
+                :constisnull false
+                :constvalue 5 [ 5 0 0 0 51 ]
+                }
+              }
+            )
+            :non_null_target (b)
+            :qual <>
+            :lefttree <>
+            :righttree <>
+            :initPlan <>
+            :extParam (b)
+            :allParam (b)
+            :nParamExec 0
+            :resconstantqual <>
+            :scanrelid 0
+            :values_lists <>
+            }
+          }
+        :righttree <>
+        :initPlan <>
+        :extParam (b)
+        :allParam (b)
+        :nParamExec 0
+        :dataMovement Distribute
+        }
+      )
+      :isTarget false
+      :streamable false
+      }
+    }
+  :righttree <>
+  :initPlan <>
+  :extParam (b)
+  :allParam (b)
+  :nParamExec 0
+  :resconstantqual (
+    { CONST
+    :consttype 16
+    :constlen 1
+    :constbyval true
+    :constisnull false
+    :constvalue 1 [ 0 0 0 0 0 0 0 0 ]
+    }
+    { CONST
+    :consttype 16
+    :constlen 1
+    :constbyval true
+    :constisnull false
+    :constvalue 1 [ 0 0 0 0 0 0 0 0 ]
+    }
+  )
+  :scanrelid 0
+  :values_lists <>
+  }
+    """
+    )
+    assert plan["targetlist"] == [
+        {
+            "expr": {
+                "args": [
+                    {
+                        "arg": {
+                            "name": "VAR",
+                            "varattno": "1",
+                            "varlevelsup": "0",
+                            "varno": "65001",
+                            "varnoold": "2",
+                            "varoattno": "1",
+                            "vartype": "1043",
+                            "vartypmod": "- 1",
+                        },
+                        "name": "RELABELTYPE",
+                        "relabelformat": "0",
+                        "resulttype": "25",
+                        "resulttypmod": "- 1",
+                    }
+                ],
+                "funcformat": "0",
+                "funcid": "2311",
+                "funcresulttype": "25",
+                "funcretset": "false",
+                "name": "FUNCEXPR",
+            },
+            "name": "TARGETENTRY",
+            "resdom": {
+                "name": "RESDOM",
+                "resjunk": "false",
+                "resname": "cola",
+                "resno": "1",
+                "resorigcol": "0",
+                "resorigtbl": "0",
+                "ressortgroupref": "0",
+                "restype": "25",
+                "restypmod": "36",
+            },
+        },
     ]


### PR DESCRIPTION
in redshift, CTAS types are not determinstic based on the logical plan of a query. adding limits or where false to an md5(...) will change from the expected varchar(32) into a varchar(1). this pr tries to detect these and then force casts projections to the right types.