### PR TITLE
Fix: Handle 0 batch_size in select_from_values

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -756,7 +756,7 @@ def extend_sqlglot() -> None:
 def select_from_values(
     values: t.List[t.Tuple[t.Any, ...]],
     columns_to_types: t.Dict[str, exp.DataType],
-    batch_size: int = sys.maxsize,
+    batch_size: int = 0,
     alias: str = "t",
 ) -> t.Iterator[exp.Select]:
     """Generate a VALUES expression that has a select wrapped around it to cast the values to their correct types.
@@ -764,12 +764,14 @@ def select_from_values(
     Args:
         values: List of values to use for the VALUES expression.
         columns_to_types: Mapping of column names to types to assign to the values.
-        batch_size: The maximum number of tuples per batch.
+        batch_size: The maximum number of tuples per batchs. Defaults to sys.maxsize if <= 0.
         alias: The alias to assign to the values expression. If not provided then will default to "t"
 
     Returns:
         This method operates as a generator and yields a VALUES expression.
     """
+    if batch_size <= 0:
+        batch_size = sys.maxsize
     num_rows = len(values)
     for i in range(0, num_rows, batch_size):
         yield select_from_values_for_batch_range(
@@ -810,7 +812,7 @@ def select_from_values_for_batch_range(
 def pandas_to_sql(
     df: pd.DataFrame,
     columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
-    batch_size: int = sys.maxsize,
+    batch_size: int = 0,
     alias: str = "t",
 ) -> t.Iterator[exp.Select]:
     """Convert a pandas dataframe into a VALUES sql statement.

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -810,7 +810,7 @@ def select_from_values_for_batch_range(
 def pandas_to_sql(
     df: pd.DataFrame,
     columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
-    batch_size: int = 0,
+    batch_size: int = sys.maxsize,
     alias: str = "t",
 ) -> t.Iterator[exp.Select]:
     """Convert a pandas dataframe into a VALUES sql statement.

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -764,7 +764,7 @@ def select_from_values(
     Args:
         values: List of values to use for the VALUES expression.
         columns_to_types: Mapping of column names to types to assign to the values.
-        batch_size: The maximum number of tuples per batchs. Defaults to sys.maxsize if <= 0.
+        batch_size: The maximum number of tuples per batches. Defaults to sys.maxsize if <= 0.
         alias: The alias to assign to the values expression. If not provided then will default to "t"
 
     Returns:
@@ -820,7 +820,7 @@ def pandas_to_sql(
     Args:
         df: A pandas dataframe to convert.
         columns_to_types: Mapping of column names to types to assign to the values.
-        batch_size: The maximum number of tuples per batchs. Defaults to sys.maxsize if <= 0.
+        batch_size: The maximum number of tuples per batches. Defaults to sys.maxsize if <= 0.
         alias: The alias to assign to the values expression. If not provided then will default to "t"
 
     Returns:

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -820,7 +820,7 @@ def pandas_to_sql(
     Args:
         df: A pandas dataframe to convert.
         columns_to_types: Mapping of column names to types to assign to the values.
-        batch_size: The maximum number of tuples per batch, if <= 0 then no batching will occur.
+        batch_size: The maximum number of tuples per batchs. Defaults to sys.maxsize if <= 0.
         alias: The alias to assign to the values expression. If not provided then will default to "t"
 
     Returns:

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -79,7 +79,7 @@ def test_dag(sushi_context):
     }
 
 
-def test_render(sushi_context, assert_exp_eq):
+def test_render_sql_model(sushi_context, assert_exp_eq):
     assert_exp_eq(
         sushi_context.render(
             "sushi.waiter_revenue_by_day",
@@ -152,6 +152,27 @@ def test_render(sushi_context, assert_exp_eq):
         GROUP BY
           "o"."waiter_id",
           "o"."event_date"
+        """,
+    )
+
+
+def test_render_seed_model(sushi_context, assert_exp_eq):
+    assert_exp_eq(
+        sushi_context.render(
+            "sushi.waiter_names",
+            start=date(2021, 1, 1),
+            end=date(2021, 1, 1),
+        ),
+        """
+        SELECT
+          CAST(id AS BIGINT) AS id,
+          CAST(name AS TEXT) AS name
+        FROM (VALUES
+          (0, 'Toby'),
+          (1, 'Tyson'),
+          (2, 'Ryan'),
+          (3, 'George'),
+          (4, 'Chris')) AS t(id, name)
         """,
     )
 


### PR DESCRIPTION
This fixes a bug when calling render from the CLI or the UI.
```
  File "sqlmesh/core/dialect.py", line 780, in select_from_values
    for i in range(0, num_rows, batch_size):
ValueError: range() arg 3 must not be zero
```