### PR TITLE
fix: further improve performance of dag by introducing a dummy node

### DIFF
--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -127,7 +127,6 @@ def test_incremental_by_unique_key_kind_dag(mocker: MockerFixture, make_snapshot
     batches = scheduler.batches(start, end, end)
     dag = scheduler._dag(batches)
     assert dag.graph == {
-        # Depends on no one
         (
             unique_by_key_snapshot.name,
             ((to_datetime("2023-01-01"), to_datetime("2023-01-07")), 0),
@@ -200,6 +199,26 @@ def test_incremental_time_self_reference_dag(mocker: MockerFixture, make_snapsho
                 ((to_datetime("2023-01-04"), to_datetime("2023-01-05")), 2),
             ),
         },
+        (incremental_self_snapshot.name, ((to_datetime(0), to_datetime(0)), -1),): set(
+            [
+                (
+                    incremental_self_snapshot.name,
+                    ((to_datetime("2023-01-01"), to_datetime("2023-01-02")), 0),
+                ),
+                (
+                    incremental_self_snapshot.name,
+                    ((to_datetime("2023-01-03"), to_datetime("2023-01-04")), 1),
+                ),
+                (
+                    incremental_self_snapshot.name,
+                    ((to_datetime("2023-01-04"), to_datetime("2023-01-05")), 2),
+                ),
+                (
+                    incremental_self_snapshot.name,
+                    ((to_datetime("2023-01-06"), to_datetime("2023-01-07")), 3),
+                ),
+            ]
+        ),
     }
 
 


### PR DESCRIPTION
nodes are now connected to a terminal node to avoid many to many edges

before:

![Screenshot_2024-01-24_19 15 44](https://github.com/TobikoData/sqlmesh/assets/8205034/762992e3-d742-47fd-ac76-60fc48a81ca0)

after:

![Screenshot_2024-01-24_19 14 38](https://github.com/TobikoData/sqlmesh/assets/8205034/c7357e02-1481-451d-8355-58e3dc17e8b9)

104 edges -> 60 edges