### PR TITLE
fix: share duckdb adapter is overlapping data files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from pytest_mock.plugin import MockerFixture
 from sqlglot import exp, maybe_parse, parse_one
 from sqlglot.helper import ensure_list
 
+from sqlmesh.core.config import DuckDBConnectionConfig
 from sqlmesh.core.context import Context
 from sqlmesh.core.engine_adapter.base import EngineAdapter
 from sqlmesh.core.macros import macro
@@ -174,6 +175,12 @@ def rescope_global_models(request):
     existing_registry = model.get_registry().copy()
     yield
     model.set_registry(existing_registry)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def rescope_duckdb_classvar(request):
+    DuckDBConnectionConfig._data_file_to_adapter = {}
+    yield
 
 
 @pytest.fixture


### PR DESCRIPTION
Part of fix for: https://github.com/TobikoData/sqlmesh/issues/2037

Result of this change: https://github.com/TobikoData/sqlmesh/pull/1975

Prior to this change we would allow multiple adapters to share a common data file for DuckDB. This actually works fine until multiple adapters are created again pointed to the already created file and then the second adapter (typically state sync) will not read any data. This is why testing before of having multiple adapter run a plan and check the result did not show any issues.

The solution is to check when creating a new adapter for DuckDB if the new adapter is going to point to file that overlaps a file already used by another adapter. If so, we just reuse the past adapter. This has a downside that any additional configuration associated with the new adapter is ignored. One could consider merging the previous and new catalogs together if this overlap is detected but then it doesn't address other config. For example, what if the new one has other connection config set? How do we merge those? I'm wondering if this naive approach will work in most cases to where we can handle the more complex situations later. For example we will eventually want to support Motherduck and that could be a good time to rework things with a more robust use-case in mind.