### PR TITLE
chore: redshift cleanup incorrect set catalog

### DIFF
--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -189,9 +189,6 @@ class RedshiftEngineAdapter(
             self.rename_table(temp_table, target_table)
             self.drop_table(old_table)
 
-    def set_current_catalog(self, catalog_name: str) -> None:
-        self.cursor.connection._database = catalog_name
-
     @set_catalog()
     def _get_data_objects(self, schema_name: SchemaName) -> t.List[DataObject]:
         """


### PR DESCRIPTION
This doesn't change any functionality since Redshift is currently being set as only supporting a single catalog. The fact that Redshift doesn't support `USE <catalog>` or something similar is currently preventing us from allowing Redshift to leverage multi-catalog features. 