### PR TITLE
Render handles for Model Column only when that column has been select

### DIFF
--- a/web/client/src/library/components/graph/Graph.tsx
+++ b/web/client/src/library/components/graph/Graph.tsx
@@ -396,13 +396,15 @@ const ModelColumn = memo(function ModelColumn({
     }
   }
 
+  const showHandles = withHandles && (hasLeft || hasRight)
+
   return (
     <div
       className={clsx(
         isActive
           ? 'bg-secondary-10 dark:bg-primary-900 text-secondary-500 dark:text-neutral-100'
           : 'text-neutral-600 dark:text-neutral-100 hover:bg-neutral-5',
-        withHandles ? 'p-0 mb-1' : 'px-2 rounded-md mb-1',
+        showHandles ? 'p-0 mb-1' : 'px-2 rounded-md mb-1',
         className,
       )}
       onClick={debounceSync(toggleColumnLineage, 500, true)}
@@ -413,7 +415,7 @@ const ModelColumn = memo(function ModelColumn({
           disabled ? 'cursor-not-allowed' : 'cursor-pointer',
         )}
       >
-        {withHandles ? (
+        {showHandles ? (
           <ModelNodeHandles
             id={id}
             nodeId={nodeId}

--- a/web/client/src/library/components/graph/ModelLineage.tsx
+++ b/web/client/src/library/components/graph/ModelLineage.tsx
@@ -209,7 +209,6 @@ function ModelColumnLineage(): JSX.Element {
       withConnected,
       withImpacted,
       withSecondary,
-      withColumns,
     )
     const newEdges = getUpdatedEdges(
       allEdges,
@@ -253,8 +252,6 @@ function ModelColumnLineage(): JSX.Element {
             setIsBuildingLayout(false)
           }, 100)
         }
-
-        setActiveNodes(newActiveNodes)
       })
 
     return () => {
@@ -264,17 +261,6 @@ function ModelColumnLineage(): JSX.Element {
       setNodes([])
     }
   }, [lineageIndex, withColumns])
-
-  useEffect(() => {
-    const newActiveNodes = getActiveNodes(
-      allEdges,
-      activeEdges,
-      selectedEdges,
-      nodesMap,
-    )
-
-    setActiveNodes(newActiveNodes)
-  }, [nodesMap, activeEdges, selectedEdges])
 
   useEffect(() => {
     if (isNil(mainNode) || isArrayEmpty(nodes)) return
@@ -295,7 +281,6 @@ function ModelColumnLineage(): JSX.Element {
       withConnected,
       withImpacted,
       withSecondary,
-      withColumns,
     )
 
     const newEdges = getUpdatedEdges(

--- a/web/client/src/library/components/graph/help.ts
+++ b/web/client/src/library/components/graph/help.ts
@@ -19,6 +19,7 @@ import { type ConnectedNode } from '~/workers/lineage'
 export interface GraphNodeData {
   label: string
   type: LineageNodeModelType
+  withColumns: boolean
   [key: string]: any
 }
 
@@ -180,6 +181,7 @@ function getNodeMap({
     const model = models.get(modelName)
     const node = createGraphNode(modelName, {
       label: model?.displayName ?? modelName,
+      withColumns,
       type: isNotNil(model)
         ? (model.type as LineageNodeModelType)
         : // If model name present in lineage but not in global models
@@ -205,7 +207,6 @@ function getNodeMap({
     node.data.height = withColumns
       ? maxHeight + NODE_BALANCE_SPACE * 2
       : NODE_BALANCE_SPACE
-    node.data.withColumns = withColumns
 
     if (isArrayNotEmpty(lineage[node.id]?.models)) {
       node.targetPosition = Position.Left
@@ -664,10 +665,9 @@ function getUpdatedNodes(
   connectedNodes: Set<string>,
   selectedNodes: Set<string>,
   connections: Map<string, Connections>,
-  withConnected: boolean = true,
-  withImpacted: boolean = true,
-  withSecondary: boolean = true,
-  withColumns: boolean = true,
+  withConnected: boolean,
+  withImpacted: boolean,
+  withSecondary: boolean,
 ): Node[] {
   return nodes.map(node => {
     node.hidden = true
@@ -687,7 +687,7 @@ function getUpdatedNodes(
       node.hidden = isFalse(isActiveNode)
     }
 
-    if (node.data.type === EnumLineageNodeModelType.cte && withColumns) {
+    if (node.data.type === EnumLineageNodeModelType.cte) {
       node.hidden = isFalse(activeNodes.has(node.id))
     }
 


### PR DESCRIPTION
Render Lineage node handles for Model Column only when that column has been selected to build column level lineage. Rendering handles (blue circle on screenshot)  for all nodes with columns upfront slows down rendering lineage and creates unnecessary html elements
![Screenshot 2024-01-19 at 5 17 35 PM](https://github.com/TobikoData/sqlmesh/assets/5644753/efa0a1d2-7a2f-43ea-a425-f3f9b6a94c1c)

Also, show columns for nodes when `withColumns: false`:
 - when node selected
 - when node has selected columns
 - when hovered over node
 - when main node (selected model)


