### PR TITLE
fix: Spark Create Table DDL WAP

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -1055,7 +1055,6 @@ class MaterializableStrategy(PromotableStrategy):
         if model.annotated:
             self.adapter.create_table(
                 name,
-                exists=False,
                 columns_to_types=model.columns_to_types_or_raise,
                 storage_format=model.storage_format,
                 partitioned_by=model.partitioned_by,
@@ -1077,7 +1076,6 @@ class MaterializableStrategy(PromotableStrategy):
                 name,
                 ctas_query,
                 model.columns_to_types,
-                exists=False,
                 storage_format=model.storage_format,
                 partitioned_by=model.partitioned_by,
                 partition_interval_unit=model.interval_unit,
@@ -1233,7 +1231,6 @@ class SCDType2Strategy(MaterializableStrategy):
             columns_to_types[model.kind.updated_at_name] = model.kind.time_data_type
             self.adapter.create_table(
                 name,
-                exists=False,
                 columns_to_types=columns_to_types,
                 storage_format=model.storage_format,
                 partitioned_by=model.partitioned_by,

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -1055,6 +1055,7 @@ class MaterializableStrategy(PromotableStrategy):
         if model.annotated:
             self.adapter.create_table(
                 name,
+                exists=False,
                 columns_to_types=model.columns_to_types_or_raise,
                 storage_format=model.storage_format,
                 partitioned_by=model.partitioned_by,
@@ -1076,6 +1077,7 @@ class MaterializableStrategy(PromotableStrategy):
                 name,
                 ctas_query,
                 model.columns_to_types,
+                exists=False,
                 storage_format=model.storage_format,
                 partitioned_by=model.partitioned_by,
                 partition_interval_unit=model.interval_unit,
@@ -1231,6 +1233,7 @@ class SCDType2Strategy(MaterializableStrategy):
             columns_to_types[model.kind.updated_at_name] = model.kind.time_data_type
             self.adapter.create_table(
                 name,
+                exists=False,
                 columns_to_types=columns_to_types,
                 storage_format=model.storage_format,
                 partitioned_by=model.partitioned_by,

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -34,7 +34,6 @@ def test_create_table_properties(make_mocked_engine_adapter: t.Callable):
     )
 
     assert to_sql_calls(adapter) == [
-        "DESCRIBE `test_table`",
         "CREATE TABLE IF NOT EXISTS `test_table` (`cola` INT, `colb` STRING, `colc` STRING) USING PARQUET PARTITIONED BY (`colb`)",
     ]
 
@@ -47,7 +46,6 @@ def test_create_table_properties(make_mocked_engine_adapter: t.Callable):
     )
 
     assert to_sql_calls(adapter) == [
-        "DESCRIBE `test_table`",
         "CREATE TABLE IF NOT EXISTS `test_table` (`cola` INT, `colb` STRING, `colc` STRING) USING PARQUET PARTITIONED BY (`cola`, `colb`)",
     ]
 
@@ -332,7 +330,6 @@ def test_create_table_table_options(make_mocked_engine_adapter: t.Callable):
     )
 
     assert to_sql_calls(adapter) == [
-        "DESCRIBE `test_table`",
         "CREATE TABLE IF NOT EXISTS `test_table` (`a` int, `b` int) TBLPROPERTIES ('test.conf.key'='value')",
     ]
 
@@ -343,7 +340,6 @@ def test_create_state_table(make_mocked_engine_adapter: t.Callable):
     adapter.create_state_table("test_table", {"a": "int", "b": "int"}, primary_key=["a"])
 
     assert to_sql_calls(adapter) == [
-        "DESCRIBE `test_table`",
         "CREATE TABLE IF NOT EXISTS `test_table` (`a` int, `b` int) PARTITIONED BY (`a`)",
     ]
 
@@ -574,11 +570,9 @@ def test_scd_type_2(
     )
 
     assert to_sql_calls(adapter) == [
-        "DESCRIBE `db`.`target`",
         "CREATE TABLE IF NOT EXISTS `db`.`target` (`id` INT, `name` STRING, `price` DOUBLE, `test_updated_at` TIMESTAMP, `test_valid_from` TIMESTAMP, `test_valid_to` TIMESTAMP)",
         "DESCRIBE `db`.`target`",
         "CREATE SCHEMA IF NOT EXISTS `db`",
-        "DESCRIBE `db`.`temp_target_abcdefgh`",
         "CREATE TABLE IF NOT EXISTS `db`.`temp_target_abcdefgh` AS SELECT `id`, `name`, `price`, `test_updated_at`, `test_valid_from`, `test_valid_to` FROM `db`.`target`",
         parse_one(
             """WITH `source` AS (


### PR DESCRIPTION
Fix after this PR: https://github.com/TobikoData/sqlmesh/pull/2031

The PR introduced a flow where we would create a table if not exists if the query is a self-referencing query. This doesn't work for Spark WAP since spark doesn't let you create a table with a WAP ID at the end. This makes sense because to have the branch you needed to create the table first and then altered it. Therefore this PR updates Spark's create table to issue the create table on the table itself without the branch. 

While working on that fix I noticed a different issue: If `_create_table` was called with `IF NOT EXISTS` included and was Iceberg and WAP capable then we would do the "Dummy" Insert into call: https://github.com/TobikoData/sqlmesh/blob/f583fcec955e9433f755737ecbab279888643fc0/sqlmesh/core/engine_adapter/spark.py#L466

The problem would be if the table has data in it which is possible since we could have done "CREATE IF NOT EXIST" and it did exist and have data. In that case we would duplicate all of the data. Therefore I also add an exists check to ensure that we only create the dummy snapshot if the table was actually created. 