### PR TITLE
Chore: "remember" last selected model from Docs and show on return

### DIFF
--- a/web/client/openapi.json
+++ b/web/client/openapi.json
@@ -612,7 +612,7 @@
     "/api/models": {
       "get": {
         "summary": "Get Models",
-        "description": "Get a mapping of model names to model metadata",
+        "description": "Get a list of models",
         "operationId": "get_models_api_models_get",
         "responses": {
           "200": {
@@ -629,6 +629,39 @@
                   ],
                   "title": "Response Get Models Api Models Get"
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/models/{name}": {
+      "get": {
+        "summary": "Get Model",
+        "description": "Get a single model",
+        "operationId": "get_model_api_models__name__get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Model" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1456,15 +1489,7 @@
       },
       "Modules": {
         "type": "string",
-        "enum": [
-          "editor",
-          "docs",
-          "plans",
-          "plan-active",
-          "tests",
-          "audits",
-          "errors"
-        ],
+        "enum": ["editor", "docs", "plans", "tests", "audits", "errors"],
         "title": "Modules"
       },
       "NodeType": {

--- a/web/client/src/context/context.ts
+++ b/web/client/src/context/context.ts
@@ -15,9 +15,11 @@ interface ContextStore {
   confirmations: Confirmation[]
   environment: ModelEnvironment
   environments: Set<ModelEnvironment>
+  lastSelectedModel?: ModelSQLMeshModel
   models: Map<string, ModelSQLMeshModel>
   modules: string[]
   splitPaneSizes: number[]
+  setLastSelectedModel: (model?: ModelSQLMeshModel) => void
   setSplitPaneSizes: (splitPaneSizes: number[]) => void
   setModules: (modules: string[]) => void
   setVersion: (version?: string) => void
@@ -59,6 +61,12 @@ export const useStoreContext = create<ContextStore>((set, get) => ({
   initialStartDate: undefined,
   initialEndDate: undefined,
   models: new Map(),
+  lastSelectedModel: undefined,
+  setLastSelectedModel(model) {
+    set(() => ({
+      lastSelectedModel: model,
+    }))
+  },
   setModules(modules) {
     set(() => ({
       modules,

--- a/web/client/src/library/components/sourceList/SourceList.tsx
+++ b/web/client/src/library/components/sourceList/SourceList.tsx
@@ -160,7 +160,7 @@ export function SourceListItem({
       to={to}
       className={({ isActive }) =>
         clsx(
-          'block overflow-hidden px-2 py-1 rounded-md w-full text-sm font-bold',
+          'block overflow-hidden px-2 py-1 rounded-md w-full text-sm font-semibold',
           disabled && 'opacity-50 pointer-events-none',
           isActive
             ? variant === EnumVariant.Primary

--- a/web/client/src/library/pages/docs/Content.tsx
+++ b/web/client/src/library/pages/docs/Content.tsx
@@ -16,10 +16,15 @@ export default function Content(): JSX.Element {
   const navigate = useNavigate()
 
   const models = useStoreContext(s => s.models)
-  const model = isNil(modelName) ? undefined : models.get(encodeURI(modelName))
+  const lastSelectedModel = useStoreContext(s => s.lastSelectedModel)
+  const setLastSelectedModel = useStoreContext(s => s.setLastSelectedModel)
 
   const files = useStoreProject(s => s.files)
   const setSelectedFile = useStoreProject(s => s.setSelectedFile)
+
+  const model = isNil(modelName)
+    ? lastSelectedModel
+    : models.get(encodeURI(modelName))
 
   useEffect(() => {
     if (isNotNil(model)) {
@@ -29,6 +34,8 @@ export default function Content(): JSX.Element {
 
       setSelectedFile(file)
     }
+
+    setLastSelectedModel(model)
   }, [model])
 
   function handleClickModel(modelName: string): void {

--- a/web/client/src/library/pages/docs/Docs.tsx
+++ b/web/client/src/library/pages/docs/Docs.tsx
@@ -18,13 +18,17 @@ export default function PageDocs(): JSX.Element {
   const { modelName } = useParams()
 
   const models = useStoreContext(s => s.models)
+  const lastSelectedModel = useStoreContext(s => s.lastSelectedModel)
+  const setLastSelectedModel = useStoreContext(s => s.setLastSelectedModel)
 
   const filtered = useMemo(() => Array.from(new Set(models.values())), [models])
 
   useEffect(() => {
     if (models.size === 0) return
 
-    const model = isNil(modelName) ? undefined : models.get(modelName)
+    const model = isNil(modelName) ? lastSelectedModel : models.get(modelName)
+
+    setLastSelectedModel(model)
 
     navigate(
       isNil(model)


### PR DESCRIPTION
Added `globally` shared `lastSelectedModel` to pre-select file or show (previous selection) when returned back to Docs.
It also allows to preserve selected model and in case when user selected `model` file from `File Explorer` to show that model in Docs or vice versa, when user selected `model` in Docs to select that `file` in `File Explorer` and `Tabs`