### PR TITLE
Fix: Missing node type for removed snapshots in context diff

### DIFF
--- a/web/server/api/endpoints/plan.py
+++ b/web/server/api/endpoints/plan.py
@@ -171,9 +171,9 @@ def _get_plan_changes(context: Context, plan: Plan) -> models.PlanChanges:
                     environment_naming_info,
                     default_catalog,
                 ),
-                node_type=models.ChangeDisplay.get_node_type(snapshots, snapshot_id),
+                node_type=snapshot_table_info.node_type,
             )
-            for snapshot_id in plan.context_diff.removed_snapshots
+            for snapshot_id, snapshot_table_info in plan.context_diff.removed_snapshots.items()
         ],
         modified=models.ModelsDiff.get_modified_snapshots(context, plan),
     )

--- a/web/server/models.py
+++ b/web/server/models.py
@@ -180,10 +180,8 @@ class ChangeDisplay(BaseModel):
         )
 
     @staticmethod
-    def get_node_type(
-        snapshots: t.Dict[SnapshotId, Snapshot], snapshot_id: SnapshotId
-    ) -> t.Optional[NodeType]:
-        return snapshots[snapshot_id].node_type if snapshot_id in snapshots else None
+    def get_node_type(snapshots: t.Dict[SnapshotId, Snapshot], snapshot_id: SnapshotId) -> NodeType:
+        return snapshots[snapshot_id].node_type
 
 
 class ChangeDirect(ChangeDisplay):


### PR DESCRIPTION
The node_type attribute is not optional in the ChangeDisplay Pydantic model.