### PR TITLE
chore: reorganize test marks

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -171,7 +171,7 @@ jobs:
           command: sudo apt-get update && sudo apt-get install libpq-dev
       - run:
           name: Install dependencies
-          command: make install-engine-it
+          command: make install-engine-test
       - run:
           name: Bring up Dockerized Engines
           command: make engine-up

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -37,7 +37,7 @@ commands:
             - run: circleci-agent step halt
 
 jobs:
-  style_and_unit_tests:
+  style_and_integration_tests:
     parameters:
       python_version:
         type: string
@@ -57,13 +57,13 @@ jobs:
           name: Run linters and code style checks
           command: make py-style
       - run:
-          name: Run unit tests
-          command: make unit-test
+          name: Run integration tests
+          command: make it-test
       - run:
           name: Run doc tests
           command: make doc-test
 
-  style_and_unit_tests_pydantic_v1:
+  style_and_integration_tests_pydantic_v1:
     docker:
       - image: cimg/python:3.10
     resource_class: small
@@ -83,8 +83,8 @@ jobs:
           name: Run linters and code style checks
           command: make py-style
       - run:
-          name: Run unit tests
-          command: make unit-test
+          name: Run integration tests
+          command: make it-test
 
   ui_style:
     docker:
@@ -132,7 +132,7 @@ jobs:
           name: Run tests
           command: npm --prefix web/client run test
 
-  core_integration_tests:
+  integration_tests:
     docker:
       - image: cimg/python:3.7
     resource_class: small
@@ -143,10 +143,10 @@ jobs:
           name: Install dependencies
           command: make install-dev
       - run:
-          name: Run Core integration tests
-          command: make core-it-test
+          name: Run integration tests
+          command: make it-test
 
-  airflow_integration_tests:
+  airflow_docker_tests:
     machine:
       image: ubuntu-2204:2022.10.2
       docker_layer_caching: true
@@ -161,7 +161,7 @@ jobs:
           command: pip3 install ruamel.yaml==0.16.0
       - run:
           name: Run Airflow integration tests
-          command: make airflow-it-test-docker-with-env
+          command: make airflow-docker-test-with-env
           no_output_timeout: 15m
       - run:
           name: Collect Airflow logs
@@ -173,7 +173,7 @@ jobs:
       - store_artifacts:
           path: /tmp/airflow_logs
 
-  engine_adapter_integration_local_only_tests:
+  engine_adapter_docker_tests:
     machine:
       image: ubuntu-2204:2022.10.2
       docker_layer_caching: true
@@ -185,39 +185,38 @@ jobs:
           command: sudo apt-get update && sudo apt-get install libpq-dev
       - run:
           name: Install dependencies
-          command: make install-engine-integration
+          command: make install-engine-it
       - run:
-          name: Bring up MySQL, Postgres, and MSSQL
-          command: make core_engine_it_test_docker
+          name: Bring up Dockerized Engines
+          command: make engine-up
       - run:
           name: Make sure DBs are ready
           command: sleep 60
       - run:
           name: Run tests
-          command: make core_engine_it_test_local_only
+          command: make engine-docker-test
           no_output_timeout: 15m
 
 workflows:
   main_pr:
     jobs:
-      - style_and_unit_tests:
+      - style_and_integration_tests:
           matrix:
             parameters:
               python_version:
                 ["3.7", "3.8", "3.9", "3.10", "3.11"]
-      - style_and_unit_tests_pydantic_v1
-      - core_integration_tests
-      - airflow_integration_tests:
+      - style_and_integration_tests_pydantic_v1
+      - airflow_docker_tests:
           requires:
-            - style_and_unit_tests
+            - style_and_integration_tests
           filters:
             branches:
               only:
                 - main
-      - engine_adapter_integration_local_only_tests:
+      - engine_adapter_docker_tests:
           context: engine_adapter_integration
           requires:
-            - style_and_unit_tests
+            - style_and_integration_tests
           filters:
             branches:
               only:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -37,7 +37,7 @@ commands:
             - run: circleci-agent step halt
 
 jobs:
-  style_and_integration_tests:
+  style_and_slow_tests:
     parameters:
       python_version:
         type: string
@@ -57,13 +57,13 @@ jobs:
           name: Run linters and code style checks
           command: make py-style
       - run:
-          name: Run integration tests
-          command: make it-test
+          name: Run slow tests
+          command: make slow-test
       - run:
           name: Run doc tests
           command: make doc-test
 
-  style_and_integration_tests_pydantic_v1:
+  style_and_slow_tests_pydantic_v1:
     docker:
       - image: cimg/python:3.10
     resource_class: small
@@ -83,8 +83,8 @@ jobs:
           name: Run linters and code style checks
           command: make py-style
       - run:
-          name: Run integration tests
-          command: make it-test
+          name: Run slow tests
+          command: make slow-test
 
   ui_style:
     docker:
@@ -132,20 +132,6 @@ jobs:
           name: Run tests
           command: npm --prefix web/client run test
 
-  integration_tests:
-    docker:
-      - image: cimg/python:3.7
-    resource_class: small
-    steps:
-      - halt_unless_core
-      - checkout
-      - run:
-          name: Install dependencies
-          command: make install-dev
-      - run:
-          name: Run integration tests
-          command: make it-test
-
   airflow_docker_tests:
     machine:
       image: ubuntu-2204:2022.10.2
@@ -160,7 +146,7 @@ jobs:
           name: Install ruamel.yaml
           command: pip3 install ruamel.yaml==0.16.0
       - run:
-          name: Run Airflow integration tests
+          name: Run Airflow slow tests
           command: make airflow-docker-test-with-env
           no_output_timeout: 15m
       - run:
@@ -200,23 +186,23 @@ jobs:
 workflows:
   main_pr:
     jobs:
-      - style_and_integration_tests:
+      - style_and_slow_tests:
           matrix:
             parameters:
               python_version:
                 ["3.7", "3.8", "3.9", "3.10", "3.11"]
-      - style_and_integration_tests_pydantic_v1
+      - style_and_slow_tests_pydantic_v1
       - airflow_docker_tests:
           requires:
-            - style_and_integration_tests
+            - style_and_slow_tests
           filters:
             branches:
               only:
                 - main
       - engine_adapter_docker_tests:
-          context: engine_adapter_integration
+          context: engine_adapter_slow
           requires:
-            - style_and_integration_tests
+            - style_and_slow_tests
           filters:
             branches:
               only:

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ clean-build:
 dev-publish: ui-build clean-build publish
 
 jupyter-example:
-	jupyter lab tests/integrations/jupyter/example_outputs.ipynb
+	jupyter lab tests/slows/jupyter/example_outputs.ipynb
 
 engine-up:
 	docker-compose -f ./tests/core/engine_adapter/docker-compose.yaml up -d
@@ -80,23 +80,23 @@ engine-up:
 engine-down:
 	docker-compose -f ./tests/core/engine_adapter/docker-compose.yaml down
 
-unit-test:
-	pytest -m "unit"
+fast-test:
+	pytest -m "fast"
 
-it-test:
-	pytest -m "unit or integration"
+slow-test:
+	pytest -m "fast or slow"
 
-core-unit-test:
-	pytest -m "unit and not web and not github and not dbt and not airflow and not jupyter"
+core-fast-test:
+	pytest -m "fast and not web and not github and not dbt and not airflow and not jupyter"
 
-core-it-test:
-	pytest -m "(unit or integration) and not web and not github and not dbt and not airflow and not jupyter"
+core-slow-test:
+	pytest -m "(fast or slow) and not web and not github and not dbt and not airflow and not jupyter"
 
-airflow-unit-test:
-	pytest -m "unit and airflow"
+airflow-fast-test:
+	pytest -m "fast and airflow"
 
 airflow-test:
-	pytest -m "(unit or integration) and airflow"
+	pytest -m "(fast or slow) and airflow"
 
 airflow-local-test:
 	export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@localhost/airflow && \
@@ -109,8 +109,8 @@ airflow-local-test-with-env: develop airflow-clean airflow-init airflow-run airf
 
 airflow-docker-test-with-env: develop airflow-clean airflow-init airflow-run airflow-docker-test airflow-stop
 
-engine-it-test:
-	pytest -m "(unit or integration) and engine"
+engine-slow-test:
+	pytest -m "(fast or slow) and engine"
 
 engine-docker-test:
 	pytest -m "docker and engine"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 install-dev:
 	pip3 install -e ".[dev,web,slack]"
 
-install-engine-integration:
+install-engine-it:
 	pip3 install -e ".[dev,web,slack,mysql,postgres,databricks,redshift,bigquery,snowflake,trino,mssql]"
 
 install-pre-commit:
@@ -18,31 +18,8 @@ py-style:
 ui-style:
 	SKIP=autoflake,isort,black,mypy pre-commit run --all-files
 
-unit-test:
-	pytest -m "not integration"
-
 doc-test:
 	PYTEST_PLUGINS=tests.common_fixtures pytest --doctest-modules sqlmesh/core sqlmesh/utils
-
-core-it-test:
-	pytest -m "core_integration"
-
-core_engine_it_test:
-	pytest -m "engine_integration"
-
-core_engine_it_test_local_only:
-	pytest -m "engine_integration_local"
-
-core_engine_it_test_docker:
-	docker-compose -f ./tests/core/engine_adapter/docker-compose.yaml up -d
-
-engine_it_test: core_engine_it_test_docker core_engine_it_test
-
-it-test: core-it-test airflow-it-test-with-env
-
-it-test-docker: core-it-test airflow-it-test-docker-with-env
-
-test: unit-test doc-test it-test
 
 package:
 	pip3 install wheel && python3 setup.py sdist bdist_wheel
@@ -71,17 +48,6 @@ airflow-psql:
 airflow-spark-sql:
 	make -C ./examples/airflow spark-sql
 
