### PR TITLE
Feat: Allow using $root in seed paths to specify path relative to context path

### DIFF
--- a/examples/wursthall/models/src/menu_item_details.sql
+++ b/examples/wursthall/models/src/menu_item_details.sql
@@ -1,7 +1,7 @@
 MODEL (
   name src.menu_item_details,
   kind SEED (
-    path '~/seeds/src/menu_item_details.csv',
+    path '$root/seeds/src/menu_item_details.csv',
   ),
   owner jen
 )

--- a/examples/wursthall/models/src/menu_item_details.sql
+++ b/examples/wursthall/models/src/menu_item_details.sql
@@ -1,7 +1,7 @@
 MODEL (
   name src.menu_item_details,
   kind SEED (
-    path '../../seeds/src/menu_item_details.csv',
+    path '~/seeds/src/menu_item_details.csv',
   ),
   owner jen
 )

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1598,9 +1598,9 @@ def create_seed_model(
             from the macro registry.
     """
     seed_path = Path(seed_kind.path)
-    base, *subdir = seed_path.parts
-    if base == "~":
-        seed_path = module_path.joinpath(*subdir)
+    base, *subdirs = seed_path.parts
+    if base.lower() == "$root":
+        seed_path = module_path.joinpath(*subdirs)
     elif not seed_path.is_absolute():
         seed_path = path / seed_path if path.is_dir() else path.parent / seed_path
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1598,8 +1598,11 @@ def create_seed_model(
             from the macro registry.
     """
     seed_path = Path(seed_kind.path)
-    if not seed_path.is_absolute():
-        seed_path = path / seed_path if path.is_dir() else path.parents[0] / seed_path
+    base, *subdir = seed_path.parts
+    if base == "~":
+        seed_path = module_path.joinpath(*subdir)
+    elif not seed_path.is_absolute():
+        seed_path = path / seed_path if path.is_dir() else path.parent / seed_path
 
     seed = create_seed(seed_path)
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -648,6 +648,31 @@ def test_seed_csv_settings():
     assert model.kind.csv_settings == CsvSettings(quotechar="'", escapechar="\\")
 
 
+def test_seed_context_home():
+    expressions = d.parse(
+        """
+        MODEL (
+            name db.seed,
+            kind SEED (
+              path '~/seeds/waiter_names.csv',
+              batch_size 100,
+            )
+        );
+    """
+    )
+
+    model = load_sql_based_model(
+        expressions,
+        path=Path("./examples/sushi/models/test_model.sql"),
+        module_path=Path("./examples/sushi"),
+    )
+
+    assert isinstance(model.kind, SeedKind)
+    assert model.kind.path == "~/seeds/waiter_names.csv"
+    assert model.seed is not None
+    assert len(model.seed.content) > 0
+
+
 def test_seed_model_diff(tmp_path):
     model_a_csv_path = (tmp_path / "model_a.csv").absolute()
     model_b_csv_path = (tmp_path / "model_b.csv").absolute()

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -654,7 +654,7 @@ def test_seed_context_home():
         MODEL (
             name db.seed,
             kind SEED (
-              path '~/seeds/waiter_names.csv',
+              path '$root/seeds/waiter_names.csv',
               batch_size 100,
             )
         );
@@ -668,7 +668,7 @@ def test_seed_context_home():
     )
 
     assert isinstance(model.kind, SeedKind)
-    assert model.kind.path == "~/seeds/waiter_names.csv"
+    assert model.kind.path == "$root/seeds/waiter_names.csv"
     assert model.seed is not None
     assert len(model.seed.content) > 0
 


### PR DESCRIPTION
Depending on how you organize your sqlmesh project, you may want to declare a seed in some nested directed colocated with a relevant model file. The `../../../../` gets kludgy. Our desire is often to specify a path from the *context root*. This should be straightforward to do. Here I have implemented it via using `~` to be indicative of the module path / context root. If we don't like the overloading we could try something else but to be fair Path.expanduser is never called anyway so it never would have worked and seeds being located in a real user home dir is an anti-pattern to say the least. 

So lets provide something nicer.

EDIT: pivoted to use a special `$root` (case-insensitive) substitution to avoid confusion