### PR TITLE
Fix: Cloud_composer scheduler config supported field validation

### DIFF
--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -230,7 +230,7 @@ class CloudComposerSchedulerConfig(_BaseAirflowSchedulerConfig, BaseConfig, extr
     @model_validator(mode="before")
     @model_validator_v1_args
     def check_supported_fields(cls, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
-        allowed_field_names = {field.alias for field in cls.all_field_infos().values()}
+        allowed_field_names = {field.alias or name for name, field in cls.all_field_infos().items()}
         allowed_field_names.add("session")
 
         for field_name in values:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -295,3 +295,27 @@ def test_load_config_from_python_module_invalid_config_object(tmp_path):
         match=r"^Config needs to be a valid object.*",
     ):
         load_config_from_python_module(config_path)
+
+
+def test_cloud_composer_scheduler_config(tmp_path_factory):
+    config_path = tmp_path_factory.mktemp("yaml_config") / "config.yaml"
+    with open(config_path, "w") as fd:
+        fd.write(
+            """
+gateways:
+    another_gateway:
+        connection:
+            type: duckdb
+            database: test_db
+        scheduler:
+            type: cloud_composer
+            airflow_url: https://airflow.url
+
+model_defaults:
+    dialect: bigquery
+        """
+        )
+
+    assert load_config_from_paths(
+        project_paths=[config_path],
+    )


### PR DESCRIPTION
The validator used to work in Pydantic v1 since a field's alias defaulted to the field's name if there was no alias specified. In v2, it's None if not specified.