### PR TITLE
Feat: Create snapshot tables on demand

### DIFF
--- a/docs/quickstart/cli.md
+++ b/docs/quickstart/cli.md
@@ -253,7 +253,7 @@ Line 15 asks you whether to proceed with executing the model backfills described
 
 ```bash linenums="1"
 Apply - Backfill Tables [y/n]: y
-Creating new model versions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.0% • 3/3 • 0:00:00
+Creating physical tables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.0% • 3/3 • 0:00:00
 
 All model versions have been created successfully
 
@@ -363,7 +363,7 @@ Hit `Enter` at the prompt to backfill data from our start date `2020-01-01`. Ano
 Enter the backfill start date (eg. '1 year', '2020-01-01') or blank to backfill from the beginning of history:
 Enter the backfill end date (eg. '1 month ago', '2020-01-01') or blank to backfill up until now:
 Apply - Backfill Tables [y/n]: y
-Creating new model versions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.0% • 2/2 • 0:00:00
+Creating physical tables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.0% • 2/2 • 0:00:00
 
 All model versions have been created successfully
 

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -365,7 +365,7 @@ class TerminalConsole(Console):
         """Indicates that a new creation progress has begun."""
         if self.creation_progress is None:
             self.creation_progress = Progress(
-                TextColumn("[bold blue]Creating new model versions", justify="right"),
+                TextColumn("[bold blue]Creating physical tables", justify="right"),
                 BarColumn(bar_width=40),
                 "[progress.percentage]{task.percentage:>3.1f}%",
                 "•",
@@ -377,7 +377,7 @@ class TerminalConsole(Console):
 
             self.creation_progress.start()
             self.creation_task = self.creation_progress.add_task(
-                "Creating new model versions...",
+                "Creating physical tables...",
                 total=total_tasks,
             )
 

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1406,7 +1406,7 @@ class EngineAdapter:
                 )
         self.execute(exp.rename_table(old_table_name, new_table_name))
 
-    def list_data_objects(
+    def get_data_objects(
         self, schema_name: SchemaName, object_names: t.Optional[t.Set[str]] = None
     ) -> t.List[DataObject]:
         """Lists all data objects in the target schema.
@@ -1419,6 +1419,8 @@ class EngineAdapter:
             A list of data objects in the target schema.
         """
         if object_names is not None:
+            if not object_names:
+                return []
             object_names_list = list(object_names)
             batches = [
                 object_names_list[i : i + self.DATA_OBJECT_FILTER_BATCH_SIZE]

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -79,6 +79,7 @@ class EngineAdapter:
 
     DIALECT = ""
     DEFAULT_BATCH_SIZE = 10000
+    DATA_OBJECT_FILTER_BATCH_SIZE = 1000
     ESCAPE_JSON = False
     SUPPORTS_TRANSACTIONS = True
     SUPPORTS_INDEXES = False
@@ -1405,6 +1406,29 @@ class EngineAdapter:
                 )
         self.execute(exp.rename_table(old_table_name, new_table_name))
 
+    def list_data_objects(
+        self, schema_name: SchemaName, object_names: t.Optional[t.Set[str]] = None
+    ) -> t.List[DataObject]:
+        """Lists all data objects in the target schema.
+
+        Args:
+            schema_name: The name of the schema to list data objects from.
+            object_names: If provided, only return data objects with these names.
+
+        Returns:
+            A list of data objects in the target schema.
+        """
+        if object_names is not None:
+            object_names_list = list(object_names)
+            batches = [
+                object_names_list[i : i + self.DATA_OBJECT_FILTER_BATCH_SIZE]
+                for i in range(0, len(object_names_list), self.DATA_OBJECT_FILTER_BATCH_SIZE)
+            ]
+            return [
+                obj for batch in batches for obj in self._get_data_objects(schema_name, set(batch))
+            ]
+        return self._get_data_objects(schema_name)
+
     def fetchone(
         self,
         query: t.Union[exp.Expression, str],
@@ -1675,7 +1699,9 @@ class EngineAdapter:
 
         return expression.sql(**sql_gen_kwargs)  # type: ignore
 
-    def _get_data_objects(self, schema_name: SchemaName) -> t.List[DataObject]:
+    def _get_data_objects(
+        self, schema_name: SchemaName, object_names: t.Optional[t.Set[str]] = None
+    ) -> t.List[DataObject]:
         """
         Returns all the data objects that exist in the given schema and optionally catalog.
         """

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -103,41 +103,44 @@ class BasePostgresEngineAdapter(EngineAdapter):
                 **create_kwargs,
             )
 
-    def _get_data_objects(self, schema_name: SchemaName) -> t.List[DataObject]:
+    def _get_data_objects(
+        self, schema_name: SchemaName, object_names: t.Optional[t.Set[str]] = None
+    ) -> t.List[DataObject]:
         """
         Returns all the data objects that exist in the given schema and optionally catalog.
         """
-        catalog_name = f"'{self.get_current_catalog()}'"
-        query = f"""
-            SELECT
-                {catalog_name} AS catalog_name,
-                tablename AS name,
-                schemaname AS schema_name,
-                'TABLE' AS type
-            FROM pg_tables
-            WHERE schemaname ILIKE '{schema_name}'
-            UNION ALL
-            SELECT
-                {catalog_name} AS catalog_name,
-                viewname AS name,
-                schemaname AS schema_name,
-                'VIEW' AS type
-            FROM pg_views
-            WHERE schemaname ILIKE '{schema_name}'
-            UNION ALL
-            SELECT
-                {catalog_name} AS catalog_name,
-                matviewname AS name,
-                schemaname AS schema_name,
-                'MATERIALIZED_VIEW' AS type
-            FROM
-                pg_matviews
-            WHERE schemaname ILIKE '{schema_name}'
-        """
+        catalog = self.get_current_catalog()
+        table_query = exp.select(
+            exp.column("schemaname").as_("schema_name"),
+            exp.column("tablename").as_("name"),
+            exp.Literal.string("TABLE").as_("type"),
+        ).from_("pg_tables")
+        view_query = exp.select(
+            exp.column("schemaname").as_("schema_name"),
+            exp.column("viewname").as_("name"),
+            exp.Literal.string("VIEW").as_("type"),
+        ).from_("pg_views")
+        materialized_view_query = exp.select(
+            exp.column("schemaname").as_("schema_name"),
+            exp.column("matviewname").as_("name"),
+            exp.Literal.string("MATERIALIZED_VIEW").as_("type"),
+        ).from_("pg_matviews")
+        subquery = exp.union(
+            table_query,
+            exp.union(view_query, materialized_view_query, distinct=False),
+            distinct=False,
+        )
+        query = (
+            exp.select("*")
+            .from_(subquery.subquery(alias="objs"))
+            .where(exp.column("schema_name").ilike(schema_name))
+        )
+        if object_names:
+            query = query.where(exp.column("name").isin(*object_names))
         df = self.fetchdf(query)
         return [
             DataObject(
-                catalog=row.catalog_name, schema=row.schema_name, name=row.name, type=DataObjectType.from_str(row.type)  # type: ignore
+                catalog=catalog, schema=row.schema_name, name=row.name, type=DataObjectType.from_str(row.type)  # type: ignore
             )
             for row in df.itertuples()
         ]

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -4,6 +4,7 @@ import typing as t
 
 from sqlglot import exp
 
+from sqlmesh.core.dialect import to_schema
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.engine_adapter.shared import (
     CatalogSupport,
@@ -133,7 +134,7 @@ class BasePostgresEngineAdapter(EngineAdapter):
         query = (
             exp.select("*")
             .from_(subquery.subquery(alias="objs"))
-            .where(exp.column("schema_name").ilike(schema_name))
+            .where(exp.column("schema_name").eq(to_schema(schema_name).db))
         )
         if object_names:
             query = query.where(exp.column("name").isin(*object_names))

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -643,7 +643,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
             .when(exp.column("table_type").eq("SNAPSHOT"), exp.Literal.string("TABLE"))
             .when(exp.column("table_type").eq("VIEW"), exp.Literal.string("VIEW"))
             .when(
-                exp.column("table_table").eq("MATERIALIZED VIEW"),
+                exp.column("table_type").eq("MATERIALIZED VIEW"),
                 exp.Literal.string("MATERIALIZED_VIEW"),
             )
             .else_(exp.column("table_type"))

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -620,28 +620,60 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
         self.cursor._set_rowcount(query_results)
         self.cursor._set_description(query_results.schema)
 
-    def _get_data_objects(self, schema_name: SchemaName) -> t.List[DataObject]:
+    def _get_data_objects(
+        self, schema_name: SchemaName, object_names: t.Optional[t.Set[str]] = None
+    ) -> t.List[DataObject]:
         """
         Returns all the data objects that exist in the given schema and optionally catalog.
         """
-        from google.api_core.exceptions import NotFound
-        from google.cloud.bigquery import DatasetReference
 
+        # The BigQuery Client's list_tables method does not support filtering by table name, so we have to
+        # resort to using SQL instead.
         schema = to_schema(schema_name)
-        catalog_name = schema.catalog or self.get_current_catalog()
-        dataset_ref = DatasetReference(project=catalog_name, dataset_id=schema.db)
+        catalog = schema.catalog or self.get_current_catalog()
+        schema_sql = schema.sql(dialect=self.dialect)
+        query = exp.select(
+            exp.column("table_catalog").as_("catalog"),
+            exp.column("table_name").as_("name"),
+            exp.column("table_schema").as_("schema_name"),
+            exp.case()
+            .when(exp.column("table_type").eq("BASE TABLE"), exp.Literal.string("TABLE"))
+            .when(exp.column("table_type").eq("CLONE"), exp.Literal.string("TABLE"))
+            .when(exp.column("table_type").eq("EXTERNAL"), exp.Literal.string("TABLE"))
+            .when(exp.column("table_type").eq("SNAPSHOT"), exp.Literal.string("TABLE"))
+            .when(exp.column("table_type").eq("VIEW"), exp.Literal.string("VIEW"))
+            .when(
+                exp.column("table_table").eq("MATERIALIZED VIEW"),
+                exp.Literal.string("MATERIALIZED_VIEW"),
+            )
+            .else_(exp.column("table_type"))
+            .as_("type"),
+        ).from_(
+            exp.to_table(
+                f"`{catalog}`.`{schema.db}`.INFORMATION_SCHEMA.TABLES", dialect=self.dialect
+            )
+        )
+        if object_names:
+            query = query.where(exp.column("table_name").isin(*object_names))
+
         try:
-            return [
-                DataObject(
-                    catalog=table.project,
-                    schema=table.dataset_id,
-                    name=table.table_id,
-                    type=DataObjectType.from_str(table.table_type),
-                )
-                for table in self._db_call(self.client.list_tables, dataset=dataset_ref)
-            ]
-        except NotFound:
+            df = self.fetchdf(query, quote_identifiers=True)
+        except Exception as e:
+            if "Not found" in str(e):
+                return []
+            raise
+
+        if df.empty:
             return []
+        return [
+            DataObject(
+                catalog=row.catalog,  # type: ignore
+                schema=row.schema_name,  # type: ignore
+                name=row.name,  # type: ignore
+                type=DataObjectType.from_str(row.type),  # type: ignore
+            )
+            for row in df.itertuples()
+        ]
 
     @property
     def _query_data(self) -> t.Any:

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -9,6 +9,7 @@ import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype  # type: ignore
 from sqlglot import exp
 
+from sqlmesh.core.dialect import to_schema
 from sqlmesh.core.engine_adapter.base import EngineAdapterWithIndexSupport
 from sqlmesh.core.engine_adapter.mixins import (
     GetCurrentCatalogFromFunctionMixin,
@@ -202,7 +203,7 @@ class MSSQLEngineAdapter(
                 .as_("type"),
             )
             .from_(exp.table_("TABLES", db="INFORMATION_SCHEMA"))
-            .where(exp.column("TABLE_SCHEMA").like(f"%{schema_name}%"))
+            .where(exp.column("TABLE_SCHEMA").eq(to_schema(schema_name).db))
         )
         if object_names:
             query = query.where(exp.column("TABLE_NAME").isin(*object_names))

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -5,6 +5,7 @@ import typing as t
 
 from sqlglot import exp, parse_one
 
+from sqlmesh.core.dialect import to_schema
 from sqlmesh.core.engine_adapter.mixins import (
     LogicalMergeMixin,
     LogicalReplaceQueryMixin,
@@ -85,7 +86,7 @@ class MySQLEngineAdapter(
                 .as_("type"),
             )
             .from_(exp.table_("tables", db="information_schema"))
-            .where(exp.column("table_schema").eq(schema_name))
+            .where(exp.column("table_schema").eq(to_schema(schema_name).db))
         )
         if object_names:
             query = query.where(exp.column("table_name").isin(*object_names))

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -6,6 +6,7 @@ import pandas as pd
 from sqlglot import exp
 from sqlglot.errors import ErrorLevel
 
+from sqlmesh.core.dialect import to_schema
 from sqlmesh.core.engine_adapter.base_postgres import BasePostgresEngineAdapter
 from sqlmesh.core.engine_adapter.mixins import (
     GetCurrentCatalogFromFunctionMixin,
@@ -271,7 +272,7 @@ class RedshiftEngineAdapter(
         query = (
             exp.select("*")
             .from_(subquery.subquery(alias="objs"))
-            .where(exp.column("schema_name").ilike(schema_name))
+            .where(exp.column("schema_name").eq(to_schema(schema_name).db))
         )
         if object_names:
             query = query.where(exp.column("name").isin(*object_names))

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -136,8 +136,6 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
             .where(exp.column("TABLE_SCHEMA").eq(schema.db))
         )
         if object_names:
-            # FIXME: Find a way to properly normalize object names.
-            object_names = {n.upper() for n in object_names}
             query = query.where(exp.column("TABLE_NAME").isin(*object_names))
         try:
             df = self.fetchdf(query, quote_identifiers=True)

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -126,7 +126,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
                 .when(exp.column("TABLE_TYPE").eq("EVENT TABLE"), exp.Literal.string("TABLE"))
                 .when(exp.column("TABLE_TYPE").eq("VIEW"), exp.Literal.string("VIEW"))
                 .when(
-                    exp.column("TABLE_TABLE").eq("MATERIALIZED VIEW"),
+                    exp.column("TABLE_TYPE").eq("MATERIALIZED VIEW"),
                     exp.Literal.string("MATERIALIZED_VIEW"),
                 )
                 .else_(exp.column("TABLE_TYPE"))

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -109,7 +109,6 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
         """
         Returns all the data objects that exist in the given schema and optionally catalog.
         """
-        from snowflake.connector.errors import ProgrammingError
 
         schema = to_schema(schema_name)
         catalog_name = schema.catalog or self.get_current_catalog()
@@ -137,12 +136,8 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
         )
         if object_names:
             query = query.where(exp.column("TABLE_NAME").isin(*object_names))
-        try:
-            df = self.fetchdf(query, quote_identifiers=True)
-        except ProgrammingError as e:
-            if "Object does not exist" in str(e):
-                return []
-            raise e
+
+        df = self.fetchdf(query, quote_identifiers=True)
         if df.empty:
             return []
         return [

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -302,9 +302,12 @@ class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTableP
             self._fetch_native_df(query, quote_identifiers=quote_identifiers)
         )
 
-    def _get_data_objects(self, schema_name: SchemaName) -> t.List[DataObject]:
+    def _get_data_objects(
+        self, schema_name: SchemaName, object_names: t.Optional[t.Set[str]] = None
+    ) -> t.List[DataObject]:
         schema_name = to_schema(schema_name).sql(dialect=self.dialect)
-        sql = f"SHOW TABLE EXTENDED IN {schema_name} LIKE '*'"
+        pattern = "*" if object_names is None else "|".join(object_names)
+        sql = f"SHOW TABLE EXTENDED IN {schema_name} LIKE '{pattern}'"
         try:
             results = (
                 self.fetch_pyspark_df(sql).collect()

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -244,7 +244,7 @@ class SnapshotEvaluator:
         existing_objects: t.Set[str] = set()
         for schema, object_names in tables_by_schema.items():
             logger.info("Listing data objects in schema %s", schema.sql())
-            objs = self.adapter.list_data_objects(schema, object_names)
+            objs = self.adapter.get_data_objects(schema, object_names)
             existing_objects.update(obj.name for obj in objs)
 
         snapshots_to_create = []

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -254,6 +254,9 @@ class SnapshotEvaluator:
             elif on_complete:
                 on_complete(snapshot)
 
+        if not snapshots_to_create:
+            return
+
         self._create_schemas(tables_by_schema)
         with self.concurrent_context():
             concurrent_apply_to_snapshots(

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import abc
 import logging
 import typing as t
+from collections import defaultdict
 from contextlib import contextmanager
 from functools import reduce
 
@@ -32,6 +33,7 @@ from sqlglot import exp, select
 from sqlglot.executor import execute
 
 from sqlmesh.core import constants as c
+from sqlmesh.core import dialect as d
 from sqlmesh.core.audit import Audit, AuditResult
 from sqlmesh.core.dialect import schema_
 from sqlmesh.core.engine_adapter import EngineAdapter
@@ -230,12 +232,32 @@ class SnapshotEvaluator:
             deployability_index: Determines snapshots that are deployable in the context of this creation.
             on_complete: A callback to call on each successfully created snapshot.
         """
-        self._create_schemas(
-            [s.table_name() for s in target_snapshots if s.is_model and not s.is_symbolic]
-        )
+        snapshots_with_table_names: t.List[t.Tuple[Snapshot, str]] = []
+        tables_by_schema = defaultdict(set)
+        for snapshot in target_snapshots:
+            if not snapshot.is_model or snapshot.is_symbolic:
+                continue
+            table = exp.to_table(snapshot.table_name(False), dialect=snapshot.model.dialect)
+            snapshots_with_table_names.append((snapshot, table.name.lower()))
+            tables_by_schema[d.schema_(table.db, catalog=table.catalog)].add(table.name)
+
+        existing_objects: t.Set[str] = set()
+        for schema, object_names in tables_by_schema.items():
+            logger.info("Listing data objects in schema %s", schema.sql())
+            objs = self.adapter.list_data_objects(schema, object_names)
+            existing_objects.update(obj.name.lower() for obj in objs)
+
+        snapshots_to_create = []
+        for snapshot, table_name in snapshots_with_table_names:
+            if table_name not in existing_objects:
+                snapshots_to_create.append(snapshot)
+            elif on_complete:
+                on_complete(snapshot)
+
+        self._create_schemas(tables_by_schema)
         with self.concurrent_context():
             concurrent_apply_to_snapshots(
-                target_snapshots,
+                snapshots_to_create,
                 lambda s: self._create_snapshot(s, snapshots, deployability_index, on_complete),
                 self.ddl_concurrent_tasks,
             )

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -238,14 +238,14 @@ class SnapshotEvaluator:
             if not snapshot.is_model or snapshot.is_symbolic:
                 continue
             table = exp.to_table(snapshot.table_name(False), dialect=snapshot.model.dialect)
-            snapshots_with_table_names.append((snapshot, table.name.lower()))
+            snapshots_with_table_names.append((snapshot, table.name))
             tables_by_schema[d.schema_(table.db, catalog=table.catalog)].add(table.name)
 
         existing_objects: t.Set[str] = set()
         for schema, object_names in tables_by_schema.items():
             logger.info("Listing data objects in schema %s", schema.sql())
             objs = self.adapter.list_data_objects(schema, object_names)
-            existing_objects.update(obj.name.lower() for obj in objs)
+            existing_objects.update(obj.name for obj in objs)
 
         snapshots_to_create = []
         for snapshot, table_name in snapshots_with_table_names:

--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -237,7 +237,7 @@ class RuntimeAdapter(BaseAdapter):
                 if do.type.is_unknown
                 else RelationType(do.type.lower().replace("_", "")),
             )
-            for do in self.engine_adapter._get_data_objects(schema)
+            for do in self.engine_adapter.get_data_objects(schema)
         ]
         return relations
 

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -85,6 +85,7 @@ class PlanDagSpec(PydanticModel):
     deployability_index: DeployabilityIndex = DeployabilityIndex.all_deployable()
     deployability_index_for_creation: DeployabilityIndex = DeployabilityIndex.all_deployable()
     no_gaps_snapshot_names: t.Optional[t.Set[str]] = None
+    models_to_backfill: t.Optional[t.Set[str]] = None
 
 
 class EnvironmentsResponse(PydanticModel):

--- a/sqlmesh/schedulers/airflow/dag_generator.py
+++ b/sqlmesh/schedulers/airflow/dag_generator.py
@@ -150,13 +150,16 @@ class SnapshotDagGenerator:
 
         environment = plan_dag_spec_to_environment(plan_dag_spec)
 
+        snapshot_ids_to_create = {s.snapshot_id for s in plan_dag_spec.promoted_snapshots} | {
+            s.snapshot_id for s in plan_dag_spec.backfill_intervals_per_snapshot
+        }
         snapshots_to_create = [
-            all_snapshots[s.snapshot_id]
-            for s in environment.snapshots
-            if s.snapshot_id in all_snapshots
+            all_snapshots[s_id]
+            for s_id in snapshot_ids_to_create
+            if s_id in all_snapshots
             and (
                 plan_dag_spec.models_to_backfill is None
-                or s.name in plan_dag_spec.models_to_backfill
+                or s_id.name in plan_dag_spec.models_to_backfill
             )
         ]
 
@@ -181,6 +184,7 @@ class SnapshotDagGenerator:
 
             (create_start_task, create_end_task) = self._create_creation_tasks(
                 snapshots_to_create,
+                plan_dag_spec.new_snapshots,
                 plan_dag_spec.ddl_concurrent_tasks,
                 plan_dag_spec.deployability_index_for_creation,
             )
@@ -268,6 +272,7 @@ class SnapshotDagGenerator:
 
     def _create_creation_tasks(
         self,
+        snapshots_to_create: t.List[Snapshot],
         new_snapshots: t.List[Snapshot],
         ddl_concurrent_tasks: int,
         deployability_index: DeployabilityIndex,
@@ -280,7 +285,7 @@ class SnapshotDagGenerator:
             return (start_task, end_task)
 
         creation_task = self._create_snapshot_create_tables_operator(
-            new_snapshots,
+            snapshots_to_create,
             ddl_concurrent_tasks,
             deployability_index,
             "snapshot_creation__create_tables",

--- a/sqlmesh/schedulers/airflow/plan.py
+++ b/sqlmesh/schedulers/airflow/plan.py
@@ -177,6 +177,7 @@ def create_plan_dag_spec(
         deployability_index=deployability_index_for_evaluation,
         deployability_index_for_creation=deployability_index_for_creation,
         no_gaps_snapshot_names=no_gaps_snapshot_names,
+        models_to_backfill=request.models_to_backfill,
     )
 
 

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -383,15 +383,7 @@ def test_get_data_objects_catalog(make_mocked_engine_adapter: t.Callable, mocker
 
     assert to_sql_calls(adapter) == [
         "USE [test_catalog];",
-        """
-            SELECT
-                'test_catalog' AS catalog_name,
-                TABLE_NAME AS name,
-                TABLE_SCHEMA AS schema_name,
-                CASE WHEN table_type = 'BASE TABLE' THEN 'TABLE' ELSE table_type END AS type
-            FROM INFORMATION_SCHEMA.TABLES
-            WHERE TABLE_SCHEMA LIKE '%test_schema%'
-        """,
+        "SELECT TABLE_NAME AS name, TABLE_SCHEMA AS schema_name, CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END AS type FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA LIKE '%test_schema%';",
         "USE [other_catalog];",
     ]
 

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -383,7 +383,7 @@ def test_get_data_objects_catalog(make_mocked_engine_adapter: t.Callable, mocker
 
     assert to_sql_calls(adapter) == [
         "USE [test_catalog];",
-        "SELECT TABLE_NAME AS name, TABLE_SCHEMA AS schema_name, CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END AS type FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA LIKE '%test_schema%';",
+        "SELECT TABLE_NAME AS name, TABLE_SCHEMA AS schema_name, CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END AS type FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test_schema';",
         "USE [other_catalog];",
     ]
 

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -370,7 +370,7 @@ def test_get_data_objects_catalog(make_mocked_engine_adapter: t.Callable, mocker
     )
     adapter.cursor.fetchall.return_value = [("test_catalog", "test_table", "test_schema", "TABLE")]
     adapter.cursor.description = [["catalog_name"], ["name"], ["schema_name"], ["type"]]
-    result = adapter._get_data_objects("test_catalog.test_schema")
+    result = adapter.get_data_objects("test_catalog.test_schema")
 
     assert result == [
         DataObject(

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -849,7 +849,7 @@ def test_select_models(init_and_plan_context: t.Callable):
     assert len(dev_df) == 7
 
     # Make sure that we only create a view for the selected model.
-    schema_objects = context.engine_adapter._get_data_objects("sushi__dev")
+    schema_objects = context.engine_adapter.get_data_objects("sushi__dev")
     assert len(schema_objects) == 1
     assert schema_objects[0].name == "waiter_revenue_by_day"
 
@@ -924,7 +924,7 @@ def test_select_models_for_backfill(init_and_plan_context: t.Callable):
     )
     assert len(dev_df) == 7
 
-    schema_objects = context.engine_adapter._get_data_objects("sushi__dev")
+    schema_objects = context.engine_adapter.get_data_objects("sushi__dev")
     assert {o.name for o in schema_objects} == {
         "items",
         "order_items",

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -80,7 +80,7 @@ def adapter_mock(mocker: MockerFixture):
     adapter_mock.dialect = "duckdb"
     adapter_mock.HAS_VIEW_BINDING = False
     adapter_mock.wap_supported.return_value = False
-    adapter_mock.list_data_objects.return_value = []
+    adapter_mock.get_data_objects.return_value = []
     return adapter_mock
 
 
@@ -541,7 +541,7 @@ def test_create_object_exists(mocker: MockerFixture, adapter_mock, make_snapshot
     snapshot = make_snapshot(model)
     snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
 
-    adapter_mock.list_data_objects.return_value = [
+    adapter_mock.get_data_objects.return_value = [
         DataObject(
             name=f"test_schema__test_model__{snapshot.version}__temp",
             schema="sqlmesh__test_schema",
@@ -552,7 +552,7 @@ def test_create_object_exists(mocker: MockerFixture, adapter_mock, make_snapshot
 
     evaluator.create([snapshot], {})
     adapter_mock.create_view.assert_not_called()
-    adapter_mock.list_data_objects.assert_called_once_with(
+    adapter_mock.get_data_objects.assert_called_once_with(
         schema_("sqlmesh__test_schema"), {f"test_schema__test_model__{snapshot.version}__temp"}
     )
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -10,7 +10,11 @@ from sqlmesh.core.audit import ModelAudit, StandaloneAudit
 from sqlmesh.core.dialect import schema_, to_schema
 from sqlmesh.core.engine_adapter import EngineAdapter, create_engine_adapter
 from sqlmesh.core.engine_adapter.base import MERGE_SOURCE_ALIAS, MERGE_TARGET_ALIAS
-from sqlmesh.core.engine_adapter.shared import InsertOverwriteStrategy
+from sqlmesh.core.engine_adapter.shared import (
+    DataObject,
+    DataObjectType,
+    InsertOverwriteStrategy,
+)
 from sqlmesh.core.environment import EnvironmentNamingInfo
 from sqlmesh.core.macros import RuntimeStage, macro
 from sqlmesh.core.model import (
@@ -76,6 +80,7 @@ def adapter_mock(mocker: MockerFixture):
     adapter_mock.dialect = "duckdb"
     adapter_mock.HAS_VIEW_BINDING = False
     adapter_mock.wap_supported.return_value = False
+    adapter_mock.list_data_objects.return_value = []
     return adapter_mock
 
 
@@ -516,6 +521,40 @@ def test_evaluate_incremental_unmanaged(
             model.render_query(),
             columns_to_types=model.columns_to_types,
         )
+
+
+def test_create_object_exists(mocker: MockerFixture, adapter_mock, make_snapshot):
+
+    model = load_sql_based_model(
+        parse(  # type: ignore
+            """
+            MODEL (
+                name test_schema.test_model,
+                kind VIEW
+            );
+
+            SELECT a::int FROM tbl;
+            """
+        ),
+    )
+
+    snapshot = make_snapshot(model)
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    adapter_mock.list_data_objects.return_value = [
+        DataObject(
+            name=f"test_schema__test_model__{snapshot.version}__temp",
+            schema="sqlmesh__test_schema",
+            type=DataObjectType.VIEW,
+        ),
+    ]
+    evaluator = SnapshotEvaluator(adapter_mock)
+
+    evaluator.create([snapshot], {})
+    adapter_mock.create_view.assert_not_called()
+    adapter_mock.list_data_objects.assert_called_once_with(
+        schema_("sqlmesh__test_schema"), {f"test_schema__test_model__{snapshot.version}__temp"}
+    )
 
 
 def test_create_materialized_view(mocker: MockerFixture, adapter_mock, make_snapshot):

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -32,7 +32,7 @@ pytestmark = [
 
 
 def get_environment_objects(controller: GithubController, environment: str) -> t.List[DataObject]:
-    return controller._context.engine_adapter._get_data_objects(f"sushi__{environment}")
+    return controller._context.engine_adapter.get_data_objects(f"sushi__{environment}")
 
 
 def get_num_days_loaded(controller: GithubController, environment: str, model: str) -> int:

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -399,6 +399,7 @@ def test_select_models_for_backfill(mocker: MockerFixture, random_name, make_sna
         dag_start_ts=to_timestamp("2023-01-01"),
         deployability_index=DeployabilityIndex.all_deployable(),
         no_gaps_snapshot_names={'"a"', '"b"'},
+        models_to_backfill={snapshot_b.name},
     )
 
 


### PR DESCRIPTION
This update makes sure that physical tables for snapshots are created lazily when they are actually needed. This is particularly helpful when using the model selector, in which case we create tables for selected models only.

Additionally, this update has a nice side effect of adding self-healing properties to the plan / apply flow by automatically re-creating snapshot tables if they happen to be missing.