### PR TITLE
fix: caching sub-second accuracy

### DIFF
--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -438,7 +438,7 @@ class SqlMeshLoader(Loader):
             ]
             return "__".join(
                 [
-                    str(int(max(m for m in mtimes if m is not None))),
+                    str(max(m for m in mtimes if m is not None)),
                     self._loader._context.config.fingerprint,
                     # We need to check default catalog since the provided config could not change but the
                     # gateway we are using could change, therefore potentially changing the default catalog


### PR DESCRIPTION
Someone would only hit this if doing programatic changes but that did happen to me when writing some new tests. I don't see an issue leaving it as a float since the period will be later sanitized anyways: https://github.com/TobikoData/sqlmesh/blob/19432843d0c09f12aa24fbce4679bc429cfce30c/sqlmesh/utils/cache.py#L122