### PR TITLE
fix: add back default catalog in cache entry id

### DIFF
--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -440,5 +440,9 @@ class SqlMeshLoader(Loader):
                 [
                     str(int(max(m for m in mtimes if m is not None))),
                     self._loader._context.config.fingerprint,
+                    # We need to check default catalog since the provided config could not change but the
+                    # gateway we are using could change, therefore potentially changing the default catalog
+                    # which would then invalidate the cached model definition.
+                    self._loader._context.default_catalog or "",
                 ]
             )


### PR DESCRIPTION
I originally thought we just needed this potentially for Airflow but realized that it is needed for reason given in the comment. 