### PR TITLE
Chore: Pin pytest-asyncio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
             "pyarrow>=10.0.1,<10.1.0",
             "PyGithub",
             "pytest",
-            "pytest-asyncio",
+            "pytest-asyncio<0.23.0",
             "pytest-lazy-fixture",
             "pytest-mock",
             "pyspark>=3.4.0",


### PR DESCRIPTION
The recent release of the pytest-asyncio library, v0.23.0+, breaks one of our unit tests (sqlmesh/tests/core/test_context.py::test_ignore_files). Will investigate further, but pinning pytest-asyncio for now.