### PR TITLE
Chore: Add plan action class to control plan flow

### DIFF
--- a/web/client/openapi.json
+++ b/web/client/openapi.json
@@ -4,16 +4,16 @@
   "paths": {
     "/api/commands/apply": {
       "post": {
-        "summary": "Apply",
+        "summary": "Initiate Apply",
         "description": "Apply a plan",
-        "operationId": "apply_api_commands_apply_post",
+        "operationId": "initiate_apply_api_commands_apply_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/Body_apply_api_commands_apply_post"
+                    "$ref": "#/components/schemas/Body_initiate_apply_api_commands_apply_post"
                   }
                 ],
                 "title": "Body"
@@ -31,7 +31,7 @@
                     { "$ref": "#/components/schemas/PlanApplyStageTracker" },
                     { "type": "null" }
                   ],
-                  "title": "Response Apply Api Commands Apply Post"
+                  "title": "Response Initiate Apply Api Commands Apply Post"
                 }
               }
             }
@@ -389,15 +389,17 @@
     },
     "/api/plan": {
       "post": {
-        "summary": "Run Plan",
+        "summary": "Initiate Plan",
         "description": "Get a plan for an environment.",
-        "operationId": "run_plan_api_plan_post",
+        "operationId": "initiate_plan_api_plan_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "allOf": [
-                  { "$ref": "#/components/schemas/Body_run_plan_api_plan_post" }
+                  {
+                    "$ref": "#/components/schemas/Body_initiate_plan_api_plan_post"
+                  }
                 ],
                 "title": "Body"
               }
@@ -414,7 +416,7 @@
                     { "$ref": "#/components/schemas/PlanOverviewStageTracker" },
                     { "type": "null" }
                   ],
-                  "title": "Response Run Plan Api Plan Post"
+                  "title": "Response Initiate Plan Api Plan Post"
                 }
               }
             }
@@ -836,7 +838,7 @@
         "required": ["completed", "total", "view_name", "start"],
         "title": "BackfillTask"
       },
-      "Body_apply_api_commands_apply_post": {
+      "Body_initiate_apply_api_commands_apply_post": {
         "properties": {
           "environment": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
@@ -868,9 +870,9 @@
           }
         },
         "type": "object",
-        "title": "Body_apply_api_commands_apply_post"
+        "title": "Body_initiate_apply_api_commands_apply_post"
       },
