### PR TITLE
fix: share connection config state sync instead of adapters

### DIFF
--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -67,9 +67,7 @@ class _SchedulerConfig(abc.ABC):
 class _EngineAdapterStateSyncSchedulerConfig(_SchedulerConfig):
     def create_state_sync(self, context: Context) -> StateSync:
         state_connection = context.config.get_state_connection(context.gateway)
-        engine_adapter = (
-            state_connection.create_engine_adapter() if state_connection else context.engine_adapter
-        )
+        engine_adapter = (state_connection or context._connection_config).create_engine_adapter()
         if not engine_adapter.SUPPORTS_ROW_LEVEL_OP:
             raise ConfigError(
                 f"The {engine_adapter.DIALECT.upper()} engine cannot be used to store SQLMesh state - please specify a different `state_connection` engine."

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -286,9 +286,9 @@ class Context(BaseContext):
         self.pinned_environments = Environment.normalize_names(self.config.pinned_environments)
         self.auto_categorize_changes = self.config.auto_categorize_changes
 
-        connection_config = self.config.get_connection(self.gateway)
-        self.concurrent_tasks = concurrent_tasks or connection_config.concurrent_tasks
-        self._engine_adapter = engine_adapter or connection_config.create_engine_adapter()
+        self._connection_config = self.config.get_connection(self.gateway)
+        self.concurrent_tasks = concurrent_tasks or self._connection_config.concurrent_tasks
+        self._engine_adapter = engine_adapter or self._connection_config.create_engine_adapter()
 
         test_connection_config = self.config.get_test_connection(self.gateway, self.default_catalog)
         self._test_engine_adapter = test_connection_config.create_engine_adapter()


### PR DESCRIPTION
Previously we shared actual engine adapters across the data warehouse connection and state sync connection (if one isn't provided). It seems more proper to have each one have a unique connection but share a common config. That way the two connections can make changes (like changing catalog settings) independent of another. 