### PR TITLE
Fix: Fetch snapshot records on demand when generating Airflow dags

### DIFF
--- a/sqlmesh/migrations/v0039_include_environment_in_plan_dag_spec.py
+++ b/sqlmesh/migrations/v0039_include_environment_in_plan_dag_spec.py
@@ -1,0 +1,65 @@
+"""Include environment in plan dag spec."""
+import json
+
+import pandas as pd
+from sqlglot import exp
+
+from sqlmesh.utils.migration import index_text_type
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    plan_dags_table = "_plan_dags"
+    if state_sync.schema:
+        plan_dags_table = f"{schema}.{plan_dags_table}"
+
+    new_specs = []
+
+    for request_id, dag_id, dag_spec in engine_adapter.fetchall(
+        exp.select("request_id", "dag_id", "dag_spec").from_(plan_dags_table),
+        quote_identifiers=True,
+    ):
+        parsed_dag_spec = json.loads(dag_spec)
+
+        environment_naming_info = parsed_dag_spec.pop("environment_naming_info")
+        promoted_snapshots = parsed_dag_spec.pop("promoted_snapshots", [])
+        start = parsed_dag_spec.pop("start")
+        parsed_dag_spec.pop("end", None)
+        plan_id = parsed_dag_spec.pop("plan_id")
+        previous_plan_id = parsed_dag_spec.pop("previous_plan_id", None)
+        expiration_ts = parsed_dag_spec.pop("environment_expiration_ts", None)
+
+        parsed_dag_spec["environment"] = {
+            **environment_naming_info,
+            "snapshots": promoted_snapshots,
+            "start_at": start,
+            "end_at": start,
+            "plan_id": plan_id,
+            "previous_plan_id": previous_plan_id,
+            "expiration_ts": expiration_ts,
+        }
+
+        new_specs.append(
+            {
+                "request_id": request_id,
+                "dag_id": dag_id,
+                "dag_spec": json.dumps(parsed_dag_spec),
+            }
+        )
+
+    if new_specs:
+        engine_adapter.delete_from(plan_dags_table, "TRUE")
+
+        index_type = index_text_type(engine_adapter.dialect)
+
+        engine_adapter.insert_append(
+            plan_dags_table,
+            pd.DataFrame(new_specs),
+            columns_to_types={
+                "request_id": exp.DataType.build(index_type),
+                "dag_id": exp.DataType.build(index_type),
+                "dag_spec": exp.DataType.build("text"),
+            },
+            contains_json=True,
+        )

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 
 from sqlmesh.core import constants as c
