### PR TITLE
Feat: parse multiline model documentation in a nice way

### DIFF
--- a/sqlmesh/core/node.py
+++ b/sqlmesh/core/node.py
@@ -235,7 +235,7 @@ class _Node(PydanticModel):
     def _description_validator(cls, v: t.Any) -> t.Optional[str]:
         maybe_str = str_or_exp_to_str(v)
         if isinstance(maybe_str, str):
-            return " ".join(inspect.cleandoc(maybe_str).splitlines())
+            return inspect.cleandoc(maybe_str)
         return maybe_str
 
     @field_validator("owner", "stamp", mode="before")

--- a/sqlmesh/core/node.py
+++ b/sqlmesh/core/node.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import typing as t
 from datetime import datetime
 from enum import Enum
@@ -229,7 +230,15 @@ class _Node(PydanticModel):
                 raise ConfigError(f"Invalid cron expression '{cron}'")
         return cron
 
-    @field_validator("owner", "description", "stamp", mode="before")
+    @field_validator("description", mode="before")
+    @classmethod
+    def _description_validator(cls, v: t.Any) -> t.Optional[str]:
+        maybe_str = str_or_exp_to_str(v)
+        if isinstance(maybe_str, str):
+            return " ".join(inspect.cleandoc(maybe_str).splitlines())
+        return maybe_str
+
+    @field_validator("owner", "stamp", mode="before")
     @classmethod
     def _string_expr_validator(cls, v: t.Any) -> t.Optional[str]:
         return str_or_exp_to_str(v)


### PR DESCRIPTION
This is predicated on how sqlglot / sqlmesh parses triple quoted strings, but the idea is that these are equivalent:

```sql
MODEL(
    name analytics_activation.license_utilization_report_v2,
    kind FULL,
    ...,
    description '''
    This is the primary output for Domo to report on license usage. It is a filtered
    view of the fct_license_utilization table with some additional columns to make
    reporting easier.
    ''',
    grain account_module_unit_key
);
```


```sql
MODEL(
    name analytics_activation.license_utilization_report_v2,
    kind FULL,
    ...,
    description 'This is the primary output for Domo to report on license usage. It is a filtered view of the fct_license_utilization table with some additional columns to make reporting easier.',
    grain account_module_unit_key
);
```


Descriptions could get very long but are valuable to have inline with the model. We should support multiline strings.


The argument could be made for column comments too. 

```sql
SELECT
  complex_computation, /*
    What is happening here is ...
    
    E = mc2
    
    And the output is as such */
  more,
  columns
FROM
  something
```


LMK thoughts. 