### PR TITLE
Feat: implement a cache for dbt's adapter.list_relations method

### DIFF
--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -339,7 +339,7 @@ class RuntimeAdapter(BaseAdapter):
 
     def _table_to_relation(self, table: exp.Table) -> BaseRelation:
         return self.relation_type.create(
-            database=table.catalog or None,
+            database=table.catalog or self.engine_adapter.default_catalog,
             schema=table.db,
             identifier=table.name,
             quote_policy=self.quote_policy,
@@ -406,7 +406,9 @@ class CachingEngineAdapter:
         table = exp.to_table(relation_name)
         schema = to_schema(table)
         relation = self.relation_type.create(
-            database=table.catalog or None, schema=table.db, identifier=table.name
+            database=table.catalog or self.engine_adapter.default_catalog,
+            schema=table.db,
+            identifier=table.name,
         )
 
         relations = self.cache.get(schema)

--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -186,11 +186,11 @@ class RuntimeAdapter(BaseAdapter):
 
         table_mapping = table_mapping or {}
 
-        self.engine_adapter = engine_adapter
         self.relation_type = relation_type or BaseRelation
         self.column_type = column_type or Column
         self.quote_policy = quote_policy or Policy()
         self.cache: t.Dict[exp.Table, t.List[BaseRelation]] = {}
+        self.engine_adapter = CachingAdapter(engine_adapter, self.cache, self.relation_type)
         self.table_mapping = {
             **to_table_mapping((snapshots or {}).values(), deployability_index),
             **table_mapping,
@@ -379,7 +379,7 @@ class CachingAdapter:
         self.cache = cache
         self.relation_type = relation_type
 
-    def __getattr__(self, attr: str) -> None:
+    def __getattr__(self, attr: str) -> t.Any:
         return getattr(self.engine_adapter, attr)
 
     def drop_table(self, *args: t.Any, **kwargs: t.Any) -> None:

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -49,7 +49,12 @@ def sqlmesh_config(
 
     return Config(
         default_gateway=profile.target_name,
-        gateways={profile.target_name: GatewayConfig(connection=profile.target.to_sqlmesh(), state_connection=state_connection)},  # type: ignore
+        gateways={
+            profile.target_name: GatewayConfig(
+                connection=profile.target.to_sqlmesh(),
+                state_connection=state_connection,
+            ),
+        },
         loader=DbtLoader,
         loader_kwargs=loader_kwargs,
         model_defaults=model_defaults,

--- a/sqlmesh/utils/jinja.py
+++ b/sqlmesh/utils/jinja.py
@@ -241,7 +241,7 @@ class JinjaMacroRegistry(PydanticModel):
         Returns:
             The macro as a Python callable or None if not found.
         """
-        env: Environment = self.build_environment(**kwargs)
+        env = self.build_environment(**kwargs)
         if reference.package is not None:
             package = env.globals.get(reference.package, {})
             return package.get(reference.name)  # type: ignore

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -47,7 +47,10 @@ def test_adapter_relation(sushi_test_project: Project, runtime_renderer: t.Calla
 
     assert renderer("{{ adapter.cache }}") == "{}"
     assert renderer("{{ adapter.list_relations(database=None, schema='foo')|length }}") == "2"
-    assert renderer("{{ adapter.cache }}") == '{(TABLE db: \n  (IDENTIFIER this: foo, quoted: True), catalog: \n  (IDENTIFIER this: memory, quoted: True)): [<DuckDBRelation "memory"."foo"."another">, <DuckDBRelation "memory"."foo"."bar">]}'
+    assert (
+        renderer("{{ adapter.cache }}")
+        == '{(TABLE db: \n  (IDENTIFIER this: foo, quoted: True), catalog: \n  (IDENTIFIER this: memory, quoted: True)): [<DuckDBRelation "memory"."foo"."another">, <DuckDBRelation "memory"."foo"."bar">]}'
+    )
     assert renderer("{{ adapter.list_relations(database=None, schema='foo')|length }}") == "2"
 
     assert (

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -45,6 +45,9 @@ def test_adapter_relation(sushi_test_project: Project, runtime_renderer: t.Calla
         "{%- set relation = adapter.get_relation(database=None, schema='foo', identifier='bar') -%} {{ adapter.get_columns_in_relation(relation) }}"
     ) == str([Column.from_description(name="baz", raw_data_type="INT")])
 
+    assert renderer("{{ adapter.cache }}") == "{}"
+    assert renderer("{{ adapter.list_relations(database=None, schema='foo')|length }}") == "2"
+    assert renderer("{{ adapter.cache }}") == '{(TABLE db: \n  (IDENTIFIER this: foo, quoted: True), catalog: \n  (IDENTIFIER this: memory, quoted: True)): [<DuckDBRelation "memory"."foo"."another">, <DuckDBRelation "memory"."foo"."bar">]}'
     assert renderer("{{ adapter.list_relations(database=None, schema='foo')|length }}") == "2"
 
     assert (

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -45,10 +45,10 @@ def test_adapter_relation(sushi_test_project: Project, runtime_renderer: t.Calla
         "{%- set relation = adapter.get_relation(database=None, schema='foo', identifier='bar') -%} {{ adapter.get_columns_in_relation(relation) }}"
     ) == str([Column.from_description(name="baz", raw_data_type="INT")])
 
-    assert renderer("{{ adapter.cache }}") == "{}"
+    assert renderer("{{ adapter.engine_adapter.cache }}") == "{}"
     assert renderer("{{ adapter.list_relations(database=None, schema='foo')|length }}") == "2"
     assert (
-        renderer("{{ adapter.cache }}")
+        renderer("{{ adapter.engine_adapter.cache }}")
         == '{(TABLE db: \n  (IDENTIFIER this: foo, quoted: True), catalog: \n  (IDENTIFIER this: memory, quoted: True)): [<DuckDBRelation "memory"."foo"."another">, <DuckDBRelation "memory"."foo"."bar">]}'
     )
     assert renderer("{{ adapter.list_relations(database=None, schema='foo')|length }}") == "2"


### PR DESCRIPTION
Still a WIP, looking to get some early feedback.

- [ ] Add a config flag that controls whether or not we'll use this cache at runtime so that there's a path to switch this off in case it turns out the implementation is unsafe and / or needs to be refactored (we'll use the cache by default).
- [ ] Add some more tests for cache clearing, updating etc