### PR TITLE
Fix: When deleting expired snapshots in janitor only fetch relevant snapshot records

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1036,6 +1036,10 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
             return None
         return t.cast(Model, self.node).fully_qualified_table
 
+    @property
+    def expiration_ts(self) -> int:
+        return to_timestamp(self.ttl, relative_base=to_datetime(self.updated_ts))
+
     def _ensure_categorized(self) -> None:
         if not self.change_category:
             raise SQLMeshError(f"Snapshot {self.snapshot_id} has not been categorized yet.")

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -57,12 +57,15 @@ from sqlmesh.core.snapshot.definition import (
 )
 from sqlmesh.core.state_sync.base import MIGRATIONS, SCHEMA_VERSION, StateSync, Versions
 from sqlmesh.core.state_sync.common import CommonStateSyncMixin, transactional
-from sqlmesh.utils import major_minor, random_id
+from sqlmesh.utils import major_minor, random_id, unique
 from sqlmesh.utils.date import TimeLike, now_timestamp, time_like_to_str
 from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.pydantic import parse_obj_as
 
 logger = logging.getLogger(__name__)
+
+
+T = t.TypeVar("T")
 
 
 if t.TYPE_CHECKING:
@@ -274,14 +277,8 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
             )
             for name, identifier, version in self.engine_adapter.fetchall(expired_query)
         }
-
-        snapshots = self._get_snapshots_with_same_version(set(expired_candidates.values()))
-
-        snapshots_by_version = defaultdict(set)
-        snapshots_by_temp_version = defaultdict(set)
-        for s in snapshots:
-            snapshots_by_version[(s.name, s.version)].add(s.snapshot_id)
-            snapshots_by_temp_version[(s.name, s.temp_version_get_or_generate())].add(s.snapshot_id)
+        if not expired_candidates:
+            return []
 
         promoted_snapshot_ids = {
             snapshot.snapshot_id
@@ -295,27 +292,41 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
                 or snapshot.snapshot_id not in expired_candidates
             )
 
-        expired_snapshots = [s for s in snapshots if not _is_snapshot_used(s)]
-
-        if expired_snapshots:
-            self.delete_snapshots(expired_snapshots)
-
+        unique_expired_versions = unique(expired_candidates.values())
+        version_batches = self._snapshot_batches(unique_expired_versions)
         cleanup_targets = []
-        for snapshot in expired_snapshots:
-            shared_version_snapshots = snapshots_by_version[(snapshot.name, snapshot.version)]
-            shared_version_snapshots.discard(snapshot.snapshot_id)
+        for versions_batch in version_batches:
+            snapshots = self._get_snapshots_with_same_version(versions_batch)
 
-            shared_temp_version_snapshots = snapshots_by_temp_version[
-                (snapshot.name, snapshot.temp_version_get_or_generate())
-            ]
-            shared_temp_version_snapshots.discard(snapshot.snapshot_id)
-
-            if not shared_temp_version_snapshots:
-                cleanup_targets.append(
-                    SnapshotTableCleanupTask(
-                        snapshot=snapshot.table_info, dev_table_only=bool(shared_version_snapshots)
-                    )
+            snapshots_by_version = defaultdict(set)
+            snapshots_by_temp_version = defaultdict(set)
+            for s in snapshots:
+                snapshots_by_version[(s.name, s.version)].add(s.snapshot_id)
+                snapshots_by_temp_version[(s.name, s.temp_version_get_or_generate())].add(
+                    s.snapshot_id
                 )
+
+            expired_snapshots = [s for s in snapshots if not _is_snapshot_used(s)]
+
+            if expired_snapshots:
+                self.delete_snapshots(expired_snapshots)
+
+            for snapshot in expired_snapshots:
+                shared_version_snapshots = snapshots_by_version[(snapshot.name, snapshot.version)]
+                shared_version_snapshots.discard(snapshot.snapshot_id)
+
+                shared_temp_version_snapshots = snapshots_by_temp_version[
+                    (snapshot.name, snapshot.temp_version_get_or_generate())
+                ]
+                shared_temp_version_snapshots.discard(snapshot.snapshot_id)
+
+                if not shared_temp_version_snapshots:
+                    cleanup_targets.append(
+                        SnapshotTableCleanupTask(
+                            snapshot=snapshot.table_info,
+                            dev_table_only=bool(shared_version_snapshots),
+                        )
+                    )
 
         return cleanup_targets
 
@@ -1096,11 +1107,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         name_identifiers = sorted(
             {(snapshot_id.name, snapshot_id.identifier) for snapshot_id in snapshot_ids}
         )
-
-        batches = [
-            name_identifiers[i : i + self.SNAPSHOT_BATCH_SIZE]
-            for i in range(0, len(name_identifiers), self.SNAPSHOT_BATCH_SIZE)
-        ]
+        batches = self._snapshot_batches(name_identifiers)
 
         if not name_identifiers:
             yield exp.false()
@@ -1131,11 +1138,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         self, snapshot_name_versions: t.Iterable[SnapshotNameVersionLike], alias: str = "snapshots"
     ) -> t.Iterator[exp.Condition]:
         name_versions = sorted({(s.name, s.version) for s in snapshot_name_versions})