-      "Body_run_plan_api_plan_post": {
+      "Body_initiate_plan_api_plan_post": {
         "properties": {
           "environment": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
@@ -890,7 +892,7 @@
           }
         },
         "type": "object",
-        "title": "Body_run_plan_api_plan_post"
+        "title": "Body_initiate_plan_api_plan_post"
       },
       "Body_write_directory_api_directories__path__post": {
         "properties": {

--- a/web/client/src/App.tsx
+++ b/web/client/src/App.tsx
@@ -8,17 +8,25 @@ import Loading from '@components/loading/Loading'
 import Spinner from '@components/logo/Spinner'
 import { useApiMeta } from './api'
 import { useStoreContext } from '@context/context'
+import { useStorePlan } from '@context/plan'
+import { EnumPlanAction, ModelPlanAction } from '@models/plan-action'
+import { isNotNil } from './utils'
 
 export default function App(): JSX.Element {
   const setVersion = useStoreContext(s => s.setVersion)
-  const setIsRunningPlan = useStoreContext(s => s.setIsRunningPlan)
+  const setPlanAction = useStorePlan(s => s.setPlanAction)
 
   const { refetch: getMeta, cancel: cancelRequestMeta } = useApiMeta()
 
   useEffect(() => {
     void getMeta().then(({ data }) => {
       setVersion(data?.version)
-      setIsRunningPlan(data?.has_running_task ?? false)
+
+      if (isNotNil(data) && Boolean(data.has_running_task)) {
+        setPlanAction(
+          new ModelPlanAction({ value: EnumPlanAction.RunningTask }),
+        )
+      }
     })
 
     return () => {

--- a/web/client/src/api/index.ts
+++ b/web/client/src/api/index.ts
@@ -20,10 +20,9 @@ import {
   getFilesApiFilesGet,
   getEnvironmentsApiEnvironmentsGet,
   writeFileApiFilesPathPost,
-  runPlanApiPlanPost,
-  applyApiCommandsApplyPost,
+  initiatePlanApiPlanPost,
+  initiateApplyApiCommandsApplyPost,
   cancelPlanApiPlanCancelPost,
-  type BodyApplyApiCommandsApplyPostCategories,
   getModelsApiModelsGet,
   type ModelLineageApiLineageModelNameGet200,
   modelLineageApiLineageModelNameGet,
@@ -47,6 +46,7 @@ import {
   type Environments,
   type PlanOverviewStageTracker,
   type PlanApplyStageTracker,
+  type BodyInitiateApplyApiCommandsApplyPostCategories,
 } from './client'
 import {
   useIDE,
@@ -235,7 +235,7 @@ export function useApiPlanRun(
     {
       queryKey: ['/api/plan', environment],
       async queryFn({ signal }) {
-        return await runPlanApiPlanPost(
+        return await initiatePlanApiPlanPost(
           {
             environment,
             plan_dates: inputs?.planDates,
@@ -258,7 +258,7 @@ export function useApiPlanApply(
   inputs?: {
     planDates?: PlanDates
     planOptions?: PlanOptions
-    categories?: BodyApplyApiCommandsApplyPostCategories
+    categories?: BodyInitiateApplyApiCommandsApplyPostCategories
   },
   options?: ApiOptions,
 ): UseQueryWithTimeoutOptions<PlanApplyStageTracker> {
@@ -266,7 +266,7 @@ export function useApiPlanApply(
     {
       queryKey: ['/api/commands/apply', environment],
       async queryFn({ signal }) {
-        return await applyApiCommandsApplyPost(
+        return await initiateApplyApiCommandsApplyPost(
           {
             environment,
             plan_dates: inputs?.planDates,

--- a/web/client/src/context/context.ts
+++ b/web/client/src/context/context.ts
@@ -11,7 +11,6 @@ import { isNil, isStringEmptyOrNil } from '~/utils'
 
 interface ContextStore {
   version?: string
-  isRunningPlan: boolean
   showConfirmation: boolean
   confirmations: Confirmation[]
   environment: ModelEnvironment
@@ -20,7 +19,6 @@ interface ContextStore {
   pinnedEnvironments: ModelEnvironment[]
   models: Map<string, ModelSQLMeshModel>
   setVersion: (version?: string) => void
-  setIsRunningPlan: (isRunningPlan: boolean) => void
   setShowConfirmation: (showConfirmation: boolean) => void
   addConfirmation: (confirmation: Confirmation) => void
   removeConfirmation: () => void
@@ -48,7 +46,6 @@ const environment = environments.values().next().value
 
 export const useStoreContext = create<ContextStore>((set, get) => ({
   version: undefined,
-  isRunningPlan: false,
   showConfirmation: false,
   confirmations: [],
   environment,
@@ -58,11 +55,6 @@ export const useStoreContext = create<ContextStore>((set, get) => ({
   initialStartDate: undefined,
   initialEndDate: undefined,
   models: new Map(),
-  setIsRunningPlan(isRunningPlan) {
-    set(() => ({
-      isRunningPlan,
-    }))
-  },
   setVersion(version) {
     set(() => ({
       version,

--- a/web/client/src/context/plan.ts
+++ b/web/client/src/context/plan.ts
@@ -1,26 +1,9 @@
 import { type BackfillTaskEnd } from '@api/client'
+import { ModelPlanAction } from '@models/plan-action'
 import { ModelPlanApplyTracker } from '@models/tracker-plan-apply'
 import { ModelPlanCancelTracker } from '@models/tracker-plan-cancel'
 import { ModelPlanOverviewTracker } from '@models/tracker-plan-overview'
 import { create } from 'zustand'
-
-export const EnumPlanAction = {
-  Done: 'done',
-  Run: 'run',
-  Running: 'running',
-  ApplyVirtual: 'apply-virtual',
-  ApplyBackfill: 'apply-backfill',
-  Applying: 'applying',
-  Cancelling: 'cancelling',
-} as const
-
-export const EnumPlanApplyType = {
-  Virtual: 'virtual',
-  Backfill: 'backfill',
-} as const
-
-export type PlanApplyType = KeyOf<typeof EnumPlanApplyType>
-export type PlanAction = KeyOf<typeof EnumPlanAction>
 
 export interface PlanTaskStatus {
   total: number
@@ -33,31 +16,25 @@ export interface PlanTaskStatus {
 }
 export type PlanTasks = Record<string, PlanTaskStatus>
 
-export interface PlanProgress {
-  ok: boolean
-  tasks: PlanTasks
-  updated_at: string
-  start?: number
-  end?: number
-  total?: number
-  completed?: number
-  is_completed?: boolean
-  type?: PlanApplyType
-}
-
 interface PlanStore {
+  planAction: ModelPlanAction
   planOverview: ModelPlanOverviewTracker
   planApply: ModelPlanApplyTracker
   planCancel: ModelPlanCancelTracker
   setPlanOverview: (planOverview?: ModelPlanOverviewTracker) => void
   setPlanApply: (planApply?: ModelPlanApplyTracker) => void
   setPlanCancel: (planCancel?: ModelPlanCancelTracker) => void
+  setPlanAction: (planAction?: ModelPlanAction) => void
 }
 
-export const useStorePlan = create<PlanStore>((set, get) => ({
+export const useStorePlan = create<PlanStore>(set => ({
+  planAction: new ModelPlanAction(),
   planOverview: new ModelPlanOverviewTracker(),
   planApply: new ModelPlanApplyTracker(),
   planCancel: new ModelPlanCancelTracker(),
+  setPlanAction: (planAction?: ModelPlanAction) => {
+    set(() => ({ planAction: new ModelPlanAction(planAction) }))
+  },
   setPlanApply: (planApply?: ModelPlanApplyTracker) => {
     set(() => ({ planApply: new ModelPlanApplyTracker(planApply) }))
   },

--- a/web/client/src/library/components/plan/PlanActions.tsx
+++ b/web/client/src/library/components/plan/PlanActions.tsx
@@ -1,13 +1,11 @@
 import { type MouseEvent } from 'react'
-import { useStoreContext } from '~/context/context'
-import { EnumPlanAction, useStorePlan, type PlanAction } from '~/context/plan'
 import useActiveFocus from '~/hooks/useActiveFocus'
 import { EnumVariant } from '~/types/enum'
-import { includes, isFalse, isStringEmptyOrNil } from '~/utils'
+import { includes, isFalse } from '~/utils'
 import { Button } from '../button/Button'
-import { usePlan } from './context'
-import { getActionName } from './help'
 import { Divider } from '@components/divider/Divider'
+import PlanActionsDescription from './PlanActionsDescription'
+import { EnumPlanAction, ModelPlanAction } from '@models/plan-action'
 
 export default function PlanActions({
   run,
@@ -16,45 +14,15 @@ export default function PlanActions({
   reset,
   close,
   planAction,
-  disabled = false,
 }: {
   apply: () => void
   run: () => void
   cancel: () => void
   close: () => void
   reset: () => void
-  planAction: PlanAction
-  disabled: boolean
+  planAction: ModelPlanAction
 }): JSX.Element {
-  const {
-    start,
-    end,
-    skip_tests,
-    auto_apply,
-    skip_backfill,
-    no_gaps,
-    no_auto_categorization,
-    forward_only,
-    restate_models,
-    include_unmodified,
-  } = usePlan()
-
-  const environment = useStoreContext(s => s.environment)
-
-  const planOverview = useStorePlan(s => s.planOverview)
-  const planApply = useStorePlan(s => s.planApply)
-  const planCancel = useStorePlan(s => s.planCancel)
-
   const setFocus = useActiveFocus<HTMLButtonElement>()
-
-  const isRun = planAction === EnumPlanAction.Run
-  const isDone = planAction === EnumPlanAction.Done
-  const isCancelling = planAction === EnumPlanAction.Cancelling
-  const isApplyVirtual = planAction === EnumPlanAction.ApplyVirtual
-  const isApplyBackfill = planAction === EnumPlanAction.ApplyBackfill
-  const isApplying = planAction === EnumPlanAction.Applying
-  const isRunning = planAction === EnumPlanAction.Running
-  const isProcessing = isRunning || isApplying || isCancelling
 
   function handleClose(e: MouseEvent): void {
     e.stopPropagation()
@@ -86,153 +54,100 @@ export default function PlanActions({
     run()
   }
 
-  const isDisabled =
-    disabled ||
-    planOverview.isRunning ||
-    planApply.isRunning ||
-    planCancel.isCancelling
-
   return (
     <div>
-      {(isRun ||
-        isRunning ||
-        isApplyVirtual ||
-        isApplyBackfill ||
-        isApplying) && (
-        <>
-          <div className="w-full flex px-4 py-2">
-            <p className="ml-2 text-xs">
-              <span>Plan for</span>
-              <b className="text-primary-500 font-bold mx-1">
-                {environment.name}
-              </b>
-              <span className="inline-block mr-1">environment</span>
-              {
-                <span className="inline-block mr-1">
-                  from{' '}
-                  <b>
-                    {isFalse(isStringEmptyOrNil(start))
-                      ? start
-                      : 'the begining of history'}
-                  </b>
-                </span>
-              }
-              {
-                <span className="inline-block mr-1">
-                  till{' '}
-                  <b>{isFalse(isStringEmptyOrNil(start)) ? end : 'today'}</b>
-                </span>
-              }
-              {no_gaps && (
-                <span className="inline-block mr-1">
-                  with <b>No Gaps</b>
-                </span>
-              )}
-              {skip_backfill && (
-                <span className="inline-block mr-1">
-                  without <b>Backfills</b>
-                </span>
-              )}
-              {forward_only && (
-                <span className="inline-block mr-1">
-                  consider as a <b>Breaking Change</b>
-                </span>
-              )}
-              {no_auto_categorization && (
-                <span className="inline-block mr-1">
-                  also set <b>Change Category</b> manually
-                </span>
-              )}
-              {isFalse(isStringEmptyOrNil(restate_models)) && (
-                <span className="inline-block mr-1">
-                  and restate folowing models <b>{restate_models}</b>
-                </span>
-              )}
-              {include_unmodified && (
-                <span className="inline-block mr-1">
-                  with views for all models
-                </span>
-              )}
-            </p>
-          </div>
-          <Divider />
-        </>
-      )}
+      <PlanActionsDescription />
+      <Divider />
       <div className="flex justify-between px-4 py-2">
         <div className="flex w-full items-center">
-          {(isRun || isRunning) && (
+          {(planAction.isRun || planAction.isRunning) && (
             <Button
-              disabled={isRunning || isDisabled}
+              disabled={planAction.isRunning}
               onClick={handleRun}
               ref={setFocus}
               variant={EnumVariant.Primary}
               autoFocus
             >
               <span>
-                {getActionName(planAction, [
+                {ModelPlanAction.getActionDisplayName(planAction, [
+                  EnumPlanAction.RunningTask,
                   EnumPlanAction.Running,
                   EnumPlanAction.Run,
                 ])}
               </span>
-              {skip_tests && (
-                <span className="inline-block ml-1">And Skip Test</span>
-              )}
-              {auto_apply && (
-                <span className="inline-block ml-1">And Auto Apply</span>
-              )}
             </Button>
           )}
-          {(isApplyBackfill || isApplyVirtual || isApplying) && (
+          {(planAction.isApply || planAction.isApplying) && (
             <Button
               onClick={handleApply}
-              disabled={isApplying || isDisabled}
+              disabled={planAction.isApplying}
               ref={setFocus}
               variant={EnumVariant.Primary}
             >
-              {getActionName(
+              {ModelPlanAction.getActionDisplayName(
                 planAction,
-                [EnumPlanAction.Applying],
-                isApplyBackfill ? 'Apply And Backfill' : 'Apply Virtual Update',
+                [
+                  EnumPlanAction.Applying,
+                  EnumPlanAction.ApplyBackfill,
+                  EnumPlanAction.ApplyVirtual,
+                  EnumPlanAction.ApplyChangesAndBackfill,
+                  EnumPlanAction.ApplyChanges,
+                  EnumPlanAction.ApplyMetadata,
+                ],
+                'Apply',
               )}
             </Button>
           )}
-          {isProcessing && (
+          {planAction.isProcessing && (
             <Button
               onClick={handleCancel}
               variant={EnumVariant.Danger}
               className="justify-self-end"
-              disabled={isCancelling}
+              disabled={planAction.isCancelling}
             >
-              {getActionName(planAction, [EnumPlanAction.Cancelling], 'Cancel')}
+              {ModelPlanAction.getActionDisplayName(
+                planAction,
+                [EnumPlanAction.Cancelling],
+                'Cancel',
+              )}
             </Button>
           )}
         </div>
         <div className="flex items-center">
-          {[isProcessing, disabled, isRun].every(isFalse) && (
+          {[planAction.isProcessing, planAction.isRun].every(isFalse) && (
             <Button
               onClick={handleReset}
               variant={EnumVariant.Neutral}
-              disabled={
-                includes(
-                  [
-                    EnumPlanAction.Running,
-                    EnumPlanAction.Applying,
-                    EnumPlanAction.Cancelling,
-                  ],
-                  planAction,
-                ) || isDisabled
-              }
+              disabled={includes(
+                [
+                  EnumPlanAction.Running,
+                  EnumPlanAction.Applying,
+                  EnumPlanAction.Cancelling,
+                ],
+                planAction.value,
+              )}
             >
-              {getActionName(planAction, [], 'Start Over')}
+              {ModelPlanAction.getActionDisplayName(
+                planAction,
+                [],
+                'Start Over',
+              )}
             </Button>
           )}
           <Button
             onClick={handleClose}
-            variant={isDone ? EnumVariant.Primary : EnumVariant.Neutral}
-            disabled={disabled}
-            ref={isDone || isApplying ? setFocus : undefined}
+            variant={
+              planAction.isDone ? EnumVariant.Primary : EnumVariant.Neutral
+            }
+            ref={
+              planAction.isDone || planAction.isApplying ? setFocus : undefined
+            }
           >
-            {getActionName(planAction, [EnumPlanAction.Done], 'Close')}
+            {ModelPlanAction.getActionDisplayName(
+              planAction,
+              [EnumPlanAction.Done],
+              'Close',
+            )}
           </Button>
         </div>
       </div>

--- a/web/client/src/library/components/plan/PlanActionsDescription.tsx
+++ b/web/client/src/library/components/plan/PlanActionsDescription.tsx
@@ -59,7 +59,7 @@ export default function PlanActionsDescription(): JSX.Element {
         )}
         {isFalse(isStringEmptyOrNil(restate_models)) && (
           <span className="inline-block mr-1">
-            and restate folowing models <b>{restate_models}</b>
+            and restate the followingmodels <b>{restate_models}</b>
           </span>
         )}
         {include_unmodified && (

--- a/web/client/src/library/components/plan/PlanActionsDescription.tsx
+++ b/web/client/src/library/components/plan/PlanActionsDescription.tsx
@@ -1,0 +1,71 @@
+import { useStoreContext } from '~/context/context'
+import { usePlan } from './context'
+import { isFalse, isStringEmptyOrNil } from '@utils/index'
+
+export default function PlanActionsDescription(): JSX.Element {
+  const {
+    start,
+    end,
+    skip_backfill,
+    no_gaps,
+    no_auto_categorization,
+    forward_only,
+    restate_models,
+    include_unmodified,
+  } = usePlan()
+
+  const environment = useStoreContext(s => s.environment)
+
+  return (
+    <div className="w-full flex px-4 py-2">
+      <p className="ml-2 text-xs">
+        <span>Plan for</span>
+        <b className="text-primary-500 font-bold mx-1">{environment.name}</b>
+        <span className="inline-block mr-1">environment</span>
+        {
+          <span className="inline-block mr-1">
+            from{' '}
+            <b>
+              {isFalse(isStringEmptyOrNil(start))
+                ? start
+                : 'the begining of history'}
+            </b>
+          </span>
+        }
+        {
+          <span className="inline-block mr-1">
+            till <b>{isFalse(isStringEmptyOrNil(start)) ? end : 'today'}</b>
+          </span>
+        }
+        {no_gaps && (
+          <span className="inline-block mr-1">
+            with <b>No Gaps</b>
+          </span>
+        )}
+        {skip_backfill && (
+          <span className="inline-block mr-1">
+            without <b>Backfills</b>
+          </span>
+        )}
+        {forward_only && (
+          <span className="inline-block mr-1">
+            consider as a <b>Breaking Change</b>
+          </span>
+        )}
+        {no_auto_categorization && (
+          <span className="inline-block mr-1">
+            also set <b>Change Category</b> manually
+          </span>
+        )}
+        {isFalse(isStringEmptyOrNil(restate_models)) && (
+          <span className="inline-block mr-1">
+            and restate folowing models <b>{restate_models}</b>
+          </span>
+        )}
+        {include_unmodified && (
+          <span className="inline-block mr-1">with views for all models</span>
+        )}
+      </p>
+    </div>
+  )
+}

--- a/web/client/src/library/components/plan/PlanApplyStageTracker.tsx
+++ b/web/client/src/library/components/plan/PlanApplyStageTracker.tsx
@@ -91,7 +91,7 @@ export default function PlanApplyStageTracker(): JSX.Element {
           </small>
         </div>
       )}
-      {planAction.isRunning || (isNotNil(changes) && isTrue(hasChanges)) ? (
+      {planAction.isRunning || isTrue(hasChanges) ? (
         <StageChanges
           report={changes ?? { meta: meta ?? { status: Status.init } }}
         />
@@ -104,7 +104,7 @@ export default function PlanApplyStageTracker(): JSX.Element {
         </PlanStageMessage>
       )}
 
-      {planAction.isRunning || (isNotNil(backfills) && isTrue(hasBackfills)) ? (
+      {planAction.isRunning || isTrue(hasBackfills) ? (
         <StageBackfills
           report={backfills ?? { meta: meta ?? { status: Status.init } }}
         />

--- a/web/client/src/library/components/plan/PlanOptions.tsx
+++ b/web/client/src/library/components/plan/PlanOptions.tsx
@@ -9,11 +9,7 @@ import { ModelEnvironment } from '~/models/environment'
 import { useStoreContext } from '~/context/context'
 import PlanBackfillDates from './PlanBackfillDates'
 
-interface PropsPlanOptions extends React.HTMLAttributes<HTMLElement> {}
-
-export default function PlanOptions({
-  className,
-}: PropsPlanOptions): JSX.Element {
+export default function PlanOptions(): JSX.Element {
   const dispatch = usePlanDispatch()
   const {
     skip_tests,
@@ -127,7 +123,7 @@ export default function PlanOptions({
                         label="Skip Tests"
                         info="Skip tests prior to generating the plan if they
               are defined"
-                        enabled={Boolean(skip_tests)}
+                        enabled={skip_tests}
                         setEnabled={(value: boolean) => {
                           dispatch({
                             type: EnumPlanActions.PlanOptions,
@@ -142,8 +138,16 @@ export default function PlanOptions({
                         info="Ensure that new snapshots have no data gaps when
               comparing to existing snapshots for matching
               models in the target environment"
-                        enabled={Boolean(no_gaps)}
-                        disabled={isInitialPlanRun}
+                        enabled={
+                          no_gaps ||
+                          (skip_backfill && environment.isDefaultInitial) ||
+                          environment.isDefaultInitial
+                        }
+                        disabled={
+                          isInitialPlanRun ||
+                          (skip_backfill && environment.isDefaultInitial) ||
+                          environment.isDefaultInitial
+                        }
                         setEnabled={(value: boolean) => {
                           dispatch({
                             type: EnumPlanActions.PlanOptions,
@@ -156,8 +160,10 @@ export default function PlanOptions({
                       <InputToggle
                         label="Skip Backfill"
                         info="Skip the backfill step"
-                        enabled={Boolean(skip_backfill)}
-                        disabled={isInitialPlanRun}
+                        enabled={skip_backfill}
+                        disabled={
+                          isInitialPlanRun || environment.isDefaultInitial
+                        }
                         setEnabled={(value: boolean) => {
                           dispatch({
                             type: EnumPlanActions.PlanOptions,
@@ -172,8 +178,10 @@ export default function PlanOptions({
                       <InputToggle
                         label="Include Unmodified"
                         info="Indicates whether to create views for all models in the target development environment or only for modified ones"
-                        enabled={Boolean(include_unmodified)}
-                        disabled={isInitialPlanRun}
+                        enabled={include_unmodified}
+                        disabled={
+                          isInitialPlanRun || environment.isDefaultInitial
+                        }
                         setEnabled={(value: boolean) => {
                           dispatch({
                             type: EnumPlanActions.PlanOptions,
@@ -184,8 +192,10 @@ export default function PlanOptions({
                       <InputToggle
                         label="Forward Only"
                         info="Create a plan for forward-only changes"
-                        enabled={Boolean(forward_only)}
-                        disabled={isInitialPlanRun}
+                        enabled={forward_only}
+                        disabled={
+                          isInitialPlanRun || environment.isDefaultInitial
+                        }
                         setEnabled={(value: boolean) => {
                           dispatch({
                             type: EnumPlanActions.PlanOptions,
@@ -198,7 +208,7 @@ export default function PlanOptions({
                       <InputToggle
                         label="Auto Apply"
                         info="Automatically apply the plan after it is generated"
-                        enabled={Boolean(auto_apply)}
+                        enabled={auto_apply}
                         setEnabled={(value: boolean) => {
                           dispatch({
                             type: EnumPlanActions.PlanOptions,
@@ -211,8 +221,10 @@ export default function PlanOptions({
                       <InputToggle
                         label="No Auto Categorization"
                         info="Set category manually"
-                        enabled={Boolean(no_auto_categorization)}
-                        disabled={isInitialPlanRun}
+                        enabled={no_auto_categorization}
+                        disabled={
+                          isInitialPlanRun || environment.isDefaultInitial
+                        }
                         setEnabled={(value: boolean) => {
                           dispatch({
                             type: EnumPlanActions.PlanOptions,

--- a/web/client/src/library/components/plan/help.spec.ts
+++ b/web/client/src/library/components/plan/help.spec.ts
@@ -1,89 +1,113 @@
 import { describe, it, expect } from 'vitest'
-import { EnumPlanAction } from '../../../context/plan'
-import { getActionName, isModified } from './help'
+import { EnumPlanAction, ModelPlanAction } from '@models/plan-action'
+import { isModified } from './help'
 
-describe('getActionName', () => {
+describe('getActionDisplayName', () => {
   it('should return "Done" when action is EnumPlanAction.Done', () => {
-    const action = EnumPlanAction.Done
+    const action = new ModelPlanAction({ value: EnumPlanAction.Done })
     const options = [EnumPlanAction.Done]
     const fallback = 'Start'
     const expected = 'Done'
 
-    const result = getActionName(action, options, fallback)
+    const result = ModelPlanAction.getActionDisplayName(
+      action,
+      options,
+      fallback,
+    )
 
     expect(result).toBe(expected)
   })
 
   it('should return "Running..." when action is EnumPlanAction.Running', () => {
-    const action = EnumPlanAction.Running
+    const action = new ModelPlanAction({ value: EnumPlanAction.Running })
     const options = [EnumPlanAction.Running]
     const fallback = 'Start'
     const expected = 'Running...'
 
-    const result = getActionName(action, options, fallback)
+    const result = ModelPlanAction.getActionDisplayName(
+      action,
+      options,
+      fallback,
+    )
 
     expect(result).toBe(expected)
   })
 
   it('should return "Applying..." when action is EnumPlanAction.Applying', () => {
-    const action = EnumPlanAction.Applying
+    const action = new ModelPlanAction({ value: EnumPlanAction.Applying })
     const options = [EnumPlanAction.Applying]
     const fallback = 'Start'
     const expected = 'Applying...'
 
-    const result = getActionName(action, options, fallback)
+    const result = ModelPlanAction.getActionDisplayName(
+      action,
+      options,
+      fallback,
+    )
 
     expect(result).toBe(expected)
   })
 
   it('should return "Cancelling..." when action is EnumPlanAction.Cancelling', () => {
-    const action = EnumPlanAction.Cancelling
+    const action = new ModelPlanAction({ value: EnumPlanAction.Cancelling })
     const options = [EnumPlanAction.Cancelling]
     const fallback = 'Start'
     const expected = 'Cancelling...'
 
-    const result = getActionName(action, options, fallback)
+    const result = ModelPlanAction.getActionDisplayName(
+      action,
+      options,
+      fallback,
+    )
 
     expect(result).toBe(expected)
   })
 
   it('should return "Run" when action is EnumPlanAction.Run', () => {
-    const action = EnumPlanAction.Run
+    const action = new ModelPlanAction({ value: EnumPlanAction.Run })
     const options = [EnumPlanAction.Run]
     const fallback = 'Start'
     const expected = 'Run'
 
-    const result = getActionName(action, options, fallback)
+    const result = ModelPlanAction.getActionDisplayName(
+      action,
+      options,
+      fallback,
+    )
 
     expect(result).toBe(expected)
   })
 
   it('should return "Apply" when action is EnumPlanAction.ApplyBackfill', () => {
     const fallback = 'Start'
-    let result = getActionName(
-      EnumPlanAction.ApplyBackfill,
+    let result = ModelPlanAction.getActionDisplayName(
+      new ModelPlanAction({ value: EnumPlanAction.ApplyBackfill }),
       [EnumPlanAction.ApplyBackfill],
       fallback,
     )
 
-    expect(result).toBe('Apply Backfill')
+    expect(result).toBe('Apply And Backfill')
 
-    result = getActionName(
-      EnumPlanAction.ApplyVirtual,
+    result = ModelPlanAction.getActionDisplayName(
+      new ModelPlanAction({ value: EnumPlanAction.ApplyVirtual }),
       [EnumPlanAction.ApplyVirtual],
       fallback,
     )
 
-    expect(result).toBe('Apply Virtual')
+    expect(result).toBe('Apply Virtual Update')
   })
 
   it('should return fallback when action is not included in options', () => {
-    const action = EnumPlanAction.Done
+    const action = new ModelPlanAction({ value: EnumPlanAction.Done })
     const options = [EnumPlanAction.Run]
     const fallback = 'Start'
     const expected = 'Start'
 
-    const result = getActionName(action, options, fallback)
+    const result = ModelPlanAction.getActionDisplayName(
+      action,
+      options,
+      fallback,
+    )
 
     expect(result).toBe(expected)
   })

--- a/web/client/src/library/components/plan/help.ts
+++ b/web/client/src/library/components/plan/help.ts
@@ -1,46 +1,6 @@
 import { type ModelPlanOverviewTracker } from '@models/tracker-plan-overview'
-import { EnumPlanAction, type PlanAction } from '../../../context/plan'
-import { isArrayNotEmpty, isNil, isNotNil } from '../../../utils'
+import { isArrayNotEmpty, isNotNil } from '../../../utils'
 import { type ModelPlanApplyTracker } from '@models/tracker-plan-apply'
-
-export function getActionName(
-  action: PlanAction,
-  options: string[] = [],
-  fallback: string = 'Start',
-): string {
-  if (!options.includes(action)) return fallback
-
-  let name: string
-
-  switch (action) {
-    case EnumPlanAction.Done:
-      name = 'Done'
-      break
-    case EnumPlanAction.Running:
-      name = 'Running...'
-      break
-    case EnumPlanAction.Applying:
-      name = 'Applying...'
-      break
-    case EnumPlanAction.Cancelling:
-      name = 'Cancelling...'
-      break
-    case EnumPlanAction.Run:
-      name = 'Run'
-      break
-    case EnumPlanAction.ApplyVirtual:
-      name = 'Apply Virtual'
-      break
-    case EnumPlanAction.ApplyBackfill:
-      name = 'Apply Backfill'
-      break
-    default:
-      name = fallback
-      break
-  }
-
-  return name
-}
 
 export function isModified<T extends object>(modified?: T): boolean {
   return Object.values(modified ?? {}).some(isArrayNotEmpty)
@@ -48,6 +8,7 @@ export function isModified<T extends object>(modified?: T): boolean {
 
 type PlanOverviewDetails = Pick<
   ModelPlanOverviewTracker,
+  | 'meta'
   | 'start'
   | 'end'
   | 'hasChanges'
@@ -56,8 +17,6 @@ type PlanOverviewDetails = Pick<
   | 'backfills'
   | 'validation'
   | 'plan_options'
-  | 'isVirtualUpdate'
-  | 'isRunning'
 >
 
 export function getPlanOverviewDetails(
@@ -66,39 +25,20 @@ export function getPlanOverviewDetails(
 ): PlanOverviewDetails {
   const isLatest =
     planApply.isFinished &&
-    isNil(planOverview.applyType) &&
+    (planOverview.isLatest || planOverview.isRunning) &&
     isNotNil(planApply.overview)
-  const start = isLatest ? planApply.start : planOverview.start
-  const end = isLatest ? planApply.end : planOverview.end
-  const hasChanges = isLatest
-    ? planApply.overview.hasChanges
-    : planOverview.hasChanges
-  const hasBackfills = isLatest
-    ? planApply.overview.hasBackfills
-    : planOverview.hasBackfills
-  const changes = isLatest ? planApply.changes : planOverview.changes
-  const backfills = isLatest ? planApply.backfills : planOverview.backfills
-  const validation = isLatest ? planApply.validation : planOverview.validation
-  const plan_options = isLatest
-    ? planApply.plan_options
-    : planOverview.plan_options
-  const isVirtualUpdate = isLatest
-    ? planApply.overview.isVirtualUpdate
-    : planOverview.isVirtualUpdate
-  const isRunning = isLatest
-    ? planApply.overview.isRunning
-    : planOverview.isRunning
+  const overview = isLatest ? planApply.overview : planOverview
+  const plan = isLatest ? planApply : planOverview
 
   return {
-    start,
-    end,
-    hasChanges,
-    hasBackfills,
-    changes,
-    backfills,
-    validation,
-    plan_options,
-    isVirtualUpdate,
-    isRunning,
+    meta: plan.meta,
+    start: plan.start,
+    end: plan.end,
+    hasChanges: overview.hasChanges,
+    hasBackfills: overview.hasBackfills,
+    changes: plan.changes,
+    backfills: plan.backfills,
+    validation: plan.validation,
+    plan_options: plan.plan_options,
   }
 }

--- a/web/client/src/library/components/plan/hooks.ts
+++ b/web/client/src/library/components/plan/hooks.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import {
-  type BodyApplyApiCommandsApplyPostCategoriesAnyOf,
-  type BodyApplyApiCommandsApplyPostCategories,
+  type BodyInitiateApplyApiCommandsApplyPostCategoriesAnyOf,
+  type BodyInitiateApplyApiCommandsApplyPostCategories,
   type PlanDates,
   type PlanOptions,
 } from '~/api/client'
@@ -80,7 +80,7 @@ export function useApplyPayload({
 }): {
   planDates?: PlanDates
   planOptions: PlanOptions
-  categories: BodyApplyApiCommandsApplyPostCategories
+  categories: BodyInitiateApplyApiCommandsApplyPostCategories
 } {
   const {
     start,
@@ -108,7 +108,7 @@ export function useApplyPayload({
   const categories = useMemo(() => {
     return Array.from(
       change_categorization.values(),
-    ).reduce<BodyApplyApiCommandsApplyPostCategoriesAnyOf>(
+    ).reduce<BodyInitiateApplyApiCommandsApplyPostCategoriesAnyOf>(
       (acc, { category, change }) => {
         acc[change.model_name] = category.value
 

--- a/web/client/src/library/pages/ide/IDE.tsx
+++ b/web/client/src/library/pages/ide/IDE.tsx
@@ -9,7 +9,13 @@ import {
 } from '../../../api'
 import { useStorePlan } from '../../../context/plan'
 import { useChannelEvents } from '../../../api/channels'
-import { isArrayEmpty, isNil, isNotNil, isObjectEmpty, isFalse } from '~/utils'
+import {
+  isArrayEmpty,
+  isNil,
+  isNotNil,
+  isFalse,
+  isObjectNotEmpty,
+} from '~/utils'
 import { useStoreContext } from '~/context/context'
 import { ArrowLongRightIcon } from '@heroicons/react/24/solid'
 import { EnumSize, EnumVariant } from '~/types/enum'
@@ -17,7 +23,12 @@ import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { EnumRoutes } from '~/routes'
 import { type Tests, useStoreProject } from '@context/project'
 import { EnumErrorKey, type ErrorIDE, useIDE } from './context'
-import { type Directory, type Model, type Environments } from '@api/client'
+import {
+  type Directory,
+  type Model,
+  type Environments,
+  type EnvironmentsEnvironments,
+} from '@api/client'
 import { Button } from '@components/button/Button'
 import { Divider } from '@components/divider/Divider'
 import Container from '@components/container/Container'
@@ -333,22 +344,16 @@ export default function PageIDE(): JSX.Element {
   }
 
   function updateEnviroments(data: Optional<Environments>): void {
-    if (
-      isNil(data) ||
-      isNil(data.environments) ||
-      isObjectEmpty(data) ||
-      isObjectEmpty(data.environments)
-    )
-      return
-
     const { environments, default_target_environment, pinned_environments } =
-      data
+      data ?? {}
 
-    addSynchronizedEnvironments(
-      Object.values(environments),
-      default_target_environment,
-      pinned_environments,
-    )
+    if (isObjectNotEmpty<EnvironmentsEnvironments>(environments)) {
+      addSynchronizedEnvironments(
+        Object.values(environments),
+        default_target_environment,
+        pinned_environments,
+      )
+    }
   }
 
   function restoreEditorTabsFromSaved(files: ModelFile[]): void {

--- a/web/client/src/library/pages/ide/IDE.tsx
+++ b/web/client/src/library/pages/ide/IDE.tsx
@@ -4,17 +4,12 @@ import {
   useApiFiles,
   useApiEnvironments,
   useApiPlanRun,
+  useApiPlanApply,
+  useApiCancelPlan,
 } from '../../../api'
 import { useStorePlan } from '../../../context/plan'
 import { useChannelEvents } from '../../../api/channels'
-import {
-  isArrayEmpty,
-  isFalse,
-  isNil,
-  isNotNil,
-  isObjectEmpty,
-  isTrue,
-} from '~/utils'
+import { isArrayEmpty, isNil, isNotNil, isObjectEmpty, isFalse } from '~/utils'
 import { useStoreContext } from '~/context/context'
 import { ArrowLongRightIcon } from '@heroicons/react/24/solid'
 import { EnumSize, EnumVariant } from '~/types/enum'
@@ -22,7 +17,7 @@ import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { EnumRoutes } from '~/routes'
 import { type Tests, useStoreProject } from '@context/project'
 import { EnumErrorKey, type ErrorIDE, useIDE } from './context'
-import { Status, type Directory, type Model } from '@api/client'
+import { type Directory, type Model, type Environments } from '@api/client'
 import { Button } from '@components/button/Button'
 import { Divider } from '@components/divider/Divider'
 import Container from '@components/container/Container'
@@ -39,6 +34,7 @@ import {
 import { type PlanOverviewTracker } from '@models/tracker-plan-overview'
 import { type PlanApplyTracker } from '@models/tracker-plan-apply'
 import { type PlanCancelTracker } from '@models/tracker-plan-cancel'
+import { ModelPlanAction } from '@models/plan-action'
 
 const ReportErrors = lazy(
   async () => await import('../../components/report/ReportErrors'),
@@ -52,28 +48,25 @@ export default function PageIDE(): JSX.Element {
 
   const { removeError, addError } = useIDE()
 
-  const isRunningPlan = useStoreContext(s => s.isRunningPlan)
-  const setIsRunningPlan = useStoreContext(s => s.setIsRunningPlan)
+  const models = useStoreContext(s => s.models)
   const showConfirmation = useStoreContext(s => s.showConfirmation)
   const setShowConfirmation = useStoreContext(s => s.setShowConfirmation)
   const confirmations = useStoreContext(s => s.confirmations)
   const removeConfirmation = useStoreContext(s => s.removeConfirmation)
-  const models = useStoreContext(s => s.models)
   const environment = useStoreContext(s => s.environment)
   const setModels = useStoreContext(s => s.setModels)
   const addSynchronizedEnvironments = useStoreContext(
     s => s.addSynchronizedEnvironments,
   )
-  const hasSynchronizedEnvironments = useStoreContext(
-    s => s.hasSynchronizedEnvironments,
-  )
 
   const planOverview = useStorePlan(s => s.planOverview)
   const planApply = useStorePlan(s => s.planApply)
   const planCancel = useStorePlan(s => s.planCancel)
+  const planAction = useStorePlan(s => s.planAction)
   const setPlanOverview = useStorePlan(s => s.setPlanOverview)
   const setPlanApply = useStorePlan(s => s.setPlanApply)
   const setPlanCancel = useStorePlan(s => s.setPlanCancel)
+  const setPlanAction = useStorePlan(s => s.setPlanAction)
 
   const project = useStoreProject(s => s.project)
   const setProject = useStoreProject(s => s.setProject)
@@ -97,20 +90,20 @@ export default function PageIDE(): JSX.Element {
   // all pages have access to models and files
   const { refetch: getModels, cancel: cancelRequestModels } = useApiModels()
   const { refetch: getFiles, cancel: cancelRequestFiles } = useApiFiles()
+  const { refetch: getEnvironments, cancel: cancelRequestEnvironments } =
+    useApiEnvironments()
+  const { isFetching: isFetchingPlanApply } = useApiPlanApply(environment.name)
+  const { isFetching: isFetchingPlanCancel } = useApiCancelPlan()
   const {
-    data: dataEnvironments,
-    refetch: getEnvironments,
-    cancel: cancelRequestEnvironments,
-  } = useApiEnvironments()
-  const { refetch: planRun, cancel: cancelRequestPlan } = useApiPlanRun(
-    environment.name,
-    {
-      planOptions: {
-        skip_tests: true,
-        include_unmodified: true,
-      },
+    refetch: planRun,
+    cancel: cancelRequestPlan,
+    isFetching: isFetchingPlanRun,
+  } = useApiPlanRun(environment.name, {
+    planOptions: {
+      skip_tests: true,
+      include_unmodified: true,
     },
-  )
+  })
 
   useEffect(() => {
     const channelModels = channel<Model[]>('models', updateModels)
@@ -219,6 +212,8 @@ export default function PageIDE(): JSX.Element {
       setProject(project)
     })
 
+    void getEnvironments().then(({ data }) => updateEnviroments(data))
+
     channelModels.subscribe()
     channelErrors.subscribe()
     channelPlanOverview.subscribe()
@@ -250,55 +245,59 @@ export default function PageIDE(): JSX.Element {
   }, [location])
 
   useEffect(() => {
-    if (
-      isNil(dataEnvironments) ||
-      isNil(dataEnvironments.environments) ||
-      isObjectEmpty(dataEnvironments) ||
-      isObjectEmpty(dataEnvironments.environments)
-    )
-      return
-
-    const { environments, default_target_environment, pinned_environments } =
-      dataEnvironments
-
-    addSynchronizedEnvironments(
-      Object.values(environments),
-      default_target_environment,
-      pinned_environments,
-    )
-
-    // This use case is happening when user refreshes the page
-    // while plan is still applying
-    if (isFalse(isRunningPlan) && isFalse(planCancel.isCancelling)) {
-      void planRun()
-    }
-  }, [dataEnvironments])
+    setShowConfirmation(confirmations.length > 0)
+  }, [confirmations])
 
   useEffect(() => {
-    if (models.size > 0 && isFalse(hasSynchronizedEnvironments())) {
-      void getEnvironments()
-    }
-
-    if (hasSynchronizedEnvironments() && isFalse(planCancel.isCancelling)) {
+    if (models.size > 0 && isFalse(planAction.isProcessing)) {
       void planRun()
     }
   }, [models])
 
   useEffect(() => {
-    setShowConfirmation(confirmations.length > 0)
-  }, [confirmations])
+    if (planOverview.isFetching !== isFetchingPlanRun) {
+      planOverview.isFetching = isFetchingPlanRun
 
-  useEffect(() => {
-    const { promote, meta } = planApply
-
-    if (
-      isNotNil(promote) &&
-      isTrue(meta?.done) &&
-      meta?.status === Status.success
-    ) {
-      void getEnvironments()
+      setPlanOverview(planOverview)
     }
-  }, [planApply])
+
+    if (planApply.isFetching !== isFetchingPlanApply) {
+      planApply.isFetching = isFetchingPlanApply
+
+      if (planApply.isFinished) {
+        void getEnvironments().then(({ data }) => {
+          updateEnviroments(data)
+
+          void planRun()
+        })
+      }
+
+      setPlanApply(planApply)
+    }
+
+    if (planCancel.isFetching !== isFetchingPlanCancel) {
+      planCancel.isFetching = isFetchingPlanCancel
+
+      setPlanCancel(planCancel)
+    }
+
+    const value = ModelPlanAction.getPlanAction({
+      planOverview,
+      planApply,
+      planCancel,
+    })
+
+    if (isNotNil(value)) {
+      setPlanAction(new ModelPlanAction({ value }))
+    }
+  }, [
+    planOverview,
+    planApply,
+    planCancel,
+    isFetchingPlanRun,
+    isFetchingPlanApply,
+    isFetchingPlanCancel,
+  ])
 
   function updateModels(models?: Model[]): void {
     if (isNotNil(models)) {
@@ -328,15 +327,28 @@ export default function PageIDE(): JSX.Element {
   }
 
   function updatePlanApplyTracker(data: PlanApplyTracker): void {
-    if (isNotNil(data)) {
-      setIsRunningPlan(isFalse(data?.meta?.done))
-    } else {
-      setIsRunningPlan(false)
-    }
-
     planApply.update(data, planOverview)
 
     setPlanApply(planApply)
+  }
+
+  function updateEnviroments(data: Optional<Environments>): void {
+    if (
+      isNil(data) ||
+      isNil(data.environments) ||
+      isObjectEmpty(data) ||
+      isObjectEmpty(data.environments)
+    )
+      return
+
+    const { environments, default_target_environment, pinned_environments } =
+      data
+
+    addSynchronizedEnvironments(
+      Object.values(environments),
+      default_target_environment,
+      pinned_environments,
+    )
   }
 
   function restoreEditorTabsFromSaved(files: ModelFile[]): void {

--- a/web/client/src/library/pages/ide/PlanSidebar.tsx
+++ b/web/client/src/library/pages/ide/PlanSidebar.tsx
@@ -30,7 +30,6 @@ const PlanSidebar = memo(function PlanSidebar(): JSX.Element {
       <Dialog.Panel className="bg-theme border-8 border-r-0 border-secondary-10 dark:border-primary-10 absolute w-[90%] md:w-[75%] xl:w-[60%] h-full right-0 flex flex-col">
         <PlanProvider>
           <Plan
-            disabled={isClosingModal}
             onClose={closeModal}
             key={environment.name}
             environment={environment}

--- a/web/client/src/models/plan-action.ts
+++ b/web/client/src/models/plan-action.ts
@@ -1,0 +1,216 @@
+import { includes, isFalse, isNil, isNotNil } from '@utils/index'
+import { ModelInitial } from './initial'
+import { type ModelPlanOverviewTracker } from './tracker-plan-overview'
+import { type ModelPlanApplyTracker } from './tracker-plan-apply'
+import { type ModelPlanCancelTracker } from './tracker-plan-cancel'
+
+export const EnumPlanAction = {
+  Done: 'done',
+  Run: 'run',
+  Running: 'running',
+  RunningTask: 'running-task',
+  ApplyVirtual: 'apply-virtual',
+  ApplyBackfill: 'apply-backfill',
+  ApplyChanges: 'apply-changes',
+  ApplyChangesAndBackfill: 'apply-changes-and-backfill',
+  ApplyMetadata: 'apply-metadata',
+  Applying: 'applying',
+  Cancelling: 'cancelling',
+} as const
+
+export type PlanAction = KeyOf<typeof EnumPlanAction>
+
+export interface InitialPlanAction {
+  value: PlanAction
+}
+
+export class ModelPlanAction<
+  T extends InitialPlanAction = InitialPlanAction,
+> extends ModelInitial<T> {
+  private readonly _value: PlanAction
+
+  constructor(initial?: T | ModelPlanAction<T>) {
+    super(
+      (initial as ModelPlanAction<T>)?.isModel
+        ? (initial as ModelPlanAction<T>).initial
+        : {
+            ...(initial as T),
+            value: initial?.value ?? EnumPlanAction.Run,
+          },
+    )
+
+    this._value = initial?.value ?? this.initial.value
+  }
+
+  get value(): PlanAction {
+    return this._value
+  }
+
+  get isRun(): boolean {
+    return this.value === EnumPlanAction.Run
+  }
+
+  get isDone(): boolean {
+    return this.value === EnumPlanAction.Done
+  }
+
+  get isApplyVirtual(): boolean {
+    return this.value === EnumPlanAction.ApplyVirtual
+  }
+
+  get isApplyBackfill(): boolean {
+    return this.value === EnumPlanAction.ApplyBackfill
+  }
+
+  get isApplyChanges(): boolean {
+    return this.value === EnumPlanAction.ApplyChanges
+  }
+
+  get isApplyChangesAndBackfill(): boolean {
+    return this.value === EnumPlanAction.ApplyChangesAndBackfill
+  }
+
+  get isApplyMetadata(): boolean {
+    return this.value === EnumPlanAction.ApplyMetadata
+  }
+
+  get isApply(): boolean {
+    return (
+      this.isApplyVirtual ||
+      this.isApplyBackfill ||
+      this.isApplyChanges ||
+      this.isApplyChangesAndBackfill ||
+      this.isApplyMetadata
+    )
+  }
+
+  get isCancelling(): boolean {
+    return this.value === EnumPlanAction.Cancelling
+  }
+
+  get isApplying(): boolean {
+    return this.value === EnumPlanAction.Applying
+  }
+
+  get isRunning(): boolean {
+    return includes(
+      [EnumPlanAction.Running, EnumPlanAction.RunningTask],
+      this.value,
+    )
+  }
+
+  get isRunningTask(): boolean {
+    return this.value === EnumPlanAction.RunningTask
+  }
+
+  get isProcessing(): boolean {
+    return this.isRunning || this.isApplying || this.isCancelling
+  }
+
+  get isIdle(): boolean {
+    return isFalse(this.isProcessing)
+  }
+
+  get displayStatus(): string {
+    if (this.isRunningTask) return 'Running Task...'
+    if (this.isApplying) return 'Applying Plan...'
+    if (this.isRunning) return 'Getting Changes...'
+
+    return 'Plan'
+  }
+
+  static getActionDisplayName(
+    action: ModelPlanAction,
+    options: PlanAction[] = [],
+    fallback: string = 'Run',
+  ): string {
+    if (!options.includes(action.value)) return fallback
+
+    let name: string
+
+    switch (action.value) {
+      case EnumPlanAction.Done:
+        name = 'Done'
+        break
+      case EnumPlanAction.Running:
+        name = 'Running...'
+        break
+      case EnumPlanAction.RunningTask:
+        name = 'Running Task...'
+        break
+      case EnumPlanAction.Applying:
+        name = 'Applying...'
+        break
+      case EnumPlanAction.Cancelling:
+        name = 'Cancelling...'
+        break
+      case EnumPlanAction.Run:
+        name = 'Run'
+        break
+      case EnumPlanAction.ApplyChangesAndBackfill:
+        name = 'Apply Changes And Backfill'
+        break
+      case EnumPlanAction.ApplyChanges:
+        name = 'Apply Changes And Skip Backfill'
+        break
+      case EnumPlanAction.ApplyVirtual:
+        name = 'Apply Virtual Update'
+        break
+      case EnumPlanAction.ApplyBackfill:
+        name = 'Apply And Backfill'
+        break
+      case EnumPlanAction.ApplyMetadata:
+        name = 'Apply Metadata'
+        break
+      default:
+        name = fallback
+        break
+    }
+
+    return name
+  }
+
+  static getPlanAction({
+    planOverview,
+    planApply,
+    planCancel,
+  }: {
+    planOverview: ModelPlanOverviewTracker
+    planApply: ModelPlanApplyTracker
+    planCancel: ModelPlanCancelTracker
+  }): Optional<PlanAction> {
+    const {
+      isLatest,
+      hasBackfills,
+      hasChanges,
+      isRunning,
+      metadata,
+      skipBackfill,
+    } = planOverview
+    const isRunningApply = planApply.isRunning
+    const isRunningCancel = planCancel.isRunning
+    const isFinished =
+      planApply.isFinished ||
+      isLatest ||
+      (isNil(hasChanges) && Boolean(hasBackfills) && skipBackfill)
+    const isMetadataUpdate = Boolean(metadata?.length) && isNil(hasBackfills)
+    const isChangesUpdate =
+      Boolean(hasChanges) && Boolean(hasBackfills) && skipBackfill
+    const isVirtualUpdate = isNotNil(hasChanges) && isNil(hasBackfills)
+    const isBackfillUpdate =
+      isNil(hasChanges) && Boolean(hasBackfills) && isFalse(skipBackfill)
+    const isChangesAndBackfillUpdate =
+      Boolean(hasChanges) && Boolean(hasBackfills) && isFalse(skipBackfill)
+
+    if (isRunning) return EnumPlanAction.Running
+    if (isRunningCancel) return EnumPlanAction.Cancelling
+    if (isRunningApply) return EnumPlanAction.Applying
+    if (isFinished) return EnumPlanAction.Done
+    if (isMetadataUpdate) return EnumPlanAction.ApplyMetadata
+    if (isVirtualUpdate) return EnumPlanAction.ApplyVirtual
+    if (isChangesUpdate) return EnumPlanAction.ApplyChanges
+    if (isBackfillUpdate) return EnumPlanAction.ApplyBackfill
+    if (isChangesAndBackfillUpdate)
+      return EnumPlanAction.ApplyChangesAndBackfill
+  }
+}

--- a/web/client/src/models/tracker-plan-apply.ts
+++ b/web/client/src/models/tracker-plan-apply.ts
@@ -38,10 +38,9 @@ export class ModelPlanApplyTracker
   _lastPlanOverview: Optional<ModelPlanOverviewTracker>
 
   constructor(model?: ModelPlanApplyTracker) {
-    super(model?.initial)
+    super(model)
 
     if (model instanceof ModelPlanApplyTracker) {
-      this._current = structuredClone(model.current)
       this._last = structuredClone(model._last)
       this._planOverview = new ModelPlanOverviewTracker(model._planOverview)
       this._lastPlanOverview = new ModelPlanOverviewTracker(

--- a/web/client/src/models/tracker-plan-cancel.ts
+++ b/web/client/src/models/tracker-plan-cancel.ts
@@ -7,14 +7,6 @@ export interface PlanCancelTracker extends PlanTracker {
 }
 
 export class ModelPlanCancelTracker extends ModelPlanTracker<PlanCancelTracker> {
-  constructor(model?: ModelPlanCancelTracker) {
-    super(model?.initial)
-
-    if (model instanceof ModelPlanCancelTracker) {
-      this._current = structuredClone(model.current)
-    }
-  }
-
   get cancel(): Optional<PlanStageCancel> {
     return this._current?.cancel
   }

--- a/web/client/src/models/tracker-plan-overview.ts
+++ b/web/client/src/models/tracker-plan-overview.ts
@@ -10,8 +10,7 @@ import {
   type PlanStageChangesRemoved,
 } from '@api/client'
 import { ModelPlanTracker, type PlanTracker } from './tracker-plan'
-import { isArrayNotEmpty, isNil, isNotNil, isTrue } from '@utils/index'
-import { EnumPlanApplyType, type PlanApplyType } from '@context/plan'
+import { isArrayNotEmpty, isNil } from '@utils/index'
 
 export interface PlanOverviewTracker extends PlanTracker {
   validation?: PlanStageValidation
@@ -31,10 +30,9 @@ export class ModelPlanOverviewTracker
   hasBackfills: Optional<boolean> = undefined
 
   constructor(model?: ModelPlanOverviewTracker) {
-    super(model?.initial)
+    super(model)
 
     if (model instanceof ModelPlanOverviewTracker) {
-      this._current = structuredClone(model.current)
       this.hasChanges = model.hasChanges
       this.hasBackfills = model.hasBackfills
     }
@@ -80,23 +78,16 @@ export class ModelPlanOverviewTracker
     return this._current?.changes?.modified?.metadata
   }
 
-  get applyType(): Optional<PlanApplyType> {
-    if (isTrue(this.hasBackfills)) return EnumPlanApplyType.Backfill
-    if (isNotNil(this.hasChanges)) return EnumPlanApplyType.Virtual
-
-    return undefined
-  }
-
   get isLatest(): boolean {
-    return this.isFinished && isNil(this.hasChanges) && isNil(this.hasBackfills)
+    return this.isFinished && isNil(this.hasBackfills) && isNil(this.hasChanges)
   }
 
-  get isVirtualUpdate(): boolean {
-    return this.isFinished && this.applyType === EnumPlanApplyType.Virtual
+  get skipTests(): boolean {
+    return this._current?.plan_options?.skip_tests ?? false
   }
 
-  get isBackfillUpdate(): boolean {
-    return this.isFinished && this.applyType === EnumPlanApplyType.Backfill
+  get skipBackfill(): boolean {
+    return this._current?.plan_options?.skip_backfill ?? false
   }
 
   update(tracker: PlanOverviewTracker): void {

--- a/web/client/src/utils/index.ts
+++ b/web/client/src/utils/index.ts
@@ -46,7 +46,7 @@ export function isObjectEmpty(value: unknown): boolean {
   return isObject(value) && isArrayEmpty(Object.keys(value as object))
 }
 
-export function isObjectNotEmpty(value: unknown): boolean {
+export function isObjectNotEmpty<TValue>(value: unknown): value is TValue {
   return isObject(value) && isArrayNotEmpty(Object.keys(value as object))
 }
 


### PR DESCRIPTION
Previous update to plan flow has introduced some regression. It inaccurately display stages and messages (Button Labels). Also not showing changes to Model Metadata and when there are some backfills but no changes.
I added class to control current `plan-action` from single source. 