### PR TITLE
fix: minor lineage search visual issues

### DIFF
--- a/web/client/src/library/components/graph/ModelLineage.tsx
+++ b/web/client/src/library/components/graph/ModelLineage.tsx
@@ -427,7 +427,7 @@ function GraphControls({ nodes = [] }: { nodes: Node[] }): JSX.Element {
     <div className="px-2 flex items-center text-xs text-neutral-400 @container">
       <div className="contents">
         <Popover
-          className="flex @lg:hidden bg-none border-none py-1"
+          className="flex @lg:hidden bg-none border-none"
           aria-label="Show lineage node details"
         >
           <Popover.Button

--- a/web/client/src/library/components/graph/ModelLineageSearch.tsx
+++ b/web/client/src/library/components/graph/ModelLineageSearch.tsx
@@ -38,7 +38,7 @@ export default function ModelLineageSearch({
       className={clsx(
         'w-full',
         showSearchInput
-          ? 'block absolute left-0 right-0 z-10 pr-10 bg-dark'
+          ? 'block absolute left-0 right-0 z-10 pr-10 bg-light dark:bg-dark @[40rem]:items-end @[40rem]:justify-end @[40rem]:flex @[40rem]:static @[40rem]:pr-0'
           : 'items-end justify-end flex',
       )}
     >

--- a/web/client/src/library/components/graph/ModelLineageSearch.tsx
+++ b/web/client/src/library/components/graph/ModelLineageSearch.tsx
@@ -38,7 +38,7 @@ export default function ModelLineageSearch({
       className={clsx(
         'w-full',
         showSearchInput
-          ? 'block absolute left-0 right-0 z-10 pr-10 bg-light dark:bg-dark @[40rem]:items-end @[40rem]:justify-end @[40rem]:flex @[40rem]:static @[40rem]:pr-0'
+          ? 'block absolute top-0 left-0 right-0 z-10 pr-10 bg-light dark:bg-dark @[40rem]:items-end @[40rem]:justify-end @[40rem]:flex @[40rem]:static @[40rem]:pr-0'
           : 'items-end justify-end flex',
       )}
     >


### PR DESCRIPTION
- Search overlay is better positioned now (it was a little too high before and now is better aligned with the items it covers up)
- If you open the lineage search at a small size and then increase width, the search overlay will disappear and no longer stay open (with a disappearing close button)
- Light mode background color for search overlay for small screens:
<img width="613" alt="image" src="https://github.com/TobikoData/sqlmesh/assets/81378/997e6179-7370-431f-820a-a36596f296a5">

(dark mode comparison)
<img width="517" alt="image" src="https://github.com/TobikoData/sqlmesh/assets/81378/eb372d0a-03d8-492d-b038-67d3278964ee">