### PR TITLE
fix: Pydantic less than 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "ipywidgets",
         "jinja2",
         "pandas",
-        "pydantic",
+        "pydantic<2.6.0",
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",


### PR DESCRIPTION
2.6 requires email-validator > 2 and our Airflow testing environment requires Airflow 2.3.3. Pinning <2.6 for now until we get this fixed. 