-airflow-it-test:
-	export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@localhost/airflow && \
-		pytest -m "airflow_integration"
-
-airflow-it-test-docker:
-	make -C ./examples/airflow it-test-docker
-
-airflow-it-test-with-env: develop airflow-clean airflow-init airflow-run airflow-it-test airflow-stop
-
-airflow-it-test-docker-with-env: develop airflow-clean airflow-init airflow-run airflow-it-test-docker airflow-stop
-
 docs-serve:
 	mkdocs serve
 
@@ -107,3 +73,95 @@ dev-publish: ui-build clean-build publish
 
 jupyter-example:
 	jupyter lab tests/integrations/jupyter/example_outputs.ipynb
+
+engine-up:
+	docker-compose -f ./tests/core/engine_adapter/docker-compose.yaml up -d
+
+engine-down:
+	docker-compose -f ./tests/core/engine_adapter/docker-compose.yaml down
+
+unit-test:
+	pytest -m "unit"
+
+it-test:
+	pytest -m "unit or integration"
+
+core-unit-test:
+	pytest -m "unit and not web and not github and not dbt and not airflow and not jupyter"
+
+core-it-test:
+	pytest -m "(unit or integration) and not web and not github and not dbt and not airflow and not jupyter"
+
+airflow-unit-test:
+	pytest -m "unit and airflow"
+
+airflow-test:
+	pytest -m "(unit or integration) and airflow"
+
+airflow-local-test:
+	export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@localhost/airflow && \
+		pytest -m "docker and airflow"
+
+airflow-docker-test:
+	make -C ./examples/airflow docker-test
+
+airflow-local-test-with-env: develop airflow-clean airflow-init airflow-run airflow-local-test airflow-stop
+
+airflow-docker-test-with-env: develop airflow-clean airflow-init airflow-run airflow-docker-test airflow-stop
+
+engine-it-test:
+	pytest -m "(unit or integration) and engine"
+
+engine-docker-test:
+	pytest -m "docker and engine"
+
+engine-remote-test:
+	pytest -m "remote and engine"
+
+engine-test:
+	pytest -m "engine"
+
+dbt-test:
+	pytest -m "dbt"
+
+github-test:
+	pytest -m "github"
+
+jupyter-test:
+	pytest -m "jupyter"
+
+web-test:
+	pytest -m "web"
+
+bigquery-test:
+	pytest -m "bigquery"
+
+databricks-test:
+	pytest -m "databricks"
+
+duckdb-test:
+	pytest -m "duckdb"
+
+mssql-test:
+	pytest -m "mssql"
+
+mysql-test:
+	pytest -m "mysql"
+
+postgres-test:
+	pytest -m "postgres"
+
+redshift-test:
+	pytest -m "redshift"
+
+snowflake-test:
+	pytest -m "snowflake"
+
+spark-test:
+	pytest -m "spark"
+
+spark-pyspark-test:
+	pytest -m "spark_pyspark"
+
+trino-test:
+	pytest -m "trino"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 install-dev:
 	pip3 install -e ".[dev,web,slack]"
 
-install-engine-it:
+install-engine-test:
 	pip3 install -e ".[dev,web,slack,mysql,postgres,databricks,redshift,bigquery,snowflake,trino,mssql]"
 
 install-pre-commit:

--- a/examples/airflow/Makefile
+++ b/examples/airflow/Makefile
@@ -52,5 +52,5 @@ psql:
 spark-sql:
 	docker exec -it airflow-airflow-worker-1 spark-sql
 
-it-test-docker: decorate-docker-compose
+docker-test: decorate-docker-compose
 	docker-compose up --exit-code-from sqlmesh-tests sqlmesh-tests

