### PR TITLE
Fix: Normalize max end interval by snapshot when models are selected explicitly

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -957,23 +957,40 @@ class Context(BaseContext):
                     f"Provided restated models do not match any models. No models will be included in plan. Provided: {', '.join(restate_models)}"
                 )
 
+        snapshots = self._snapshots(models_override)
+        context_diff = self._context_diff(
+            environment or c.PROD,
+            snapshots=snapshots,
+            create_from=create_from,
+            force_no_diff=(restate_models is not None and not expanded_restate_models)
+            or (backfill_models is not None and not backfill_models),
+        )
+
+        if backfill_models is not None:
+            # If the selected model is a newly added model, then we should narrow down the intervals
+            # that should be considered for the default plan end value by including its parents.
+            max_end_models = backfill_models.copy()
+            for name in backfill_models:
+                if name not in snapshots:
+                    continue
+                snapshot = snapshots[name]
+                snapshot_id = snapshot.snapshot_id
+                if snapshot_id in context_diff.added and snapshot_id in context_diff.new_snapshots:
+                    max_end_models |= {s.name for s in snapshot.parents}
+        else:
+            max_end_models = None
+
         # If no end date is specified, use the max interval end from prod
         # to prevent unintended evaluation of the entire DAG.
         default_end = (
-            self.state_sync.max_interval_end_for_environment(c.PROD, models=backfill_models)
+            self.state_sync.max_interval_end_for_environment(c.PROD, models=max_end_models)
             if not run
             else None
         )
         default_start = to_date(default_end) - timedelta(days=1) if default_end and is_dev else None
 
         return PlanBuilder(
-            context_diff=self._context_diff(
-                environment or c.PROD,
-                snapshots=self._snapshots(models_override),
-                create_from=create_from,
-                force_no_diff=(restate_models is not None and not expanded_restate_models)
-                or (backfill_models is not None and not backfill_models),
-            ),
+            context_diff=context_diff,
             start=start,
             end=end,
             execution_time=execution_time,

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -138,15 +138,23 @@ class StateReader(abc.ABC):
         """
 
     @abc.abstractmethod
-    def max_interval_end_for_environment(
-        self, environment: str, models: t.Optional[t.Set[str]] = None
-    ) -> t.Optional[int]:
+    def max_interval_end_for_environment(self, environment: str) -> t.Optional[int]:
         """Returns the max interval end for the given environment.
 
         Args:
             environment: The environment.
-            models: The optional model FQNs to pick intervals from. If not provided all
-                models in the environment will be used.
+
+        Returns:
+            A timestamp or None if no interval or environment exists.
+        """
+
+    @abc.abstractmethod
+    def greatest_common_interval_end(self, environment: str, models: t.Set[str]) -> t.Optional[int]:
+        """Returns the greatest common interval end for given models in the target environment.
+
+        Args:
+            environment: The environment.
+            models: The model FQNs to select intervals from.
 
         Returns:
             A timestamp or None if no interval or environment exists.

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -631,6 +631,9 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
     def max_interval_end_for_environment(
         self, environment: str, models: t.Optional[t.Set[str]] = None
     ) -> t.Optional[int]:
+        if models == set():
+            return None
+
         env = self._get_environment(environment)
         if not env:
             return None
@@ -638,22 +641,49 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         snapshots = (
             [s for s in env.snapshots if s.name in models] if models is not None else env.snapshots
         )
-        max_end = None
-        for where in self._snapshot_name_version_filter(snapshots, "intervals"):
-            end = self.engine_adapter.fetchone(
-                exp.select(exp.func("MAX", exp.to_column("end_ts")))
-                .from_(exp.to_table(self.intervals_table).as_("intervals"))
-                .where(where, copy=False)
-                .where(exp.to_column("is_dev").not_(), copy=False),
-                quote_identifiers=True,
-            )[0]
+        snapshots = snapshots or env.snapshots
 
-            if max_end is None:
-                max_end = end
+        result_end = None
+        comparator = min if models else max
+
+        table_alias = "intervals"
+        name_col = exp.column("name", table=table_alias)
+        version_col = exp.column("version", table=table_alias)
+        intervals_table = exp.to_table(self.intervals_table).as_(table_alias)
+
+        for where in self._snapshot_name_version_filter(snapshots, table_alias):
+            if models:
+                # Models have been selected explicitly.
+                max_end_subquery = (
+                    exp.select(
+                        name_col,
+                        version_col,
+                        exp.func("MAX", exp.column("end_ts", table=table_alias)).as_("max_end_ts"),
+                    )
+                    .from_(intervals_table)
+                    .where(where, copy=False)
+                    .where(exp.to_column("is_dev").not_(), copy=False)
+                    .group_by(name_col, version_col, copy=False)
+                )
+                query = exp.select(exp.func("MIN", exp.column("max_end_ts"))).from_(
+                    max_end_subquery.subquery()
+                )
+            else:
+                query = (
+                    exp.select(exp.func("MAX", exp.column("end_ts", table=table_alias)))
+                    .from_(intervals_table)
+                    .where(where, copy=False)
+                    .where(exp.to_column("is_dev").not_(), copy=False)
+                )
+
+            end = self.engine_adapter.fetchone(query, quote_identifiers=True)[0]
+
+            if result_end is None:
+                result_end = end
             elif end is not None:
-                max_end = max(max_end, end)
+                result_end = comparator(result_end, end)
 
-        return max_end
+        return result_end
 
     def recycle(self) -> None:
         self.engine_adapter.recycle()

--- a/sqlmesh/schedulers/airflow/api.py
+++ b/sqlmesh/schedulers/airflow/api.py
@@ -75,14 +75,19 @@ def get_environments() -> Response:
 @check_authentication
 def get_max_interval_end(name: str) -> Response:
     with util.scoped_state_sync() as state_sync:
-        models = None
-        if "models" in request.args:
-            models = json.loads(request.args["models"])
+        max_interval_end = state_sync.max_interval_end_for_environment(name)
+        response = common.IntervalEndResponse(environment=name, max_interval_end=max_interval_end)
+        return _success(response)
 
-        max_interval_end = state_sync.max_interval_end_for_environment(name, models=models)
-        response = common.MaxIntervalEndResponse(
-            environment=name, max_interval_end=max_interval_end
-        )
+
+@sqlmesh_api_v1.route("/environments/<name>/greatest_common_interval_end")
+@csrf.exempt
+@check_authentication
+def get_greatest_common_interval_end(name: str) -> Response:
+    with util.scoped_state_sync() as state_sync:
+        models = json.loads(request.args["models"]) if "models" in request.args else []
+        max_interval_end = state_sync.greatest_common_interval_end(name, set(models))
+        response = common.IntervalEndResponse(environment=name, max_interval_end=max_interval_end)
         return _success(response)
 
 

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -271,16 +271,18 @@ class AirflowClient(BaseAirflowClient):
         response = self._get(ENVIRONMENTS_PATH)
         return common.EnvironmentsResponse.parse_obj(response).environments
 
-    def max_interval_end_for_environment(
-        self, environment: str, models: t.Optional[t.Collection[str]] = None
+    def max_interval_end_for_environment(self, environment: str) -> t.Optional[int]:
+        response = self._get(f"{ENVIRONMENTS_PATH}/{environment}/max_interval_end")
+        return common.IntervalEndResponse.parse_obj(response).max_interval_end
+
+    def greatest_common_interval_end(
+        self, environment: str, models: t.Collection[str]
     ) -> t.Optional[int]:
-        url = f"{ENVIRONMENTS_PATH}/{environment}/max_interval_end"
-        if models is not None:
-            models_param = _json_query_param(list(models))
-            response = self._get(url, models=models_param)
-        else:
-            response = self._get(url)
-        return common.MaxIntervalEndResponse.parse_obj(response).max_interval_end
+        response = self._get(
+            f"{ENVIRONMENTS_PATH}/{environment}/greatest_common_interval_end",
+            models=_json_query_param(list(models)),
+        )
+        return common.IntervalEndResponse.parse_obj(response).max_interval_end
 
     def invalidate_environment(self, environment: str) -> None:
         response = self._session.delete(

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -110,7 +110,7 @@ class InvalidateEnvironmentResponse(PydanticModel):
     name: str
 
 
-class MaxIntervalEndResponse(PydanticModel):
+class IntervalEndResponse(PydanticModel):
     environment: str
     max_interval_end: t.Optional[int] = None
 

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -67,20 +67,28 @@ class HttpStateSync(StateSync):
         """
         return self._client.get_environments()
 
-    def max_interval_end_for_environment(
-        self, environment: str, models: t.Optional[t.Set[str]] = None
-    ) -> t.Optional[int]:
+    def max_interval_end_for_environment(self, environment: str) -> t.Optional[int]:
         """Returns the max interval end for the given environment.
 
         Args:
             environment: The environment.
-            models: The optional model FQNs to pick intervals from. If not provided all
-                models in the environment will be used.
 
         Returns:
             A timestamp or None if no interval or environment exists.
         """
-        return self._client.max_interval_end_for_environment(environment, models=models)
+        return self._client.max_interval_end_for_environment(environment)
+
+    def greatest_common_interval_end(self, environment: str, models: t.Set[str]) -> t.Optional[int]:
+        """Returns the greatest common interval end for given models in the target environment.
+
+        Args:
+            environment: The environment.
+            models: The model FQNs to select intervals from.
+
+        Returns:
+            A timestamp or None if no interval or environment exists.
+        """
+        return self._client.greatest_common_interval_end(environment, models)
 
     def get_snapshots(
         self,

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -1597,9 +1597,7 @@ def test_max_interval_end_for_environment(
 
     state_sync.add_interval(snapshot_a, "2023-01-01", "2023-01-01")
     state_sync.add_interval(snapshot_a, "2023-01-02", "2023-01-02")
-    state_sync.add_interval(snapshot_a, "2023-01-03", "2023-01-03")
     state_sync.add_interval(snapshot_b, "2023-01-01", "2023-01-01")
-    state_sync.add_interval(snapshot_b, "2023-01-02", "2023-01-02")
 
     environment_name = "test_max_interval_end_for_environment"
 
@@ -1616,25 +1614,69 @@ def test_max_interval_end_for_environment(
     )
 
     assert state_sync.max_interval_end_for_environment(environment_name) == to_timestamp(
-        "2023-01-04"
+        "2023-01-03"
     )
 
-    assert state_sync.max_interval_end_for_environment(
-        environment_name, models={snapshot_a.name}
+
+def test_greatest_common_interval_end(
+    state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
+) -> None:
+    snapshot_a = make_snapshot(
+        SqlModel(
+            name="a",
+            cron="@daily",
+            query=parse_one("select 1, ds"),
+        ),
+    )
+    snapshot_a.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    snapshot_b = make_snapshot(
+        SqlModel(
+            name="b",
+            cron="@daily",
+            query=parse_one("select 2, ds"),
+        ),
+    )
+    snapshot_b.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    state_sync.push_snapshots([snapshot_a, snapshot_b])
+
+    state_sync.add_interval(snapshot_a, "2023-01-01", "2023-01-01")
+    state_sync.add_interval(snapshot_a, "2023-01-02", "2023-01-02")
+    state_sync.add_interval(snapshot_a, "2023-01-03", "2023-01-03")
+    state_sync.add_interval(snapshot_b, "2023-01-01", "2023-01-01")
+    state_sync.add_interval(snapshot_b, "2023-01-02", "2023-01-02")
+
+    environment_name = "test_max_interval_end_for_environment"
+
+    assert state_sync.greatest_common_interval_end(environment_name, {snapshot_a.name}) is None
+
+    state_sync.promote(
+        Environment(
+            name=environment_name,
+            snapshots=[snapshot_a.table_info, snapshot_b.table_info],
+            start_at="2023-01-01",
+            end_at="2023-01-03",
+            plan_id="test_plan_id",
+        )
+    )
+
+    assert state_sync.greatest_common_interval_end(
+        environment_name, {snapshot_a.name}
     ) == to_timestamp("2023-01-04")
 
-    assert state_sync.max_interval_end_for_environment(
-        environment_name, models={snapshot_b.name}
+    assert state_sync.greatest_common_interval_end(
+        environment_name, {snapshot_b.name}
     ) == to_timestamp("2023-01-03")
 
-    assert state_sync.max_interval_end_for_environment(
-        environment_name, models={snapshot_a.name, snapshot_b.name}
+    assert state_sync.greatest_common_interval_end(
+        environment_name, {snapshot_a.name, snapshot_b.name}
     ) == to_timestamp("2023-01-03")
 
-    assert state_sync.max_interval_end_for_environment(
-        environment_name, models={"missing"}
-    ) == to_timestamp("2023-01-03")
-    assert state_sync.max_interval_end_for_environment(environment_name, models=set()) is None
+    assert state_sync.greatest_common_interval_end(environment_name, {"missing"}) == to_timestamp(
+        "2023-01-03"
+    )
+    assert state_sync.greatest_common_interval_end(environment_name, set()) is None
 
 
 def test_get_snapshots(mocker):

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -1597,7 +1597,9 @@ def test_max_interval_end_for_environment(
 
     state_sync.add_interval(snapshot_a, "2023-01-01", "2023-01-01")
     state_sync.add_interval(snapshot_a, "2023-01-02", "2023-01-02")
+    state_sync.add_interval(snapshot_a, "2023-01-03", "2023-01-03")
     state_sync.add_interval(snapshot_b, "2023-01-01", "2023-01-01")
+    state_sync.add_interval(snapshot_b, "2023-01-02", "2023-01-02")
 
     environment_name = "test_max_interval_end_for_environment"
 
@@ -1608,24 +1610,30 @@ def test_max_interval_end_for_environment(
             name=environment_name,
             snapshots=[snapshot_a.table_info, snapshot_b.table_info],
             start_at="2023-01-01",
-            end_at="2023-01-02",
+            end_at="2023-01-03",
             plan_id="test_plan_id",
         )
     )
 
     assert state_sync.max_interval_end_for_environment(environment_name) == to_timestamp(
-        "2023-01-03"
+        "2023-01-04"
     )
 
     assert state_sync.max_interval_end_for_environment(
         environment_name, models={snapshot_a.name}
-    ) == to_timestamp("2023-01-03")
+    ) == to_timestamp("2023-01-04")
 
     assert state_sync.max_interval_end_for_environment(
         environment_name, models={snapshot_b.name}
-    ) == to_timestamp("2023-01-02")
+    ) == to_timestamp("2023-01-03")
 
-    assert state_sync.max_interval_end_for_environment(environment_name, models={"missing"}) is None
+    assert state_sync.max_interval_end_for_environment(
+        environment_name, models={snapshot_a.name, snapshot_b.name}
+    ) == to_timestamp("2023-01-03")
+
+    assert state_sync.max_interval_end_for_environment(
+        environment_name, models={"missing"}
+    ) == to_timestamp("2023-01-03")
     assert state_sync.max_interval_end_for_environment(environment_name, models=set()) is None
 
 

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -350,7 +350,7 @@ def test_get_environments(mocker: MockerFixture, snapshot: Snapshot):
 
 
 def test_max_interval_end_for_environment(mocker: MockerFixture, snapshot: Snapshot):
-    response = common.MaxIntervalEndResponse(
+    response = common.IntervalEndResponse(
         environment="test_environment", max_interval_end=to_timestamp("2023-01-01")
     )
 
@@ -370,8 +370,8 @@ def test_max_interval_end_for_environment(mocker: MockerFixture, snapshot: Snaps
     )
 
 
-def test_max_interval_end_for_environment_with_models(mocker: MockerFixture, snapshot: Snapshot):
-    response = common.MaxIntervalEndResponse(
+def test_greatest_common_interval_end(mocker: MockerFixture, snapshot: Snapshot):
+    response = common.IntervalEndResponse(
         environment="test_environment", max_interval_end=to_timestamp("2023-01-01")
     )
 
@@ -382,12 +382,12 @@ def test_max_interval_end_for_environment_with_models(mocker: MockerFixture, sna
     max_interval_end_mock.return_value = max_interval_end_response_mock
 
     client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
-    result = client.max_interval_end_for_environment("test_environment", models={"a.b.c"})
+    result = client.greatest_common_interval_end("test_environment", {"a.b.c"})
 
     assert result == response.max_interval_end
 
     max_interval_end_mock.assert_called_once_with(
-        "http://localhost:8080/sqlmesh/api/v1/environments/test_environment/max_interval_end?models=%5B%22a.b.c%22%5D"
+        "http://localhost:8080/sqlmesh/api/v1/environments/test_environment/greatest_common_interval_end?models=%5B%22a.b.c%22%5D"
     )
 
 


### PR DESCRIPTION
This update ensures that the latest intervals are normalized by snapshot and the minimum value is picked to guarantee that no unexpected backfills get triggered during plan application with explicit model selection.

This also solves the issue of having unexpected backfills when a newly added model is explicitly selected with `--select-model`, in which case there would be no existing intervals to get the max value from and the `now` is used for the plan end as a result, causing unrelated models to be backfilled.