### PR TITLE
Feat: Use max interval end of selected models when picking a default plan end

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -879,7 +879,11 @@ class Context(BaseContext):
 
         # If no end date is specified, use the max interval end from prod
         # to prevent unintended evaluation of the entire DAG.
-        default_end = self.state_sync.max_interval_end_for_environment(c.PROD) if not run else None
+        default_end = (
+            self.state_sync.max_interval_end_for_environment(c.PROD, model_fqns=backfill_models)
+            if not run
+            else None
+        )
         default_start = to_date(default_end) - timedelta(days=1) if default_end and is_dev else None
 
         plan = Plan(

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -880,7 +880,7 @@ class Context(BaseContext):
         # If no end date is specified, use the max interval end from prod
         # to prevent unintended evaluation of the entire DAG.
         default_end = (
-            self.state_sync.max_interval_end_for_environment(c.PROD, model_fqns=backfill_models)
+            self.state_sync.max_interval_end_for_environment(c.PROD, models=backfill_models)
             if not run
             else None
         )

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -139,13 +139,13 @@ class StateReader(abc.ABC):
 
     @abc.abstractmethod
     def max_interval_end_for_environment(
-        self, environment: str, model_fqns: t.Optional[t.Set[str]] = None
+        self, environment: str, models: t.Optional[t.Set[str]] = None
     ) -> t.Optional[int]:
         """Returns the max interval end for the given environment.
 
         Args:
             environment: The environment.
-            model_fqns: The optional model FQNs to pick intervals from. If not provided all
+            models: The optional model FQNs to pick intervals from. If not provided all
                 models in the environment will be used.
 
         Returns:

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -138,11 +138,15 @@ class StateReader(abc.ABC):
         """
 
     @abc.abstractmethod
-    def max_interval_end_for_environment(self, environment: str) -> t.Optional[int]:
+    def max_interval_end_for_environment(
+        self, environment: str, model_fqns: t.Optional[t.Set[str]] = None
+    ) -> t.Optional[int]:
         """Returns the max interval end for the given environment.
 
         Args:
             environment: The environment.
+            model_fqns: The optional model FQNs to pick intervals from. If not provided all
+                models in the environment will be used.
 
         Returns:
             A timestamp or None if no interval or environment exists.

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -612,14 +612,14 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         return Snapshot.hydrate_with_intervals_by_version(snapshots, intervals)
 
     def max_interval_end_for_environment(
-        self, environment: str, model_fqns: t.Optional[t.Set[str]] = None
+        self, environment: str, models: t.Optional[t.Set[str]] = None
     ) -> t.Optional[int]:
         env = self._get_environment(environment)
         if not env:
             return None
 
         snapshots = (
-            [s for s in env.snapshots if s.name in model_fqns] if model_fqns else env.snapshots
+            [s for s in env.snapshots if s.name in models] if models is not None else env.snapshots
         )
         max_end = None
         for where in self._snapshot_name_version_filter(snapshots, "intervals"):

--- a/sqlmesh/schedulers/airflow/api.py
+++ b/sqlmesh/schedulers/airflow/api.py
@@ -75,11 +75,11 @@ def get_environments() -> Response:
 @check_authentication
 def get_max_interval_end(name: str) -> Response:
     with util.scoped_state_sync() as state_sync:
-        model_fqns = None
+        models = None
         if "models" in request.args:
-            model_fqns = json.loads(request.args["models"])
+            models = json.loads(request.args["models"])
 
-        max_interval_end = state_sync.max_interval_end_for_environment(name, model_fqns=model_fqns)
+        max_interval_end = state_sync.max_interval_end_for_environment(name, models=models)
         response = common.MaxIntervalEndResponse(
             environment=name, max_interval_end=max_interval_end
         )

--- a/sqlmesh/schedulers/airflow/api.py
+++ b/sqlmesh/schedulers/airflow/api.py
@@ -75,7 +75,11 @@ def get_environments() -> Response:
 @check_authentication
 def get_max_interval_end(name: str) -> Response:
     with util.scoped_state_sync() as state_sync:
-        max_interval_end = state_sync.max_interval_end_for_environment(name)
+        model_fqns = None
+        if "models" in request.args:
+            model_fqns = json.loads(request.args["models"])
+
+        max_interval_end = state_sync.max_interval_end_for_environment(name, model_fqns=model_fqns)
         response = common.MaxIntervalEndResponse(
             environment=name, max_interval_end=max_interval_end
         )

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -272,11 +272,11 @@ class AirflowClient(BaseAirflowClient):
         return common.EnvironmentsResponse.parse_obj(response).environments
 
     def max_interval_end_for_environment(
-        self, environment: str, model_fqns: t.Optional[t.Collection[str]] = None
+        self, environment: str, models: t.Optional[t.Collection[str]] = None
     ) -> t.Optional[int]:
         url = f"{ENVIRONMENTS_PATH}/{environment}/max_interval_end"
-        if model_fqns is not None:
-            models_param = _json_query_param(list(model_fqns))
+        if models is not None:
+            models_param = _json_query_param(list(models))
             response = self._get(url, models=models_param)
         else:
             response = self._get(url)

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -271,8 +271,15 @@ class AirflowClient(BaseAirflowClient):
         response = self._get(ENVIRONMENTS_PATH)
         return common.EnvironmentsResponse.parse_obj(response).environments
 
-    def max_interval_end_for_environment(self, environment: str) -> t.Optional[int]:
-        response = self._get(f"{ENVIRONMENTS_PATH}/{environment}/max_interval_end")
+    def max_interval_end_for_environment(
+        self, environment: str, model_fqns: t.Optional[t.Collection[str]] = None
+    ) -> t.Optional[int]:
+        url = f"{ENVIRONMENTS_PATH}/{environment}/max_interval_end"
+        if model_fqns is not None:
+            models_param = _json_query_param(list(model_fqns))
+            response = self._get(url, models=models_param)
+        else:
+            response = self._get(url)
         return common.MaxIntervalEndResponse.parse_obj(response).max_interval_end
 
     def invalidate_environment(self, environment: str) -> None:
@@ -336,7 +343,11 @@ def _list_to_json(models: t.Collection[T], batch_size: t.Optional[int] = None) -
         batches = [serialized[i : i + batch_size] for i in range(0, len(serialized), batch_size)]
     else:
         batches = [serialized]
-    return [json.dumps(batch, separators=(",", ":")) for batch in batches]
+    return [_json_query_param(batch) for batch in batches]
+
+
+def _json_query_param(value: t.Any) -> str:
+    return json.dumps(value, separators=(",", ":"))
 
 
 def raise_for_status(response: Response) -> None:

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -67,16 +67,20 @@ class HttpStateSync(StateSync):
         """
         return self._client.get_environments()
 
-    def max_interval_end_for_environment(self, environment: str) -> t.Optional[int]:
+    def max_interval_end_for_environment(
+        self, environment: str, model_fqns: t.Optional[t.Set[str]] = None
+    ) -> t.Optional[int]:
         """Returns the max interval end for the given environment.
 
         Args:
             environment: The environment.
+            model_fqns: The optional model FQNs to pick intervals from. If not provided all
+                models in the environment will be used.
 
         Returns:
             A timestamp or None if no interval or environment exists.
         """
-        return self._client.max_interval_end_for_environment(environment)
+        return self._client.max_interval_end_for_environment(environment, model_fqns=model_fqns)
 
     def get_snapshots(
         self,

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -68,19 +68,19 @@ class HttpStateSync(StateSync):
         return self._client.get_environments()
 
     def max_interval_end_for_environment(
-        self, environment: str, model_fqns: t.Optional[t.Set[str]] = None
+        self, environment: str, models: t.Optional[t.Set[str]] = None
     ) -> t.Optional[int]:
         """Returns the max interval end for the given environment.
 
         Args:
             environment: The environment.
-            model_fqns: The optional model FQNs to pick intervals from. If not provided all
+            models: The optional model FQNs to pick intervals from. If not provided all
                 models in the environment will be used.
 
         Returns:
             A timestamp or None if no interval or environment exists.
         """
-        return self._client.max_interval_end_for_environment(environment, model_fqns=model_fqns)
+        return self._client.max_interval_end_for_environment(environment, models=models)
 
     def get_snapshots(
         self,

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -1607,17 +1607,15 @@ def test_max_interval_end_for_environment(
     )
 
     assert state_sync.max_interval_end_for_environment(
-        environment_name, model_fqns={snapshot_a.name}
+        environment_name, models={snapshot_a.name}
     ) == to_timestamp("2023-01-03")
 
     assert state_sync.max_interval_end_for_environment(
-        environment_name, model_fqns={snapshot_b.name}
+        environment_name, models={snapshot_b.name}
     ) == to_timestamp("2023-01-02")
 
-    assert (
-        state_sync.max_interval_end_for_environment(environment_name, model_fqns={"missing"})
-        is None
-    )
+    assert state_sync.max_interval_end_for_environment(environment_name, models={"missing"}) is None
+    assert state_sync.max_interval_end_for_environment(environment_name, models=set()) is None
 
 
 def test_get_snapshots(mocker):

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -380,7 +380,7 @@ def test_max_interval_end_for_environment_with_models(mocker: MockerFixture, sna
     max_interval_end_mock.return_value = max_interval_end_response_mock
 
     client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
-    result = client.max_interval_end_for_environment("test_environment", model_fqns={"a.b.c"})
+    result = client.max_interval_end_for_environment("test_environment", models={"a.b.c"})
 
     assert result == response.max_interval_end
 

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -368,6 +368,27 @@ def test_max_interval_end_for_environment(mocker: MockerFixture, snapshot: Snaps
     )
 
 
+def test_max_interval_end_for_environment_with_models(mocker: MockerFixture, snapshot: Snapshot):
+    response = common.MaxIntervalEndResponse(
+        environment="test_environment", max_interval_end=to_timestamp("2023-01-01")
+    )
+
+    max_interval_end_response_mock = mocker.Mock()
+    max_interval_end_response_mock.status_code = 200
+    max_interval_end_response_mock.json.return_value = response.dict()
+    max_interval_end_mock = mocker.patch("requests.Session.get")
+    max_interval_end_mock.return_value = max_interval_end_response_mock
+
+    client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
+    result = client.max_interval_end_for_environment("test_environment", model_fqns={"a.b.c"})
+
+    assert result == response.max_interval_end
+
+    max_interval_end_mock.assert_called_once_with(
+        "http://localhost:8080/sqlmesh/api/v1/environments/test_environment/max_interval_end?models=%5B%22a.b.c%22%5D"
+    )
+
+
 def test_get_dag_run_state(mocker: MockerFixture):
     get_dag_run_state_mock = mocker.Mock()
     get_dag_run_state_mock.status_code = 200


### PR DESCRIPTION
This update ensures that when using model selector the default plan end will be inferred using the last backfilled interval of the selected model on prod.