### PR TITLE
chore: parallelize tests by module

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -43,7 +43,9 @@ jobs:
         type: string
     docker:
       - image: cimg/python:<< parameters.python_version >>
-    resource_class: small
+    resource_class: medium
+    environment:
+      PYTEST_XDIST_AUTO_NUM_WORKERS: 2
     steps:
       - halt_unless_core
       - checkout
@@ -66,7 +68,9 @@ jobs:
   style_and_slow_tests_pydantic_v1:
     docker:
       - image: cimg/python:3.10
-    resource_class: small
+    resource_class: medium
+    environment:
+      PYTEST_XDIST_AUTO_NUM_WORKERS: 2
     steps:
       - halt_unless_core
       - checkout
@@ -137,6 +141,8 @@ jobs:
       image: ubuntu-2204:2022.10.2
       docker_layer_caching: true
     resource_class: large
+    environment:
+      PYTEST_XDIST_AUTO_NUM_WORKERS: 4
     steps:
       - checkout
       - run:
@@ -164,6 +170,8 @@ jobs:
       image: ubuntu-2204:2022.10.2
       docker_layer_caching: true
     resource_class: large
+    environment:
+      PYTEST_XDIST_AUTO_NUM_WORKERS: 4
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ airflow-test:
 
 airflow-local-test:
 	export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@localhost/airflow && \
-		pytest -m "docker and airflow"
+		pytest -n 1 -m "docker and airflow"
 
 airflow-docker-test:
 	make -C ./examples/airflow docker-test