-from sqlmesh.core.environment import Environment, EnvironmentNamingInfo
+from sqlmesh.core.environment import Environment
 from sqlmesh.core.notification_target import NotificationTarget
 from sqlmesh.core.scheduler import Interval
 from sqlmesh.core.snapshot import (
@@ -63,24 +63,18 @@ class BackfillIntervalsPerSnapshot(PydanticModel):
 
 class PlanDagSpec(PydanticModel):
     request_id: str
-    environment_naming_info: EnvironmentNamingInfo
+    environment: Environment
     new_snapshots: t.List[Snapshot]
     backfill_intervals_per_snapshot: t.List[BackfillIntervalsPerSnapshot]
-    promoted_snapshots: t.List[SnapshotTableInfo]
     demoted_snapshots: t.List[SnapshotTableInfo]
-    start: TimeLike
-    end: t.Optional[TimeLike] = None
     unpaused_dt: t.Optional[TimeLike] = None
     no_gaps: bool
-    plan_id: str
-    previous_plan_id: t.Optional[str] = None
     notification_targets: t.List[NotificationTarget]
     backfill_concurrent_tasks: int
     ddl_concurrent_tasks: int
     users: t.List[User]
     is_dev: bool
     forward_only: t.Optional[bool] = None
-    environment_expiration_ts: t.Optional[int] = None
     dag_start_ts: t.Optional[int] = None
     deployability_index: DeployabilityIndex = DeployabilityIndex.all_deployable()
     deployability_index_for_creation: DeployabilityIndex = DeployabilityIndex.all_deployable()

--- a/sqlmesh/schedulers/airflow/plan.py
+++ b/sqlmesh/schedulers/airflow/plan.py
@@ -48,7 +48,7 @@ class PlanDagState:
                 {
                     "request_id": spec.request_id,
                     "dag_id": common.plan_application_dag_id(
-                        spec.environment_naming_info.name, spec.request_id
+                        spec.environment.name, spec.request_id
                     ),
                     "dag_spec": spec.json(),
                 }
@@ -154,24 +154,18 @@ def create_plan_dag_spec(
 
     return common.PlanDagSpec(
         request_id=request.request_id,
-        environment_naming_info=request.environment.naming_info,
+        environment=request.environment,
         new_snapshots=request.new_snapshots,
         backfill_intervals_per_snapshot=backfill_intervals_per_snapshot,
-        promoted_snapshots=request.environment.promoted_snapshots,
         demoted_snapshots=_get_demoted_snapshots(request.environment, state_sync),
-        start=request.environment.start_at,
-        end=request.environment.end_at,
         unpaused_dt=unpaused_dt,
         no_gaps=request.no_gaps,
-        plan_id=request.environment.plan_id,
-        previous_plan_id=request.environment.previous_plan_id,
         notification_targets=request.notification_targets,
         backfill_concurrent_tasks=request.backfill_concurrent_tasks,
         ddl_concurrent_tasks=request.ddl_concurrent_tasks,
         users=request.users,
         is_dev=request.is_dev,
         forward_only=request.forward_only,
-        environment_expiration_ts=request.environment.expiration_ts,
         dag_start_ts=to_timestamp(now_dt),
         deployability_index=deployability_index_for_evaluation,
         deployability_index_for_creation=deployability_index_for_creation,

--- a/sqlmesh/schedulers/airflow/util.py
+++ b/sqlmesh/schedulers/airflow/util.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import Session
 from sqlmesh.core import constants as c
 from sqlmesh.core.config import parse_connection_config
 from sqlmesh.core.engine_adapter import create_engine_adapter
-from sqlmesh.core.state_sync import EngineAdapterStateSync, StateSync
+from sqlmesh.core.state_sync import CachingStateSync, EngineAdapterStateSync, StateSync
 from sqlmesh.schedulers.airflow import common
 from sqlmesh.utils.date import now
 from sqlmesh.utils.errors import SQLMeshError
@@ -63,7 +63,7 @@ def scoped_state_sync() -> t.Iterator[StateSync]:
         )
 
     try:
-        yield EngineAdapterStateSync(engine_adapter, state_schema)
+        yield CachingStateSync(EngineAdapterStateSync(engine_adapter, state_schema))  # type: ignore
     finally:
         engine_adapter.close()
 

--- a/tests/schedulers/airflow/operators/test_hwm_sensor.py
+++ b/tests/schedulers/airflow/operators/test_hwm_sensor.py
@@ -30,7 +30,7 @@ def test_no_current_hwm(mocker: MockerFixture, make_snapshot, random_name):
     )
 
     get_snapshots_mock = mocker.patch(
-        "sqlmesh.core.state_sync.engine_adapter.EngineAdapterStateSync.get_snapshots"
+        "sqlmesh.core.state_sync.cache.CachingStateSync.get_snapshots"
     )
     get_snapshots_mock.return_value = {target_snapshot.snapshot_id: target_snapshot}
 
@@ -68,7 +68,7 @@ def test_current_hwm_below_target(mocker: MockerFixture, make_snapshot):
     )
 
     get_snapshots_mock = mocker.patch(
-        "sqlmesh.core.state_sync.engine_adapter.EngineAdapterStateSync.get_snapshots"
+        "sqlmesh.core.state_sync.cache.CachingStateSync.get_snapshots"
     )
     get_snapshots_mock.return_value = {target_snapshot_v1.snapshot_id: target_snapshot_v1}
 
@@ -101,7 +101,7 @@ def test_current_hwm_above_target(mocker: MockerFixture, make_snapshot):
     )
 
     get_snapshots_mock = mocker.patch(
-        "sqlmesh.core.state_sync.engine_adapter.EngineAdapterStateSync.get_snapshots"
+        "sqlmesh.core.state_sync.cache.CachingStateSync.get_snapshots"
     )
     get_snapshots_mock.return_value = {target_snapshot_v1.snapshot_id: target_snapshot_v1}
 

