### PR TITLE
Feat: Add @default_catalog to the macro environment

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -121,7 +121,10 @@ class MacroEvaluator:
     ):
         self.dialect = dialect
         self.generator = MacroDialect().generator()
-        self.locals: t.Dict[str, t.Any] = {"runtime_stage": runtime_stage.value}
+        self.locals: t.Dict[str, t.Any] = {
+            "runtime_stage": runtime_stage.value,
+            "default_catalog": default_catalog,
+        }
         self.env = {**ENV, "self": self}
         self.python_env = python_env or {}
         self._jinja_env: t.Optional[Environment] = jinja_env

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -106,7 +106,6 @@ class BaseExpressionRenderer:
                     cache_key[0] if not self._only_execution_time else None,
                     cache_key[1] if not self._only_execution_time else None,
                 ),
-                "default_catalog": self._default_catalog,
                 **kwargs,
             }
 

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -106,6 +106,7 @@ class BaseExpressionRenderer:
                     cache_key[0] if not self._only_execution_time else None,
                     cache_key[1] if not self._only_execution_time else None,
                 ),
+                "default_catalog": self._default_catalog,
                 **kwargs,
             }
 
@@ -527,11 +528,6 @@ class QueryRenderer(BaseExpressionRenderer):
 
 @contextmanager
 def _normalize_and_quote(query: E, dialect: str, default_catalog: t.Optional[str]) -> t.Iterator[E]:
-    if isinstance(query, (exp.Command, exp.AlterTable)) and default_catalog:
-        for table in query.find_all(exp.Table):
-            if isinstance(table.this, exp.Identifier):
-                if not table.args.get("catalog") and table.args.get("db"):
-                    table.set("catalog", exp.parse_identifier(default_catalog, dialect=dialect))
     qualify_tables(query, catalog=default_catalog, dialect=dialect)
     normalize_identifiers(query, dialect=dialect)
     yield query

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -527,6 +527,11 @@ class QueryRenderer(BaseExpressionRenderer):
 
 @contextmanager
 def _normalize_and_quote(query: E, dialect: str, default_catalog: t.Optional[str]) -> t.Iterator[E]:
+    if isinstance(query, (exp.Command, exp.AlterTable)) and default_catalog:
+        for table in query.find_all(exp.Table):
+            if isinstance(table.this, exp.Identifier):
+                if not table.args.get("catalog") and table.args.get("db"):
+                    table.set("catalog", exp.parse_identifier(default_catalog, dialect=dialect))
     qualify_tables(query, catalog=default_catalog, dialect=dialect)
     normalize_identifiers(query, dialect=dialect)
     yield query


### PR DESCRIPTION
EDIT: The original crux of the issue was to fix the below

```sql
MODEL (
  name my.model,
  kind FULL,
  dialect bigquery,
  grain id
);

SELECT * FROM upstream.table;

ALTER TABLE my.model ADD PRIMARY KEY (id) NOT ENFORCED; -- this is not mapped to snapshot
```

We have fixed this in sqlglot. Part 2 is making available default catalog. Part 3 would be properly parsing `GRANTs` into dedicated nodes? Otherwise the mapping from name -> snapshot will never work?