### PR TITLE
fix!: ignore private attributes doing equality pydantic

### DIFF
--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 from sqlmesh.utils.date import TimeLike, to_date, to_datetime
 from sqlmesh.utils.pydantic import PYDANTIC_MAJOR_VERSION, PydanticModel
 
@@ -16,3 +18,44 @@ def test_datetime_date_serialization() -> None:
     else:
         assert deserialized_date.ds == target_ds
         assert deserialized_datetime.ds == "2022-01-01T00:00:00+00:00"
+
+
+def test_pydantic_2_equality() -> None:
+    class TestModel(PydanticModel):
+        name: str
+
+        @cached_property
+        def private(self) -> str:
+            return "should be ignored"
+
+    model_a = TestModel(name="a")
+    model_a_duplicate = TestModel(name="a")
+    assert model_a == model_a_duplicate
+    model_b = TestModel(name="b")
+    assert model_a != model_b
+
+
+def test_pydantic_2_hash() -> None:
+    class TestModel(PydanticModel):
+        name: str
+
+        @cached_property
+        def private(self) -> str:
+            return "should be ignored"
+
+    class TestModel2(PydanticModel):
+        name: str
+        field2: str = "test"
+
+        @cached_property
+        def private(self) -> str:
+            return "should be ignored"
+
+    model_a = TestModel(name="a")
+    model_a_duplicate = TestModel(name="a")
+    assert hash(model_a) == hash(model_a_duplicate)
+
+    model_2_a = TestModel2(name="a")
+    model_2_b = TestModel2(name="a")
+    assert hash(model_2_a) == hash(model_2_b)
+    assert hash(model_a) != hash(model_2_a)


### PR DESCRIPTION
We have an issue that Pydantic includes private attributes in the equality check:
https://github.com/pydantic/pydantic/blob/b785d5b1db4eccb922dd2bf17faea5fc842e6a57/pydantic/main.py#L880

We use these for caching values. When we do equality checks our intent is to check if the public attributes of the class are the same and not if the cached attributes are equal. 

This PR has a way of solving this problem but involves mutating the actual objects themselves so it would be best if we had a solution that didn't involve that. Are there Pydantic config properties that can help us here? @izeigerman do you have any ideas? I want to find a solution that works for all Pydantic classes instead requiring each one to provide an override if they introduce private attributes. 