### PR TITLE
Fix!: workaround for weird date dtype bug exposed by duckdb v0.9.2

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -100,8 +100,8 @@ class ModelTest(unittest.TestCase):
             actual_types, errors="ignore"
         )
 
-        expected = expected.replace({np.nan: None, "nan": None})
-        actual = actual.replace({np.nan: None, "nan": None})
+        expected = expected.replace({None: np.nan, "nan": np.nan})
+        actual = actual.replace({None: np.nan, "nan": np.nan})
 
         try:
             pd.testing.assert_frame_equal(

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -100,8 +100,8 @@ class ModelTest(unittest.TestCase):
             actual_types, errors="ignore"
         )
 
-        expected = expected.replace({None: np.nan, "nan": np.nan})
-        actual = actual.replace({None: np.nan, "nan": np.nan})
+        expected = expected.replace({None: np.nan})
+        actual = actual.replace({None: np.nan})
 
         try:
             pd.testing.assert_frame_equal(

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -222,34 +222,9 @@ test_foo:
     assert result and result.wasSuccessful()
 
 
-def test_nan(sushi_context: Context, full_model_without_ctes: SqlModel) -> None:
-    model = t.cast(SqlModel, sushi_context.upsert_model(full_model_without_ctes))
-    body = load_yaml(
-        """
-test_foo:
-  model: sushi.foo
-  inputs:
-    raw:
-      - id: 1
-        value: nan
-        ds: 3
-  outputs:
-    query:
-      - id: 1
-        value: null
-        ds: 3
-  vars:
-    start: 2022-01-01
-    end: 2022-01-01
-        """
-    )
-    result = _create_test(body, "test_foo", model, sushi_context).run()
-    assert result and result.wasSuccessful()
-
-
 def test_partial_data(sushi_context: Context) -> None:
     model = _create_model(
-        "WITH source AS (SELECT id, name FROM sushi.waiter_names) SELECT id, name FROM source"
+        "WITH source AS (SELECT id, name FROM sushi.waiter_names) SELECT id, name, 'nan' as str FROM source"
     )
     model = t.cast(SqlModel, sushi_context.upsert_model(model))
 
@@ -274,9 +249,12 @@ test_foo:
           name: 'bob'
     query:
       - id: 1
+        str: nan
       - id: 2
+        str: nan
       - id: 3
         name: 'bob'
+        str: nan
         """
     )
     result = _create_test(body, "test_foo", model, sushi_context).run()


### PR DESCRIPTION
Fixes #1799

Not quite sure if this change will have unintended side effects, but normalizing "non-existent" values to `np.nan` instead of `None` (previous approach) seemed just as reasonable to me.

@vchan the previous logic was introduced in https://github.com/TobikoData/sqlmesh/pull/1110, just tagging to make sure I'm not missing additional context here.