### PR TITLE
Fix: Default value for the max snapshot IDs per request used for Cloud Composer

### DIFF
--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -212,7 +212,7 @@ class CloudComposerSchedulerConfig(_BaseAirflowSchedulerConfig, BaseConfig, extr
     backfill_concurrent_tasks: int = 4
     ddl_concurrent_tasks: int = 4
 
-    max_snapshot_ids_per_request: t.Optional[int] = 40
+    max_snapshot_ids_per_request: t.Optional[int] = 20
     use_state_connection: bool = False
 
     type_: Literal["cloud_composer"] = Field(alias="type", default="cloud_composer")


### PR DESCRIPTION
Provided we now use FQN for Snapshot names the size of each individual Snapshot ID has grown significantly. Therefore we need to reduce the default batch size to account for the increased snapshot ID payload size.