### PR TITLE
Feat: Make editor inspector collapsable on click

### DIFF
--- a/web/client/src/library/components/button/Button.tsx
+++ b/web/client/src/library/components/button/Button.tsx
@@ -63,7 +63,7 @@ const VARIANT = new Map<ButtonVariant, string>([
   ],
   [
     'alternative',
-    'border-primary-500 bg-primary-10 hover:bg-primary-20 active:bg-primary-200 text-primary-500',
+    'border-neutral-300 bg-neutral-5 hover:bg-neutral-20 active:bg-neutral-200 text-neutral-600',
   ],
   [
     'secondary',

--- a/web/client/src/library/components/editor/Editor.tsx
+++ b/web/client/src/library/components/editor/Editor.tsx
@@ -26,6 +26,7 @@ import { getTableDataFromArrowStreamResult } from '@components/table/help'
 import { type Table } from 'apache-arrow'
 import { type KeyBinding } from '@codemirror/view'
 import { useStoreContext } from '@context/context'
+import { useIDE } from '~/library/pages/ide/context'
 
 function Editor(): JSX.Element {
   const tab = useStoreEditor(s => s.tab)
@@ -94,6 +95,7 @@ function EditorLoading(): JSX.Element {
 }
 
 function EditorMain({ tab }: { tab: EditorTab }): JSX.Element {
+  const { errors } = useIDE()
   const models = useStoreContext(s => s.models)
   const isModel = useStoreContext(s => s.isModel)
 
@@ -224,7 +226,8 @@ function EditorMain({ tab }: { tab: EditorTab }): JSX.Element {
       isFalse(tab.file.isEmpty) && isNotNil(model) && isModel(tab.file.path)
     const showPreview =
       (tab.file.isLocal && [previewTable, previewDiff].some(Boolean)) ||
-      showLineage
+      showLineage ||
+      errors.size > 0
 
     return showPreview ? [70, 30] : [100, 0]
   }

--- a/web/client/src/library/components/editor/EditorInspector.tsx
+++ b/web/client/src/library/components/editor/EditorInspector.tsx
@@ -152,9 +152,7 @@ function InspectorModel({
           </Tab.Panel>
           <Tab.Panel
             unmount={false}
-            className={clsx(
-              'text-xs w-full h-full ring-white ring-opacity-60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2 px-2',
-            )}
+            className="text-xs w-full h-full ring-white ring-opacity-60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2 px-2"
           >
             <ModelColumns
               className="max-h-[15rem]"

--- a/web/client/src/library/components/editor/EditorInspector.tsx
+++ b/web/client/src/library/components/editor/EditorInspector.tsx
@@ -30,10 +30,6 @@ import TabList from '@components/tab/Tab'
 import { getTableDataFromArrowStreamResult } from '@components/table/help'
 import Spinner from '@components/logo/Spinner'
 import { ModelColumns } from '@components/graph/Graph'
-import { CodeEditorDefault } from './EditorCode'
-import { EnumFileExtensions } from '@models/file'
-import { useSQLMeshModelExtensions } from './hooks'
-import { useLineageFlow } from '@components/graph/context'
 
 const DAY = 24 * 60 * 60 * 1000
 const LIMIT = 1000
@@ -89,8 +85,6 @@ function InspectorModel({
   isOpen?: boolean
   toggle?: () => void
 }): JSX.Element {
-  const { handleClickModel } = useLineageFlow()
-
   const environment = useStoreContext(s => s.environment)
   const environments = useStoreContext(s => s.environments)
   const list = Array.from(environments)
@@ -111,9 +105,6 @@ function InspectorModel({
     }
   }, [model.name])
 
-  const modelExtensions = useSQLMeshModelExtensions(model.path, model => {
-    handleClickModel?.(model.name)
-  })
   return (
     <Tab.Group>
       <div className="flex w-full items-center">
@@ -139,7 +130,6 @@ function InspectorModel({
               [
                 'Evaluate',
                 'Columns',
-                model.isModelSQL && 'Query',
                 list.length > 1 && environment.isRemote && 'Diff',
               ].filter(Boolean) as string[]
             }
@@ -175,17 +165,6 @@ function InspectorModel({
               withSource={false}
               withDescription={true}
               limit={10}
-            />
-          </Tab.Panel>
-          <Tab.Panel
-            unmount={false}
-            className="text-xs w-full h-full ring-white ring-opacity-60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2"
-          >
-            <CodeEditorDefault
-              type={EnumFileExtensions.SQL}
-              content={model.sql ?? ''}
-              extensions={modelExtensions}
-              className="text-xs"
             />
           </Tab.Panel>
           {list.length > 1 && environment.isRemote && (

--- a/web/client/src/library/components/editor/EditorPreview.tsx
+++ b/web/client/src/library/components/editor/EditorPreview.tsx
@@ -185,9 +185,7 @@ export default function EditorPreview({
             {errors.size > 0 && (
               <Tab.Panel
                 unmount={false}
-                className={clsx(
-                  'w-full h-full ring-white ring-opacity-60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2 py-2',
-                )}
+                className="w-full h-full ring-white ring-opacity-60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2 py-2"
               >
                 <ul className="w-full h-full p-2 overflow-auto hover:scrollbar scrollbar--vertical scrollbar--horizontal">
                   {Array.from(errors)

--- a/web/client/src/library/components/editor/EditorPreview.tsx
+++ b/web/client/src/library/components/editor/EditorPreview.tsx
@@ -15,6 +15,8 @@ import TabList from '@components/tab/Tab'
 import { useSQLMeshModelExtensions } from './hooks'
 import Table from '@components/table/Table'
 import { useStoreContext } from '@context/context'
+import { useIDE } from '~/library/pages/ide/context'
+import { DisplayError } from '@components/report/ReportErrors'
 
 const ModelLineage = lazy(
   async () => await import('@components/graph/ModelLineage'),
@@ -26,6 +28,7 @@ export const EnumEditorPreviewTabs = {
   Console: 'Logs',
   Lineage: 'Lineage',
   Diff: 'Diff',
+  Errors: 'Errors',
 } as const
 
 export type EditorPreviewTabs = KeyOf<typeof EnumEditorPreviewTabs>
@@ -37,6 +40,7 @@ export default function EditorPreview({
   tab: EditorTab
   className?: string
 }): JSX.Element {
+  const { errors } = useIDE()
   const navigate = useNavigate()
 
   const models = useStoreContext(s => s.models)
@@ -65,19 +69,22 @@ export default function EditorPreview({
         isNotNil(previewQuery) && EnumEditorPreviewTabs.Query,
         showLineage && EnumEditorPreviewTabs.Lineage,
         isNotNil(previewDiff) && EnumEditorPreviewTabs.Diff,
+        errors.size > 0 && EnumEditorPreviewTabs.Errors,
       ].filter(Boolean) as string[],
-    [tab.id, previewTable, previewQuery, previewDiff, showLineage],
+    [tab.id, previewTable, previewQuery, previewDiff, showLineage, errors],
   )
 
   useEffect(() => {
-    if (isNotNil(previewDiff)) {
+    if (errors.size > 0) {
+      setActiveTabIndex(tabs.indexOf(EnumEditorPreviewTabs.Errors))
+    } else if (isNotNil(previewDiff)) {
       setActiveTabIndex(tabs.indexOf(EnumEditorPreviewTabs.Diff))
     } else if (isNotNil(previewTable)) {
       setActiveTabIndex(tabs.indexOf(EnumEditorPreviewTabs.Table))
     } else if (showLineage) {
       setActiveTabIndex(tabs.indexOf(EnumEditorPreviewTabs.Lineage))
     }
-  }, [tabs, previewTable, previewQuery, previewDiff, showLineage])
+  }, [tabs, previewTable, previewQuery, previewDiff, showLineage, errors])
 
   return (
     <div
@@ -173,6 +180,30 @@ export default function EditorPreview({
                   key={tab.id}
                   diff={previewDiff}
                 />
+              </Tab.Panel>
+            )}
+            {errors.size > 0 && (
+              <Tab.Panel
+                unmount={false}
+                className={clsx(
+                  'w-full h-full ring-white ring-opacity-60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2 py-2',
+                )}
+              >
+                <ul className="w-full h-full p-2 overflow-auto hover:scrollbar scrollbar--vertical scrollbar--horizontal">
+                  {Array.from(errors)
+                    .reverse()
+                    .map(error => (
+                      <li
+                        key={error.id}
+                        className="bg-danger-10 mb-4 last:m-0 p-2 rounded-md"
+                      >
+                        <DisplayError
+                          scope={error.key}
+                          error={error}
+                        />
+                      </li>
+                    ))}
+                </ul>
               </Tab.Panel>
             )}
           </Tab.Panels>

--- a/web/client/src/library/components/editor/EditorTabs.tsx
+++ b/web/client/src/library/components/editor/EditorTabs.tsx
@@ -80,7 +80,7 @@ export default function EditorTabs(): JSX.Element {
   return (
     <div className="flex items-center">
       <Button
-        className="h-6 m-0 ml-1 mr-3 bg-primary-10  hover:bg-secondary-10 active:bg-secondary-10 border-none"
+        className="h-6 m-0 ml-1 mr-2 border-none"
         variant={EnumVariant.Alternative}
         size={EnumSize.sm}
         onClick={(e: MouseEvent) => {
@@ -89,7 +89,7 @@ export default function EditorTabs(): JSX.Element {
           addTabAndSelect()
         }}
       >
-        <PlusIcon className="inline-block w-3 h-4 text-secondary-500 dark:text-primary-500" />
+        <PlusIcon className="inline-block w-3 h-4" />
       </Button>
       <ul className="w-full whitespace-nowrap min-h-[2rem] max-h-[2rem] overflow-hidden overflow-x-auto hover:scrollbar scrollbar--horizontal">
         {tabsLocal.map((tab, idx) => (

--- a/web/client/src/library/components/input/Input.tsx
+++ b/web/client/src/library/components/input/Input.tsx
@@ -58,7 +58,7 @@ function Input({
         className,
       )}
     >
-      {isNotNil(label) && <InputLabel>{label}</InputLabel>}
+      {isNotNil(label) && <InputLabel size={size}>{label}</InputLabel>}
       {typeof children === 'function'
         ? children({ disabled, required, autoFocus, size, className: cn })
         : children}
@@ -71,16 +71,21 @@ function InputLabel({
   htmlFor,
   className,
   children,
+  size = EnumSize.md,
 }: {
   htmlFor?: string
   className?: string
   children: React.ReactNode
+  size?: Size
 }): JSX.Element {
   return (
     <label
       htmlFor={htmlFor}
       className={clsx(
-        'block mb-1 px-3 text-sm font-bold whitespace-nowrap',
+        'block mb-1 px-2 text-sm whitespace-nowrap',
+        size === EnumSize.sm && 'text-xs',
+        size === EnumSize.md && 'text-sm',
+        size === EnumSize.lg && 'text-md',
         className,
       )}
     >

--- a/web/client/src/library/components/splitPane/SplitPane.tsx
+++ b/web/client/src/library/components/splitPane/SplitPane.tsx
@@ -1,5 +1,6 @@
 import Split, { type SplitProps } from 'react-split'
 import './SplitPane.css'
+import { useRef } from 'react'
 
 export default function SplitPane({
   className,
@@ -10,12 +11,20 @@ export default function SplitPane({
   direction,
   expandToMin = false,
   snapOffset,
-  onDragEnd,
-}: SplitProps): JSX.Element {
+  cursor,
+  handleDrag,
+}: SplitProps & {
+  className?: string
+  children: React.ReactNode
+  handleDrag?: (sizes: number[], elSplit?: Maybe<HTMLElement & any>) => void
+}): JSX.Element {
+  const elSplit = useRef(null)
   return (
     <Split
+      ref={elSplit}
       className={className}
       sizes={sizes}
+      cursor={cursor}
       expandToMin={expandToMin}
       gutterAlign="center"
       gutterSize={2}
@@ -23,7 +32,7 @@ export default function SplitPane({
       minSize={minSize}
       maxSize={maxSize}
       snapOffset={snapOffset}
-      onDragEnd={onDragEnd}
+      onDrag={sizes => handleDrag?.(sizes, elSplit.current)}
     >
       {children}
     </Split>

--- a/web/client/src/library/components/tab/Tab.tsx
+++ b/web/client/src/library/components/tab/Tab.tsx
@@ -11,14 +11,14 @@ export default function TabList({
   className?: string
 }): JSX.Element {
   return (
-    <Tab.List className="w-full whitespace-nowrap px-2 py-0.5 flex justify-between items-center">
+    <Tab.List className="w-full whitespace-nowrap px-2 flex justify-center items-center">
       <div
         className={clsx(
           'flex w-full overflow-hidden overflow-x-auto py-1 hover:scrollbar scrollbar--horizontal',
           className,
         )}
       >
-        <div className="flex items-center bg-secondary-5 dark:bg-primary-5 cursor-pointer rounded-full p-1 overflow-hidden">
+        <div className="flex p-1 items-center bg-secondary-10 dark:bg-primary-10 cursor-pointer rounded-full overflow-hidden">
           {list.map(item => (
             <Tab
               key={item}


### PR DESCRIPTION
Add manual trigger (icon) to Editor Inspector, to manually collapse/expend and hide by default

![Screenshot 2024-01-24 at 12 34 47 PM](https://github.com/TobikoData/sqlmesh/assets/5644753/2bd56eda-65b4-42da-9051-c8a4f339c801)

Also make `Inputs` smaller
![Screenshot 2024-01-24 at 12 37 19 PM](https://github.com/TobikoData/sqlmesh/assets/5644753/f8812de0-6731-4850-9036-dd2114ba7f67)