--- a/examples/airflow/docker_compose_decorator.py
+++ b/examples/airflow/docker_compose_decorator.py
@@ -73,7 +73,7 @@ docker_compose["services"]["sqlmesh-tests"] = {
     "entrypoint": "/bin/bash",
     "command": [
         "-c",
-        "make install-dev && pytest -m 'airflow_integration'",
+        "make install-dev && pytest -m 'airflow and docker'",
     ],
     "image": "airflow-sqlmesh",
     "user": "airflow",

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,8 +2,8 @@
 markers =
     # Test Type Markers
     # Tests are ordered from fastest to slowest
-    unit: unit test (automatically applied if no type markers)
-    integration: test that involves interacting with a local DB (like DuckDB)
+    fast: fast tests (automatically applied if no type markers)
+    slow: slow tests that typically involve interacting with a local DB (like DuckDB)
     docker: test that involves interacting with a Docker container
     remote: test that involves interacting with a remote DB
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,12 +1,33 @@
 [pytest]
 markers =
-    integration: mark test as an integration test which can take longer to run and require an external environment
-    core_integration: mark test as an integration test that does not require an external environment
-    airflow_integration: mark test as needing the Airflow cluster to run successfully
-    spark: mark test as requiring the PySpark dependency
-    airflow: mark test as requiring the Airflow dependency
-    engine_integration: Engine adapter tests that require external services
-    engine_integration_local: Engine adapter tests that require local Docker containers
+    # Test Type Markers
+    # Tests are ordered from fastest to slowest
+    unit: unit test (automatically applied if no type markers)
+    integration: test that involves interacting with a local DB (like DuckDB)
+    docker: test that involves interacting with a Docker container
+    remote: test that involves interacting with a remote DB
+
+    # Test Domain Markers
+    # default: core functionality
+    airflow: test for Airflow scheduler
+    cli: test for CLI
+    dbt: test for dbt adapter
+    github: test for Github CI/CD bot
+    jupyter: tests for Jupyter integration
+    web: tests for web UI
+    spark_pyspark: test for Spark with PySpark dependency
+    # Engine Adapters
+    engine: test all engine adapters
+    bigquery: test for BigQuery
+    databricks: test for Databricks
+    duckdb: test for DuckDB
+    mssql: test for MSSQL
+    mysql: test for MySQL
+    postgres: test for Postgres
+    redshift: test for Redshift
+    snowflake: test for Snowflake
+    spark: test for Spark
+    trino: test for Trino
 
 # Set this to True to enable logging during tests
 log_cli = False

--- a/setup.py
+++ b/setup.py
@@ -101,9 +101,10 @@ setup(
             "tenacity==8.1.0",
             "types-croniter",
             "types-dateparser",
-            "typing-extensions",
+            "types-python-dateutil",
             "types-pytz",
             "types-requests==2.28.8",
+            "typing-extensions",
         ],
         "dbt": [
             "dbt-core<1.5.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,17 @@ class SushiDataValidator:
             raise NotImplementedError(f"Unknown model_name: {model_name}")
 
 
+def pytest_collection_modifyitems(items, *args, **kwargs):
+    test_type_markers = {"unit", "integration", "docker", "remote"}
+    for item in items:
+        for marker in item.iter_markers():
+            if marker.name in test_type_markers:
+                break
+        else:
+            # if no test type marker is found, assume unit test
+            item.add_marker("unit")
+
+
 # Ignore all local config files
 @pytest.fixture(scope="session", autouse=True)
 def ignore_local_config_files():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,14 +134,14 @@ class SushiDataValidator:
 
 
 def pytest_collection_modifyitems(items, *args, **kwargs):
-    test_type_markers = {"unit", "integration", "docker", "remote"}
+    test_type_markers = {"fast", "slow", "docker", "remote"}
     for item in items:
         for marker in item.iter_markers():
             if marker.name in test_type_markers:
                 break
         else:
-            # if no test type marker is found, assume unit test
-            item.add_marker("unit")
+            # if no test type marker is found, assume fast test
+            item.add_marker("fast")
 
 
 # Ignore all local config files

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -18,6 +18,8 @@ from sqlmesh.utils.date import to_ds
 from sqlmesh.utils.errors import UnsupportedCatalogOperationError
 from tests.core.engine_adapter import to_sql_calls
 
+pytestmark = pytest.mark.engine
+
 
 def test_create_view(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(EngineAdapter)

--- a/tests/core/engine_adapter/test_base_postgres.py
+++ b/tests/core/engine_adapter/test_base_postgres.py
@@ -2,9 +2,12 @@
 import typing as t
 from unittest.mock import call
 
+import pytest
 from sqlglot import exp, parse_one
 
 from sqlmesh.core.engine_adapter.base_postgres import BasePostgresEngineAdapter
+
+pytestmark = [pytest.mark.postgres, pytest.mark.redshift]
 
 
 def test_columns(make_mocked_engine_adapter: t.Callable):

--- a/tests/core/engine_adapter/test_base_postgres.py
+++ b/tests/core/engine_adapter/test_base_postgres.py
@@ -7,7 +7,7 @@ from sqlglot import exp, parse_one
 
 from sqlmesh.core.engine_adapter.base_postgres import BasePostgresEngineAdapter
 
-pytestmark = [pytest.mark.postgres, pytest.mark.redshift]
+pytestmark = [pytest.mark.engine, pytest.mark.postgres, pytest.mark.redshift]
 
 
 def test_columns(make_mocked_engine_adapter: t.Callable):

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -16,7 +16,7 @@ from sqlmesh.core.engine_adapter.bigquery import select_partitions_expr
 from sqlmesh.core.node import IntervalUnit
 from sqlmesh.utils import AttributeDict
 
-pytestmark = pytest.mark.bigquery
+pytestmark = [pytest.mark.bigquery, pytest.mark.engine]
 
 
 def test_insert_overwrite_by_time_partition_query(

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -16,6 +16,8 @@ from sqlmesh.core.engine_adapter.bigquery import select_partitions_expr
 from sqlmesh.core.node import IntervalUnit
 from sqlmesh.utils import AttributeDict
 
+pytestmark = pytest.mark.bigquery
+
 
 def test_insert_overwrite_by_time_partition_query(
     make_mocked_engine_adapter: t.Callable, mocker: MockerFixture

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -2,10 +2,13 @@
 import typing as t
 
 import pandas as pd
+import pytest
 from sqlglot import parse_one
 
 from sqlmesh.core.engine_adapter import DatabricksEngineAdapter
 from tests.core.engine_adapter import to_sql_calls
+
+pytestmark = pytest.mark.databricks
 
 
 def test_replace_query(make_mocked_engine_adapter: t.Callable):

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -8,7 +8,7 @@ from sqlglot import parse_one
 from sqlmesh.core.engine_adapter import DatabricksEngineAdapter
 from tests.core.engine_adapter import to_sql_calls
 
-pytestmark = pytest.mark.databricks
+pytestmark = [pytest.mark.databricks, pytest.mark.engine]
 
 
 def test_replace_query(make_mocked_engine_adapter: t.Callable):

--- a/tests/core/engine_adapter/test_duckdb.py
+++ b/tests/core/engine_adapter/test_duckdb.py
@@ -8,7 +8,7 @@ from sqlglot import parse_one
 from sqlmesh.core.engine_adapter import DuckDBEngineAdapter, EngineAdapter
 from tests.core.engine_adapter import to_sql_calls
 
-pytestmark = pytest.mark.duckdb
+pytestmark = [pytest.mark.duckdb, pytest.mark.engine]
 
 
 @pytest.fixture

--- a/tests/core/engine_adapter/test_duckdb.py
+++ b/tests/core/engine_adapter/test_duckdb.py
@@ -8,6 +8,8 @@ from sqlglot import parse_one
 from sqlmesh.core.engine_adapter import DuckDBEngineAdapter, EngineAdapter
 from tests.core.engine_adapter import to_sql_calls
 
+pytestmark = pytest.mark.duckdb
+
 
 @pytest.fixture
 def adapter(duck_conn):

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -220,51 +220,86 @@ def config() -> Config:
 
 @pytest.fixture(
     params=[
-        "duckdb",
+        pytest.param(
+            "duckdb",
+            marks=[
+                pytest.mark.duckdb,
+                pytest.mark.engine,
+                pytest.mark.integration,
+            ],
+        ),
         pytest.param(
             "postgres",
             marks=[
-                pytest.mark.integration,
-                pytest.mark.engine_integration,
-                pytest.mark.engine_integration_local,
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.postgres,
             ],
         ),
         pytest.param(
             "mysql",
             marks=[
-                pytest.mark.integration,
-                pytest.mark.engine_integration,
-                pytest.mark.engine_integration_local,
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.mysql,
             ],
         ),
         pytest.param(
             "mssql",
             marks=[
-                pytest.mark.integration,
-                pytest.mark.engine_integration,
-                pytest.mark.engine_integration_local,
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.mssql,
             ],
         ),
         pytest.param(
             "trino",
             marks=[
-                pytest.mark.integration,
-                pytest.mark.engine_integration,
-                pytest.mark.engine_integration_local,
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.trino,
             ],
         ),
         pytest.param(
             "spark",
             marks=[
-                pytest.mark.integration,
-                pytest.mark.engine_integration,
-                pytest.mark.engine_integration_local,
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.spark,
             ],
         ),
-        pytest.param("bigquery", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
-        pytest.param("databricks", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
-        pytest.param("redshift", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
-        pytest.param("snowflake", marks=[pytest.mark.integration, pytest.mark.engine_integration]),
+        pytest.param(
+            "bigquery",
+            marks=[
+                pytest.mark.bigquery,
+                pytest.mark.engine,
+                pytest.mark.remote,
+            ],
+        ),
+        pytest.param(
+            "databricks",
+            marks=[
+                pytest.mark.databricks,
+                pytest.mark.engine,
+                pytest.mark.remote,
+            ],
+        ),
+        pytest.param(
+            "redshift",
+            marks=[
+                pytest.mark.engine,
+                pytest.mark.remote,
+                pytest.mark.redshift,
+            ],
+        ),
+        pytest.param(
+            "snowflake",
+            marks=[
+                pytest.mark.engine,
+                pytest.mark.remote,
+                pytest.mark.snowflake,
+            ],
+        ),
     ]
 )
 def engine_adapter(request, config) -> EngineAdapter:

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -91,6 +91,8 @@ class TestContext:
 
     @classmethod
     def _compare_dfs(cls, actual: pd.DataFrame, expected: pd.DataFrame) -> None:
+        actual.reset_index(drop=True, inplace=True)
+        expected.reset_index(drop=True, inplace=True)
         actual = actual.apply(lambda x: x.sort_values().values).reset_index(drop=True)
         expected = expected.apply(lambda x: x.sort_values().values).reset_index(drop=True)
         pd.testing.assert_frame_equal(actual, expected, check_dtype=False, check_index_type=False)

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -91,8 +91,8 @@ class TestContext:
 
     @classmethod
     def _compare_dfs(cls, actual: pd.DataFrame, expected: pd.DataFrame) -> None:
-        actual.reset_index(drop=True, inplace=True)
-        expected.reset_index(drop=True, inplace=True)
+        actual = actual.reset_index(drop=True)
+        expected = expected.reset_index(drop=True)
         actual = actual.apply(lambda x: x.sort_values().values).reset_index(drop=True)
         expected = expected.apply(lambda x: x.sort_values().values).reset_index(drop=True)
         pd.testing.assert_frame_equal(actual, expected, check_dtype=False, check_index_type=False)
@@ -225,7 +225,7 @@ def config() -> Config:
             marks=[
                 pytest.mark.duckdb,
                 pytest.mark.engine,
-                pytest.mark.integration,
+                pytest.mark.slow,
             ],
         ),
         pytest.param(

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -9,7 +9,6 @@ from datetime import timedelta
 
 import pandas as pd
 import pytest
-from pandas._libs import NaTType
 from sqlglot import exp, parse_one
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
@@ -91,17 +90,10 @@ class TestContext:
         return self.engine_adapter.dialect
 
     @classmethod
-    def _compare_dfs(
-        cls, actual: t.Union[pd.DataFrame, exp.Expression, str], expected: pd.DataFrame
-    ) -> None:
-        def replace_nat_with_none(df):
-            return [
-                col if type(col) != NaTType else None
-                for row in sorted(list(df.itertuples(index=False, name=None)))
-                for col in row
-            ]
-
-        assert replace_nat_with_none(actual) == replace_nat_with_none(expected)
+    def _compare_dfs(cls, actual: pd.DataFrame, expected: pd.DataFrame) -> None:
+        actual = actual.apply(lambda x: x.sort_values().values).reset_index(drop=True)
+        expected = expected.apply(lambda x: x.sort_values().values).reset_index(drop=True)
+        pd.testing.assert_frame_equal(actual, expected, check_dtype=False, check_index_type=False)
 
     def get_metadata_results(self, schema: str = TEST_SCHEMA) -> MetadataResults:
         return MetadataResults.from_data_objects(
@@ -116,7 +108,10 @@ class TestContext:
     def _format_df(self, data: pd.DataFrame, to_datetime: bool = True) -> pd.DataFrame:
         for timestamp_column in self.timestamp_columns:
             if timestamp_column in data.columns and to_datetime:
-                data[timestamp_column] = pd.to_datetime(data[timestamp_column])
+                value = pd.to_datetime(data[timestamp_column])
+                if self.dialect in {"bigquery", "databricks", "duckdb", "spark"}:
+                    value = value.astype("datetime64[us]")
+                data[timestamp_column] = value
         return data
 
     def init(self):
@@ -170,7 +165,10 @@ class TestContext:
         )
 
     def get_current_data(self, table: exp.Table) -> pd.DataFrame:
-        return self.engine_adapter.fetchdf(exp.select("*").from_(table), quote_identifiers=True)
+        df = self.engine_adapter.fetchdf(exp.select("*").from_(table), quote_identifiers=True)
+        if self.dialect == "snowflake" and "id" in df.columns:
+            df["id"] = df["id"].astype("int")
+        return df
 
     def compare_with_current(self, table: exp.Table, expected: pd.DataFrame) -> None:
         self._compare_dfs(self.get_current_data(table), self.output_data(expected))

--- a/tests/core/engine_adapter/test_mixins.py
+++ b/tests/core/engine_adapter/test_mixins.py
@@ -2,6 +2,7 @@
 import typing as t
 from unittest.mock import call
 
+import pytest
 from pytest_mock.plugin import MockerFixture
 from sqlglot import exp, parse_one
 
@@ -11,6 +12,8 @@ from sqlmesh.core.engine_adapter.mixins import (
     NonTransactionalTruncateMixin,
 )
 from tests.core.engine_adapter import to_sql_calls
+
+pytestmark = pytest.mark.engine
 
 
 def test_logical_replace_query_already_exists(

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -18,7 +18,7 @@ from sqlmesh.core.engine_adapter.shared import (
 from sqlmesh.utils.date import to_ds
 from tests.core.engine_adapter import to_sql_calls
 
-pytestmark = pytest.mark.mssql
+pytestmark = [pytest.mark.engine, pytest.mark.mssql]
 
 
 def test_columns(make_mocked_engine_adapter: t.Callable):

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -4,6 +4,7 @@ from datetime import date
 from unittest import mock
 
 import pandas as pd
+import pytest
 from pytest_mock.plugin import MockerFixture
 from sqlglot import expressions as exp
 from sqlglot import parse_one
@@ -16,6 +17,8 @@ from sqlmesh.core.engine_adapter.shared import (
 )
 from sqlmesh.utils.date import to_ds
 from tests.core.engine_adapter import to_sql_calls
+
+pytestmark = pytest.mark.mssql
 
 
 def test_columns(make_mocked_engine_adapter: t.Callable):

--- a/tests/core/engine_adapter/test_postgres.py
+++ b/tests/core/engine_adapter/test_postgres.py
@@ -8,6 +8,8 @@ from sqlmesh.core.engine_adapter import PostgresEngineAdapter
 from sqlmesh.utils.errors import UnsupportedCatalogOperationError
 from tests.core.engine_adapter import to_sql_calls
 
+pytestmark = pytest.mark.postgres
+
 
 @pytest.mark.parametrize(
     "kwargs, expected",

--- a/tests/core/engine_adapter/test_postgres.py
+++ b/tests/core/engine_adapter/test_postgres.py
@@ -8,7 +8,7 @@ from sqlmesh.core.engine_adapter import PostgresEngineAdapter
 from sqlmesh.utils.errors import UnsupportedCatalogOperationError
 from tests.core.engine_adapter import to_sql_calls
 
-pytestmark = pytest.mark.postgres
+pytestmark = [pytest.mark.engine, pytest.mark.postgres]
 
 
 @pytest.mark.parametrize(

--- a/tests/core/engine_adapter/test_redshift.py
+++ b/tests/core/engine_adapter/test_redshift.py
@@ -11,7 +11,7 @@ from sqlmesh.core.engine_adapter import RedshiftEngineAdapter
 from sqlmesh.core.engine_adapter.redshift import parse_plan
 from tests.core.engine_adapter import to_sql_calls
 
-pytestmark = pytest.mark.redshift
+pytestmark = [pytest.mark.engine, pytest.mark.redshift]
 
 
 @pytest.fixture

--- a/tests/core/engine_adapter/test_redshift.py
+++ b/tests/core/engine_adapter/test_redshift.py
@@ -11,6 +11,8 @@ from sqlmesh.core.engine_adapter import RedshiftEngineAdapter
 from sqlmesh.core.engine_adapter.redshift import parse_plan
 from tests.core.engine_adapter import to_sql_calls
 
+pytestmark = pytest.mark.redshift
+
 
 @pytest.fixture
 def adapter(make_mocked_engine_adapter):

--- a/tests/core/engine_adapter/test_snowflake.py
+++ b/tests/core/engine_adapter/test_snowflake.py
@@ -6,7 +6,7 @@ from pytest_mock.plugin import MockerFixture
 from sqlmesh.core.dialect import normalize_model_name
 from sqlmesh.core.engine_adapter import SnowflakeEngineAdapter
 
-pytestmark = pytest.mark.snowflake
+pytestmark = [pytest.mark.engine, pytest.mark.snowflake]
 
 
 def test_get_temp_table(mocker: MockerFixture, make_mocked_engine_adapter: t.Callable):

--- a/tests/core/engine_adapter/test_snowflake.py
+++ b/tests/core/engine_adapter/test_snowflake.py
@@ -1,9 +1,12 @@
 import typing as t
 
+import pytest
 from pytest_mock.plugin import MockerFixture
 
 from sqlmesh.core.dialect import normalize_model_name
 from sqlmesh.core.engine_adapter import SnowflakeEngineAdapter
+
+pytestmark = pytest.mark.snowflake
 
 
 def test_get_temp_table(mocker: MockerFixture, make_mocked_engine_adapter: t.Callable):

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -14,6 +14,8 @@ from sqlmesh.core.engine_adapter import SparkEngineAdapter
 from sqlmesh.utils.errors import SQLMeshError
 from tests.core.engine_adapter import to_sql_calls
 
+pytestmark = pytest.mark.spark
+
 
 def test_create_table_properties(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(SparkEngineAdapter)

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -14,7 +14,7 @@ from sqlmesh.core.engine_adapter import SparkEngineAdapter
 from sqlmesh.utils.errors import SQLMeshError
 from tests.core.engine_adapter import to_sql_calls
 
-pytestmark = pytest.mark.spark
+pytestmark = [pytest.mark.engine, pytest.mark.spark]
 
 
 def test_create_table_properties(make_mocked_engine_adapter: t.Callable):

--- a/tests/core/engine_adapter/test_trino.py
+++ b/tests/core/engine_adapter/test_trino.py
@@ -1,7 +1,11 @@
 import typing as t
 
+import pytest
+
 from sqlmesh.core.engine_adapter import TrinoEngineAdapter
 from tests.core.engine_adapter import to_sql_calls
+
+pytestmark = pytest.mark.trino
 
 
 def test_set_current_catalog(make_mocked_engine_adapter: t.Callable, duck_conn):

--- a/tests/core/engine_adapter/test_trino.py
+++ b/tests/core/engine_adapter/test_trino.py
@@ -5,7 +5,7 @@ import pytest
 from sqlmesh.core.engine_adapter import TrinoEngineAdapter
 from tests.core.engine_adapter import to_sql_calls
 
-pytestmark = pytest.mark.trino
+pytestmark = [pytest.mark.engine, pytest.mark.trino]
 
 
 def test_set_current_catalog(make_mocked_engine_adapter: t.Callable, duck_conn):

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -79,7 +79,7 @@ def test_dag(sushi_context):
     }
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_render_sql_model(sushi_context, assert_exp_eq):
     assert_exp_eq(
         sushi_context.render(
@@ -157,7 +157,7 @@ def test_render_sql_model(sushi_context, assert_exp_eq):
     )
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_render_seed_model(sushi_context, assert_exp_eq):
     assert_exp_eq(
         sushi_context.render(
@@ -179,7 +179,7 @@ def test_render_seed_model(sushi_context, assert_exp_eq):
     )
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_diff(sushi_context: Context, mocker: MockerFixture):
     mock_console = mocker.Mock()
     sushi_context.console = mock_console
@@ -202,7 +202,7 @@ def test_diff(sushi_context: Context, mocker: MockerFixture):
     assert success
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_evaluate_limit():
     context = Context(config=Config())
 
@@ -291,7 +291,7 @@ def test():
     assert "test" in context._macros
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_plan_apply(sushi_context_pre_scheduling) -> None:
     logger = logging.getLogger("sqlmesh.core.renderer")
     with patch.object(logger, "warning") as mock_logger:
@@ -350,7 +350,7 @@ model_defaults:
         assert snowflake_connection.password == "XYZ"
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_physical_schema_override() -> None:
     def get_schemas(context: Context):
         return {
@@ -388,7 +388,7 @@ def test_physical_schema_override() -> None:
     )
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_janitor(sushi_context, mocker: MockerFixture) -> None:
     adapter_mock = mocker.MagicMock()
     state_sync_mock = mocker.MagicMock()
@@ -445,7 +445,7 @@ def test_janitor(sushi_context, mocker: MockerFixture) -> None:
     )
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_plan_default_end(sushi_context_pre_scheduling: Context):
     prod_plan = sushi_context_pre_scheduling.plan("prod", no_prompts=True)
     # Simulate that the prod is 3 days behind.
@@ -465,7 +465,7 @@ def test_plan_default_end(sushi_context_pre_scheduling: Context):
     assert forward_only_dev_plan._start == plan_end
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_schema_error_no_default(sushi_context_pre_scheduling) -> None:
     context = sushi_context_pre_scheduling
 
@@ -482,7 +482,7 @@ def test_schema_error_no_default(sushi_context_pre_scheduling) -> None:
         )
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_gateway_macro(sushi_context: Context) -> None:
     sushi_context.upsert_model(
         load_sql_based_model(
@@ -523,7 +523,7 @@ def test_gateway_macro(sushi_context: Context) -> None:
     )
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_unrestorable_snapshot(sushi_context: Context) -> None:
     model_v1 = load_sql_based_model(
         parse(

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -79,6 +79,7 @@ def test_dag(sushi_context):
     }
 
 
+@pytest.mark.integration
 def test_render_sql_model(sushi_context, assert_exp_eq):
     assert_exp_eq(
         sushi_context.render(
@@ -156,6 +157,7 @@ def test_render_sql_model(sushi_context, assert_exp_eq):
     )
 
 
+@pytest.mark.integration
 def test_render_seed_model(sushi_context, assert_exp_eq):
     assert_exp_eq(
         sushi_context.render(
@@ -177,6 +179,7 @@ def test_render_seed_model(sushi_context, assert_exp_eq):
     )
 
 
+@pytest.mark.integration
 def test_diff(sushi_context: Context, mocker: MockerFixture):
     mock_console = mocker.Mock()
     sushi_context.console = mock_console
@@ -199,6 +202,7 @@ def test_diff(sushi_context: Context, mocker: MockerFixture):
     assert success
 
 
+@pytest.mark.integration
 def test_evaluate_limit():
     context = Context(config=Config())
 
@@ -287,6 +291,7 @@ def test():
     assert "test" in context._macros
 
 
+@pytest.mark.integration
 def test_plan_apply(sushi_context_pre_scheduling) -> None:
     logger = logging.getLogger("sqlmesh.core.renderer")
     with patch.object(logger, "warning") as mock_logger:
@@ -345,6 +350,7 @@ model_defaults:
         assert snowflake_connection.password == "XYZ"
 
 
+@pytest.mark.integration
 def test_physical_schema_override() -> None:
     def get_schemas(context: Context):
         return {
@@ -382,6 +388,7 @@ def test_physical_schema_override() -> None:
     )
 
 
+@pytest.mark.integration
 def test_janitor(sushi_context, mocker: MockerFixture) -> None:
     adapter_mock = mocker.MagicMock()
     state_sync_mock = mocker.MagicMock()
@@ -438,6 +445,7 @@ def test_janitor(sushi_context, mocker: MockerFixture) -> None:
     )
 
 
+@pytest.mark.integration
 def test_plan_default_end(sushi_context_pre_scheduling: Context):
     prod_plan = sushi_context_pre_scheduling.plan("prod", no_prompts=True)
     # Simulate that the prod is 3 days behind.
@@ -457,6 +465,7 @@ def test_plan_default_end(sushi_context_pre_scheduling: Context):
     assert forward_only_dev_plan._start == plan_end
 
 
+@pytest.mark.integration
 def test_schema_error_no_default(sushi_context_pre_scheduling) -> None:
     context = sushi_context_pre_scheduling
 
@@ -473,6 +482,7 @@ def test_schema_error_no_default(sushi_context_pre_scheduling) -> None:
         )
 
 
+@pytest.mark.integration
 def test_gateway_macro(sushi_context: Context) -> None:
     sushi_context.upsert_model(
         load_sql_based_model(
@@ -513,6 +523,7 @@ def test_gateway_macro(sushi_context: Context) -> None:
     )
 
 
+@pytest.mark.integration
 def test_unrestorable_snapshot(sushi_context: Context) -> None:
     model_v1 = load_sql_based_model(
         parse(

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -38,7 +38,7 @@ from sqlmesh.core.snapshot import (
 from sqlmesh.utils.date import TimeLike, to_date, to_datetime, to_timestamp, to_ts
 from tests.conftest import DuckDBMetadata, SushiDataValidator, init_and_plan_context
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.slow
 
 
 @pytest.fixture(autouse=True)
@@ -1697,10 +1697,10 @@ def test_scd_type_2(tmp_path: pathlib.Path):
             },
         )
 
-    def compare_dataframes(df1: pd.DataFrame, df2: pd.DataFrame):
-        df1 = df1.sort_values(by=["customer_id"]).reset_index(drop=True)
-        df2 = df2.sort_values(by=["customer_id"]).reset_index(drop=True)
-        pd.testing.assert_frame_equal(df1, df2)
+    def compare_dataframes(actual: pd.DataFrame, expected: pd.DataFrame):
+        actual = actual.apply(lambda x: x.sort_values().values).reset_index(drop=True)
+        expected = expected.apply(lambda x: x.sort_values().values).reset_index(drop=True)
+        pd.testing.assert_frame_equal(actual, expected)
 
     def get_current_df(context: Context):
         return context.engine_adapter.fetchdf("SELECT * FROM sushi.marketing")

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -1698,8 +1698,8 @@ def test_scd_type_2(tmp_path: pathlib.Path):
         )
 
     def compare_dataframes(actual: pd.DataFrame, expected: pd.DataFrame):
-        actual = actual.apply(lambda x: x.sort_values().values).reset_index(drop=True)
-        expected = expected.apply(lambda x: x.sort_values().values).reset_index(drop=True)
+        actual = actual.apply(lambda x: x.sort_values().values).reset_index(drop=True)  # type: ignore
+        expected = expected.apply(lambda x: x.sort_values().values).reset_index(drop=True)  # type: ignore
         pd.testing.assert_frame_equal(actual, expected)
 
     def get_current_df(context: Context):

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -38,6 +38,8 @@ from sqlmesh.core.snapshot import (
 from sqlmesh.utils.date import TimeLike, to_date, to_datetime, to_timestamp, to_ts
 from tests.conftest import DuckDBMetadata, SushiDataValidator, init_and_plan_context
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.fixture(autouse=True)
 def mock_choices(mocker: MockerFixture):
@@ -52,8 +54,6 @@ def plan_choice(plan: Plan, choice: SnapshotChangeCategory) -> None:
 
 
 @freeze_time("2023-01-08 15:00:00")
-@pytest.mark.integration
-@pytest.mark.core_integration
 @pytest.mark.parametrize(
     "context_fixture",
     ["sushi_context", "sushi_no_default_catalog"],
@@ -193,8 +193,6 @@ def test_forward_only_plan_with_effective_date(context_fixture: Context, request
 
 
 @freeze_time("2023-01-08 15:00:00")
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_forward_only_model_regular_plan(mocker: MockerFixture):
     context, plan = init_and_plan_context("examples/sushi", mocker)
     context.apply(plan)
@@ -288,8 +286,6 @@ def test_forward_only_model_regular_plan(mocker: MockerFixture):
 
 
 @freeze_time("2023-01-08 15:00:00")
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_plan_set_choice_is_reflected_in_missing_intervals(mocker: MockerFixture):
     context, plan = init_and_plan_context("examples/sushi", mocker)
     context.apply(plan)
@@ -434,8 +430,6 @@ def test_plan_set_choice_is_reflected_in_missing_intervals(mocker: MockerFixture
 
 
 @freeze_time("2023-01-08 15:00:00")
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_non_breaking_change_after_forward_only_in_dev(mocker: MockerFixture):
     context, plan = init_and_plan_context("examples/sushi", mocker)
     context.apply(plan)
@@ -554,8 +548,6 @@ def test_non_breaking_change_after_forward_only_in_dev(mocker: MockerFixture):
 
 
 @freeze_time("2023-01-08 15:00:00")
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_indirect_non_breaking_change_after_forward_only_in_dev(mocker: MockerFixture):
     context, plan = init_and_plan_context("examples/sushi", mocker)
     context.apply(plan)
@@ -678,8 +670,6 @@ def test_indirect_non_breaking_change_after_forward_only_in_dev(mocker: MockerFi
 
 
 @freeze_time("2023-01-08 15:00:00")
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_forward_only_precedence_over_indirect_non_breaking(mocker: MockerFixture):
     context, plan = init_and_plan_context("examples/sushi", mocker)
     context.apply(plan)
@@ -753,8 +743,6 @@ def test_forward_only_precedence_over_indirect_non_breaking(mocker: MockerFixtur
 
 
 @freeze_time("2023-01-08 15:00:00")
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_select_models_for_backfill(mocker: MockerFixture):
     context, _ = init_and_plan_context("examples/sushi", mocker)
 
@@ -806,8 +794,6 @@ def test_select_models_for_backfill(mocker: MockerFixture):
     assert dev_df.empty
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 @pytest.mark.parametrize(
     "context_fixture",
     ["sushi_context", "sushi_dbt_context", "sushi_test_dbt_context", "sushi_no_default_catalog"],
@@ -816,8 +802,6 @@ def test_model_add(context_fixture: Context, request):
     initial_add(request.getfixturevalue(context_fixture), "dev")
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_model_removed(sushi_context: Context):
     environment = "dev"
     initial_add(sushi_context, environment)
@@ -848,32 +832,24 @@ def test_model_removed(sushi_context: Context):
     )
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_non_breaking_change(sushi_context: Context):
     environment = "dev"
     initial_add(sushi_context, environment)
     validate_query_change(sushi_context, environment, SnapshotChangeCategory.NON_BREAKING, False)
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_breaking_change(sushi_context: Context):
     environment = "dev"
     initial_add(sushi_context, environment)
     validate_query_change(sushi_context, environment, SnapshotChangeCategory.BREAKING, False)
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_forward_only(sushi_context: Context):
     environment = "dev"
     initial_add(sushi_context, environment)
     validate_query_change(sushi_context, environment, SnapshotChangeCategory.FORWARD_ONLY, False)
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_logical_change(sushi_context: Context):
     environment = "dev"
     initial_add(sushi_context, environment)
@@ -961,8 +937,6 @@ def validate_query_change(
     )
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 @pytest.mark.parametrize(
     "from_, to",
     [
@@ -1050,8 +1024,6 @@ def validate_model_kind_change(
     )
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_environment_isolation(sushi_context: Context):
     prod_snapshots = sushi_context.snapshots.values()
 
@@ -1088,8 +1060,6 @@ def test_environment_isolation(sushi_context: Context):
     )
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_environment_promotion(sushi_context: Context):
     initial_add(sushi_context, "dev")
 
@@ -1148,8 +1118,6 @@ def test_environment_promotion(sushi_context: Context):
     )
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_no_override(sushi_context: Context) -> None:
     change_data_type(
         sushi_context,
@@ -1185,8 +1153,6 @@ def test_no_override(sushi_context: Context) -> None:
     assert not waiter_revenue.is_new_version
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_rebase_remote_break(sushi_context: Context):
     setup_rebase(
         sushi_context,
@@ -1196,8 +1162,6 @@ def test_rebase_remote_break(sushi_context: Context):
     )
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_rebase_local_break(sushi_context: Context):
     setup_rebase(
         sushi_context,
@@ -1206,8 +1170,6 @@ def test_rebase_local_break(sushi_context: Context):
     )
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_rebase_no_break(sushi_context: Context):
     setup_rebase(
         sushi_context,
@@ -1216,8 +1178,6 @@ def test_rebase_no_break(sushi_context: Context):
     )
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_rebase_break(sushi_context: Context):
     setup_rebase(
         sushi_context,
@@ -1323,8 +1283,6 @@ def setup_rebase(
         )
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 @pytest.mark.parametrize(
     "change_categories, expected",
     [
@@ -1382,8 +1340,6 @@ def test_revert(
     assert sushi_context.get_snapshot("sushi.items", raise_if_missing=True) == original_snapshot_id
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_revert_after_downstream_change(sushi_context: Context):
     environment = "prod"
     change_data_type(sushi_context, "sushi.items", DataType.Type.DOUBLE, DataType.Type.FLOAT)
@@ -1412,8 +1368,6 @@ def test_revert_after_downstream_change(sushi_context: Context):
     )
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_auto_categorization(sushi_context: Context):
     environment = "dev"
     for config in sushi_context.configs.values():
@@ -1449,8 +1403,6 @@ def test_auto_categorization(sushi_context: Context):
     )
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_multi(mocker):
     context = Context(paths=["examples/multi/repo_1", "examples/multi/repo_2"], gateway="memory")
     context._new_state_sync().reset(default_catalog=context.default_catalog)
@@ -1478,8 +1430,6 @@ def test_multi(mocker):
     validate_apply_basics(context, c.PROD, plan.snapshots)
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_incremental_time_self_reference(
     mocker: MockerFixture, sushi_context: Context, sushi_data_validator: SushiDataValidator
 ):
@@ -1550,8 +1500,6 @@ def test_incremental_time_self_reference(
     )
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_invalidating_environment(sushi_context: Context):
     apply_to_environment(sushi_context, "dev")
     start_environment = sushi_context.state_sync.get_environment("dev")
@@ -1571,8 +1519,6 @@ def test_invalidating_environment(sushi_context: Context):
     assert start_schemas - schemas_after_janitor == {"sushi__dev"}
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_environment_suffix_target_table(mocker: MockerFixture):
     context, plan = init_and_plan_context(
         "examples/sushi", mocker, config="environment_suffix_config"
@@ -1612,8 +1558,6 @@ def test_environment_suffix_target_table(mocker: MockerFixture):
     } == set()
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_environment_catalog_mapping(mocker: MockerFixture):
     environments_schemas = {"raw", "sushi"}
 
@@ -1676,8 +1620,6 @@ def test_environment_catalog_mapping(mocker: MockerFixture):
     assert len(non_default_tables) == 0
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 @pytest.mark.parametrize(
     "context_fixture",
     ["sushi_context", "sushi_no_default_catalog"],
@@ -1711,8 +1653,6 @@ def test_ignored_snapshots(context_fixture: Context, request):
     assert exp.table_("order_items", "sushi__dev", catalog) in metadata.qualified_views
 
 
-@pytest.mark.integration
-@pytest.mark.core_integration
 def test_scd_type_2(tmp_path: pathlib.Path):
     def create_source_dataframe(values: t.List[t.Tuple[int, str, str]]) -> pd.DataFrame:
         return pd.DataFrame(

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -169,6 +169,7 @@ def test_paused_forward_only_parent(make_snapshot, mocker: MockerFixture):
     assert snapshot_b.change_category == SnapshotChangeCategory.BREAKING
 
 
+@pytest.mark.integration
 @freeze_time()
 def test_restate_models(sushi_context_pre_scheduling: Context):
     plan = sushi_context_pre_scheduling.plan(
@@ -215,6 +216,7 @@ def test_restate_models(sushi_context_pre_scheduling: Context):
     assert not plan.requires_backfill
 
 
+@pytest.mark.integration
 @freeze_time()
 def test_restate_models_with_existing_missing_intervals(sushi_context: Context):
     yesterday_ts = to_timestamp(yesterday_ds())

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -169,7 +169,7 @@ def test_paused_forward_only_parent(make_snapshot, mocker: MockerFixture):
     assert snapshot_b.change_category == SnapshotChangeCategory.BREAKING
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 @freeze_time()
 def test_restate_models(sushi_context_pre_scheduling: Context):
     plan = sushi_context_pre_scheduling.plan(
@@ -216,7 +216,7 @@ def test_restate_models(sushi_context_pre_scheduling: Context):
     assert not plan.requires_backfill
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 @freeze_time()
 def test_restate_models_with_existing_missing_intervals(sushi_context: Context):
     yesterday_ts = to_timestamp(yesterday_ds())

--- a/tests/core/test_plan_evaluator.py
+++ b/tests/core/test_plan_evaluator.py
@@ -29,7 +29,7 @@ def sushi_plan(sushi_context: Context, mocker: MockerFixture) -> Plan:
     )
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_builtin_evaluator_push(sushi_context: Context, make_snapshot):
     new_model = SqlModel(
         name="sushi.new_test_model",

--- a/tests/core/test_plan_evaluator.py
+++ b/tests/core/test_plan_evaluator.py
@@ -29,6 +29,7 @@ def sushi_plan(sushi_context: Context, mocker: MockerFixture) -> Plan:
     )
 
 
+@pytest.mark.integration
 def test_builtin_evaluator_push(sushi_context: Context, make_snapshot):
     new_model = SqlModel(
         name="sushi.new_test_model",

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -26,7 +26,7 @@ def orders(sushi_context_fixed_date: Context) -> Snapshot:
     return sushi_context_fixed_date.get_snapshot("sushi.orders", raise_if_missing=True)
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_interval_params(scheduler: Scheduler, sushi_context_fixed_date: Context, orders: Snapshot):
     waiter_revenue = sushi_context_fixed_date.get_snapshot(
         "sushi.waiter_revenue_by_day", raise_if_missing=True
@@ -62,7 +62,7 @@ def test_interval_params_nonconsecutive(scheduler: Scheduler, orders: Snapshot):
     }
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_interval_params_missing(scheduler: Scheduler, sushi_context_fixed_date: Context):
     waiters = sushi_context_fixed_date.get_snapshot(
         "sushi.waiter_as_customer_by_day", raise_if_missing=True
@@ -77,7 +77,7 @@ def test_interval_params_missing(scheduler: Scheduler, sushi_context_fixed_date:
     ]
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_run(sushi_context_fixed_date: Context, scheduler: Scheduler):
     adapter = sushi_context_fixed_date.engine_adapter
     snapshot = sushi_context_fixed_date.get_snapshot("sushi.items", raise_if_missing=True)

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -26,6 +26,7 @@ def orders(sushi_context_fixed_date: Context) -> Snapshot:
     return sushi_context_fixed_date.get_snapshot("sushi.orders", raise_if_missing=True)
 
 
+@pytest.mark.integration
 def test_interval_params(scheduler: Scheduler, sushi_context_fixed_date: Context, orders: Snapshot):
     waiter_revenue = sushi_context_fixed_date.get_snapshot(
         "sushi.waiter_revenue_by_day", raise_if_missing=True
@@ -61,6 +62,7 @@ def test_interval_params_nonconsecutive(scheduler: Scheduler, orders: Snapshot):
     }
 
 
+@pytest.mark.integration
 def test_interval_params_missing(scheduler: Scheduler, sushi_context_fixed_date: Context):
     waiters = sushi_context_fixed_date.get_snapshot(
         "sushi.waiter_as_customer_by_day", raise_if_missing=True
@@ -75,6 +77,7 @@ def test_interval_params_missing(scheduler: Scheduler, sushi_context_fixed_date:
     ]
 
 
+@pytest.mark.integration
 def test_run(sushi_context_fixed_date: Context, scheduler: Scheduler):
     adapter = sushi_context_fixed_date.engine_adapter
     snapshot = sushi_context_fixed_date.get_snapshot("sushi.items", raise_if_missing=True)

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -43,7 +43,7 @@ from sqlmesh.core.state_sync.base import (
 from sqlmesh.utils.date import now_timestamp, to_datetime, to_timestamp
 from sqlmesh.utils.errors import SQLMeshError
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.slow
 
 
 @pytest.fixture

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -43,6 +43,8 @@ from sqlmesh.core.state_sync.base import (
 from sqlmesh.utils.date import now_timestamp, to_datetime, to_timestamp
 from sqlmesh.utils.errors import SQLMeshError
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.fixture
 def state_sync(duck_conn):

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -5,7 +5,7 @@ from sqlmesh.core.config import AutoCategorizationMode, CategorizerConfig
 from sqlmesh.core.model import SqlModel
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_data_diff(sushi_context_fixed_date):
     model = sushi_context_fixed_date.models['"memory"."sushi"."customer_revenue_by_day"']
 

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -1,9 +1,11 @@
+import pytest
 from sqlglot import exp
 
 from sqlmesh.core.config import AutoCategorizationMode, CategorizerConfig
 from sqlmesh.core.model import SqlModel
 
 
+@pytest.mark.integration
 def test_data_diff(sushi_context_fixed_date):
     model = sushi_context_fixed_date.models['"memory"."sushi"."customer_revenue_by_day"']
 

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -16,7 +16,7 @@ from sqlmesh.core.test.definition import SqlModelTest
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.yaml import load as load_yaml
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.slow
 
 SUSHI_FOO_META = "MODEL (name sushi.foo, kind FULL)"
 

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -16,6 +16,8 @@ from sqlmesh.core.test.definition import SqlModelTest
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.yaml import load as load_yaml
 
+pytestmark = pytest.mark.integration
+
 SUSHI_FOO_META = "MODEL (name sushi.foo, kind FULL)"
 
 

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -16,6 +16,8 @@ from sqlmesh.dbt.project import Project
 from sqlmesh.dbt.target import SnowflakeConfig
 from sqlmesh.utils.errors import ConfigError
 
+pytestmark = pytest.mark.dbt
+
 
 def test_adapter_relation(sushi_test_project: Project, runtime_renderer: t.Callable):
     context = sushi_test_project.context

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -30,6 +30,8 @@ from sqlmesh.dbt.test import TestConfig
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.yaml import load as yaml_load
 
+pytestmark = pytest.mark.dbt
+
 
 @pytest.mark.parametrize(
     "current, new, expected",

--- a/tests/dbt/test_manifest.py
+++ b/tests/dbt/test_manifest.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from sqlmesh.dbt.basemodel import Dependencies
 from sqlmesh.dbt.context import DbtContext
 from sqlmesh.dbt.manifest import ManifestHelper
 from sqlmesh.dbt.profile import Profile
 from sqlmesh.utils.jinja import MacroReference
+
+pytestmark = pytest.mark.dbt
 
 
 def test_manifest_helper():

--- a/tests/dbt/test_model.py
+++ b/tests/dbt/test_model.py
@@ -6,6 +6,8 @@ from sqlmesh.dbt.model import ModelConfig
 from sqlmesh.dbt.test import TestConfig
 from sqlmesh.utils.errors import ConfigError
 
+pytestmark = pytest.mark.dbt
+
 
 def test_model_test_circular_references() -> None:
     upstream_model = ModelConfig(name="upstream")

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -39,6 +39,8 @@ from sqlmesh.dbt.target import BigQueryConfig, DuckDbConfig, SnowflakeConfig
 from sqlmesh.dbt.test import TestConfig
 from sqlmesh.utils.errors import ConfigError, MacroEvalError, SQLMeshError
 
+pytestmark = pytest.mark.dbt
+
 
 def test_model_name():
     context = DbtContext()

--- a/tests/engines/spark/test_db_api.py
+++ b/tests/engines/spark/test_db_api.py
@@ -4,8 +4,12 @@ from pyspark.sql import SparkSession
 from sqlmesh.engines.spark.db_api import errors
 from sqlmesh.engines.spark.db_api import spark_session as spark_session_db
 
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.spark_pyspark,
+]
 
-@pytest.mark.spark
+
 def test_spark_session_cursor(spark_session: SparkSession):
     connection = spark_session_db.connection(spark_session)
     cursor = connection.cursor()
@@ -47,7 +51,6 @@ def test_spark_session_cursor(spark_session: SparkSession):
         cursor.fetchmany(size=-1)
 
 
-@pytest.mark.spark
 def test_spark_session_cursor_execute_parameters_not_supported(
     spark_session: SparkSession,
 ):

--- a/tests/engines/spark/test_db_api.py
+++ b/tests/engines/spark/test_db_api.py
@@ -5,7 +5,7 @@ from sqlmesh.engines.spark.db_api import errors
 from sqlmesh.engines.spark.db_api import spark_session as spark_session_db
 
 pytestmark = [
-    pytest.mark.integration,
+    pytest.mark.slow,
     pytest.mark.spark_pyspark,
 ]
 

--- a/tests/integrations/github/cicd/test_config.py
+++ b/tests/integrations/github/cicd/test_config.py
@@ -10,6 +10,8 @@ from sqlmesh.core.config import (
 from sqlmesh.integrations.github.cicd.config import MergeMethod
 from tests.utils.test_filesystem import create_temp_file
 
+pytestmark = pytest.mark.github
+
 
 def test_load_yaml_config_default(tmp_path):
     create_temp_file(

--- a/tests/integrations/github/cicd/test_github_commands.py
+++ b/tests/integrations/github/cicd/test_github_commands.py
@@ -4,6 +4,7 @@ import pathlib
 from unittest import TestCase, mock
 from unittest.result import TestResult
 
+import pytest
 from pytest_mock.plugin import MockerFixture
 
 from sqlmesh.core import constants as c
@@ -18,6 +19,10 @@ from sqlmesh.integrations.github.cicd.controller import (
 from sqlmesh.utils.errors import PlanError
 
 pytest_plugins = ["tests.integrations.github.cicd.fixtures"]
+pytestmark = [
+    pytest.mark.github,
+    pytest.mark.integration,
+]
 
 
 def test_run_all_success_with_approvers_approved(

--- a/tests/integrations/github/cicd/test_github_commands.py
+++ b/tests/integrations/github/cicd/test_github_commands.py
@@ -21,7 +21,7 @@ from sqlmesh.utils.errors import PlanError
 pytest_plugins = ["tests.integrations.github.cicd.fixtures"]
 pytestmark = [
     pytest.mark.github,
-    pytest.mark.integration,
+    pytest.mark.slow,
 ]
 
 

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -22,7 +22,7 @@ from sqlmesh.integrations.github.cicd.controller import (
 from tests.integrations.github.cicd.fixtures import MockIssueComment
 
 pytest_plugins = ["tests.integrations.github.cicd.fixtures"]
-
+pytestmark = pytest.mark.github
 
 github_controller_approvers_params = [
     (

--- a/tests/integrations/github/cicd/test_github_event.py
+++ b/tests/integrations/github/cicd/test_github_event.py
@@ -1,4 +1,7 @@
+import pytest
+
 pytest_plugins = ["tests.integrations.github.cicd.fixtures"]
+pytestmark = pytest.mark.github
 
 
 def test_pull_request_review_submit_event(make_event_from_fixture):

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -7,6 +7,7 @@ import pathlib
 import typing as t
 from unittest import mock
 
+import pytest
 from freezegun import freeze_time
 from pytest_mock.plugin import MockerFixture
 from sqlglot import exp
@@ -24,6 +25,10 @@ from sqlmesh.integrations.github.cicd.controller import (
 from tests.integrations.github.cicd.fixtures import MockIssueComment
 
 pytest_plugins = ["tests.integrations.github.cicd.fixtures"]
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.github,
+]
 
 
 def get_environment_objects(controller: GithubController, environment: str) -> t.List[DataObject]:

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -26,7 +26,7 @@ from tests.integrations.github.cicd.fixtures import MockIssueComment
 
 pytest_plugins = ["tests.integrations.github.cicd.fixtures"]
 pytestmark = [
-    pytest.mark.integration,
+    pytest.mark.slow,
     pytest.mark.github,
 ]
 

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -162,7 +162,7 @@ def test_init(tmp_path, notebook, convert_all_html_output_to_text, get_all_html_
     ]
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_render(
     notebook, sushi_context, convert_all_html_output_to_text, convert_all_html_output_to_tags
 ):
@@ -190,7 +190,7 @@ LIMIT 10"""
     assert convert_all_html_output_to_tags(output) == [["pre"] + (["span"] * 93)]
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_render_no_format(
     notebook, sushi_context, convert_all_html_output_to_text, convert_all_html_output_to_tags
 ):
@@ -218,7 +218,7 @@ LIMIT 10"""
     assert convert_all_html_output_to_tags(output) == [["pre"] + (["span"] * 32)]
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 @freeze_time(FREEZE_TIME)
 def test_evaluate(notebook, loaded_sushi_context):
     with capture_output() as output:
@@ -258,7 +258,7 @@ FROM table"""
     )
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_diff(sushi_context, notebook, convert_all_html_output_to_text, get_all_html_output):
     with capture_output():
         test_model_path = sushi_context.path / "models" / "test_model.sql"
@@ -313,7 +313,7 @@ def test_diff(sushi_context, notebook, convert_all_html_output_to_text, get_all_
     ]
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_plan(
     notebook, sushi_context, convert_all_html_output_to_text, convert_all_html_output_to_tags
 ):
@@ -345,7 +345,7 @@ def test_plan(
     ]
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 @freeze_time("2023-01-03 00:00:00")
 def test_run_dag(
     notebook, loaded_sushi_context, convert_all_html_output_to_text, get_all_html_output
@@ -376,7 +376,7 @@ def test_run_dag(
     ]
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 @freeze_time(FREEZE_TIME)
 def test_invalidate(
     notebook, loaded_sushi_context, convert_all_html_output_to_text, get_all_html_output
@@ -500,7 +500,7 @@ def test_run_test(notebook, sushi_context):
     assert not output.outputs
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_audit(notebook, loaded_sushi_context, convert_all_html_output_to_text):
     with capture_output() as output:
         notebook.run_line_magic(magic_name="audit", line="sushi.top_waiters")
@@ -601,7 +601,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
     ]
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_migrate(
     notebook, loaded_sushi_context, convert_all_html_output_to_text, get_all_html_output
 ):
@@ -636,7 +636,7 @@ def test_migrate(
 #
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_create_external_models(notebook, loaded_sushi_context):
     external_model_file = loaded_sushi_context.path / "schema.yaml"
     external_model_file.unlink()
@@ -659,7 +659,7 @@ def test_create_external_models(notebook, loaded_sushi_context):
     )
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 @freeze_time(FREEZE_TIME)
 def test_table_diff(notebook, loaded_sushi_context, convert_all_html_output_to_text):
     with capture_output():

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -28,9 +28,13 @@ RICH_PRE_STYLE = "white-space:pre;overflow-x:auto;line-height:normal;font-family
 FREEZE_TIME = "2023-01-01 00:00:00"
 
 # Remove once 3.7 support is dropped
-pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 8), reason="3.7 runs an old version of IPython and has issue with tests"
-)
+pytestmark = [
+    pytest.mark.jupyter,
+    pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="3.7 runs an old version of IPython and has issue with tests",
+    ),
+]
 
 
 @pytest.fixture(scope="session")
@@ -158,6 +162,7 @@ def test_init(tmp_path, notebook, convert_all_html_output_to_text, get_all_html_
     ]
 
 
+@pytest.mark.integration
 def test_render(
     notebook, sushi_context, convert_all_html_output_to_text, convert_all_html_output_to_tags
 ):
@@ -185,6 +190,7 @@ LIMIT 10"""
     assert convert_all_html_output_to_tags(output) == [["pre"] + (["span"] * 93)]
 
 
+@pytest.mark.integration
 def test_render_no_format(
     notebook, sushi_context, convert_all_html_output_to_text, convert_all_html_output_to_tags
 ):
@@ -212,6 +218,7 @@ LIMIT 10"""
     assert convert_all_html_output_to_tags(output) == [["pre"] + (["span"] * 32)]
 
 
+@pytest.mark.integration
 @freeze_time(FREEZE_TIME)
 def test_evaluate(notebook, loaded_sushi_context):
     with capture_output() as output:
@@ -251,6 +258,7 @@ FROM table"""
     )
 
 
+@pytest.mark.integration
 def test_diff(sushi_context, notebook, convert_all_html_output_to_text, get_all_html_output):
     with capture_output():
         test_model_path = sushi_context.path / "models" / "test_model.sql"
@@ -305,6 +313,7 @@ def test_diff(sushi_context, notebook, convert_all_html_output_to_text, get_all_
     ]
 
 
+@pytest.mark.integration
 def test_plan(
     notebook, sushi_context, convert_all_html_output_to_text, convert_all_html_output_to_tags
 ):
@@ -336,6 +345,7 @@ def test_plan(
     ]
 
 
+@pytest.mark.integration
 @freeze_time("2023-01-03 00:00:00")
 def test_run_dag(
     notebook, loaded_sushi_context, convert_all_html_output_to_text, get_all_html_output
@@ -366,6 +376,7 @@ def test_run_dag(
     ]
 
 
+@pytest.mark.integration
 @freeze_time(FREEZE_TIME)
 def test_invalidate(
     notebook, loaded_sushi_context, convert_all_html_output_to_text, get_all_html_output
@@ -489,6 +500,7 @@ def test_run_test(notebook, sushi_context):
     assert not output.outputs
 
 
+@pytest.mark.integration
 def test_audit(notebook, loaded_sushi_context, convert_all_html_output_to_text):
     with capture_output() as output:
         notebook.run_line_magic(magic_name="audit", line="sushi.top_waiters")
@@ -589,6 +601,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
     ]
 
 
+@pytest.mark.integration
 def test_migrate(
     notebook, loaded_sushi_context, convert_all_html_output_to_text, get_all_html_output
 ):
@@ -623,6 +636,7 @@ def test_migrate(
 #
 
 
+@pytest.mark.integration
 def test_create_external_models(notebook, loaded_sushi_context):
     external_model_file = loaded_sushi_context.path / "schema.yaml"
     external_model_file.unlink()
@@ -645,6 +659,7 @@ def test_create_external_models(notebook, loaded_sushi_context):
     )
 
 
+@pytest.mark.integration
 @freeze_time(FREEZE_TIME)
 def test_table_diff(notebook, loaded_sushi_context, convert_all_html_output_to_text):
     with capture_output():

--- a/tests/schedulers/airflow/operators/test_hwm_sensor.py
+++ b/tests/schedulers/airflow/operators/test_hwm_sensor.py
@@ -13,8 +13,9 @@ from sqlmesh.schedulers.airflow.operators.hwm_sensor import (
 )
 from sqlmesh.utils.date import to_datetime
 
+pytestmark = pytest.mark.airflow
 
-@pytest.mark.airflow
+
 def test_no_current_hwm(mocker: MockerFixture, make_snapshot, random_name):
     this_snapshot = make_snapshot(SqlModel(name="this", query=parse_one("select 1, ds")))
     this_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
@@ -42,7 +43,6 @@ def test_no_current_hwm(mocker: MockerFixture, make_snapshot, random_name):
     get_snapshots_mock.assert_called_once_with([target_snapshot.table_info])
 
 
-@pytest.mark.airflow
 def test_current_hwm_below_target(mocker: MockerFixture, make_snapshot):
     this_snapshot = make_snapshot(
         SqlModel(name="this", query=parse_one("select 1, ds")), version="a"
@@ -82,7 +82,6 @@ def test_current_hwm_below_target(mocker: MockerFixture, make_snapshot):
     get_snapshots_mock.assert_called_once_with([target_snapshot_v1.table_info])
 
 
-@pytest.mark.airflow
 def test_current_hwm_above_target(mocker: MockerFixture, make_snapshot):
     this_snapshot = make_snapshot(
         SqlModel(name="this", query=parse_one("select 1, ds")), version="a"

--- a/tests/schedulers/airflow/operators/test_targets.py
+++ b/tests/schedulers/airflow/operators/test_targets.py
@@ -18,6 +18,8 @@ from sqlmesh.engines import commands
 from sqlmesh.schedulers.airflow.operators import targets
 from sqlmesh.utils.date import to_datetime
 
+pytestmark = pytest.mark.airflow
+
 
 @pytest.fixture
 def model() -> Model:
@@ -27,7 +29,6 @@ def model() -> Model:
     )
 
 
-@pytest.mark.airflow
 def test_evaluation_target_execute(mocker: MockerFixture, make_snapshot: t.Callable, model: Model):
     interval_ds = to_datetime("2022-01-01")
     logical_ds = to_datetime("2022-01-02")
@@ -77,7 +78,6 @@ def test_evaluation_target_execute(mocker: MockerFixture, make_snapshot: t.Calla
     )
 
 
-@pytest.mark.airflow
 def test_evaluation_target_execute_seed_model(mocker: MockerFixture, make_snapshot: t.Callable):
     interval_ds = to_datetime("2022-01-01")
     logical_ds = to_datetime("2022-01-02")
@@ -139,7 +139,6 @@ def test_evaluation_target_execute_seed_model(mocker: MockerFixture, make_snapsh
     )
 
 
-@pytest.mark.airflow
 def test_cleanup_target_execute(mocker: MockerFixture, make_snapshot: t.Callable, model: Model):
     snapshot = make_snapshot(model)
     snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
@@ -185,7 +184,6 @@ def test_cleanup_target_execute(mocker: MockerFixture, make_snapshot: t.Callable
     delete_xcom_mock.assert_called_once()
 
 
-@pytest.mark.airflow
 def test_cleanup_target_skip_execution(
     mocker: MockerFixture, make_snapshot: t.Callable, model: Model
 ):

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -16,6 +16,8 @@ from sqlmesh.schedulers.airflow import common
 from sqlmesh.schedulers.airflow.client import AirflowClient, _list_to_json
 from sqlmesh.utils.date import to_timestamp
 
+pytestmark = pytest.mark.airflow
+
 
 @pytest.fixture
 def snapshot() -> Snapshot:

--- a/tests/schedulers/airflow/test_common.py
+++ b/tests/schedulers/airflow/test_common.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import pytest
+
 from sqlmesh.schedulers.airflow import common
+
+pytestmark = pytest.mark.airflow
 
 
 def test_snapshot_dag_id():

--- a/tests/schedulers/airflow/test_end_to_end.py
+++ b/tests/schedulers/airflow/test_end_to_end.py
@@ -9,6 +9,11 @@ from sqlmesh.schedulers.airflow.client import AirflowClient
 from sqlmesh.utils.date import now, to_date, yesterday
 from tests.conftest import SushiDataValidator
 
+pytestmark = [
+    pytest.mark.airflow,
+    pytest.mark.docker,
+]
+
 
 @pytest.fixture(autouse=True)
 def wait_for_airflow(airflow_client: AirflowClient):
@@ -19,8 +24,6 @@ def wait_for_airflow(airflow_client: AirflowClient):
     get_receiver_dag()
 
 
-@pytest.mark.integration
-@pytest.mark.airflow_integration
 def test_sushi(mocker: MockerFixture, is_docker: bool):
     start = to_date(now() - timedelta(days=7))
     end = now()

--- a/tests/schedulers/airflow/test_integration.py
+++ b/tests/schedulers/airflow/test_integration.py
@@ -15,13 +15,17 @@ from sqlmesh.utils import random_id
 from sqlmesh.utils.date import yesterday
 from sqlmesh.utils.errors import SQLMeshError
 
+pytestmark = [
+    pytest.mark.airflow,
+    pytest.mark.docker,
+]
+
+
 DAG_CREATION_WAIT_INTERVAL = 3
 DAG_CREATION_RETRY_ATTEMPTS = 5
 DAG_RUN_POLL_INTERVAL = 1
 
 
-@pytest.mark.integration
-@pytest.mark.airflow_integration
 def test_system_dags(airflow_client: AirflowClient):
     @retry(wait=wait_fixed(2), stop=stop_after_attempt(15), reraise=True)
     def get_system_dags() -> t.List[t.Dict[str, t.Any]]:
@@ -33,8 +37,6 @@ def test_system_dags(airflow_client: AirflowClient):
     assert all(d["is_active"] for d in system_dags)
 
 
-@pytest.mark.integration
-@pytest.mark.airflow_integration
 def test_apply_plan_create_backfill_promote(
     airflow_client: AirflowClient, make_snapshot, random_name
 ):

--- a/tests/schedulers/airflow/test_mwaa_client.py
+++ b/tests/schedulers/airflow/test_mwaa_client.py
@@ -1,9 +1,12 @@
 import base64
 import json
 
+import pytest
 from pytest_mock.plugin import MockerFixture
 
 from sqlmesh.schedulers.airflow.mwaa_client import MWAAClient
+
+pytestmark = pytest.mark.airflow
 
 
 def test_get_first_dag_run_id(mocker: MockerFixture):

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -29,6 +29,8 @@ from sqlmesh.schedulers.airflow.plan import PlanDagState, create_plan_dag_spec
 from sqlmesh.utils.date import to_datetime, to_timestamp
 from sqlmesh.utils.errors import SQLMeshError
 
+pytestmark = pytest.mark.airflow
+
 
 @pytest.fixture
 def snapshot(make_snapshot, random_name) -> Snapshot:
@@ -59,7 +61,6 @@ def depends_on_past_snapshot(make_snapshot, random_name) -> Snapshot:
     return result
 
 
-@pytest.mark.airflow
 @pytest.mark.parametrize(
     "the_snapshot, expected_intervals, paused_forward_only",
     [
@@ -188,7 +189,6 @@ def test_create_plan_dag_spec(
     list(state_sync_mock.refresh_snapshot_intervals.call_args_list[0][0][0]) == [the_snapshot]
 
 
-@pytest.mark.airflow
 @pytest.mark.parametrize(
     "the_snapshot, expected_intervals",
     [
@@ -399,7 +399,6 @@ def test_select_models_for_backfill(mocker: MockerFixture, random_name, make_sna
     )
 
 
-@pytest.mark.airflow
 def test_create_plan_dag_spec_duplicated_snapshot(
     mocker: MockerFixture, snapshot: Snapshot, random_name
 ):
@@ -440,7 +439,6 @@ def test_create_plan_dag_spec_duplicated_snapshot(
     state_sync_mock.get_snapshots.assert_called_once()
 
 
-@pytest.mark.airflow
 @pytest.mark.parametrize("unbounded_end", [None, ""])
 def test_create_plan_dag_spec_unbounded_end(
     mocker: MockerFixture,

--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -15,6 +15,9 @@ from sqlmesh.utils.errors import PlanError
 from web.server.main import api_console, app
 from web.server.settings import Settings, get_loaded_context, get_settings
 
+pytestmark = pytest.mark.web
+
+
 client = TestClient(app)
 
 


### PR DESCRIPTION
No logic changes but changes to CI/CD workflow.

Expanded test marks to make it easier to test specific subsets of tests. See new marks here: https://github.com/TobikoData/sqlmesh/blob/eakmanrq/refactor_test_markings/pytest.ini

If working on core features and want quick iteration cycle, `make core-unit-test` now provides a quicker feedback loop. Going to also look into parallelizing our tests but that will require some changes for tests that are not properly isolated. 

For make commands assumed that if a user wants integration tests then they also want unit tests (since they are so fast in comparison). As a result CI/CD now just runs unit/integration tests together. 

This change also now makes it much easier to isolate specific engines for testing compared to before (which was just commenting out code). 