--- a/tests/schedulers/airflow/operators/test_targets.py
+++ b/tests/schedulers/airflow/operators/test_targets.py
@@ -45,9 +45,7 @@ def test_evaluation_target_execute(mocker: MockerFixture, make_snapshot: t.Calla
     )
     evaluator_evaluate_mock.return_value = None
 
-    add_interval_mock = mocker.patch(
-        "sqlmesh.core.state_sync.engine_adapter.EngineAdapterStateSync.add_interval"
-    )
+    add_interval_mock = mocker.patch("sqlmesh.core.state_sync.cache.CachingStateSync.add_interval")
 
     variable_get_mock = mocker.patch("sqlmesh.schedulers.airflow.operators.targets.Variable.get")
 
@@ -109,12 +107,10 @@ def test_evaluation_target_execute_seed_model(mocker: MockerFixture, make_snapsh
     )
     evaluator_evaluate_mock.return_value = None
 
-    add_interval_mock = mocker.patch(
-        "sqlmesh.core.state_sync.engine_adapter.EngineAdapterStateSync.add_interval"
-    )
+    add_interval_mock = mocker.patch("sqlmesh.core.state_sync.cache.CachingStateSync.add_interval")
 
     get_snapshots_mock = mocker.patch(
-        "sqlmesh.core.state_sync.engine_adapter.EngineAdapterStateSync.get_snapshots"
+        "sqlmesh.core.state_sync.cache.CachingStateSync.get_snapshots"
     )
     get_snapshots_mock.return_value = {snapshot.snapshot_id: snapshot}
 

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -10,7 +10,7 @@ from sqlglot import parse_one
 
 from sqlmesh.core.config import EnvironmentSuffixTarget
 from sqlmesh.core.context import Context
