### PR TITLE
fix!: make logging more intuitive to use

### DIFF
--- a/sqlmesh/__init__.py
+++ b/sqlmesh/__init__.py
@@ -122,7 +122,7 @@ class CustomFormatter(logging.Formatter):
 def configure_logging(
     force_debug: bool = False,
     ignore_warnings: bool = False,
-    write_to_stdout: bool = True,
+    write_to_stdout: bool = False,
     write_to_file: bool = True,
     log_limit: int = c.DEFAULT_LOG_LIMIT,
 ) -> None:

--- a/sqlmesh/cicd/bot.py
+++ b/sqlmesh/cicd/bot.py
@@ -21,7 +21,7 @@ def bot(
     config: t.Optional[str] = None,
 ) -> None:
     """SQLMesh CI/CD Bot. Currently only Github Actions is supported. See https://sqlmesh.readthedocs.io/en/stable/integrations/github/ for details"""
-    configure_logging(write_to_file=False)
+    configure_logging(write_to_stdout=True, write_to_file=False)
 
     ctx.obj = {
         "paths": paths,

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -77,7 +77,7 @@ def cli(
 
     configs = load_configs(config, paths)
     log_limit = list(configs.values())[0].log_limit
-    configure_logging(debug, ignore_warnings, write_to_stdout=False, log_limit=log_limit)
+    configure_logging(debug, ignore_warnings, log_limit=log_limit)
 
     try:
         context = Context(


### PR DESCRIPTION
if i call configure_logging() in the notebook, i expect ignore_warnings to work, with the current it doesn't work because write_to_stdout is set to true make the default log level info.