### PR TITLE
Feat: Simple inline macro functions

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -225,8 +225,10 @@ class MacroEvaluator:
     def evaluate(self, node: MacroFunc) -> exp.Expression | t.List[exp.Expression] | None:
         if isinstance(node, MacroDef):
             if isinstance(node.expression, exp.Lambda):
-                _, fn = _norm_var_arg_lambda(self, node.expression, node.expression.this.name)
-                self.macros[normalize_macro_name(node.name)] = lambda _, *args: fn(*args)
+                _, fn = _norm_var_arg_lambda(self, node.expression)
+                self.macros[normalize_macro_name(node.name)] = lambda _, *args: fn(
+                    exp.Tuple(expressions=args) if len(args) > 1 else args
+                )
             else:
                 self.locals[node.name] = self.transform(node.expression)
             return node

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -224,7 +224,13 @@ class MacroEvaluator:
 
     def evaluate(self, node: MacroFunc) -> exp.Expression | t.List[exp.Expression] | None:
         if isinstance(node, MacroDef):
-            self.locals[node.name] = self.transform(node.expression)
+            if isinstance(node.expression, exp.Lambda):
+                _, func = _norm_var_arg_lambda(
+                    self, node.expression, node.expression.this.name
+                )
+                self.macros[normalize_macro_name(node.name)] = lambda _, *args: func(*args)
+            else:
+                self.locals[node.name] = self.transform(node.expression)
             return node
 
         if isinstance(node, (MacroSQL, MacroStrReplace)):

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -225,10 +225,8 @@ class MacroEvaluator:
     def evaluate(self, node: MacroFunc) -> exp.Expression | t.List[exp.Expression] | None:
         if isinstance(node, MacroDef):
             if isinstance(node.expression, exp.Lambda):
-                _, func = _norm_var_arg_lambda(
-                    self, node.expression, node.expression.this.name
-                )
-                self.macros[normalize_macro_name(node.name)] = lambda _, *args: func(*args)
+                _, fn = _norm_var_arg_lambda(self, node.expression, node.expression.this.name)
+                self.macros[normalize_macro_name(node.name)] = lambda _, *args: fn(*args)
             else:
                 self.locals[node.name] = self.transform(node.expression)
             return node

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -227,7 +227,7 @@ class MacroEvaluator:
             if isinstance(node.expression, exp.Lambda):
                 _, fn = _norm_var_arg_lambda(self, node.expression)
                 self.macros[normalize_macro_name(node.name)] = lambda _, *args: fn(
-                    exp.Tuple(expressions=args) if len(args) > 1 else args
+                    list(args) if len(args) <= 1 else exp.Tuple(expressions=list(args))
                 )
             else:
                 self.locals[node.name] = self.transform(node.expression)

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1823,6 +1823,10 @@ def _python_env(
             for macro_func_or_var in expression.find_all(d.MacroFunc, d.MacroVar):
                 if macro_func_or_var.__class__ is d.MacroFunc:
                     name = macro_func_or_var.this.name.lower()
+                    if name not in macros:
+                        # This macro is assumed to be in the same file as the model definition.
+                        # If it's not, it will be caught later when the macro is rendered.
+                        continue
                     used_macros[name] = macros[name]
                 elif macro_func_or_var.__class__ is d.MacroVar:
                     name = macro_func_or_var.name

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1823,11 +1823,8 @@ def _python_env(
             for macro_func_or_var in expression.find_all(d.MacroFunc, d.MacroVar):
                 if macro_func_or_var.__class__ is d.MacroFunc:
                     name = macro_func_or_var.this.name.lower()
-                    if name not in macros:
-                        # This macro is assumed to be in the same file as the model definition.
-                        # If it's not, it will be caught later when the macro is rendered.
-                        continue
-                    used_macros[name] = macros[name]
+                    if name in macros:
+                        used_macros[name] = macros[name]
                 elif macro_func_or_var.__class__ is d.MacroVar:
                     name = macro_func_or_var.name
                     if name in macros:


### PR DESCRIPTION
An attempt at allowing inline defs to be callables like macros. Works for the simplest case.

```sql
MODEL(...);

-- A macrodef should be able to take a simple lambda and do substitution as a callable
-- Allows for highly specific macros to be colocated with the model
-- Makes models with complex biz logic easier to break down, inline
@DEF(convert_to_int, x -> case when left(x, 1) = 'A' then 1 when left(x, 1) = 'B' then 2 when left(x, 1) = 'C' then 3 end);

SELECT
  id,
  cust_rank_1, 
  cust_rank_2,
  cust_rank_3
  @convert_to_int(cust_rank_1) as cust_rank_1_int,
  @convert_to_int(cust_rank_2) as cust_rank_2_int,
  @convert_to_int(cust_rank_3) as cust_rank_3_int
FROM
  some.model
```

Can add a test and run this direction if you think its the right way. Otherwise defer to you all 😃 