### PR TITLE
Fix: pass dialect to name field value converter

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -178,6 +178,13 @@ class _Model(ModelMeta, frozen=True):
                             value=field_value.to_expression(dialect=self.dialect),
                         )
                     )
+                elif field_name == "name":
+                    expressions.append(
+                        exp.Property(
+                            this=field_info.alias or field_name,
+                            value=exp.to_table(field_value, dialect=self.dialect),
+                        )
+                    )
                 elif field_name not in ("column_descriptions_", "default_catalog"):
                     expressions.append(
                         exp.Property(
@@ -1928,7 +1935,6 @@ def _refs_to_sql(values: t.Any) -> exp.Expression:
 
 
 META_FIELD_CONVERTER: t.Dict[str, t.Callable] = {
-    "name": lambda value: exp.to_table(value),
     "start": lambda value: exp.Literal.string(value),
     "cron": lambda value: exp.Literal.string(value),
     "batch_size": lambda value: exp.Literal.number(value),

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -181,7 +181,7 @@ class _Model(ModelMeta, frozen=True):
                 elif field_name == "name":
                     expressions.append(
                         exp.Property(
-                            this=field_info.alias or field_name,
+                            this=field_name,
                             value=exp.to_table(field_value, dialect=self.dialect),
                         )
                     )

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2522,6 +2522,26 @@ def test_scd_type_2_overrides():
     assert not scd_type_2_model.kind.disable_restatement
 
 
+def test_model_dialect_name():
+    expressions = d.parse(
+        """
+        MODEL (
+            name `project-1`.`db`.`tbl1`,
+            dialect bigquery
+        );
+        SELECT 1;
+        """
+    )
+
+    model = load_sql_based_model(expressions)
+    assert model.fqn == '"project-1"."db"."tbl1"'
+
+    model = create_external_model(
+        "`project-1`.`db`.`tbl1`", columns={"x": "STRING"}, dialect="bigquery"
+    )
+    assert "name `project-1`.`db`.`tbl1`" in model.render_definition()[0].sql(dialect="bigquery")
+
+
 def test_model_allow_partials():
     expressions = d.parse(
         """


### PR DESCRIPTION
External models are written like this:

<img width="731" alt="image" src="https://github.com/TobikoData/sqlmesh/assets/41213451/3019d243-fe75-4ac1-b378-3fcc4664597b">


But they fail when the method render definition is called due to the meta converter lookup not having a dialect argument. 

<img width="931" alt="image" src="https://github.com/TobikoData/sqlmesh/assets/41213451/ed52ca26-ba73-4924-9d0b-3e87e4dcea34">

---

This PR fixes that with what is likely the correct behavior