--- a/examples/airflow/docker_compose_decorator.py
+++ b/examples/airflow/docker_compose_decorator.py
@@ -73,7 +73,7 @@ docker_compose["services"]["sqlmesh-tests"] = {
     "entrypoint": "/bin/bash",
     "command": [
         "-c",
-        "make install-dev && pytest -m 'airflow and docker'",
+        "make install-dev && pytest -n 1 -m 'airflow and docker'",
     ],
     "image": "airflow-sqlmesh",
     "user": "airflow",

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,7 @@ markers =
     snowflake: test for Snowflake
     spark: test for Spark
     trino: test for Trino
+addopts = -n auto --dist=loadscope
 
 # Set this to True to enable logging during tests
 log_cli = False

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
             "pytest-asyncio<0.23.0",
             "pytest-lazy-fixture",
             "pytest-mock",
+            "pytest-xdist",
             "pyspark>=3.4.0",
             "pytz",
             "snowflake-connector-python[pandas,secure-local-storage]>=3.0.2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import datetime
 import typing as t
+import uuid
 from pathlib import Path
-from shutil import rmtree
+from shutil import copytree, rmtree
 from tempfile import TemporaryDirectory
 from unittest import mock
 from unittest.mock import PropertyMock
@@ -180,15 +181,15 @@ def push_plan(context: Context, plan: Plan) -> None:
 
 
 @pytest.fixture()
-def sushi_context_pre_scheduling(mocker: MockerFixture) -> Context:
-    context, plan = init_and_plan_context("examples/sushi", mocker)
+def sushi_context_pre_scheduling(init_and_plan_context: t.Callable) -> Context:
+    context, plan = init_and_plan_context("examples/sushi")
     push_plan(context, plan)
     return context
 
 
 @pytest.fixture()
-def sushi_context_fixed_date(mocker: MockerFixture) -> Context:
-    context, plan = init_and_plan_context("examples/sushi", mocker)
+def sushi_context_fixed_date(init_and_plan_context: t.Callable) -> Context:
+    context, plan = init_and_plan_context("examples/sushi")
 
     for model in context.models.values():
         if model.start:
@@ -200,25 +201,25 @@ def sushi_context_fixed_date(mocker: MockerFixture) -> Context:
 
 
 @pytest.fixture()
-def sushi_context(mocker: MockerFixture) -> Context:
-    context, plan = init_and_plan_context("examples/sushi", mocker)
+def sushi_context(init_and_plan_context: t.Callable) -> Context:
+    context, plan = init_and_plan_context("examples/sushi")
     context.apply(plan)
     return context
 
 
 @pytest.fixture()
-def sushi_dbt_context(mocker: MockerFixture) -> Context:
-    context, plan = init_and_plan_context("examples/sushi_dbt", mocker)
+def sushi_dbt_context(init_and_plan_context: t.Callable) -> Context:
+    context, plan = init_and_plan_context("examples/sushi_dbt")
 
     context.apply(plan)
     return context
 
 
 @pytest.fixture()
-def sushi_test_dbt_context(mocker: MockerFixture) -> Context:
+def sushi_test_dbt_context(init_and_plan_context) -> Context:
     from tests.fixtures.dbt.sushi_test.seed_sources import init_raw_schema
 
-    context, plan = init_and_plan_context("tests/fixtures/dbt/sushi_test", mocker)
+    context, plan = init_and_plan_context("tests/fixtures/dbt/sushi_test")
     init_raw_schema(context.engine_adapter)
 
     context.apply(plan)
@@ -226,30 +227,32 @@ def sushi_test_dbt_context(mocker: MockerFixture) -> Context:
 
 
 @pytest.fixture()
-def sushi_no_default_catalog(mocker: MockerFixture) -> Context:
+def sushi_no_default_catalog(mocker: MockerFixture, init_and_plan_context: t.Callable) -> Context:
     mocker.patch(
         "sqlmesh.core.engine_adapter.base.EngineAdapter.default_catalog",
         PropertyMock(return_value=None),
     )
-    context, plan = init_and_plan_context("examples/sushi", mocker)
+    context, plan = init_and_plan_context("examples/sushi")
     assert context.default_catalog is None
     context.apply(plan)
     return context
 
 
-def init_and_plan_context(
-    paths: str | t.List[str],
-    mocker: MockerFixture,
-    config="test_config",
-) -> t.Tuple[Context, Plan]:
-    delete_cache(paths)
-    sushi_context = Context(paths=paths, config=config)
-    confirm = mocker.patch("sqlmesh.core.console.Confirm")
-    confirm.ask.return_value = False
+@pytest.fixture
+def init_and_plan_context(copy_to_temp_path, mocker) -> t.Callable:
+    def _make_function(
+        paths: str | t.List[str] | Path | t.List[Path], config="test_config"
+    ) -> t.Tuple[Context, Plan]:
+        paths = [str(x) for x in ensure_list(paths)]
+        sushi_context = Context(paths=paths, config=config)
+        confirm = mocker.patch("sqlmesh.core.console.Confirm")
+        confirm.ask.return_value = False
 
-    plan = sushi_context.plan("prod")
+        plan = sushi_context.plan("prod")
 
-    return (sushi_context, plan)
+        return sushi_context, plan
+
+    return _make_function
 
 
 @pytest.fixture
@@ -309,6 +312,27 @@ def make_mocked_engine_adapter(mocker: MockerFixture) -> t.Callable:
         connection_mock.cursor.return_value = cursor_mock
         cursor_mock.connection.return_value = connection_mock
         return klass(lambda: connection_mock, dialect=dialect or klass.DIALECT)
+
+    return _make_function
+
+
+@pytest.fixture
+def copy_to_temp_path(tmp_path: Path) -> t.Callable:
+    def ignore(src, names):
+        if Path(src).name in {".cache", "__pycache__", "logs", "data"}:
+            return names
+        return []
+
+    def _make_function(
+        paths: t.Union[t.Union[str, Path], t.Collection[t.Union[str, Path]]]
+    ) -> t.List[Path]:
+        paths = ensure_list(paths)
+        temp_dirs = []
+        for path in paths:
+            temp_dir = Path(tmp_path) / uuid.uuid4().hex
+            copytree(path, temp_dir, ignore=ignore)
+            temp_dirs.append(temp_dir)
+        return temp_dirs
 
     return _make_function
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,8 +243,7 @@ def init_and_plan_context(copy_to_temp_path, mocker) -> t.Callable:
     def _make_function(
         paths: str | t.List[str] | Path | t.List[Path], config="test_config"
     ) -> t.Tuple[Context, Plan]:
-        paths = [str(x) for x in ensure_list(paths)]
-        sushi_context = Context(paths=paths, config=config)
+        sushi_context = Context(paths=[str(x) for x in copy_to_temp_path(paths)], config=config)
         confirm = mocker.patch("sqlmesh.core.console.Confirm")
         confirm.ask.return_value = False
 
@@ -319,7 +318,7 @@ def make_mocked_engine_adapter(mocker: MockerFixture) -> t.Callable:
 @pytest.fixture
 def copy_to_temp_path(tmp_path: Path) -> t.Callable:
     def ignore(src, names):
-        if Path(src).name in {".cache", "__pycache__", "logs", "data"}:
+        if Path(src).name in {".cache", "__pycache__", "logs", "data", "target"}:
             return names
         return []
 
@@ -330,7 +329,7 @@ def copy_to_temp_path(tmp_path: Path) -> t.Callable:
         temp_dirs = []
         for path in paths:
             temp_dir = Path(tmp_path) / uuid.uuid4().hex
-            copytree(path, temp_dir, ignore=ignore)
+            copytree(path, temp_dir, symlinks=True, ignore=ignore)
             temp_dirs.append(temp_dir)
         return temp_dirs
 

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -36,7 +36,7 @@ from sqlmesh.core.snapshot import (
     SnapshotTableInfo,
 )
 from sqlmesh.utils.date import TimeLike, to_date, to_datetime, to_timestamp, to_ts
-from tests.conftest import DuckDBMetadata, SushiDataValidator, init_and_plan_context
+from tests.conftest import DuckDBMetadata, SushiDataValidator
 
 pytestmark = pytest.mark.slow
 
@@ -194,8 +194,8 @@ def test_forward_only_plan_with_effective_date(context_fixture: Context, request
 
 
 @freeze_time("2023-01-08 15:00:00")
-def test_forward_only_model_regular_plan(mocker: MockerFixture):
-    context, plan = init_and_plan_context("examples/sushi", mocker)
+def test_forward_only_model_regular_plan(init_and_plan_context: t.Callable):
+    context, plan = init_and_plan_context("examples/sushi")
     context.apply(plan)
 
     model_name = "sushi.waiter_revenue_by_day"
@@ -287,8 +287,8 @@ def test_forward_only_model_regular_plan(mocker: MockerFixture):
 
 
 @freeze_time("2023-01-08 15:00:00")
-def test_plan_set_choice_is_reflected_in_missing_intervals(mocker: MockerFixture):
-    context, plan = init_and_plan_context("examples/sushi", mocker)
+def test_plan_set_choice_is_reflected_in_missing_intervals(init_and_plan_context: t.Callable):
+    context, plan = init_and_plan_context("examples/sushi")
     context.apply(plan)
 
     model_name = "sushi.waiter_revenue_by_day"
@@ -432,8 +432,8 @@ def test_plan_set_choice_is_reflected_in_missing_intervals(mocker: MockerFixture
 
 
 @freeze_time("2023-01-08 15:00:00")
-def test_non_breaking_change_after_forward_only_in_dev(mocker: MockerFixture):
-    context, plan = init_and_plan_context("examples/sushi", mocker)
+def test_non_breaking_change_after_forward_only_in_dev(init_and_plan_context: t.Callable):
+    context, plan = init_and_plan_context("examples/sushi")
     context.apply(plan)
 
     model = context.get_model("sushi.waiter_revenue_by_day")
@@ -550,8 +550,8 @@ def test_non_breaking_change_after_forward_only_in_dev(mocker: MockerFixture):
 
 
 @freeze_time("2023-01-08 15:00:00")
-def test_indirect_non_breaking_change_after_forward_only_in_dev(mocker: MockerFixture):
-    context, plan = init_and_plan_context("examples/sushi", mocker)
+def test_indirect_non_breaking_change_after_forward_only_in_dev(init_and_plan_context: t.Callable):
+    context, plan = init_and_plan_context("examples/sushi")
     context.apply(plan)
 
     # Make sushi.orders a forward-only model.
@@ -672,8 +672,8 @@ def test_indirect_non_breaking_change_after_forward_only_in_dev(mocker: MockerFi
 
 
 @freeze_time("2023-01-08 15:00:00")
-def test_forward_only_precedence_over_indirect_non_breaking(mocker: MockerFixture):
-    context, plan = init_and_plan_context("examples/sushi", mocker)
+def test_forward_only_precedence_over_indirect_non_breaking(init_and_plan_context: t.Callable):
+    context, plan = init_and_plan_context("examples/sushi")
     context.apply(plan)
 
     # Make sushi.orders a forward-only model.
@@ -745,8 +745,8 @@ def test_forward_only_precedence_over_indirect_non_breaking(mocker: MockerFixtur
 
 
 @freeze_time("2023-01-08 15:00:00")
-def test_select_models_for_backfill(mocker: MockerFixture):
-    context, _ = init_and_plan_context("examples/sushi", mocker)
+def test_select_models_for_backfill(init_and_plan_context: t.Callable):
+    context, _ = init_and_plan_context("examples/sushi")
 
     expected_intervals = [
         (to_timestamp("2023-01-01"), to_timestamp("2023-01-02")),
@@ -1527,10 +1527,8 @@ def test_invalidating_environment(sushi_context: Context):
     assert start_schemas - schemas_after_janitor == {"sushi__dev"}
 
 
-def test_environment_suffix_target_table(mocker: MockerFixture):
-    context, plan = init_and_plan_context(
-        "examples/sushi", mocker, config="environment_suffix_config"
-    )
+def test_environment_suffix_target_table(init_and_plan_context: t.Callable):
+    context, plan = init_and_plan_context("examples/sushi", config="environment_suffix_config")
     context.apply(plan)
     metadata = DuckDBMetadata.from_context(context)
     environments_schemas = {"raw", "sushi"}
@@ -1566,7 +1564,7 @@ def test_environment_suffix_target_table(mocker: MockerFixture):
     } == set()
 
 
-def test_environment_catalog_mapping(mocker: MockerFixture):
+def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
     environments_schemas = {"raw", "sushi"}
 
     def get_prod_dev_views(metadata: DuckDBMetadata) -> t.Tuple[t.Set[exp.Table], t.Set[exp.Table]]:
@@ -1586,7 +1584,7 @@ def test_environment_catalog_mapping(mocker: MockerFixture):
         return default_tables, non_default_tables
 
     context, plan = init_and_plan_context(
-        "examples/sushi", mocker, config="environment_catalog_mapping_config"
+        "examples/sushi", config="environment_catalog_mapping_config"
     )
     context.apply(plan)
     metadata = DuckDBMetadata.from_context(context)

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -1,6 +1,5 @@
 import logging
 import pathlib
-import shutil
 import sys
 import typing as t
 from unittest.mock import MagicMock
@@ -55,15 +54,8 @@ def notebook(mocker: MockerFixture, ip):
 
 
 @pytest.fixture
-def sushi_context(tmp_path, notebook) -> Context:
-    sushi_dir = tmp_path / "sushi"
-
-    def ignore(src, names):
-        if pathlib.Path(src).name in {".cache", "__pycache__", "logs", "data"}:
-            return names
-        return []
-
-    shutil.copytree(str(SUSHI_EXAMPLE_PATH), str(sushi_dir), ignore=ignore)
+def sushi_context(copy_to_temp_path, notebook) -> Context:
+    sushi_dir = copy_to_temp_path(SUSHI_EXAMPLE_PATH)[0]
     notebook.run_line_magic(magic_name="context", line=str(sushi_dir))
     return notebook.user_ns["context"]
 


### PR DESCRIPTION
Low effort way to improve test performance. Cut times locally in half. Changed Circle from Small to Medium and nearly cut the test time (just test) in half. 

Biggest issue now is that we load balance the tests across the workers by module. This is because some module assume we aren't running in parallel and therefore share resources across tests. This results in a skew across the workers. Fix shouldn't be too bad but taking the easy win for now. 