### PR TITLE
Feat: Fetch model's sql from API on demand

### DIFF
--- a/web/client/src/api/index.ts
+++ b/web/client/src/api/index.ts
@@ -47,6 +47,8 @@ import {
   type PlanOverviewStageTracker,
   type PlanApplyStageTracker,
   type BodyInitiateApplyApiCommandsApplyPostCategories,
+  type Model,
+  getModelApiModelsNameGet,
 } from './client'
 import {
   useIDE,
@@ -112,6 +114,24 @@ export function useApiModels(
       ...options,
       errorKey: EnumErrorKey.Models,
       trigger: 'API -> useApiModels',
+    },
+  )
+}
+
+export function useApiModel(
+  modelName: string,
+  options?: ApiOptions,
+): UseQueryWithTimeoutOptions<Model> {
+  return useQueryWithTimeout(
+    {
+      queryKey: ['/api/models', modelName],
+      queryFn: async ({ signal }) =>
+        await getModelApiModelsNameGet(modelName, { signal }),
+    },
+    {
+      ...options,
+      errorKey: EnumErrorKey.Models,
+      trigger: 'API -> useApiModel',
     },
   )
 }

--- a/web/client/src/library/components/documentation/Documentation.tsx
+++ b/web/client/src/library/components/documentation/Documentation.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Disclosure, Tab } from '@headlessui/react'
 import { MinusCircleIcon, PlusCircleIcon } from '@heroicons/react/24/solid'
 import { EnumFileExtensions } from '@models/file'
@@ -21,6 +21,7 @@ import {
   CodeEditorDefault,
   CodeEditorRemoteFile,
 } from '@components/editor/EditorCode'
+import { useApiModel } from '@api/index'
 
 const Documentation = function Documentation({
   model,
@@ -38,6 +39,20 @@ const Documentation = function Documentation({
   withColumns?: boolean
 }): JSX.Element {
   const { handleClickModel } = useLineageFlow()
+
+  const { refetch: getModel, cancel: cancelRequestModel } = useApiModel(
+    model.name,
+  )
+
+  useEffect(() => {
+    void getModel().then(({ data }) => {
+      model.update(data)
+    })
+
+    return () => {
+      cancelRequestModel()
+    }
+  }, [model.name])
 
   const modelExtensions = useSQLMeshModelExtensions(model.path, model => {
     handleClickModel?.(model.name)

--- a/web/client/src/library/components/editor/EditorInspector.tsx
+++ b/web/client/src/library/components/editor/EditorInspector.tsx
@@ -15,6 +15,7 @@ import { type ModelSQLMeshModel } from '@models/sqlmesh-model'
 import {
   useApiEvaluate,
   useApiFetchdf,
+  useApiModel,
   useApiRender,
   useApiTableDiff,
 } from '@api/index'
@@ -47,7 +48,7 @@ export default function EditorInspector({
       )}
     >
       {isModel(tab.file.path) ? (
-        model != null && (
+        isNotNil(model) && (
           <InspectorModel
             tab={tab}
             model={model}
@@ -74,6 +75,20 @@ function InspectorModel({
   const list = Array.from(environments)
     .filter(({ isRemote }) => isRemote)
     .map(({ name }) => ({ text: name, value: name }))
+
+  const { refetch: getModel, cancel: cancelRequestModel } = useApiModel(
+    model.name,
+  )
+
+  useEffect(() => {
+    void getModel().then(({ data }) => {
+      model.update(data)
+    })
+
+    return () => {
+      cancelRequestModel()
+    }
+  }, [model.name])
 
   const modelExtensions = useSQLMeshModelExtensions(model.path, model => {
     handleClickModel?.(model.name)

--- a/web/server/api/endpoints/models.py
+++ b/web/server/api/endpoints/models.py
@@ -46,8 +46,14 @@ def get_model(
     return serialize_model(model, context.path, render_query=True)
 
 
-def serialize_all_models(context: Context) -> t.List[models.Model]:
-    return [serialize_model(model, context.path) for model in context.models.values()]
+def serialize_all_models(
+    context: Context, render_queries: t.Optional[t.List[str]] = None
+) -> t.List[models.Model]:
+    render_queries = render_queries or []
+    return [
+        serialize_model(model, context.path, model.name in render_queries)
+        for model in context.models.values()
+    ]
 
 
 def serialize_model(

--- a/web/server/api/endpoints/models.py
+++ b/web/server/api/endpoints/models.py
@@ -47,9 +47,9 @@ def get_model(
 
 
 def serialize_all_models(
-    context: Context, render_queries: t.Optional[t.List[str]] = None
+    context: Context, render_queries: t.Optional[t.Set[str]] = None
 ) -> t.List[models.Model]:
-    render_queries = render_queries or []
+    render_queries = render_queries or set()
     return [
         serialize_model(model, context.path, model.name in render_queries)
         for model in context.models.values()

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -92,7 +92,7 @@ def reload_context_and_update_models(context: Context, change_path: Path) -> Non
         maybe_model = path_to_model_mapping.get(change_path)
         api_console.log_event(
             event=models.EventName.MODELS,
-            data=serialize_all_models(context, [maybe_model.name] if maybe_model else []),
+            data=serialize_all_models(context, {maybe_model.name} if maybe_model else set()),
         )
     except Exception:
         error = ApiException(

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -10,7 +10,7 @@ from web.server.api.endpoints.files import _get_directory, _get_file_with_conten
 from web.server.api.endpoints.models import serialize_all_models
 from web.server.console import api_console
 from web.server.exceptions import ApiException
-from web.server.settings import get_context, get_settings
+from web.server.settings import _get_path_to_model_mapping, get_context, get_settings
 from web.server.utils import is_relative_to, run_in_executor
 
 
@@ -37,8 +37,8 @@ async def watch_project() -> None:
         directories: t.Dict[str, models.Directory] = {}
 
         for change, path_str in entries:
+            path = Path(path_str)
             try:
-                path = Path(path_str)
                 relative_path = path.relative_to(settings.project_path)
                 should_load_context = should_load_context or any(
                     is_relative_to(path, p) for p in paths
@@ -82,13 +82,18 @@ async def watch_project() -> None:
         )
 
         if should_load_context:
-            await run_in_executor(reload_context, context)
+            await run_in_executor(reload_context_and_update_models, context, path)
 
 
-def reload_context(context: Context) -> None:
+def reload_context_and_update_models(context: Context, change_path: Path) -> None:
     try:
         context.load()
-        api_console.log_event(event=models.EventName.MODELS, data=serialize_all_models(context))
+        path_to_model_mapping = _get_path_to_model_mapping(context)
+        maybe_model = path_to_model_mapping.get(change_path)
+        api_console.log_event(
+            event=models.EventName.MODELS,
+            data=serialize_all_models(context, [maybe_model.name] if maybe_model else []),
+        )
     except Exception:
         error = ApiException(
             message="Error refreshing the models while watching file changes",


### PR DESCRIPTION
`Models` API endpoint returns only model's essential details and omits `sql`. In order to get `rendered sql` we need to send another API call to `Model` API endpoint. Also when `model's` file's changed, include `rendered sql` in payload sent via SSE.