### PR TITLE
Fix: Send sse error if file watcher throws

### DIFF
--- a/web/client/openapi.json
+++ b/web/client/openapi.json
@@ -264,7 +264,13 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/File" }
+                "schema": {
+                  "anyOf": [
+                    { "$ref": "#/components/schemas/File" },
+                    { "type": "null" }
+                  ],
+                  "title": "Response Write File Api Files  Path  Post"
+                }
               }
             }
           },

--- a/web/server/api/endpoints/files.py
+++ b/web/server/api/endpoints/files.py
@@ -46,21 +46,22 @@ def get_file(
     """Get a file, including its contents."""
     try:
         file_path = Path(path)
-        file = _get_file_with_content(file_path, settings)
+        file = _get_file_with_content(settings.project_path / file_path, str(file_path))
     except FileNotFoundError:
         raise HTTPException(status_code=HTTP_404_NOT_FOUND)
 
     return file
 
 
-@router.post("/{path:path}", response_model=models.File)
+@router.post("/{path:path}", response_model=t.Optional[models.File])
 async def write_file(
+    response: Response,
     content: str = Body("", embed=True),
     new_path: t.Optional[str] = Body(None, embed=True),
     path: str = Depends(validate_path),
     settings: Settings = Depends(get_settings),
     context: Context = Depends(get_context),
-) -> models.File:
+) -> t.Optional[models.File]:
     """Create, update, or rename a file."""
     path_or_new_path = path
     if new_path:
@@ -86,12 +87,11 @@ async def write_file(
                     ServerSentEvent(event="errors", data=json.dumps(error))
                 )
 
-        full_path.write_text(content, encoding="utf-8")
+        full_path.write_text(content)
 
-    content = (settings.project_path / path_or_new_path).read_text()
-    return models.File(
-        name=os.path.basename(path_or_new_path), path=path_or_new_path, content=content
-    )
+    response.status_code = HTTP_204_NO_CONTENT
+
+    return None
 
 
 @router.delete("/{path:path}")
@@ -154,6 +154,7 @@ def _get_directory(
 
     directories, files = walk_path(path)
     relative_path = str(Path(path).relative_to(settings.project_path))
+
     return models.Directory(
         name=os.path.basename(path),
         path="" if relative_path == "." else relative_path,
@@ -162,18 +163,10 @@ def _get_directory(
     )
 
 
-def _get_file_with_content(
-    path: Path,
-    settings: Settings,
-) -> models.File:
+def _get_file_with_content(file_path: Path, relative_path: str) -> models.File:
     """Get a file, including its contents."""
-    file_path = settings.project_path / path
-
-    with open(file_path) as f:
-        content = f.read()
-
     return models.File(
-        name=path.name,
-        path=str(path),
-        content=content,
+        name=file_path.name,
+        path=relative_path,
+        content=file_path.read_text(),
     )

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -78,8 +78,6 @@ async def watch_project() -> None:
                     ServerSentEvent(event="errors", data=json.dumps(error))
                 )
 
-                continue
-
         api_console.queue.put_nowait(
             ServerSentEvent(
                 event="file",

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -40,30 +40,45 @@ async def watch_project() -> None:
         directories: t.Dict[str, models.Directory] = {}
 
         for change, path_str in entries:
-            path = Path(path_str)
-            relative_path = path.relative_to(settings.project_path)
-
-            should_load_context = should_load_context or any(is_relative_to(path, p) for p in paths)
-
-            if change == Change.modified and path.is_dir():
-                directory = _get_directory(path, settings, context)
-                directories[directory.path] = directory
-            elif change == Change.deleted or not path.exists():
-                changes.append(
-                    models.ArtifactChange(
-                        change=Change.deleted,
-                        path=str(relative_path),
-                    )
+            try:
+                path = Path(path_str)
+                relative_path = path.relative_to(settings.project_path)
+                should_load_context = should_load_context or any(
+                    is_relative_to(path, p) for p in paths
                 )
-            elif change == Change.modified and path.is_file():
-                changes.append(
-                    models.ArtifactChange(
-                        type=models.ArtifactType.file,
-                        change=change,
-                        path=str(relative_path),
-                        file=_get_file_with_content(relative_path, settings),
+
+                if change == Change.modified and path.is_dir():
+                    directory = _get_directory(path, settings, context)
+                    directories[directory.path] = directory
+                elif change == Change.deleted or not path.exists():
+                    changes.append(
+                        models.ArtifactChange(
+                            change=Change.deleted,
+                            path=str(relative_path),
+                        )
                     )
+                elif change == Change.modified and path.is_file():
+                    changes.append(
+                        models.ArtifactChange(
+                            type=models.ArtifactType.file,
+                            change=change,
+                            path=str(relative_path),
+                            file=_get_file_with_content(
+                                settings.project_path / relative_path, str(relative_path)
+                            ),
+                        )
+                    )
+            except Exception:
+                error = ApiException(
+                    message="Error updating file",
+                    origin=f"API -> watcher -> watch_project",
+                    trigger=path_str,
+                ).to_dict()
+                api_console.queue.put_nowait(
+                    ServerSentEvent(event="errors", data=json.dumps(error))
                 )
+
+                continue
 
         api_console.queue.put_nowait(
             ServerSentEvent(


### PR DESCRIPTION
When saving files and file watcher catch error , it should send SSE event and continue collecting changes. And eventually it should send SSE with changes back to update UI. 