### PR TITLE
Fix: rollback should not fail if versions are not in alignment since …

### DIFF
--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -157,11 +157,12 @@ class StateReader(abc.ABC):
     def close(self) -> None:
         """Closes all open connections and releases all allocated resources."""
 
-    def get_versions(self, validate: bool = True) -> Versions:
+    def get_versions(self, validate: bool = True, force: bool = False) -> Versions:
         """Get the current versions of the SQLMesh schema and libraries.
 
         Args:
             validate: Whether or not to raise error if the running version is ahead of state.
+            force: Whether or not to force the versions to be fetched and not raise an error.
 
         Returns:
             The versions object.
@@ -190,7 +191,7 @@ class StateReader(abc.ABC):
                 f"{lib} (local) is using version '{local}' which is behind '{remote}' (remote).{upgrade_suggestion}"
             )
 
-        if SCHEMA_VERSION < versions.schema_version:
+        if SCHEMA_VERSION < versions.schema_version and not force:
             raise_error(
                 "SQLMesh",
                 SCHEMA_VERSION,
@@ -198,7 +199,7 @@ class StateReader(abc.ABC):
                 remote_package_version=versions.sqlmesh_version,
             )
 
-        if major_minor(SQLGLOT_VERSION) < major_minor(versions.sqlglot_version):
+        if major_minor(SQLGLOT_VERSION) < major_minor(versions.sqlglot_version) and not force:
             raise_error(
                 "SQLGlot",
                 SQLGLOT_VERSION,
@@ -206,7 +207,7 @@ class StateReader(abc.ABC):
                 remote_package_version=versions.sqlglot_version,
             )
 
-        if validate:
+        if validate and not force:
             if SCHEMA_VERSION > versions.schema_version:
                 raise_error("SQLMesh", SCHEMA_VERSION, versions.schema_version, ahead=True)
 

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -792,7 +792,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         logger.info("Starting migration rollback.")
         tables = (self.snapshots_table, self.environments_table, self.versions_table)
         optional_tables = (self.seeds_table, self.intervals_table, self.plan_dags_table)
-        versions = self.get_versions(validate=False)
+        versions = self.get_versions(force=True)
         if versions.schema_version == 0:
             # Clean up state tables
             for table in tables + optional_tables:


### PR DESCRIPTION
…its essentially expected. Rollbacks should make an effort to proceed. Otherwise its difficult for users to reconcile depending on how they manage their prod environment. In my particular case, a dev install I did (the one I was asked to test) ended up having a newer schema version than the prod release which incorporated the changes. It means prod would not work and it was asking me to "update" from `0.62.1` to  `0.61.1dev8` or something along those lines which doesnt even make sense from a semver perspective. 

Since rollbacks just swap tables, this seems fine. 

Another unrelated error, **but** also affecting rollbacks (on postgres unfortunately) fixed here:
https://github.com/tobymao/sqlglot/pull/2736