### PR TITLE
fix: improve error logging for common config import errors. currently…

### DIFF
--- a/sqlmesh/core/config/loader.py
+++ b/sqlmesh/core/config/loader.py
@@ -125,10 +125,7 @@ def load_config_from_yaml(path: Path) -> t.Dict[str, t.Any]:
 
 def load_config_from_python_module(module_path: Path, config_name: str = "config") -> Config:
     with sys_path(module_path.parent):
-        try:
-            config_module = import_python_file(module_path, module_path.parent)
-        except ImportError:
-            raise ConfigError(f"Config module '{module_path}' was not found.")
+        config_module = import_python_file(module_path, module_path.parent)
 
     try:
         config_obj = getattr(config_module, config_name)


### PR DESCRIPTION
… we eat errors and they are useless, debug flag doesn't work because this happens before logging gets configured