### PR TITLE
feat: CI/CD Capture Console Errors

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1290,18 +1290,35 @@ class CaptureTerminalConsole(TerminalConsole):
     def __init__(self, console: t.Optional[RichConsole] = None, **kwargs: t.Any) -> None:
         super().__init__(console=console, **kwargs)
         self._captured_outputs: t.List[str] = []
+        self._errors: t.List[str] = []
 
     @property
     def captured_output(self) -> str:
         return "".join(self._captured_outputs)
+
+    @property
+    def captured_errors(self) -> str:
+        return "".join(self._errors)
 
     def consume_captured_output(self) -> str:
         output = self.captured_output
         self.clear_captured_outputs()
         return output
 
+    def consume_captured_errors(self) -> str:
+        errors = self.captured_errors
+        self.clear_captured_errors()
+        return errors
+
     def clear_captured_outputs(self) -> None:
         self._captured_outputs = []
+
+    def clear_captured_errors(self) -> None:
+        self._errors = []
+
+    def log_error(self, message: str) -> None:
+        self._errors.append(message)
+        super().log_error(message)
 
     def _print(self, value: t.Any, **kwargs: t.Any) -> None:
         with self.console.capture() as capture:
@@ -1493,6 +1510,9 @@ class MarkdownConsole(CaptureTerminalConsole):
                 if isinstance(test, ModelTest):
                     self._print(f"* Failure Test: `{test.model.name}` - `{test.test_name}`\n\n")
             self._print(f"```{output}```\n\n")
+
+    def log_error(self, message: str) -> None:
+        super().log_error(f"```\n{message}```\n\n")
 
 
 class DatabricksMagicConsole(CaptureTerminalConsole):

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -796,6 +796,9 @@ class GithubController:
                 if updated_comment:
                     self._append_output("created_pr_environment", "true")
             else:
+                captured_errors = self._console.consume_captured_errors()
+                if captured_errors:
+                    logger.debug(f"Captured errors: {captured_errors}")
                 if isinstance(exception, NoChangesPlanError):
                     skip_reason = "No changes were detected compared to the prod environment."
                 elif isinstance(exception, TestFailure):
@@ -803,19 +806,23 @@ class GithubController:
                 else:
                     skip_reason = "A prior stage failed resulting in skipping PR creation."
 
-                if isinstance(exception, NodeExecutionFailedError):
-                    logger.debug(
-                        "Got Node Execution Failed Error. Stack trace: " + traceback.format_exc()
-                    )
-                    failure_msg = f"Node `{exception.node.name}` failed to apply.\n\n**Stack Trace:**\n```\n{traceback.format_exc()}\n```"
+                if not captured_errors:
+                    if isinstance(exception, NodeExecutionFailedError):
+                        logger.debug(
+                            "Got Node Execution Failed Error. Stack trace: "
+                            + traceback.format_exc()
+                        )
+                        failure_msg = f"Node `{exception.node.name}` failed to apply.\n\n**Stack Trace:**\n```\n{traceback.format_exc()}\n```"
+                    else:
+                        logger.debug(
+                            "Got unexpected error. Error Type: "
+                            + str(type(exception))
+                            + " Stack trace: "
+                            + traceback.format_exc()
+                        )
+                        failure_msg = f"This is an unexpected error.\n\n**Exception:**\n```\n{traceback.format_exc()}\n```"
                 else:
-                    logger.debug(
-                        "Got unexpected error. Error Type: "
-                        + str(type(exception))
-                        + " Stack trace: "
-                        + traceback.format_exc()
-                    )
-                    failure_msg = f"This is an unexpected error.\n\n**Exception:**\n```\n{traceback.format_exc()}\n```"
+                    failure_msg = f"**Errors:**\n{captured_errors}\n"
                 conclusion_to_summary = {
                     GithubCheckConclusion.SKIPPED: f":next_track_button: Skipped creating or updating PR Environment `{self.pr_environment_name}`. {skip_reason}",
                     GithubCheckConclusion.FAILURE: f":x: Failed to create or update PR Environment `{self.pr_environment_name}`.\n{failure_msg}",


### PR DESCRIPTION
Prior to this change if you had an error during PR plan application you would just get a plan application error in the output and none of the details of the error from the individual node evaluations themselves. This improves that so those errors will be printed. 