### PR TITLE
chore: Make set catalog a class decorator

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -62,6 +62,7 @@ MERGE_TARGET_ALIAS = "__MERGE_TARGET__"
 MERGE_SOURCE_ALIAS = "__MERGE_SOURCE__"
 
 
+@set_catalog()
 class EngineAdapter:
     """Base class wrapping a Database API compliant connection.
 
@@ -647,7 +648,6 @@ class EngineAdapter:
                 )
             )
 
-    @set_catalog()
     def create_schema(
         self,
         schema_name: SchemaName,
@@ -668,7 +668,6 @@ class EngineAdapter:
                 raise
             logger.warning("Failed to create schema '%s': %s", schema_name, e)
 
-    @set_catalog()
     def drop_schema(
         self,
         schema_name: SchemaName,
@@ -702,7 +701,6 @@ class EngineAdapter:
             )
         )
 
-    @set_catalog()
     def columns(
         self, table_name: TableName, include_pseudo_columns: bool = False
     ) -> t.Dict[str, exp.DataType]:
@@ -719,7 +717,6 @@ class EngineAdapter:
             if column_name and column_name.strip() and column_type and column_type.strip()
         }
 
-    @set_catalog()
     def table_exists(self, table_name: TableName) -> bool:
         try:
             self.execute(exp.Describe(this=exp.to_table(table_name), kind="TABLE"))
@@ -941,7 +938,6 @@ class EngineAdapter:
             )
         )
 
-    @set_catalog()
     def scd_type_2(
         self,
         target_table: TableName,
@@ -1192,7 +1188,6 @@ class EngineAdapter:
                     match_expressions=[when_matched, when_not_matched],
                 )
 
-    @set_catalog()
     def rename_table(
         self,
         old_table_name: TableName,
@@ -1494,6 +1489,7 @@ class EngineAdapter:
         self.execute(f"TRUNCATE TABLE {table.sql(dialect=self.dialect, identify=True)}")
 
 
+@set_catalog()
 class EngineAdapterWithIndexSupport(EngineAdapter):
     SUPPORTS_INDEXES = True
 

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -9,7 +9,6 @@ from sqlmesh.core.engine_adapter.shared import (
     CatalogSupport,
     DataObject,
     DataObjectType,
-    set_catalog,
 )
 from sqlmesh.utils.errors import SQLMeshError
 
@@ -23,7 +22,6 @@ class BasePostgresEngineAdapter(EngineAdapter):
     COLUMNS_TABLE = "information_schema.columns"
     CATALOG_SUPPORT = CatalogSupport.SINGLE_CATALOG_ONLY
 
-    @set_catalog()
     def columns(
         self, table_name: TableName, include_pseudo_columns: bool = False
     ) -> t.Dict[str, exp.DataType]:
@@ -45,7 +43,6 @@ class BasePostgresEngineAdapter(EngineAdapter):
             for column_name, data_type in resp
         }
 
-    @set_catalog()
     def table_exists(self, table_name: TableName) -> bool:
         """
         Postgres doesn't support describe so I'm using what the redshift cursor does to check if a table
@@ -70,7 +67,6 @@ class BasePostgresEngineAdapter(EngineAdapter):
 
         return result[0] == 1 if result is not None else False
 
-    @set_catalog()
     def create_view(
         self,
         view_name: TableName,
@@ -99,7 +95,6 @@ class BasePostgresEngineAdapter(EngineAdapter):
                 **create_kwargs,
             )
 
-    @set_catalog()
     def _get_data_objects(self, schema_name: SchemaName) -> t.List[DataObject]:
         """
         Returns all the data objects that exist in the given schema and optionally catalog.

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -14,6 +14,7 @@ from sqlmesh.core.engine_adapter.shared import (
     DataObject,
     DataObjectType,
     SourceQuery,
+    set_catalog,
 )
 from sqlmesh.core.node import IntervalUnit
 from sqlmesh.core.schema_diff import SchemaDiffer
@@ -36,6 +37,7 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@set_catalog()
 class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
     """
     BigQuery Engine Adapter using the `google-cloud-bigquery` library's DB API.

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -6,7 +6,11 @@ import typing as t
 import pandas as pd
 from sqlglot import exp
 
-from sqlmesh.core.engine_adapter.shared import CatalogSupport, InsertOverwriteStrategy
+from sqlmesh.core.engine_adapter.shared import (
+    CatalogSupport,
+    InsertOverwriteStrategy,
+    set_catalog,
+)
 from sqlmesh.core.engine_adapter.spark import SparkEngineAdapter
 from sqlmesh.core.schema_diff import SchemaDiffer
 from sqlmesh.utils import classproperty
@@ -19,6 +23,7 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@set_catalog()
 class DatabricksEngineAdapter(SparkEngineAdapter):
     DIALECT = "databricks"
     INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -21,6 +21,7 @@ if t.TYPE_CHECKING:
     from sqlmesh.core.engine_adapter._typing import DF
 
 
+@set_catalog(override_mapping={"_get_data_objects": CatalogSupport.REQUIRES_SET_CATALOG})
 class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin):
     DIALECT = "duckdb"
     SUPPORTS_TRANSACTIONS = False
@@ -51,7 +52,6 @@ class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin)
             )
         ]
 
