### PR TITLE
Chore: Add animation to plan stages transition

### DIFF
--- a/web/client/openapi.json
+++ b/web/client/openapi.json
@@ -612,7 +612,7 @@
     "/api/models": {
       "get": {
         "summary": "Get Models",
-        "description": "Get a mapping of model names to model metadata",
+        "description": "Get a list of models",
         "operationId": "get_models_api_models_get",
         "responses": {
           "200": {
@@ -629,6 +629,39 @@
                   ],
                   "title": "Response Get Models Api Models Get"
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/models/{name}": {
+      "get": {
+        "summary": "Get Model",
+        "description": "Get a single model",
+        "operationId": "get_model_api_models__name__get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Model" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1456,15 +1489,7 @@
       },
       "Modules": {
         "type": "string",
-        "enum": [
-          "editor",
-          "docs",
-          "plans",
-          "plan-active",
-          "tests",
-          "audits",
-          "errors"
-        ],
+        "enum": ["editor", "docs", "plans", "tests", "audits", "errors"],
         "title": "Modules"
       },
       "NodeType": {

--- a/web/client/src/library/components/plan/Plan.tsx
+++ b/web/client/src/library/components/plan/Plan.tsx
@@ -1,4 +1,4 @@
-import { isNil, isTrue } from '~/utils'
+import { isFalse, isNil, isTrue } from '~/utils'
 import { useStorePlan } from '~/context/plan'
 import { useApiPlanRun, useApiPlanApply, useApiCancelPlan } from '~/api'
 import PlanHeader from './PlanHeader'
@@ -14,6 +14,8 @@ import { EnumPlanAction, ModelPlanAction } from '@models/plan-action'
 import { useStoreProject } from '@context/project'
 import { useIDE } from '~/library/pages/ide/context'
 import { useStoreContext } from '@context/context'
+import { Transition } from '@headlessui/react'
+import PlanActionsDescription from './PlanActionsDescription'
 
 function Plan(): JSX.Element {
   const dispatch = usePlanDispatch()
@@ -102,13 +104,47 @@ function Plan(): JSX.Element {
     <div className="flex flex-col w-full h-full overflow-hidden">
       <PlanHeader />
       <div className="w-full h-full px-4 overflow-y-scroll hover:scrollbar scrollbar--vertical">
-        <PlanOptions />
-        {planAction.isCancelling ? (
-          <CancellingPlanApply />
-        ) : (
-          <PlanApplyStageTracker />
-        )}
+        <Transition
+          appear
+          show
+          enter="transition ease duration-700 transform"
+          enterFrom="opacity-0 -translate-y-full"
+          enterTo="opacity-100 translate-y-0"
+          leave="transition ease duration-1000 transform"
+          leaveFrom="opacity-100 translate-y-0"
+          leaveTo="opacity-0 -translate-y-full"
+        >
+          <PlanOptions />
+        </Transition>
+        <Transition
+          appear
+          show
+          enter="transition ease duration-700 transform"
+          enterFrom="opacity-0 scale-95"
+          enterTo="opacity-100 scale-100"
+          leave="transition ease duration-1000 transform"
+          leaveFrom="opacity-100 scale-100"
+          leaveTo="opacity-0 scale-95"
+        >
+          {planAction.isCancelling ? (
+            <CancellingPlanApply />
+          ) : (
+            <PlanApplyStageTracker />
+          )}
+        </Transition>
       </div>
+      <Transition
+        appear
+        show={isFalse(planAction.isDone)}
+        enter="transition ease duration-1000 transform"
+        enterFrom="opacity-0 translate-y-full"
+        enterTo="opacity-100 translate-y-0"
+        leave="transition ease duration-500 transform"
+        leaveFrom="opacity-100 translate-y-0"
+        leaveTo="opacity-0 translate-y-full"
+      >
+        <PlanActionsDescription />
+      </Transition>
       <PlanActions
         apply={apply}
         run={run}

--- a/web/client/src/library/components/plan/PlanActions.tsx
+++ b/web/client/src/library/components/plan/PlanActions.tsx
@@ -3,7 +3,6 @@ import useActiveFocus from '~/hooks/useActiveFocus'
 import { EnumVariant } from '~/types/enum'
 import { includes, isFalse } from '~/utils'
 import { Button } from '../button/Button'
-import PlanActionsDescription from './PlanActionsDescription'
 import { EnumPlanAction, ModelPlanAction } from '@models/plan-action'
 import { useStorePlan } from '@context/plan'
 
@@ -48,7 +47,6 @@ export default function PlanActions({
 
   return (
     <>
-      {isFalse(planAction.isDone) && <PlanActionsDescription />}
       <div className="flex justify-between px-4 pb-2">
         <div className="flex w-full items-center">
           {(planAction.isRun || planAction.isRunning) && (

--- a/web/client/src/library/pages/ide/IDE.tsx
+++ b/web/client/src/library/pages/ide/IDE.tsx
@@ -328,10 +328,6 @@ export default function PageIDE(): JSX.Element {
   function updatePlanOverviewTracker(data: PlanOverviewTracker): void {
     planOverview.update(data)
 
-    if (planOverview.meta?.status === Status.init) {
-      setTests(undefined)
-    }
-
     setPlanOverview(planOverview)
   }
 


### PR DESCRIPTION
Animates transition between different stages when `run plan/apply plan`. Animation is very simple and need some work but makes plan UX less choppy 