### PR TITLE
fix: context close on Create/Update/Delete operations

### DIFF
--- a/sqlmesh/cli/__init__.py
+++ b/sqlmesh/cli/__init__.py
@@ -5,6 +5,7 @@ from functools import wraps
 import click
 from sqlglot.errors import SqlglotError
 
+from sqlmesh.core.context import Context
 from sqlmesh.utils import debug_mode_enabled
 from sqlmesh.utils.concurrency import NodeExecutionFailedError
 from sqlmesh.utils.errors import SQLMeshError
@@ -19,15 +20,21 @@ def error_handler(
     func: t.Callable[..., DECORATOR_RETURN_TYPE]
 ) -> t.Callable[..., DECORATOR_RETURN_TYPE]:
     @wraps(func)
-    def wrapper(*args: t.Any, **kwargs: t.Any) -> DECORATOR_RETURN_TYPE:
+    def wrapper(*args: t.List[t.Any], **kwargs: t.Any) -> DECORATOR_RETURN_TYPE:
+        context_or_obj = args[0]
+        sqlmesh_context = (
+            context_or_obj.obj if isinstance(context_or_obj, click.Context) else context_or_obj
+        )
+        if not isinstance(sqlmesh_context, Context):
+            sqlmesh_context = None
         handler = _debug_exception_handler if debug_mode_enabled() else _default_exception_handler
-        return handler(lambda: func(*args, **kwargs))
+        return handler(sqlmesh_context, lambda: func(*args, **kwargs))
 
     return wrapper
 
 
 def _default_exception_handler(
-    func: t.Callable[[], DECORATOR_RETURN_TYPE]
+    context: t.Optional[Context], func: t.Callable[[], DECORATOR_RETURN_TYPE]
 ) -> DECORATOR_RETURN_TYPE:
     try:
         return func()
@@ -36,11 +43,19 @@ def _default_exception_handler(
         raise click.ClickException(f"Failed processing {ex.node}. {cause}")
     except (SQLMeshError, SqlglotError, ValueError) as ex:
         raise click.ClickException(str(ex))
+    finally:
+        if context:
+            context.close()
 
 
-def _debug_exception_handler(func: t.Callable[[], DECORATOR_RETURN_TYPE]) -> DECORATOR_RETURN_TYPE:
+def _debug_exception_handler(
+    context: t.Optional[Context], func: t.Callable[[], DECORATOR_RETURN_TYPE]
+) -> DECORATOR_RETURN_TYPE:
     try:
         return func()
     except Exception:
         logger.exception("Unhandled exception")
         raise
+    finally:
+        if context:
+            context.close()

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -320,16 +320,13 @@ def plan(
     select_models = kwargs.pop("select_model") or None
     backfill_models = kwargs.pop("backfill_model") or None
     context.console.verbose = verbose
-    try:
-        context.plan(
-            environment,
-            restate_models=restate_models,
-            select_models=select_models,
-            backfill_models=backfill_models,
-            **kwargs,
-        )
-    finally:
-        context.close()
+    context.plan(
+        environment,
+        restate_models=restate_models,
+        select_models=select_models,
+        backfill_models=backfill_models,
+        **kwargs,
+    )
 
 
 @cli.command("run")
@@ -347,10 +344,7 @@ def plan(
 def run(ctx: click.Context, environment: t.Optional[str] = None, **kwargs: t.Any) -> None:
     """Evaluate missing intervals for the target environment."""
     context = ctx.obj
-    try:
-        success = context.run(environment, **kwargs)
-    finally:
-        context.close()
+    success = context.run(environment, **kwargs)
     if not success:
         raise click.ClickException("Run DAG Failed. See output for details.")
 
@@ -362,10 +356,7 @@ def run(ctx: click.Context, environment: t.Optional[str] = None, **kwargs: t.Any
 def invalidate(ctx: click.Context, environment: str) -> None:
     """Invalidate the target environment, forcing its removal during the next run of the janitor process."""
     context = ctx.obj
-    try:
-        context.invalidate_environment(environment)
-    finally:
-        context.close()
+    context.invalidate_environment(environment)
 
 
 @cli.command("dag")

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -550,10 +550,7 @@ def ui(
 @error_handler
 def migrate(ctx: click.Context) -> None:
     """Migrate SQLMesh to the current running version."""
-    try:
-        ctx.obj.migrate()
-    finally:
-        ctx.obj.close()
+    ctx.obj.migrate()
 
 
 @cli.command("rollback")
@@ -561,10 +558,7 @@ def migrate(ctx: click.Context) -> None:
 @error_handler
 def rollback(obj: Context) -> None:
     """Rollback SQLMesh to the previous migration."""
-    try:
-        obj.rollback()
-    finally:
-        obj.close()
+    obj.rollback()
 
 
 @cli.command("create_external_models")


### PR DESCRIPTION
Part of the fix for this issue: https://github.com/TobikoData/sqlmesh/issues/2037

It makes sense that we close connections when using CLI prior to exiting. Open question about how we would mimic this in environments with long-running python instances (Notebook/UI) but fixing in CLI for now. 