### PR TITLE
Chore: Do not load a context when starting the UI

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -68,7 +68,7 @@ def cli(
         if ctx.invoked_subcommand == "init":
             ctx.obj = path
             return
-        elif ctx.invoked_subcommand in ("create_external_models", "migrate", "rollback"):
+        elif ctx.invoked_subcommand in ("create_external_models", "migrate", "rollback", "ui"):
             load = False
 
     # Delegates the execution of the --help option to the corresponding subcommand


### PR DESCRIPTION
The context created by the CLI cannot be passed to the uvicorn process so the UI will need to create its own anyway.