-    @set_catalog(override=CatalogSupport.REQUIRES_SET_CATALOG)
     def _get_data_objects(self, schema_name: SchemaName) -> t.List[DataObject]:
         """
         Returns all the data objects that exist in the given schema and optionally catalog.

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -7,7 +7,7 @@ from sqlglot import exp
 from sqlglot.optimizer.qualify_columns import quote_identifiers
 
 from sqlmesh.core.engine_adapter.base import EngineAdapter
-from sqlmesh.core.engine_adapter.shared import SourceQuery, set_catalog
+from sqlmesh.core.engine_adapter.shared import SourceQuery
 from sqlmesh.core.node import IntervalUnit
 from sqlmesh.utils.errors import SQLMeshError
 
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 
 class LogicalMergeMixin(EngineAdapter):
-    @set_catalog()
     def merge(
         self,
         target_table: TableName,
@@ -105,7 +104,6 @@ class LogicalReplaceQueryMixin(EngineAdapter):
             engine_adapter._truncate_table(target_table)
             return engine_adapter._insert_append_query(target_table, temp_query, columns_to_types)
 
-    @set_catalog()
     def replace_query(
         self,
         table_name: TableName,

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -14,6 +14,7 @@ if t.TYPE_CHECKING:
     from sqlmesh.core._typing import SchemaName, TableName
 
 
+@set_catalog()
 class MySQLEngineAdapter(
     LogicalMergeMixin,
     LogicalReplaceQueryMixin,
@@ -48,7 +49,6 @@ class MySQLEngineAdapter(
         # MySQL doesn't support CASCADE clause and drops schemas unconditionally.
         super().drop_schema(schema_name, ignore_if_not_exists=ignore_if_not_exists, cascade=False)
 
-    @set_catalog()
     def _get_data_objects(self, schema_name: SchemaName) -> t.List[DataObject]:
         """
         Returns all the data objects that exist in the given schema and optionally catalog.

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -11,6 +11,7 @@ from sqlmesh.core.engine_adapter.mixins import (
     LogicalReplaceQueryMixin,
     PandasNativeFetchDFSupportMixin,
 )
+from sqlmesh.core.engine_adapter.shared import set_catalog
 
 if t.TYPE_CHECKING:
     from sqlmesh.core.engine_adapter._typing import DF
@@ -18,6 +19,7 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@set_catalog()
 class PostgresEngineAdapter(
     BasePostgresEngineAdapter,
     LogicalReplaceQueryMixin,

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -25,6 +25,7 @@ if t.TYPE_CHECKING:
     from sqlmesh.core.engine_adapter.base import QueryOrDF
 
 
+@set_catalog()
 class RedshiftEngineAdapter(
     BasePostgresEngineAdapter,
     LogicalReplaceQueryMixin,
@@ -194,7 +195,6 @@ class RedshiftEngineAdapter(
             self.rename_table(temp_table, target_table)
             self.drop_table(old_table)
 
-    @set_catalog()
     def _get_data_objects(self, schema_name: SchemaName) -> t.List[DataObject]:
         """
         Returns all the data objects that exist in the given schema and optionally catalog.

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -41,6 +41,13 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@set_catalog(
+    override_mapping={
+        "_get_data_objects": CatalogSupport.REQUIRES_SET_CATALOG,
+        "create_schema": CatalogSupport.REQUIRES_SET_CATALOG,
+        "drop_schema": CatalogSupport.REQUIRES_SET_CATALOG,
+    }
+)
 class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTablePropertiesMixin):
     DIALECT = "spark"
     ESCAPE_JSON = True
@@ -291,7 +298,6 @@ class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTableP
             self._fetch_native_df(query, quote_identifiers=quote_identifiers)
         )
 
-    @set_catalog(override=CatalogSupport.REQUIRES_SET_CATALOG)
     def _get_data_objects(self, schema_name: SchemaName) -> t.List[DataObject]:
         schema_name = to_schema(schema_name).sql(dialect=self.dialect)
         sql = f"SHOW TABLE EXTENDED IN {schema_name} LIKE '*'"
@@ -333,7 +339,6 @@ class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTableP
             return self.spark.catalog.currentDatabase()
         return self.fetchone(exp.select(exp.func("current_database")))[0]
 
-    @set_catalog(override=CatalogSupport.REQUIRES_SET_CATALOG)
     def create_schema(
         self,
         schema_name: SchemaName,
@@ -344,7 +349,6 @@ class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTableP
             schema_name, ignore_if_exists=ignore_if_exists, warn_on_error=warn_on_error
         )
 
-    @set_catalog(override=CatalogSupport.REQUIRES_SET_CATALOG)
     def drop_schema(
         self,
         schema_name: SchemaName,

--- a/sqlmesh/core/engine_adapter/trino.py
+++ b/sqlmesh/core/engine_adapter/trino.py
@@ -19,6 +19,7 @@ from sqlmesh.core.engine_adapter.shared import (
     DataObjectType,
     InsertOverwriteStrategy,
     SourceQuery,
+    set_catalog,
 )
 
 if t.TYPE_CHECKING:
@@ -28,6 +29,7 @@ if t.TYPE_CHECKING:
     from sqlmesh.core.engine_adapter._typing import DF
 
 
+@set_catalog()
 class TrinoEngineAdapter(
     PandasNativeFetchDFSupportMixin,
     LogicalReplaceQueryMixin,


### PR DESCRIPTION
Instead of having to put a decorate on each class method in order for it to run `set_catalog`, now it is defined at the class level with overrides defined there too. This removes the chance of mistakes when adding new public methods and removes some code redundancy of having to override parent methods just to override `set_catalog`. 

The only logic change is reorganizing the decorator to be a class decorator and checking the attributes of a class to find methods to wrap. 