### PR TITLE
Chore: Return 204 on empty reuqest

### DIFF
--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -375,7 +375,7 @@ def test_apply(project_tmp_path: Path) -> None:
     sql_file.write_text("MODEL (name foo); SELECT 1;")
 
     response = client.post("/api/commands/apply", json={"environment": "dev"})
-    assert response.status_code == 200
+    assert response.status_code == 204
 
 
 @pytest.mark.skip(
@@ -390,7 +390,7 @@ def test_apply_test_failures(web_sushi_context: Context, mocker: MockerFixture) 
 
 def test_plan(web_sushi_context: Context) -> None:
     response = client.post("/api/plan", json={"environment": "dev"})
-    assert response.status_code == 200
+    assert response.status_code == 204
 
 
 @pytest.mark.skip(
@@ -408,7 +408,7 @@ async def test_cancel() -> None:
     app.state.task = asyncio.create_task(asyncio.sleep(1))
     response = client.post("/api/plan/cancel")
     await asyncio.sleep(0.1)
-    assert response.status_code == 200
+    assert response.status_code == 204
     assert app.state.task.cancelled()
 
 

--- a/web/client/src/api/instance.ts
+++ b/web/client/src/api/instance.ts
@@ -1,3 +1,4 @@
+import { isNil } from '@utils/index'
 import { tableFromIPC } from 'apache-arrow'
 
 const baseURL = window.location.origin
@@ -64,8 +65,10 @@ export async function fetchAPI<T = any, B extends object = any>(
       signal: options?.signal,
     })
       .then(async response => {
+        if (response.status === 204) return { ok: true }
+
         const headerContentType = response.headers.get('Content-Type')
-        if (headerContentType == null)
+        if (isNil(headerContentType))
           return { ok: false, message: 'Empty response' }
         if (response.status >= 400) {
           try {
@@ -81,8 +84,6 @@ export async function fetchAPI<T = any, B extends object = any>(
             } as unknown as Error
           }
         }
-
-        if (response.status === 204) return { ok: true }
 
         const isEventStream = headerContentType.includes('text/event-stream')
         const isApplicationJson = headerContentType.includes('application/json')

--- a/web/server/api/endpoints/commands.py
+++ b/web/server/api/endpoints/commands.py
@@ -5,7 +5,8 @@ import io
 import typing as t
 
 import pandas as pd
-from fastapi import APIRouter, Body, Depends, Request
+from fastapi import APIRouter, Body, Depends, Request, Response
+from starlette.status import HTTP_204_NO_CONTENT
 
 from sqlmesh.core.context import Context
 from sqlmesh.core.snapshot.definition import SnapshotChangeCategory
@@ -28,6 +29,7 @@ router = APIRouter()
 @router.post("/apply", response_model=t.Optional[models.PlanApplyStageTracker])
 async def initiate_apply(
     request: Request,
+    response: Response,
     context: Context = Depends(get_loaded_context),
     environment: t.Optional[str] = Body(None),
     plan_dates: t.Optional[models.PlanDates] = None,
@@ -51,6 +53,7 @@ async def initiate_apply(
             categories,
         )
     )
+    response.status_code = HTTP_204_NO_CONTENT
 
     return None
 


### PR DESCRIPTION
when returning `None` from endpoint with `200` response has `null` in it. So returning 204  is more predictable