### PR TITLE
Fix: Don't send sqlmesh type with files, and handle that independently on ui

### DIFF
--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -76,9 +76,7 @@ def test_get_files(project_tmp_path: Path) -> None:
                         "name": "foo.sql",
                         "path": "models/foo.sql",
                         "extension": ".sql",
-                        "is_supported": True,
                         "content": None,
-                        "type": "model",
                     }
                 ],
             }
@@ -88,9 +86,7 @@ def test_get_files(project_tmp_path: Path) -> None:
                 "name": "config.py",
                 "path": "config.py",
                 "extension": ".py",
-                "is_supported": True,
                 "content": None,
-                "type": None,
             }
         ],
     }
@@ -106,9 +102,7 @@ def test_get_file(project_tmp_path: Path) -> None:
         "name": "foo.txt",
         "path": "foo.txt",
         "extension": ".txt",
-        "is_supported": False,
         "content": "bar",
-        "type": None,
     }
 
 
@@ -138,9 +132,7 @@ def test_write_file(project_tmp_path: Path) -> None:
         "name": "foo.txt",
         "path": "foo.txt",
         "extension": ".txt",
-        "is_supported": False,
         "content": "bar",
-        "type": None,
     }
     assert (project_tmp_path / "foo.txt").read_text() == "bar"
 
@@ -155,9 +147,7 @@ def test_update_file(project_tmp_path: Path) -> None:
         "name": "foo.txt",
         "path": "foo.txt",
         "extension": ".txt",
-        "is_supported": False,
         "content": "baz",
-        "type": None,
     }
     assert (project_tmp_path / "foo.txt").read_text() == "baz"
 
@@ -172,9 +162,7 @@ def test_rename_file(project_tmp_path: Path) -> None:
         "name": "baz.txt",
         "path": "baz.txt",
         "extension": ".txt",
-        "is_supported": False,
         "content": "bar",
-        "type": None,
     }
     assert not txt_file.exists()
     assert (project_tmp_path / "baz.txt").read_text() == "bar"
@@ -192,9 +180,7 @@ def test_rename_file_and_keep_content(project_tmp_path: Path) -> None:
         "name": "baz.txt",
         "path": "baz.txt",
         "extension": ".txt",
-        "is_supported": False,
         "content": "bar",
-        "type": None,
     }
     assert not txt_file.exists()
     assert (project_tmp_path / "baz.txt").read_text() == "bar"
@@ -217,9 +203,7 @@ def test_rename_file_already_exists(project_tmp_path: Path) -> None:
         "name": "bar.txt",
         "path": "bar.txt",
         "extension": ".txt",
-        "is_supported": False,
         "content": "foo",
-        "type": None,
     }
     assert not foo_file.exists()
 
@@ -242,9 +226,7 @@ def test_write_file_empty_body() -> None:
         "name": "foo.txt",
         "path": "foo.txt",
         "extension": ".txt",
-        "is_supported": False,
         "content": "",
-        "type": None,
     }
 
 

--- a/web/client/openapi.json
+++ b/web/client/openapi.json
@@ -1137,31 +1137,14 @@
             "title": "Extension",
             "default": ""
           },
-          "is_supported": {
-            "type": "boolean",
-            "title": "Is Supported",
-            "default": false
-          },
           "content": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Content"
-          },
-          "type": {
-            "anyOf": [
-              { "$ref": "#/components/schemas/FileType" },
-              { "type": "null" }
-            ]
           }
         },
         "type": "object",
         "required": ["name", "path"],
         "title": "File"
