### PR TITLE
Fix: Correct the inclusive arg audits and docs

### DIFF
--- a/docs/concepts/audits.md
+++ b/docs/concepts/audits.md
@@ -346,9 +346,9 @@ MODEL (
 ```
 
 #### string_length_between_audit
-Ensures that all rows of a column contain a string with number of characters in the specified range. Range is inclusive by default, such that values equal to the range boundaries do not pass the audit.
+Ensures that all rows of a column contain a string with number of characters in the specified range. Range is inclusive by default, such that values equal to the range boundaries will pass the audit.
 
-This example asserts that all `name` values have more than 5 and fewer than 50 characters:
+This example asserts that all `name` values have 5 or more and 50 or fewer characters:
 
 ```sql linenums="1"
 MODEL (
@@ -359,13 +359,13 @@ MODEL (
 );
 ```
 
-This example specifies the `inclusive=False` argument to assert that all rows have a `name` with 4 or more and 60 or fewer characters:
+This example specifies the `inclusive=false` argument to assert that all rows have a `name` with 5 or more and 59 or fewer characters:
 
 ```sql linenums="1"
 MODEL (
   name sushi.customers,
   audits [
-    string_length_between_audit(column=zip, min_v=4, max_v=60, inclusive=False)
+    string_length_between_audit(column=zip, min_v=4, max_v=60, inclusive=false)
     ]
 );
 ```
@@ -490,32 +490,32 @@ These audits concern the statistical distributions of numeric columns.
 NOTE: audit thresholds will likely require fine-tuning via trial and error for each column being audited.
 
 #### mean_in_range
-Ensures that a numeric column's mean is in the specified range. Range is inclusive by default, such that values equal to the range boundaries do not pass the audit.
+Ensures that a numeric column's mean is in the specified range. Range is inclusive by default, such that values equal to the range boundaries will pass the audit.
 
-This example asserts that the `age` column has a mean greater than 18 and less than 65:
+This example asserts that the `age` column has a mean of at least 21 and at most 50:
 
 ```sql linenums="1"
 MODEL (
   audits [
-    mean_in_range(column=age, min_v=18, max_v=65)
+    mean_in_range(column=age, min_v=21, max_v=50)
     ]
 );
 ```
 
-This example specifies the `inclusive=False` argument to assert that `age` has a mean of at least 21 and at most 50:
+This example specifies the `inclusive=false` argument to assert that `age` has a mean greater than 18 and less than 65:
 
 ```sql linenums="1"
 MODEL (
   audits [
-    mean_in_range(column=age, min_v=21, max_v=50, inclusive=False)
+    mean_in_range(column=age, min_v=18, max_v=65, inclusive=false)
     ]
 );
 ```
 
 #### stddev_in_range
-Ensures that a numeric column's standard deviation is in the specified range. Range is inclusive by default, such that values equal to the range boundaries do not pass the audit.
+Ensures that a numeric column's standard deviation is in the specified range. Range is inclusive by default, such that values equal to the range boundaries will pass the audit.
 
-This example asserts that the `age` column has a standard deviation greater than 2 and less than 5:
+This example asserts that the `age` column has a standard deviation of at least 2 and at most 5:
 
 ```sql linenums="1"
 MODEL (
@@ -525,12 +525,12 @@ MODEL (
 );
 ```
 
-This example specifies the `inclusive=False` argument to assert that `age` has a standard deviation of at least 3 and at most 6:
+This example specifies the `inclusive=false` argument to assert that `age` has a standard deviation greater than 3 and less than 6:
 
 ```sql linenums="1"
 MODEL (
   audits [
-    mean_in_range(column=age, min_v=3, max_v=6, inclusive=False)
+    mean_in_range(column=age, min_v=3, max_v=6, inclusive=false)
     ]
 );
 ```

--- a/docs/concepts/audits.md
+++ b/docs/concepts/audits.md
@@ -274,26 +274,26 @@ MODEL (
 ```
 
 #### accepted_range
-Ensures that a column's values are in a numeric range. Range is inclusive by default, such that values equal to the range boundaries do not pass the audit.
+Ensures that a column's values are in a numeric range. Range is inclusive by default, such that values equal to the range boundaries will pass the audit.
 
-This example asserts that all rows have a `price` greater than 0 and less than 100:
+This example asserts that all rows have a `price` greater than or equal 1 and less than or equal to 100:
 
 ```sql linenums="1"
 MODEL (
   name sushi.items,
   audits [
-    accepted_range(column=price, min_v=0, max_v=100)
+    accepted_range(column=price, min_v=1, max_v=100)
   ]
 );
 ```
 
-This example specifies the `inclusive=False` argument to assert that all rows have a `price` of 1 or more and 100 or less:
+This example specifies the `inclusive=false` argument to assert that all rows have a `price` greater than 0 and less than 100:
 
 ```sql linenums="1"
 MODEL (
   name sushi.items,
   audits [
-    accepted_range(column=price, min_v=1, max_v=100, inclusive=False)
+    accepted_range(column=price, min_v=0, max_v=100, inclusive=false)
   ]
 );
 ```

--- a/sqlmesh/core/audit/builtin.py
+++ b/sqlmesh/core/audit/builtin.py
@@ -98,10 +98,10 @@ SELECT *
 FROM @this_model
 WHERE
   False
-  OR @IF(@min_v IS NOT NULL AND @inclusive, @column <= @min_v, False)
-  OR @IF(@min_v IS NOT NULL AND NOT @inclusive, @column < @min_v, False)
-  OR @IF(@max_v IS NOT NULL AND @inclusive, @column >= @max_v, False)
-  OR @IF(@max_v IS NOT NULL AND NOT @inclusive, @column > @max_v, False)
+  OR @IF(@min_v IS NOT NULL AND @inclusive, @column < @min_v, False)
+  OR @IF(@min_v IS NOT NULL AND NOT @inclusive, @column <= @min_v, False)
+  OR @IF(@max_v IS NOT NULL AND @inclusive, @column > @max_v, False)
+  OR @IF(@max_v IS NOT NULL AND NOT @inclusive, @column >= @max_v, False)
     """,
 )
 
@@ -377,10 +377,10 @@ SELECT *
 FROM @this_model
 WHERE
   False
-  OR @IF(@min_v IS NOT NULL AND @inclusive, LENGTH(@column) <= @min_v, False)
-  OR @IF(@min_v IS NOT NULL AND NOT @inclusive, LENGTH(@column) < @min_v, False)
-  OR @IF(@max_v IS NOT NULL AND @inclusive, LENGTH(@column) >= @max_v, False)
-  OR @IF(@max_v IS NOT NULL AND NOT @inclusive, LENGTH(@column) > @max_v, False)
+  OR @IF(@min_v IS NOT NULL AND @inclusive, LENGTH(@column) < @min_v, False)
+  OR @IF(@min_v IS NOT NULL AND NOT @inclusive, LENGTH(@column) <= @min_v, False)
+  OR @IF(@max_v IS NOT NULL AND @inclusive, LENGTH(@column) > @max_v, False)
+  OR @IF(@max_v IS NOT NULL AND NOT @inclusive, LENGTH(@column) >= @max_v, False)
     """,
 )
 
@@ -406,10 +406,10 @@ FROM (
 )
 WHERE
   False
-  OR @IF(@min_v IS NOT NULL AND @inclusive, stddev_@column <= @min_v, False)
-  OR @IF(@min_v IS NOT NULL AND NOT @inclusive, stddev_@column < @min_v, False)
-  OR @IF(@max_v IS NOT NULL AND @inclusive, stddev_@column >= @max_v, False)
-  OR @IF(@max_v IS NOT NULL AND NOT @inclusive, stddev_@column > @max_v, False)
+  OR @IF(@min_v IS NOT NULL AND @inclusive, stddev_@column < @min_v, False)
+  OR @IF(@min_v IS NOT NULL AND NOT @inclusive, stddev_@column <= @min_v, False)
+  OR @IF(@max_v IS NOT NULL AND @inclusive, stddev_@column > @max_v, False)
+  OR @IF(@max_v IS NOT NULL AND NOT @inclusive, stddev_@column >= @max_v, False)
     """,
 )
 
@@ -425,10 +425,10 @@ FROM (
 )
 WHERE
   False
-  OR @IF(@min_v IS NOT NULL AND @inclusive, mean_@column <= @min_v, False)
-  OR @IF(@min_v IS NOT NULL AND NOT @inclusive, mean_@column < @min_v, False)
-  OR @IF(@max_v IS NOT NULL AND @inclusive, mean_@column >= @max_v, False)
-  OR @IF(@max_v IS NOT NULL AND NOT @inclusive, mean_@column > @max_v, False)
+  OR @IF(@min_v IS NOT NULL AND @inclusive, mean_@column < @min_v, False)
+  OR @IF(@min_v IS NOT NULL AND NOT @inclusive, mean_@column <= @min_v, False)
+  OR @IF(@max_v IS NOT NULL AND @inclusive, mean_@column > @max_v, False)
+  OR @IF(@max_v IS NOT NULL AND NOT @inclusive, mean_@column >= @max_v, False)
     """,
 )
 

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -494,21 +494,21 @@ def test_accepted_range_audit(model: Model):
     )
     assert (
         rendered_query.sql()
-        == 'SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" BETWEEN \'1970-01-01\' AND \'1970-01-01\') AS "_q_0" WHERE FALSE OR "a" <= 0 OR FALSE OR FALSE OR FALSE'
+        == 'SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" BETWEEN \'1970-01-01\' AND \'1970-01-01\') AS "_q_0" WHERE FALSE OR "a" < 0 OR FALSE OR FALSE OR FALSE'
     )
     rendered_query = builtin.accepted_range_audit.render_query(
         model, column=exp.to_column("a"), max_v=100, inclusive=exp.false()
     )
     assert (
         rendered_query.sql()
-        == 'SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" BETWEEN \'1970-01-01\' AND \'1970-01-01\') AS "_q_0" WHERE FALSE OR FALSE OR FALSE OR FALSE OR "a" > 100'
+        == 'SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" BETWEEN \'1970-01-01\' AND \'1970-01-01\') AS "_q_0" WHERE FALSE OR FALSE OR FALSE OR FALSE OR "a" >= 100'
     )
     rendered_query = builtin.accepted_range_audit.render_query(
         model, column=exp.to_column("a"), min_v=100, max_v=100
     )
     assert (
         rendered_query.sql()
-        == 'SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" BETWEEN \'1970-01-01\' AND \'1970-01-01\') AS "_q_0" WHERE FALSE OR "a" <= 100 OR FALSE OR "a" >= 100 OR FALSE'
+        == 'SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" BETWEEN \'1970-01-01\' AND \'1970-01-01\') AS "_q_0" WHERE FALSE OR "a" < 100 OR FALSE OR "a" > 100 OR FALSE'
     )
 
 


### PR DESCRIPTION
As per the slack thread. The inclusive argument application is inverted in the handful of audits using the pattern. 
https://tobiko-data.slack.com/archives/C044BRE5W4S/p1705526103351769
