### PR TITLE
Fix: SQL for a model freezes in Docs

### DIFF
--- a/web/client/src/library/components/documentation/Documentation.tsx
+++ b/web/client/src/library/components/documentation/Documentation.tsx
@@ -121,7 +121,10 @@ const Documentation = function Documentation({
       )}
       {(withCode || withQuery) && (
         <Section headline="SQL">
-          <CodeEditorRemoteFile path={model.path}>
+          <CodeEditorRemoteFile
+            key={model.path}
+            path={model.path}
+          >
             {({ file }) => (
               <Tab.Group defaultIndex={withQuery ? 1 : 0}>
                 <TabList


### PR DESCRIPTION
In docs, viewing the SQL for a model, when I change models, the SQL doesn't update until minimize the section and expand it again.