### PR TITLE
Fix: Config fingerprint is not deterministic resulting in cache misses when...

### DIFF
--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -220,4 +220,4 @@ class Config(BaseConfig):
 
     @property
     def fingerprint(self) -> str:
-        return str(zlib.crc32(pickle.dumps(self.dict(exclude={"loader"}))))
+        return str(zlib.crc32(pickle.dumps(self.dict(exclude={"loader", "notification_targets"}))))

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import abc
+import functools
 import linecache
 import logging
 import os
+import time
 import typing as t
 from collections import defaultdict
 from dataclasses import dataclass
@@ -39,6 +41,32 @@ if t.TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+_LoadMethod = t.TypeVar("_LoadMethod", bound=t.Callable[..., t.Sized])
+
+
+def _log_load_perf(func: _LoadMethod) -> _LoadMethod:
+    """Decorator to track how long it takes in each loader function."""
+
+    @functools.wraps(func)
+    def wrapper(*args: t.Any, **kwargs: t.Any) -> t.Sized:
+        start = time.perf_counter()
+        loaded = 0
+        try:
+            rv = func(*args, **kwargs)
+            loaded = len(rv)
+            return rv
+        finally:
+            logger.debug(
+                f"%s executed method %s loading %d objects in %.4fs",
+                args[0].__class__.__name__,
+                func.__name__,
+                loaded,
+                time.perf_counter() - start,
+            )
+
+    return t.cast(_LoadMethod, wrapper)
 
 
 # TODO: consider moving this to context
@@ -179,6 +207,7 @@ class Loader(abc.ABC):
     def _load_metrics(self) -> UniqueKeyDict[str, MetricMeta]:
         return UniqueKeyDict("metrics")
 
+    @_log_load_perf
     def _load_external_models(self) -> UniqueKeyDict[str, Model]:
         models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")
         for context_path, config in self._context.configs.items():
@@ -210,6 +239,7 @@ class Loader(abc.ABC):
 class SqlMeshLoader(Loader):
     """Loads macros and models for a context using the SQLMesh file formats"""
 
+    @_log_load_perf
     def _load_scripts(self) -> t.Tuple[MacroRegistry, JinjaMacroRegistry]:
         """Loads all user defined macros."""
         # Store a copy of the macro registry
@@ -253,6 +283,7 @@ class SqlMeshLoader(Loader):
 
         return macros, jinja_macros
 
+    @_log_load_perf
     def _load_models(
         self, macros: MacroRegistry, jinja_macros: JinjaMacroRegistry
     ) -> UniqueKeyDict[str, Model]:
@@ -266,6 +297,7 @@ class SqlMeshLoader(Loader):
 
         return models
 
+    @_log_load_perf
     def _load_sql_models(
         self, macros: MacroRegistry, jinja_macros: JinjaMacroRegistry
     ) -> UniqueKeyDict[str, Model]:
@@ -314,6 +346,7 @@ class SqlMeshLoader(Loader):
 
         return models
 
+    @_log_load_perf
     def _load_python_models(self) -> UniqueKeyDict[str, Model]:
         """Loads the python models into a Dict"""
         models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")
@@ -345,6 +378,7 @@ class SqlMeshLoader(Loader):
 
         return models
 
+    @_log_load_perf
     def _load_audits(
         self, macros: MacroRegistry, jinja_macros: JinjaMacroRegistry
     ) -> UniqueKeyDict[str, Audit]:
@@ -368,6 +402,7 @@ class SqlMeshLoader(Loader):
                         audits_by_name[audit.name] = audit
         return audits_by_name
 
+    @_log_load_perf
     def _load_metrics(self) -> UniqueKeyDict[str, MetricMeta]:
         """Loads all metrics."""
         metrics: UniqueKeyDict[str, MetricMeta] = UniqueKeyDict("metrics")


### PR DESCRIPTION
...using notification targets which are stored as a frozenset. That key is not needed for the current usage of the `fingerprint` method which its only use currently is in cache entry id generation. 

Furthermore there was no easy logging on how the needle is moving when loading various components of a sqlmesh project. So I added logging too. 