-      },
-      "FileType": {
-        "type": "string",
-        "enum": ["audit", "macros", "model", "tests"],
-        "title": "FileType",
-        "description": "An enumeration of possible file types."
       },
       "HTTPValidationError": {
         "properties": {
@@ -1234,7 +1217,7 @@
           "name": { "type": "string", "title": "Name" },
           "path": { "type": "string", "title": "Path" },
           "dialect": { "type": "string", "title": "Dialect" },
-          "type": { "type": "string", "title": "Type" },
+          "type": { "$ref": "#/components/schemas/ModelType" },
           "columns": {
             "items": { "$ref": "#/components/schemas/Column" },
             "type": "array",
@@ -1388,6 +1371,11 @@
         ],
         "title": "ModelKindName",
         "description": "The kind of model, determining how this data is computed and stored in the warehouse."
+      },
+      "ModelType": {
+        "type": "string",
+        "enum": ["python", "sql", "seed", "external"],
+        "title": "ModelType"
       },
       "ModelsDiff": {
         "properties": {

--- a/web/client/src/context/context.ts
+++ b/web/client/src/context/context.ts
@@ -21,6 +21,7 @@ interface ContextStore {
   addConfirmation: (confirmation: Confirmation) => void
   removeConfirmation: () => void
   setModels: (models?: Model[]) => void
+  isModel: (nameOrPath: string) => boolean
   isExistingEnvironment: (
     environment: ModelEnvironment | EnvironmentName,
   ) => boolean
@@ -52,6 +53,9 @@ export const useStoreContext = create<ContextStore>((set, get) => ({
   initialStartDate: undefined,
   initialEndDate: undefined,
   models: new Map(),
+  isModel(nameOrPath) {
+    return get().models.has(nameOrPath)
+  },
   setVersion(version) {
     set(() => ({
       version,

--- a/web/client/src/library/components/documentation/Documentation.tsx
+++ b/web/client/src/library/components/documentation/Documentation.tsx
@@ -95,7 +95,7 @@ const Documentation = function Documentation({
             className="max-h-[15rem]"
             nodeId={model.name}
             columns={model.columns}
-            disabled={model?.type === 'python'}
+            disabled={model?.isModelPython}
             withHandles={false}
             withSource={false}
             withDescription={true}

--- a/web/client/src/library/components/editor/Editor.tsx
+++ b/web/client/src/library/components/editor/Editor.tsx
@@ -26,6 +26,7 @@ import { useApiFetchdf } from '@api/index'
 import { getTableDataFromArrowStreamResult } from '@components/table/help'
 import { type Table } from 'apache-arrow'
 import { type KeyBinding } from '@codemirror/view'
+import { ModelSQLMeshModel } from '@models/sqlmesh-model'
 
 function Editor(): JSX.Element {
   const tab = useStoreEditor(s => s.tab)
@@ -170,7 +171,8 @@ function EditorMain({ tab }: { tab: EditorTab }): JSX.Element {
   const sizesCodeEditorAndInspector = useMemo(() => {
     const model = models.get(tab?.file.path)
     const showInspector =
-      ((tab.file.isSQLMeshModel && model != null) || tab.file.isLocal) &&
+      ((isNotNil(model) && ModelSQLMeshModel.isSQLMeshModel(tab.file)) ||
+        tab.file.isLocal) &&
       isFalse(isStringEmptyOrNil(tab.file.content))
 
     return showInspector ? [75, 25] : [100, 0]
@@ -179,7 +181,9 @@ function EditorMain({ tab }: { tab: EditorTab }): JSX.Element {
   const sizesCodeEditorAndPreview = useMemo(() => {
     const model = models.get(tab.file.path)
     const showLineage =
-      isFalse(tab.file.isEmpty) && isNotNil(model) && tab.file.isSQLMeshModel
+      isFalse(tab.file.isEmpty) &&
+      isNotNil(model) &&
+      ModelSQLMeshModel.isSQLMeshModel(tab.file)
     const showPreview =
       (tab.file.isLocal && [previewTable, previewDiff].some(Boolean)) ||
       showLineage

--- a/web/client/src/library/components/editor/Editor.tsx
+++ b/web/client/src/library/components/editor/Editor.tsx
@@ -26,7 +26,7 @@ import { useApiFetchdf } from '@api/index'
 import { getTableDataFromArrowStreamResult } from '@components/table/help'
 import { type Table } from 'apache-arrow'
 import { type KeyBinding } from '@codemirror/view'
-import { ModelSQLMeshModel } from '@models/sqlmesh-model'
+import { useStoreContext } from '@context/context'
 
 function Editor(): JSX.Element {
   const tab = useStoreEditor(s => s.tab)
@@ -95,6 +95,9 @@ function EditorLoading(): JSX.Element {
 }
 
 function EditorMain({ tab }: { tab: EditorTab }): JSX.Element {
+  const models = useStoreContext(s => s.models)
+  const isModel = useStoreContext(s => s.isModel)
+
   const files = useStoreProject(s => s.files)
   const setSelectedFile = useStoreProject(s => s.setSelectedFile)
 
@@ -108,7 +111,7 @@ function EditorMain({ tab }: { tab: EditorTab }): JSX.Element {
   const setPreviewDiff = useStoreEditor(s => s.setPreviewDiff)
   const setDialects = useStoreEditor(s => s.setDialects)
 
-  const { models, setManuallySelectedColumn } = useLineageFlow()
+  const { setManuallySelectedColumn } = useLineageFlow()
 
   const defaultKeymapsEditorTab = useDefaultKeymapsEditorTab()
   const modelExtensions = useSQLMeshModelExtensions(
@@ -171,8 +174,7 @@ function EditorMain({ tab }: { tab: EditorTab }): JSX.Element {
   const sizesCodeEditorAndInspector = useMemo(() => {
     const model = models.get(tab?.file.path)
     const showInspector =
-      ((isNotNil(model) && ModelSQLMeshModel.isSQLMeshModel(tab.file)) ||
-        tab.file.isLocal) &&
+      ((isNotNil(model) && isModel(tab.file.path)) || tab.file.isLocal) &&
       isFalse(isStringEmptyOrNil(tab.file.content))
 
     return showInspector ? [75, 25] : [100, 0]
@@ -181,9 +183,7 @@ function EditorMain({ tab }: { tab: EditorTab }): JSX.Element {
   const sizesCodeEditorAndPreview = useMemo(() => {
     const model = models.get(tab.file.path)
     const showLineage =
-      isFalse(tab.file.isEmpty) &&
-      isNotNil(model) &&
-      ModelSQLMeshModel.isSQLMeshModel(tab.file)
+      isFalse(tab.file.isEmpty) && isNotNil(model) && isModel(tab.file.path)
     const showPreview =
       (tab.file.isLocal && [previewTable, previewDiff].some(Boolean)) ||
       showLineage

--- a/web/client/src/library/components/editor/EditorFooter.tsx
+++ b/web/client/src/library/components/editor/EditorFooter.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react'
 import { isNil, isNotNil, isStringEmptyOrNil } from '~/utils'
 import Input from '@components/input/Input'
 import { EnumSize } from '~/types/enum'
-import { ModelSQLMeshModel } from '@models/sqlmesh-model'
+import { useStoreContext } from '@context/context'
 
 const EnumFileType = {
   Model: 'model',
@@ -18,12 +18,14 @@ const EnumFileType = {
   Seed: 'seed',
   Metric: 'metric',
   Schema: 'schema',
-  None: 'none',
+  Unknown: 'unknown',
 } as const
 
 export type FileType = (typeof EnumFileType)[keyof typeof EnumFileType]
 
 export default function EditorFooter({ tab }: { tab: EditorTab }): JSX.Element {
+  const isModel = useStoreContext(s => s.isModel)
+
   const engine = useStoreEditor(s => s.engine)
   const dialects = useStoreEditor(s => s.dialects)
   const refreshTab = useStoreEditor(s => s.refreshTab)
@@ -90,16 +92,14 @@ export default function EditorFooter({ tab }: { tab: EditorTab }): JSX.Element {
           </Input>
         </EditorIndicator>
       )}
-      {ModelSQLMeshModel.isSQLMeshModel(tab.file) &&
-        isNotNil(tab.dialect) &&
-        tab.dialect !== '' && (
-          <EditorIndicator
-            className="mr-2"
-            text="Dialect"
-          >
-            <EditorIndicator.Text text={tab.dialect} />
-          </EditorIndicator>
-        )}
+      {isModel(tab.file.path) && !isStringEmptyOrNil(tab.dialect) && (
+        <EditorIndicator
+          className="mr-2"
+          text="Dialect"
+        >
+          <EditorIndicator.Text text={tab.dialect} />
+        </EditorIndicator>
+      )}
       <EditorIndicator
         className="mr-2"
         text="SQLMesh Type"
@@ -111,7 +111,7 @@ export default function EditorFooter({ tab }: { tab: EditorTab }): JSX.Element {
 }
 
 function getFileType(path?: string): FileType {
-  if (isStringEmptyOrNil(path)) return EnumFileType.None
+  if (isStringEmptyOrNil(path)) return EnumFileType.Unknown
 
   if (path.startsWith('models')) return EnumFileType.Model
   if (path.startsWith('tests')) return EnumFileType.Test
@@ -124,5 +124,5 @@ function getFileType(path?: string): FileType {
     return EnumFileType.Config
   if (['schema.yaml', 'schema.yml'].includes(path)) return EnumFileType.Schema
 
-  return EnumFileType.None
+  return EnumFileType.Unknown
 }

--- a/web/client/src/library/components/editor/EditorFooter.tsx
+++ b/web/client/src/library/components/editor/EditorFooter.tsx
@@ -5,6 +5,23 @@ import { useEffect } from 'react'
 import { isNil, isNotNil, isStringEmptyOrNil } from '~/utils'
 import Input from '@components/input/Input'
 import { EnumSize } from '~/types/enum'
+import { ModelSQLMeshModel } from '@models/sqlmesh-model'
+
+const EnumFileType = {
+  Model: 'model',
+  Test: 'test',
+  Audit: 'audit',
+  Macro: 'macro',
+  Hook: 'hook',
+  Log: 'log',
+  Config: 'config',
+  Seed: 'seed',
+  Metric: 'metric',
+  Schema: 'schema',
+  None: 'none',
+} as const
+
+export type FileType = (typeof EnumFileType)[keyof typeof EnumFileType]
 
 export default function EditorFooter({ tab }: { tab: EditorTab }): JSX.Element {
   const engine = useStoreEditor(s => s.engine)
@@ -73,24 +90,39 @@ export default function EditorFooter({ tab }: { tab: EditorTab }): JSX.Element {
           </Input>
         </EditorIndicator>
       )}
-      {tab.file.isSQLMeshModel && tab.dialect != null && tab.dialect !== '' && (
-        <EditorIndicator
-          className="mr-2"
-          text="Dialect"
-        >
-          <EditorIndicator.Text text={tab.dialect} />
-        </EditorIndicator>
-      )}
-      {tab.file.type != null && (
-        <EditorIndicator
-          className="mr-2"
-          text="SQLMesh Type"
-        >
-          <EditorIndicator.Text
-            text={tab.file.isSQLMeshModel ? 'Model' : 'Unsupported'}
-          />
-        </EditorIndicator>
-      )}
+      {ModelSQLMeshModel.isSQLMeshModel(tab.file) &&
+        isNotNil(tab.dialect) &&
+        tab.dialect !== '' && (
+          <EditorIndicator
+            className="mr-2"
+            text="Dialect"
+          >
+            <EditorIndicator.Text text={tab.dialect} />
+          </EditorIndicator>
+        )}
+      <EditorIndicator
+        className="mr-2"
+        text="SQLMesh Type"
+      >
+        <EditorIndicator.Text text={getFileType(tab.file.path)} />
+      </EditorIndicator>
     </div>
   )
+}
+
+function getFileType(path?: string): FileType {
+  if (isStringEmptyOrNil(path)) return EnumFileType.None
+
+  if (path.startsWith('models')) return EnumFileType.Model
+  if (path.startsWith('tests')) return EnumFileType.Test
+  if (path.startsWith('logs')) return EnumFileType.Log
+  if (path.startsWith('macros')) return EnumFileType.Macro
+  if (path.startsWith('hooks')) return EnumFileType.Hook
+  if (path.startsWith('seeds')) return EnumFileType.Seed
+  if (path.startsWith('metrics')) return EnumFileType.Metric
+  if (['config.yaml', 'config.yml', 'config.py'].includes(path))
+    return EnumFileType.Config
+  if (['schema.yaml', 'schema.yml'].includes(path)) return EnumFileType.Schema
+
+  return EnumFileType.None
 }

--- a/web/client/src/library/components/editor/EditorInspector.tsx
+++ b/web/client/src/library/components/editor/EditorInspector.tsx
@@ -11,7 +11,7 @@ import Input from '../input/Input'
 import { type EditorTab, useStoreEditor } from '~/context/editor'
 import { Tab } from '@headlessui/react'
 import Banner from '@components/banner/Banner'
-import { ModelSQLMeshModel } from '@models/sqlmesh-model'
+import { type ModelSQLMeshModel } from '@models/sqlmesh-model'
 import {
   useApiEvaluate,
   useApiFetchdf,
@@ -37,6 +37,7 @@ export default function EditorInspector({
   tab: EditorTab
 }): JSX.Element {
   const models = useStoreContext(s => s.models)
+  const isModel = useStoreContext(s => s.isModel)
   const model = useMemo(() => models.get(tab.file.path), [tab, models])
 
   return (
@@ -45,7 +46,7 @@ export default function EditorInspector({
         'flex flex-col w-full h-full items-center overflow-hidden',
       )}
     >
-      {ModelSQLMeshModel.isSQLMeshModel(tab.file) ? (
+      {isModel(tab.file.path) ? (
         model != null && (
           <InspectorModel
             tab={tab}
@@ -300,6 +301,8 @@ function FormActionsModel({
   tab: EditorTab
   model: ModelSQLMeshModel
 }): JSX.Element {
+  const isModel = useStoreContext(s => s.isModel)
+
   const setPreviewQuery = useStoreEditor(s => s.setPreviewQuery)
   const setPreviewTable = useStoreEditor(s => s.setPreviewTable)
 
@@ -323,8 +326,7 @@ function FormActionsModel({
   )
 
   const shouldEvaluate =
-    ModelSQLMeshModel.isSQLMeshModel(tab.file) &&
-    Object.values(form).every(Boolean)
+    isModel(tab.file.path) && Object.values(form).every(Boolean)
 
   useEffect(() => {
     return () => {
@@ -448,7 +450,7 @@ function FormActionsModel({
       <Divider />
       <InspectorActions>
         <div className="flex w-full justify-end">
-          {ModelSQLMeshModel.isSQLMeshModel(tab.file) && isFetching ? (
+          {isModel(tab.file.path) && isFetching ? (
             <div className="flex items-center">
               <Spinner className="w-3" />
               <small className="text-xs text-neutral-400 block mx-2">
@@ -497,6 +499,8 @@ function FormDiffModel({
   list: Array<{ text: string; value: string }>
   target: { text: string; value: string }
 }): JSX.Element {
+  const isModel = useStoreContext(s => s.isModel)
+
   const setPreviewDiff = useStoreEditor(s => s.setPreviewDiff)
 
   const [selectedSource, setSelectedSource] = useState(list[0]!.value)
@@ -536,8 +540,7 @@ function FormDiffModel({
   }, [list])
 
   const shouldEnableAction =
-    ModelSQLMeshModel.isSQLMeshModel(tab.file) &&
-    [selectedSource, target, limit].every(Boolean)
+    isModel(tab.file.path) && [selectedSource, target, limit].every(Boolean)
 
   return (
     <>

--- a/web/client/src/library/components/editor/EditorInspector.tsx
+++ b/web/client/src/library/components/editor/EditorInspector.tsx
@@ -11,7 +11,7 @@ import Input from '../input/Input'
 import { type EditorTab, useStoreEditor } from '~/context/editor'
 import { Tab } from '@headlessui/react'
 import Banner from '@components/banner/Banner'
-import { type ModelSQLMeshModel } from '@models/sqlmesh-model'
+import { ModelSQLMeshModel } from '@models/sqlmesh-model'
 import {
   useApiEvaluate,
   useApiFetchdf,
@@ -45,7 +45,7 @@ export default function EditorInspector({
         'flex flex-col w-full h-full items-center overflow-hidden',
       )}
     >
-      {tab.file.isSQLMeshModel ? (
+      {ModelSQLMeshModel.isSQLMeshModel(tab.file) ? (
         model != null && (
           <InspectorModel
             tab={tab}
@@ -84,7 +84,7 @@ function InspectorModel({
           [
             'Actions',
             'Columns',
-            tab.file.isSQLMeshModelSQL && 'Query',
+            model.isModelSQL && 'Query',
             list.length > 1 && environment.isRemote && 'Diff',
           ].filter(Boolean) as string[]
         }
@@ -112,7 +112,7 @@ function InspectorModel({
             className="max-h-[15rem]"
             nodeId={model.name}
             columns={model.columns}
-            disabled={model.type === 'python'}
+            disabled={model.isModelPython}
             withHandles={false}
             withSource={false}
             withDescription={true}
@@ -323,7 +323,8 @@ function FormActionsModel({
   )
 
   const shouldEvaluate =
-    tab.file.isSQLMeshModel && Object.values(form).every(Boolean)
+    ModelSQLMeshModel.isSQLMeshModel(tab.file) &&
+    Object.values(form).every(Boolean)
 
   useEffect(() => {
     return () => {
@@ -447,7 +448,7 @@ function FormActionsModel({
       <Divider />
       <InspectorActions>
         <div className="flex w-full justify-end">
-          {tab.file.isSQLMeshModel && isFetching ? (
+          {ModelSQLMeshModel.isSQLMeshModel(tab.file) && isFetching ? (
             <div className="flex items-center">
               <Spinner className="w-3" />
               <small className="text-xs text-neutral-400 block mx-2">
@@ -535,7 +536,8 @@ function FormDiffModel({
   }, [list])
 
   const shouldEnableAction =
-    tab.file.isSQLMeshModel && [selectedSource, target, limit].every(Boolean)
+    ModelSQLMeshModel.isSQLMeshModel(tab.file) &&
+    [selectedSource, target, limit].every(Boolean)
 
   return (
     <>

--- a/web/client/src/library/components/editor/EditorPreview.tsx
+++ b/web/client/src/library/components/editor/EditorPreview.tsx
@@ -6,7 +6,6 @@ import { type EditorTab, useStoreEditor } from '~/context/editor'
 import { ViewColumnsIcon } from '@heroicons/react/24/solid'
 import { Button } from '@components/button/Button'
 import { EnumSize, EnumVariant } from '~/types/enum'
-import { useLineageFlow } from '@components/graph/context'
 import { EnumFileExtensions } from '@models/file'
 import { CodeEditorDefault } from './EditorCode'
 import { EnumRoutes } from '~/routes'
@@ -15,7 +14,7 @@ import TableDiff from '@components/tableDiff/TableDiff'
 import TabList from '@components/tab/Tab'
 import { useSQLMeshModelExtensions } from './hooks'
 import Table from '@components/table/Table'
-import { ModelSQLMeshModel } from '@models/sqlmesh-model'
+import { useStoreContext } from '@context/context'
 
 const ModelLineage = lazy(
   async () => await import('@components/graph/ModelLineage'),
@@ -40,7 +39,8 @@ export default function EditorPreview({
 }): JSX.Element {
   const navigate = useNavigate()
 
-  const { models } = useLineageFlow()
+  const models = useStoreContext(s => s.models)
+  const isModel = useStoreContext(s => s.isModel)
 
   const direction = useStoreEditor(s => s.direction)
   const previewQuery = useStoreEditor(s => s.previewQuery)
@@ -56,9 +56,7 @@ export default function EditorPreview({
 
   const model = models.get(tab.file.path)
   const showLineage =
-    isFalse(tab.file.isEmpty) &&
-    isNotNil(model) &&
-    ModelSQLMeshModel.isSQLMeshModel(tab.file)
+    isFalse(tab.file.isEmpty) && isNotNil(model) && isModel(tab.file.path)
 
   const tabs: string[] = useMemo(
     () =>

--- a/web/client/src/library/components/editor/EditorPreview.tsx
+++ b/web/client/src/library/components/editor/EditorPreview.tsx
@@ -15,6 +15,7 @@ import TableDiff from '@components/tableDiff/TableDiff'
 import TabList from '@components/tab/Tab'
 import { useSQLMeshModelExtensions } from './hooks'
 import Table from '@components/table/Table'
+import { ModelSQLMeshModel } from '@models/sqlmesh-model'
 
 const ModelLineage = lazy(
   async () => await import('@components/graph/ModelLineage'),
@@ -55,7 +56,9 @@ export default function EditorPreview({
 
   const model = models.get(tab.file.path)
   const showLineage =
-    isFalse(tab.file.isEmpty) && isNotNil(model) && tab.file.isSQLMeshModel
+    isFalse(tab.file.isEmpty) &&
+    isNotNil(model) &&
+    ModelSQLMeshModel.isSQLMeshModel(tab.file)
 
   const tabs: string[] = useMemo(
     () =>

--- a/web/client/src/library/components/fileExplorer/File.tsx
+++ b/web/client/src/library/components/fileExplorer/File.tsx
@@ -220,7 +220,6 @@ function FileDisplay({ file }: { file: ModelFile }): JSX.Element {
       title={file.name}
       className={clsx(
         'inline-block overflow-hidden overflow-ellipsis py-[0.125rem]',
-        !file.is_supported && 'opacity-50',
       )}
     >
       {truncate(file.name, 50, 20)}

--- a/web/client/src/library/components/graph/Graph.tsx
+++ b/web/client/src/library/components/graph/Graph.tsx
@@ -62,6 +62,7 @@ import {
   type ColumnLineageApiLineageModelNameColumnNameGet200,
   type LineageColumn,
   type LineageColumnSource,
+  ModelType,
 } from '@api/client'
 import Loading from '@components/loading/Loading'
 import Spinner from '@components/logo/Spinner'
@@ -82,11 +83,8 @@ import ListboxShow from '@components/listbox/ListboxShow'
 import SearchList from '@components/search/SearchList'
 
 export const EnumLineageNodeModelType = {
-  python: 'python',
-  sql: 'sql',
+  ...ModelType,
   cte: 'cte',
-  seed: 'seed',
-  external: 'external',
   unknown: 'unknown',
 } as const
 
@@ -997,7 +995,6 @@ function ColumnLoading({
 function GraphControls({ nodes = [] }: { nodes: Node[] }): JSX.Element {
   const {
     withColumns,
-    models,
     lineage,
     mainNode,
     selectedNodes,
@@ -1043,13 +1040,11 @@ function GraphControls({ nodes = [] }: { nodes: Node[] }): JSX.Element {
   const countDataSources = nodes.filter(
     n =>
       isFalse(n.hidden) &&
-      (models.get(n.id)?.type === EnumLineageNodeModelType.external ||
-        models.get(n.id)?.type === EnumLineageNodeModelType.seed),
+      (n.data.type === EnumLineageNodeModelType.external ||
+        n.data.type === EnumLineageNodeModelType.seed),
   ).length
   const countCTEs = nodes.filter(
-    n =>
-      isFalse(n.hidden) &&
-      models.get(n.id)?.type === EnumLineageNodeModelType.cte,
+    n => isFalse(n.hidden) && n.data.type === EnumLineageNodeModelType.cte,
   ).length
   const highlightedNodeModels = useMemo(
     () => Object.values(highlightedNodes ?? {}).flat(),

--- a/web/client/src/library/components/graph/ModelNode.tsx
+++ b/web/client/src/library/components/graph/ModelNode.tsx
@@ -37,7 +37,7 @@ export default function ModelNode({
     highlightedNodes,
   } = useLineageFlow()
 
-  const { model, columns } = useMemo(() => {
+  const { columns } = useMemo(() => {
     const model = models.get(id)
     const columns = model?.columns ?? []
 
@@ -60,7 +60,6 @@ export default function ModelNode({
     })
 
     return {
-      model,
       columns,
     }
   }, [id, models, lineage])
@@ -104,8 +103,9 @@ export default function ModelNode({
   const splat = highlightedNodes?.['*']
   const isInteractive = mainNode !== id && isNotNil(handleClickModel)
   const isCTE = data.type === EnumLineageNodeModelType.cte
-  const isModelExternal = model?.type === EnumLineageNodeModelType.external
-  const isModelSeed = model?.type === EnumLineageNodeModelType.seed
+  const isModelExternal = data.type === EnumLineageNodeModelType.external
+  const isModelSeed = data.type === EnumLineageNodeModelType.seed
+  const isModelSQL = data.type === EnumLineageNodeModelType.sql
   const showColumns = withColumns && isArrayNotEmpty(columns)
   const isMainNode = mainNode === id || highlightedNodeModels.includes(id)
   const isActiveNode =
@@ -164,7 +164,7 @@ export default function ModelNode({
             className="max-h-[15rem]"
             nodeId={id}
             columns={columns}
-            disabled={model?.type !== EnumLineageNodeModelType.sql}
+            disabled={isModelSQL}
             withHandles={true}
             withSource={true}
             withDescription={false}

--- a/web/client/src/library/pages/docs/Content.tsx
+++ b/web/client/src/library/pages/docs/Content.tsx
@@ -52,7 +52,7 @@ export default function Content(): JSX.Element {
             <div className="flex flex-col h-full dark:bg-theme-lighter round">
               <Documentation
                 model={model}
-                withQuery={model.type === 'sql'}
+                withQuery={model.isModelSQL}
               />
             </div>
             <div className="flex flex-col h-full px-2">

--- a/web/client/src/models/file.ts
+++ b/web/client/src/models/file.ts
@@ -1,4 +1,4 @@
-import { type File, FileType } from '../api/client'
+import { type File } from '../api/client'
 import { type ModelDirectory } from './directory'
 import { type InitialArtifact, ModelArtifact } from './artifact'
 import { isFalse, isNil, isStringEmptyOrNil, toUniqueName } from '@utils/index'
@@ -11,20 +11,19 @@ export const EnumFileExtensions = {
   YML: '.yml',
   None: '',
 } as const
+
 export type FileExtensions =
   (typeof EnumFileExtensions)[keyof typeof EnumFileExtensions]
+
 export interface InitialFile extends InitialArtifact, File {
   content: string
   extension: string
-  is_supported: boolean
 }
 
 export class ModelFile extends ModelArtifact<InitialFile> {
   private _content: string = ''
-  private _type?: Maybe<FileType>
 
   content: string
-  is_supported: boolean
   extension: FileExtensions
 
   constructor(initial?: File | ModelFile, parent?: ModelDirectory) {
@@ -34,7 +33,6 @@ export class ModelFile extends ModelArtifact<InitialFile> {
         : {
             ...(initial as File),
             extension: initial?.extension ?? EnumFileExtensions.SQL,
-            is_supported: initial?.is_supported ?? true,
             content: initial?.content ?? '',
           },
       parent,
@@ -42,19 +40,8 @@ export class ModelFile extends ModelArtifact<InitialFile> {
 
     this.extension =
       ((initial?.extension ?? this.initial.extension) as FileExtensions) ?? ''
-    this.is_supported =
-      initial?.is_supported ?? this.initial.is_supported ?? false
     this._content = this.content =
       initial?.content ?? this.initial.content ?? ''
-    this.type = initial?.type
-  }
-
-  get type(): Maybe<FileType> {
-    return this._type
-  }
-
-  set type(newType: Maybe<FileType>) {
-    this._type = newType ?? getFileType(this.path)
   }
 
   get isSynced(): boolean {
@@ -65,28 +52,12 @@ export class ModelFile extends ModelArtifact<InitialFile> {
     return isStringEmptyOrNil(this.content)
   }
 
-  get isSupported(): boolean {
-    return this.is_supported
-  }
-
   get isChanged(): boolean {
     return this.content !== this._content
   }
 
-  get isSQLMeshModel(): boolean {
-    return this.is_supported && this.type === 'model'
-  }
-
   get fingerprint(): string {
     return this._content + this.name + this.path
-  }
-
-  get isSQLMeshModelPython(): boolean {
-    return this.isSQLMeshModel && this.extension === EnumFileExtensions.PY
-  }
-
-  get isSQLMeshModelSQL(): boolean {
-    return this.isSQLMeshModel && this.extension === EnumFileExtensions.SQL
   }
 
   removeChanges(): void {
@@ -116,18 +87,10 @@ export class ModelFile extends ModelArtifact<InitialFile> {
     if (isNil(newFile)) {
       this.updateContent('')
     } else {
-      this.is_supported = newFile.is_supported ?? false
       this.extension =
         (newFile.extension as FileExtensions) ?? EnumFileExtensions.None
-      this.type = newFile.type as FileType
 
       this.updateContent(newFile.content ?? '')
     }
   }
-}
-
-function getFileType(path?: string): FileType | undefined {
-  if (isStringEmptyOrNil(path)) return
-
-  if (path.startsWith('models')) return FileType.model
 }

--- a/web/client/src/models/sqlmesh-model.ts
+++ b/web/client/src/models/sqlmesh-model.ts
@@ -92,8 +92,4 @@ export class ModelSQLMeshModel<
       }
     }
   }
-
-  static isSQLMeshModel(file?: ModelFile): boolean {
-    return Boolean(file?.path?.startsWith('models'))
-  }
 }

--- a/web/client/src/models/sqlmesh-model.ts
+++ b/web/client/src/models/sqlmesh-model.ts
@@ -4,9 +4,11 @@ import {
   type Model,
   type ModelDescription,
   type ModelSql,
+  ModelType,
 } from '@api/client'
 import { type Lineage } from '@context/editor'
 import { ModelInitial } from './initial'
+import { type ModelFile } from './file'
 
 export interface InitialSQLMeshModel extends Model {
   lineage?: Record<string, Lineage>
@@ -18,7 +20,7 @@ export class ModelSQLMeshModel<
   path: string
   name: string
   dialect: string
-  type: string
+  type: ModelType
   columns: Column[]
   details: ModelDetails
   description?: ModelDescription
@@ -39,11 +41,11 @@ export class ModelSQLMeshModel<
     this.path = this.initial.path
     this.name = this.initial.name
     this.dialect = this.initial.dialect
-    this.type = this.initial.type
     this.description = this.initial.description
     this.sql = this.initial.sql
     this.columns = this.initial.columns ?? []
     this.details = this.initial.details ?? {}
+    this.type = this.initial.type
   }
 
   get index(): string {
@@ -62,6 +64,22 @@ export class ModelSQLMeshModel<
       .toLocaleLowerCase()
   }
 
+  get isModelPython(): boolean {
+    return this.type === ModelType.python
+  }
+
+  get isModelSQL(): boolean {
+    return this.type === ModelType.sql
+  }
+
+  get isModelSeed(): boolean {
+    return this.type === ModelType.seed
+  }
+
+  get isModelExternal(): boolean {
+    return this.type === ModelType.external
+  }
+
   update(initial: Partial<InitialSQLMeshModel> = {}): void {
     for (const [key, value] of Object.entries(initial)) {
       if (key === 'columns') {
@@ -73,5 +91,9 @@ export class ModelSQLMeshModel<
           value as string
       }
     }
+  }
+
+  static isSQLMeshModel(file?: ModelFile): boolean {
+    return Boolean(file?.path?.startsWith('models'))
   }
 }

--- a/web/server/api/endpoints/meta.py
+++ b/web/server/api/endpoints/meta.py
@@ -16,6 +16,8 @@ def get_api_meta(
     request: Request,
 ) -> models.Meta:
     """Get the metadata"""
+    api_console.log_event_plan_cancel()
+    api_console.log_event_plan_overview()
     api_console.log_event_plan_apply()
     return models.Meta(
         version=_sqlmesh_version(),

--- a/web/server/api/endpoints/models.py
+++ b/web/server/api/endpoints/models.py
@@ -32,12 +32,12 @@ def get_all_models(context: Context) -> t.List[models.Model]:
 
     def _get_model_type(model: Model) -> str:
         if model.is_sql:
-            return "sql"
+            return models.ModelType.SQL
         if model.is_python:
-            return "python"
+            return models.ModelType.PYTHON
         if model.is_seed:
-            return "seed"
-        return "external"
+            return models.ModelType.SEED
+        return models.ModelType.EXTERNAL
 
     for model in context.models.values():
         type = _get_model_type(model)

--- a/web/server/main.py
+++ b/web/server/main.py
@@ -37,7 +37,7 @@ async def startup_event() -> None:
 
     app.state.console_listeners = []
     app.state.dispatch_task = asyncio.create_task(dispatch())
-    app.state.watch_task = asyncio.create_task(watch_project(api_console.queue))
+    app.state.watch_task = asyncio.create_task(watch_project())
     app.state.circuit_breaker = threading.Event()
 
 

--- a/web/server/models.py
+++ b/web/server/models.py
@@ -24,6 +24,13 @@ from sqlmesh.utils.pydantic import (
 SUPPORTED_EXTENSIONS = {".py", ".sql", ".yaml", ".yml", ".csv"}
 
 
+class ModelType(str, enum.Enum):
+    PYTHON = "python"
+    SQL = "sql"
+    SEED = "seed"
+    EXTERNAL = "external"
+
+
 class FileType(str, enum.Enum):
     """An enumeration of possible file types."""
 
@@ -74,9 +81,7 @@ class File(BaseModel):
     name: str
     path: str
     extension: str = ""
-    is_supported: bool = False
     content: t.Optional[str] = None
-    type: t.Optional[FileType] = None
 
     if PYDANTIC_MAJOR_VERSION >= 2:
         model_config = pydantic.ConfigDict(validate_default=True)  # type: ignore
@@ -86,13 +91,6 @@ class File(BaseModel):
     def default_extension(cls, v: str, values: t.Dict[str, t.Any]) -> str:
         if "name" in values:
             return pathlib.Path(values["name"]).suffix
-        return v
-
-    @field_validator("is_supported", always=True, mode="before")
-    @field_validator_v1_args
-    def default_is_supported(cls, v: bool, values: t.Dict[str, t.Any]) -> bool:
-        if "extension" in values:
-            return values["extension"] in SUPPORTED_EXTENSIONS
         return v
 
 
@@ -232,7 +230,7 @@ class Model(BaseModel):
     name: str
     path: str
     dialect: str
-    type: str
+    type: ModelType
     columns: t.List[Column]
     description: t.Optional[str] = None
     details: t.Optional[ModelDetails] = None


### PR DESCRIPTION
Decouple files from models to speed up loading of file system (files don't need loaded_context).
Move checking for whether a file is a model and of which type to Model class