### PR TITLE
fix: show only user macro count in info

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -63,7 +63,7 @@ from sqlmesh.core.dialect import (
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.environment import Environment, EnvironmentNamingInfo
 from sqlmesh.core.loader import Loader, update_model_schemas
-from sqlmesh.core.macros import ExecutableOrMacro
+from sqlmesh.core.macros import ExecutableOrMacro, macro
 from sqlmesh.core.metric import Metric, rewrite
 from sqlmesh.core.model import Model
 from sqlmesh.core.notification_target import (
@@ -1409,7 +1409,7 @@ class Context(BaseContext):
     def print_info(self) -> None:
         """Prints information about connections, models, macros, etc. to the console."""
         self.console.log_status_update(f"Models: {len(self.models)}")
-        self.console.log_status_update(f"Macros: {len(self._macros)}")
+        self.console.log_status_update(f"Macros: {len(self._macros) - len(macro.get_registry())}")
 
         self._try_connection("data warehouse", self._engine_adapter)
 

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -528,7 +528,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
     assert len(output.outputs) == 4
     assert convert_all_html_output_to_text(output) == [
         "Models: 14",
-        "Macros: 23",
+        "Macros: 4",
         "Data warehouse connection succeeded",
         "Test connection succeeded",
     ]
@@ -557,7 +557,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
                     h(
                         "span",
                         {"style": f"{NEUTRAL_STYLE}; font-weight: bold"},
-                        "23",
+                        "4",
                     )
                 ),
             )


### PR DESCRIPTION
Thanks @crericha for pointing out the problem and providing a solution.

We used to display in info the system macros + user macros but users likely only care about seeing their own macros listed in info. 

Also updated one test to allow for the existence of other tables in the sqlmesh schema. 