### PR TITLE
Fix: expand seed $root marker in constructor

### DIFF
--- a/docs/concepts/models/seed_models.md
+++ b/docs/concepts/models/seed_models.md
@@ -28,7 +28,7 @@ MODEL (
   )
 );
 ```
-The `path` attribute contains the path to the seed's CSV file **relative** to the path of the model's `.sql` file.
+The `path` attribute contains the path to the seed's CSV file **relative** to the path of the model's `.sql` file. If you want to specify a path relative to the root of the SQLMesh project, use the `$root` marker (see [Markers](#markers)).
 
 The physical table with the seed CSV's content is created using column types inferred by Pandas. Alternatively, you can manually specify the dataset schema as part of the `MODEL` definition:
 ```sql linenums="1" hl_lines="6 7 8 9"
@@ -44,6 +44,21 @@ MODEL (
 );
 ```
 **Note:** The dataset schema provided in the definition takes precedence over column names defined in the header of the CSV file. This means that the order in which columns are provided in the `MODEL` definition must match the order of columns in the CSV file.
+
+### Markers
+
+The `$root` marker can be used in the `path` attribute to indicate that the CSV file path is relative to the root of the SQLMesh project:
+
+```sql linenums="1" hl_lines="3-5"
+MODEL (
+  name test_db.national_holidays,
+  kind SEED (
+    path '$root/seeds/national_holidays.csv'
+  )
+);
+```
+
+This is useful when you want to keep all seed CSV files in a top-level directory such as `seeds/` but don't want to keep track of or manage a bunch of relative paths.
 
 ## Example
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1598,9 +1598,10 @@ def create_seed_model(
             from the macro registry.
     """
     seed_path = Path(seed_kind.path)
-    base, *subdirs = seed_path.parts
-    if base.lower() == "$root":
+    marker, *subdirs = seed_path.parts
+    if marker.lower() == "$root":
         seed_path = module_path.joinpath(*subdirs)
+        seed_kind.path = str(seed_path)
     elif not seed_path.is_absolute():
         seed_path = path / seed_path if path.is_dir() else path.parent / seed_path
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -648,7 +648,7 @@ def test_seed_csv_settings():
     assert model.kind.csv_settings == CsvSettings(quotechar="'", escapechar="\\")
 
 
-def test_seed_context_home():
+def test_seed_marker_substitution():
     expressions = d.parse(
         """
         MODEL (
@@ -668,7 +668,7 @@ def test_seed_context_home():
     )
 
     assert isinstance(model.kind, SeedKind)
-    assert model.kind.path == "$root/seeds/waiter_names.csv"
+    assert model.kind.path == "examples/sushi/seeds/waiter_names.csv"
     assert model.seed is not None
     assert len(model.seed.content) > 0
 


### PR DESCRIPTION
We must "expand" any markers (`$root` is the only one currently) eagerly in the SeedModel constructor. (vs currently just doing it for the sake of the `Seed` container.

Main reason is so the [_track_file](https://github.com/z3z1ma/sqlmesh/blob/284990baa4fe72310f5beeef35f9201cc6e2f107/sqlmesh/core/loader.py#L311-L313) call here does not throw (not that anyone is using this feature just yet), but also looking forward so `SeedModel.seed_path` is correct without any additional work and  the SeedKind path makes sense.

I may slip in a documentation update in this PR too mentioning the marker in the SeedKind section