-from sqlmesh.core.environment import Environment, EnvironmentNamingInfo
+from sqlmesh.core.environment import Environment
 from sqlmesh.core.model import (
     IncrementalByTimeRangeKind,
     ModelKindName,
@@ -26,7 +26,7 @@ from sqlmesh.core.snapshot import (
 )
 from sqlmesh.schedulers.airflow import common
 from sqlmesh.schedulers.airflow.plan import PlanDagState, create_plan_dag_spec
-from sqlmesh.utils.date import to_datetime, to_timestamp
+from sqlmesh.utils.date import to_date, to_datetime, to_timestamp
 from sqlmesh.utils.errors import SQLMeshError
 
 pytestmark = pytest.mark.airflow
@@ -152,11 +152,7 @@ def test_create_plan_dag_spec(
         plan_spec = create_plan_dag_spec(plan_request, state_sync_mock)
     assert plan_spec == common.PlanDagSpec(
         request_id="test_request_id",
-        environment_naming_info=EnvironmentNamingInfo(
-            name=environment_name,
-            suffix_target=EnvironmentSuffixTarget.TABLE,
-            catalog_name_override="test_catalog",
-        ),
+        environment=new_environment,
         new_snapshots=[the_snapshot],
         backfill_intervals_per_snapshot=[
             common.BackfillIntervalsPerSnapshot(
@@ -165,14 +161,9 @@ def test_create_plan_dag_spec(
                 before_promote=not paused_forward_only,
             )
         ],
-        promoted_snapshots=[the_snapshot.table_info],
         demoted_snapshots=[deleted_snapshot],
-        start="2022-01-01",
-        end="2022-01-04",
         unpaused_dt="2022-01-04",
         no_gaps=True,
-        plan_id="test_plan_id",
-        previous_plan_id=None,
         notification_targets=[],
         backfill_concurrent_tasks=1,
         ddl_concurrent_tasks=1,
@@ -267,9 +258,7 @@ def test_restatement(
 
     assert plan_spec == common.PlanDagSpec(
         request_id="test_request_id",
-        environment_naming_info=EnvironmentNamingInfo(
-            name=environment_name, suffix_target=EnvironmentSuffixTarget.SCHEMA
-        ),
+        environment=new_environment,
         new_snapshots=[],
         backfill_intervals_per_snapshot=[
             common.BackfillIntervalsPerSnapshot(
@@ -277,14 +266,9 @@ def test_restatement(
                 intervals=expected_intervals,
             )
         ],
-        promoted_snapshots=[the_snapshot.table_info],
         demoted_snapshots=[],
-        start="2022-01-01",
-        end="2022-01-07",
         unpaused_dt=None,
         no_gaps=True,
-        plan_id="test_plan_id",
-        previous_plan_id=None,
         notification_targets=[],
         backfill_concurrent_tasks=1,
         ddl_concurrent_tasks=1,
@@ -371,9 +355,7 @@ def test_select_models_for_backfill(mocker: MockerFixture, random_name, make_sna
 
     assert plan_spec == common.PlanDagSpec(
         request_id="test_request_id",
-        environment_naming_info=EnvironmentNamingInfo(
-            name=environment_name, suffix_target=EnvironmentSuffixTarget.TABLE
-        ),
+        environment=new_environment,
         new_snapshots=[snapshot_a, snapshot_b],
         backfill_intervals_per_snapshot=[
             common.BackfillIntervalsPerSnapshot(
@@ -382,14 +364,9 @@ def test_select_models_for_backfill(mocker: MockerFixture, random_name, make_sna
                 before_promote=True,
             )
         ],
-        promoted_snapshots=[snapshot_a.table_info, snapshot_b.table_info],
         demoted_snapshots=[],
-        start="2022-01-01",
-        end="2022-01-04",
         unpaused_dt="2022-01-04",
         no_gaps=True,
-        plan_id="test_plan_id",
-        previous_plan_id=None,
         notification_targets=[],
         backfill_concurrent_tasks=1,
         ddl_concurrent_tasks=1,
@@ -497,21 +474,21 @@ def test_create_plan_dag_spec_unbounded_end(
 
 def test_plan_dag_state(snapshot: Snapshot, sushi_context: Context, random_name):
     environment_name = random_name()
+    environment = Environment(
+        name=environment_name,
+        snapshots=[snapshot.table_info],
+        start_at=to_date("2022-01-01"),
+        end_at=None,
+        plan_id="test_plan_id",
+    )
     plan_dag_spec = common.PlanDagSpec(
         request_id="test_request_id",
-        environment_naming_info=EnvironmentNamingInfo(
-            name=environment_name, suffix_target=EnvironmentSuffixTarget.SCHEMA
-        ),
+        environment=environment,
         new_snapshots=[],
         backfill_intervals_per_snapshot=[],
-        promoted_snapshots=[snapshot.table_info],
         demoted_snapshots=[],
-        start=to_timestamp("2022-01-02"),
-        end=None,
         unpaused_dt=None,
         no_gaps=True,
-        plan_id="test_plan_id",
-        previous_plan_id=None,
         notification_targets=[],
         backfill_concurrent_tasks=1,
         ddl_concurrent_tasks=1,

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -26,7 +26,7 @@ from sqlmesh.core.snapshot import (
 )
 from sqlmesh.schedulers.airflow import common
 from sqlmesh.schedulers.airflow.plan import PlanDagState, create_plan_dag_spec
-from sqlmesh.utils.date import to_date, to_datetime, to_timestamp
+from sqlmesh.utils.date import to_datetime, to_timestamp
 from sqlmesh.utils.errors import SQLMeshError
 
 pytestmark = pytest.mark.airflow
@@ -477,7 +477,7 @@ def test_plan_dag_state(snapshot: Snapshot, sushi_context: Context, random_name)
     environment = Environment(
         name=environment_name,
         snapshots=[snapshot.table_info],
-        start_at=to_date("2022-01-01"),
+        start_at=to_timestamp("2022-01-01"),
         end_at=None,
         plan_id="test_plan_id",
     )


### PR DESCRIPTION
Currently we fetch all snapshots on the scheduler side which may lead to high memory consumption there. Additionally we had passed all these snapshots into underlying DAG tasks potentially causing high memory consumption at the execution time which could lead to tasks being SIGKILLed.