-
-        batches = [
-            name_versions[i : i + self.SNAPSHOT_BATCH_SIZE]
-            for i in range(0, len(name_versions), self.SNAPSHOT_BATCH_SIZE)
-        ]
+        batches = self._snapshot_batches(name_versions)
 
         if not name_versions:
             return exp.false()
@@ -1161,6 +1164,11 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
                         for name, version in versions
                     ]
                 )
+
+    def _snapshot_batches(self, l: t.List[T]) -> t.List[t.List[T]]:
+        return [
+            l[i : i + self.SNAPSHOT_BATCH_SIZE] for i in range(0, len(l), self.SNAPSHOT_BATCH_SIZE)
+        ]
 
     @contextlib.contextmanager
     def _transaction(self) -> t.Iterator[None]:

--- a/sqlmesh/migrations/v0038_add_expiration_ts_to_snapshot.py
+++ b/sqlmesh/migrations/v0038_add_expiration_ts_to_snapshot.py
@@ -1,0 +1,69 @@
+"""Add the expiration_ts column to the snapshots table."""
+import json
+
+import pandas as pd
+from sqlglot import exp
+
+from sqlmesh.utils.date import to_datetime, to_timestamp
+from sqlmesh.utils.migration import index_text_type
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+
+    index_type = index_text_type(engine_adapter.dialect)
+
+    alter_table_exp = exp.AlterTable(
+        this=exp.to_table(snapshots_table),
+        actions=[
+            exp.ColumnDef(
+                this=exp.to_column("expiration_ts"),
+                kind=exp.DataType.build("bigint"),
+            )
+        ],
+    )
+    engine_adapter.execute(alter_table_exp)
+
+    new_snapshots = []
+
+    for name, identifier, version, snapshot, kind_name in engine_adapter.fetchall(
+        exp.select("name", "identifier", "version", "snapshot", "kind_name").from_(snapshots_table),
+        quote_identifiers=True,
+    ):
+        parsed_snapshot = json.loads(snapshot)
+
+        updated_ts = parsed_snapshot["updated_ts"]
+        ttl = parsed_snapshot["ttl"]
+        expiration_ts = to_timestamp(ttl, relative_base=to_datetime(updated_ts))
+
+        new_snapshots.append(
+            {
+                "name": name,
+                "identifier": identifier,
+                "version": version,
+                "snapshot": snapshot,
+                "kind_name": kind_name,
+                "expiration_ts": expiration_ts,
+            }
+        )
+
+    if new_snapshots:
+        engine_adapter.delete_from(snapshots_table, "TRUE")
+
+        engine_adapter.insert_append(
+            snapshots_table,
+            pd.DataFrame(new_snapshots),
+            columns_to_types={
+                "name": exp.DataType.build(index_type),
+                "identifier": exp.DataType.build(index_type),
+                "version": exp.DataType.build(index_type),
+                "snapshot": exp.DataType.build("text"),
+                "kind_name": exp.DataType.build(index_type),
+                "expiration_ts": exp.DataType.build("bigint"),
+            },
+            contains_json=True,
+        )

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -909,8 +909,8 @@ def test_delete_expired_snapshots_promoted(
     env.snapshots = []
     state_sync.promote(env)
 
-    now_mock = mocker.patch("sqlmesh.core.state_sync.common.now")
-    now_mock.return_value = to_datetime(now_timestamp() + 11000)
+    now_timestamp_mock = mocker.patch("sqlmesh.core.state_sync.engine_adapter.now_timestamp")
+    now_timestamp_mock.return_value = now_timestamp() + 11000
 
     assert state_sync.delete_expired_snapshots() == [
         SnapshotTableCleanupTask(snapshot=snapshot.table_info, dev_table_only=False)


### PR DESCRIPTION
Previously,  the janitor process would fetch all snapshot records to figure out what needs to be cleaned up. This led to a large memory footprint for projects with many models and / or changes.

This update ensures that only records that actually expired are fetched from the state DB.