### PR TITLE
chore: pin pytest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,8 @@ setup(
             "psycopg2-binary",
             "pyarrow>=10.0.1,<10.1.0",
             "PyGithub",
-            "pytest",
+            # 8.0.0 broke compatability with lazy-fixture
+            "pytest<8.0.0",
             "pytest-asyncio<0.23.0",
             "pytest-lazy-fixture",
             "pytest-mock",


### PR DESCRIPTION
Pytest just made a new major release: https://github.com/pytest-dev/pytest/releases/tag/8.0.0

It has a bunch of breaking changes and at a minimum broke compatibility with `pytest-lazy-fixture`. Therefore pinning for now until we can ensure full compatibility. 