### PR TITLE
Fix: Child snapshot targeting a wrong parent forward-only snapshot table when the parent was created in dev and the child in prod

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1062,7 +1062,7 @@ class DeployabilityIndex(PydanticModel, frozen=True):
 
     indexed_ids: t.FrozenSet[str]
     is_opposite_index: bool = False
-    representative_shared_version_ids: t.Optional[t.FrozenSet[str]] = None
+    representative_shared_version_ids: t.FrozenSet[str] = frozenset()
 
     @field_validator("indexed_ids", "representative_shared_version_ids", mode="before")
     @classmethod
@@ -1109,10 +1109,7 @@ class DeployabilityIndex(PydanticModel, frozen=True):
             True if the snapshot is representative, False otherwise.
         """
         snapshot_id = self._snapshot_id_key(snapshot.snapshot_id)
-        representative = (
-            self.representative_shared_version_ids is not None
-            and snapshot_id in self.representative_shared_version_ids
-        )
+        representative = snapshot_id in self.representative_shared_version_ids
         return representative or self.is_deployable(snapshot)
 
     def with_non_deployable(self, snapshot: SnapshotIdLike) -> DeployabilityIndex:

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -587,7 +587,7 @@ class SnapshotEvaluator:
                     self.adapter.drop_table(tmp_table_name)
             else:
                 table_deployability_flags = [False]
-                if not snapshot.is_indirect_non_breaking:
+                if not snapshot.is_indirect_non_breaking and not snapshot.is_forward_only:
                     table_deployability_flags.append(True)
                 for is_table_deployable in table_deployability_flags:
                     evaluation_strategy.create(

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -83,6 +83,7 @@ class PlanDagSpec(PydanticModel):
     environment_expiration_ts: t.Optional[int] = None
     dag_start_ts: t.Optional[int] = None
     deployability_index: DeployabilityIndex = DeployabilityIndex.all_deployable()
+    deployability_index_for_creation: DeployabilityIndex = DeployabilityIndex.all_deployable()
     no_gaps_snapshot_names: t.Optional[t.Set[str]] = None
 
 

--- a/sqlmesh/schedulers/airflow/dag_generator.py
+++ b/sqlmesh/schedulers/airflow/dag_generator.py
@@ -172,7 +172,7 @@ class SnapshotDagGenerator:
             (create_start_task, create_end_task) = self._create_creation_tasks(
                 plan_dag_spec.new_snapshots,
                 plan_dag_spec.ddl_concurrent_tasks,
-                plan_dag_spec.deployability_index,
+                plan_dag_spec.deployability_index_for_creation,
             )
 
             (

--- a/sqlmesh/schedulers/airflow/plan.py
+++ b/sqlmesh/schedulers/airflow/plan.py
@@ -142,7 +142,11 @@ def create_plan_dag_spec(
     ]
 
     no_gaps_snapshot_names = (
-        {s.name for s in all_snapshots.values() if deployability_index_for_creation.is_representative(s)}
+        {
+            s.name
+            for s in all_snapshots.values()
+            if deployability_index_for_creation.is_representative(s)
+        }
         if request.no_gaps and not request.is_dev
         else None
         if request.no_gaps

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -991,11 +991,6 @@ def test_forward_only_snapshot_for_added_model(mocker: MockerFixture, adapter_mo
                 column_descriptions=None,
                 **common_create_args,
             ),
-            call(
-                f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}",
-                column_descriptions={},
-                **common_create_args,
-            ),
         ]
     )
 

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -181,6 +181,9 @@ def test_create_plan_dag_spec(
         forward_only=True,
         dag_start_ts=to_timestamp("2023-01-01"),
         no_gaps_snapshot_names=expected_no_gaps_snapshot_names,
+        deployability_index_for_creation=DeployabilityIndex.all_deployable()
+        if not paused_forward_only
+        else DeployabilityIndex.none_deployable(),
     )
 
     state_sync_mock.get_snapshots.assert_called_once()


### PR DESCRIPTION
The following chain of events must take place for the issue to materialize:

1. A schema of a forward-only model A have been updated.
2. It was pushed to a dev environment.
3. Changes to model A haven't been deployed to prod yet.
4. A downstream model B have been updated to use schema changes from A.
5. Changes to model B were never pushed to a dev environment.
6. Instead both changes were pushed to prod at the same time.