### PR TITLE
chore: parallelize by test

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -45,7 +45,7 @@ jobs:
       - image: cimg/python:<< parameters.python_version >>
     resource_class: medium
     environment:
-      PYTEST_XDIST_AUTO_NUM_WORKERS: 2
+      PYTEST_XDIST_AUTO_NUM_WORKERS: 4
     steps:
       - halt_unless_core
       - checkout
@@ -70,7 +70,7 @@ jobs:
       - image: cimg/python:3.10
     resource_class: medium
     environment:
-      PYTEST_XDIST_AUTO_NUM_WORKERS: 2
+      PYTEST_XDIST_AUTO_NUM_WORKERS: 4
     steps:
       - halt_unless_core
       - checkout
@@ -142,7 +142,7 @@ jobs:
       docker_layer_caching: true
     resource_class: large
     environment:
-      PYTEST_XDIST_AUTO_NUM_WORKERS: 4
+      PYTEST_XDIST_AUTO_NUM_WORKERS: 8
     steps:
       - checkout
       - run:
@@ -171,7 +171,7 @@ jobs:
       docker_layer_caching: true
     resource_class: large
     environment:
-      PYTEST_XDIST_AUTO_NUM_WORKERS: 4
+      PYTEST_XDIST_AUTO_NUM_WORKERS: 8
     steps:
       - checkout
       - run:

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,7 +28,7 @@ markers =
     snowflake: test for Snowflake
     spark: test for Spark
     trino: test for Trino
-addopts = -n auto --dist=loadscope
+addopts = -n auto --dist=worksteal
 
 # Set this to True to enable logging during tests
 log_cli = False


### PR DESCRIPTION
Combined with the improvements from #1939 it seems like we can now parallelize all tests except for Airflow.

`worksteal` approach means that workers can take work from other workers if they finish their queue early (shared/greedy approach). 

From some simple testing, it seems like assigning 2 workers per code is ideal on CircleCI so updated config to match that. Tests are now 3x faster on CircleCI than prior to these two PRs. 