### PR TITLE
Docs: define arrays with parentheses in MODEL DDL

### DIFF
--- a/docs/concepts/audits.md
+++ b/docs/concepts/audits.md
@@ -36,7 +36,7 @@ To run the audit, include it in a model's `MODEL` statement:
 ```sql linenums="1"
 MODEL (
   name sushi.items,
-  audits [assert_item_price_is_not_null]
+  audits (assert_item_price_is_not_null)
 );
 ```
 
@@ -64,10 +64,10 @@ Apply the generic audit to a model by referencing it in the `MODEL` statement:
 ```sql linenums="1"
 MODEL (
   name sushi.items,
-  audits [
+  audits (
     does_not_exceed_threshold(column=id, threshold=1000),
     does_not_exceed_threshold(column=price, threshold=100)
-  ]
+  )
 );
 ```
 
@@ -83,9 +83,9 @@ For example, if an audit `my_audit` uses a `values` parameter, invoking it will 
 ```sql linenums="1" hl_lines="4"
 MODEL (
   name sushi.items,
-  audits[
-    my_audit(column=a, "values"=[1,2,3])
-  ]
+  audits (
+    my_audit(column=a, "values"=(1,2,3))
+  )
 )
 ```
 
@@ -106,12 +106,12 @@ This example asserts that all rows have a `price` greater than 0 and a `name` va
 ```sql linenums="1" hl_lines="4-7"
 MODEL (
   name sushi.items,
-  audits [
-    forall(criteria=[
+  audits (
+    forall(criteria=(
       price > 0,
       LENGTH(name) > 0
-    ])
-  ]
+    ))
+  )
 );
 ```
 
@@ -127,9 +127,9 @@ This example asserts that the model has more than 10 rows:
 ```sql linenums="1"
 MODEL (
   name sushi.orders,
-  audits [
+  audits (
     number_of_rows(threshold=10)
-  ]
+  )
 );
 ```
 
@@ -141,9 +141,9 @@ This example asserts that none of the `id`, `customer_id`, or `waiter_id` column
 ```sql linenums="1"
 MODEL (
   name sushi.orders,
-  audits [
-    not_null(columns=[id, customer_id, waiter_id])
-  ]
+  audits (
+    not_null(columns=(id, customer_id, waiter_id))
+  )
 );
 ```
 
@@ -155,9 +155,9 @@ This example asserts that the `zip` column contains at least one non-NULL value:
 ```sql linenums="1"
 MODEL (
   name sushi.customers,
-  audits [
+  audits (
     at_least_one(column=zip)
-    ]
+    )
 );
 ```
 
@@ -169,9 +169,9 @@ This example asserts that the `zip` column has no more than 80% `NULL` values:
 ```sql linenums="1"
 MODEL (
   name sushi.customers,
-  audits [
+  audits (
     not_null_proportion(column=zip, threshold=0.8)
-    ]
+    )
 );
 ```
 
@@ -187,9 +187,9 @@ This example asserts that the column `customer_id` has at least two non-NULL val
 ```sql linenums="1"
 MODEL (
   name sushi.customer_revenue_by_day,
-  audits [
+  audits (
     not_constant(column=customer_id)
-    ]
+    )
 );
 ```
 
@@ -201,9 +201,9 @@ This example asserts that the `id` and `item_id` columns have unique values:
 ```sql linenums="1"
 MODEL (
   name sushi.orders,
-  audits [
-    unique_values(columns=[id, item_id])
-  ]
+  audits (
+    unique_values(columns=(id, item_id))
+  )
 );
 ```
 
@@ -215,9 +215,9 @@ This example asserts that the combination of `id` and `ds` columns has no duplic
 ```sql linenums="1"
 MODEL (
   name sushi.orders,
-  audits [
-    unique_combination_of_columns(columns=[id, ds])
-  ]
+  audits (
+    unique_combination_of_columns(columns=(id, ds))
+  )
 );
 ```
 
@@ -231,9 +231,9 @@ This example asserts that column `name` has a value of 'Hamachi', 'Unagi', or 'S
 ```sql linenums="1"
 MODEL (
   name sushi.items,
-  audits [
-    accepted_values(column=name, is_in=['Hamachi', 'Unagi', 'Sake'])
-  ]
+  audits (
+    accepted_values(column=name, is_in=('Hamachi', 'Unagi', 'Sake'))
+  )
 );
 ```
 
@@ -247,9 +247,9 @@ This example asserts that column `name` is not one of 'Hamburger' or 'French fri
 ```sql linenums="1"
 MODEL (
   name sushi.items,
-  audits [
-    not_accepted_values(column=name, is_in=['Hamburger', 'French fries'])
-  ]
+  audits (
+    not_accepted_values(column=name, is_in=('Hamburger', 'French fries'))
+  )
 );
 ```
 
@@ -267,9 +267,9 @@ This example asserts that column `item_id` contains sequential values that diffe
 ```sql linenums="1"
 MODEL (
   name sushi.items,
-  audits [
+  audits (
     sequential_values(column=item_id, interval=1)
-  ]
+  )
 );
 ```
 
@@ -281,9 +281,9 @@ This example asserts that all rows have a `price` greater than or equal 1 and le
 ```sql linenums="1"
 MODEL (
   name sushi.items,
-  audits [
+  audits (
     accepted_range(column=price, min_v=1, max_v=100)
-  ]
+  )
 );
 ```
 
@@ -292,9 +292,9 @@ This example specifies the `inclusive=false` argument to assert that all rows ha
 ```sql linenums="1"
 MODEL (
   name sushi.items,
-  audits [
+  audits (
     accepted_range(column=price, min_v=0, max_v=100, inclusive=false)
-  ]
+  )
 );
 ```
 
@@ -305,9 +305,9 @@ This example asserts that each row's range [min_price, max_price] does not overl
 
 ```sql linenums="1"
 MODEL (
-  audits [
+  audits (
     mutually_exclusive_ranges(lower_bound_column=min_price, upper_bound_column=max_price)
-  ]
+  )
 );
 ```
 
@@ -325,9 +325,9 @@ This example asserts that no `name` is an empty string:
 ```sql linenums="1"
 MODEL (
   name sushi.items,
-  audits [
+  audits (
     not_empty_string(column=name)
-  ]
+  )
 );
 ```
 
@@ -339,9 +339,9 @@ This example asserts that all `zip` values are 5 characters long:
 ```sql linenums="1"
 MODEL (
   name sushi.customers,
-  audits [
+  audits (
     string_length_equal_audit(column=zip, v=5)
-    ]
+    )
 );
 ```
 
@@ -353,9 +353,9 @@ This example asserts that all `name` values have 5 or more and 50 or fewer chara
 ```sql linenums="1"
 MODEL (
   name sushi.customers,
-  audits [
+  audits (
     string_length_between_audit(column=name, min_v=5, max_v=50)
-    ]
+    )
 );
 ```
 
@@ -364,9 +364,9 @@ This example specifies the `inclusive=false` argument to assert that all rows ha
 ```sql linenums="1"
 MODEL (
   name sushi.customers,
-  audits [
+  audits (
     string_length_between_audit(column=zip, min_v=4, max_v=60, inclusive=false)
-    ]
+    )
 );
 ```
 
@@ -379,9 +379,9 @@ This example asserts that all `uuid` values have the UUID structure:
 
 ```sql linenums="1"
 MODEL (
-  audits [
+  audits (
     valid_uuid(column=uuid)
-    ]
+    )
 );
 ```
 
@@ -394,9 +394,9 @@ This example asserts that all `email` values have the email address structure:
 
 ```sql linenums="1"
 MODEL (
-  audits [
+  audits (
     valid_email(column=email)
-    ]
+    )
 );
 ```
 
@@ -409,9 +409,9 @@ This example asserts that all `url` values have the URL structure:
 
 ```sql linenums="1"
 MODEL (
-  audits [
+  audits (
     valid_url(column=url)
-    ]
+    )
 );
 ```
 
@@ -424,9 +424,9 @@ This example asserts that all `http_method` values are valid HTTP methods:
 
 ```sql linenums="1"
 MODEL (
-  audits [
+  audits (
     valid_http_method(column=http_method)
-    ]
+    )
 );
 ```
 
@@ -437,9 +437,9 @@ This example asserts that all `todo` values match one of `'^\d.*'` (string start
 
 ```sql linenums="1"
 MODEL (
-  audits [
-    match_regex_pattern_list(column=todo, patterns=['^\d.*', '.*!$'])
-    ]
+  audits (
+    match_regex_pattern_list(column=todo, patterns=('^\d.*', '.*!$'))
+  )
 );
 ```
 
@@ -450,9 +450,9 @@ This example asserts that no `todo` values match one of `'^!.*'` (string starts 
 
 ```sql linenums="1"
 MODEL (
-  audits [
-    match_regex_pattern_list(column=todo, patterns=['^!.*', '.*\d$'])
-    ]
+  audits (
+    match_regex_pattern_list(column=todo, patterns=('^!.*', '.*\d$'))
+  )
 );
 ```
 
@@ -463,9 +463,9 @@ This example asserts that all `name` values are `LIKE` one of `'jim%'` or `'pam%
 
 ```sql linenums="1"
 MODEL (
-  audits [
-    match_like_pattern_list(column=name, patterns=['jim%', 'pam%'])
-    ]
+  audits (
+    match_like_pattern_list(column=name, patterns=('jim%', 'pam%'))
+  )
 );
 ```
 
@@ -476,9 +476,9 @@ This example asserts that no `name` values are `LIKE` `'%doe'` or `'%smith'`:
 
 ```sql linenums="1"
 MODEL (
-  audits [
-    not_match_like_pattern_list(column=name, patterns=['%doe', '%smith'])
-    ]
+  audits (
+    not_match_like_pattern_list(column=name, patterns=('%doe', '%smith'))
+  )
 );
 ```
 
@@ -496,9 +496,9 @@ This example asserts that the `age` column has a mean of at least 21 and at most
 
 ```sql linenums="1"
 MODEL (
-  audits [
+  audits (
     mean_in_range(column=age, min_v=21, max_v=50)
-    ]
+    )
 );
 ```
 
@@ -506,9 +506,9 @@ This example specifies the `inclusive=false` argument to assert that `age` has a
 
 ```sql linenums="1"
 MODEL (
-  audits [
+  audits (
     mean_in_range(column=age, min_v=18, max_v=65, inclusive=false)
-    ]
+    )
 );
 ```
 
@@ -519,9 +519,9 @@ This example asserts that the `age` column has a standard deviation of at least 
 
 ```sql linenums="1"
 MODEL (
-  audits [
+  audits (
     stddev_in_range(column=age, min_v=2, max_v=5)
-    ]
+    )
 );
 ```
 
@@ -529,9 +529,9 @@ This example specifies the `inclusive=false` argument to assert that `age` has a
 
 ```sql linenums="1"
 MODEL (
-  audits [
+  audits (
     mean_in_range(column=age, min_v=3, max_v=6, inclusive=false)
-    ]
+    )
 );
 ```
 
@@ -544,9 +544,9 @@ This example asserts that the `age` column contains no rows with z-scores greate
 
 ```sql linenums="1"
 MODEL (
-  audits [
+  audits (
     z_score(column=age, threshold=3)
-    ]
+    )
 );
 ```
 
@@ -557,9 +557,9 @@ This example asserts that the symmetrised KL Divergence between columns `age` an
 
 ```sql linenums="1"
 MODEL (
-  audits [
+  audits (
     kl_divergence(column=age, target_column=reference_age, threshold=0.1)
-    ]
+    )
 );
 ```
 
@@ -578,9 +578,9 @@ This example asserts that the chi-square statistic0 for columns `user_state` and
 
 ```sql linenums="1"
 MODEL (
-  audits [
+  audits (
     chi_square(column=user_state, target_column=user_type, critical_value=6.635)
-    ]
+    )
 );
 ```
 

--- a/docs/concepts/macros/jinja_macros.md
+++ b/docs/concepts/macros/jinja_macros.md
@@ -60,7 +60,7 @@ MODEL (
   name sqlmesh_example.full_model,
   kind FULL,
   cron '@daily',
-  audits [assert_positive_order_ids],
+  audits (assert_positive_order_ids),
 );
 
 JINJA_QUERY_BEGIN;

--- a/docs/concepts/macros/sqlmesh_macros.md
+++ b/docs/concepts/macros/sqlmesh_macros.md
@@ -60,7 +60,7 @@ MODEL (
   name sqlmesh_example.full_model,
   kind FULL,
   cron '@daily',
-  audits [assert_positive_order_ids],
+  audits (assert_positive_order_ids),
 );
 
 SELECT
@@ -78,7 +78,7 @@ MODEL (
   name sqlmesh_example.full_model,
   kind FULL,
   cron '@daily',
-  audits [assert_positive_order_ids],
+  audits (assert_positive_order_ids),
 ); -- NOTE: semi-colon at end of MODEL statement
 
 @DEF(size, 1); -- NOTE: semi-colon at end of @DEF operator
@@ -401,7 +401,7 @@ MODEL (
   kind FULL,
   cron '@daily',
   grain item_id,
-  audits [assert_positive_order_ids],
+  audits (assert_positive_order_ids),
 );
 
 SELECT
@@ -545,7 +545,7 @@ MODEL (
   name sqlmesh_example.full_model,
   kind FULL,
   cron '@daily',
-  audits [assert_positive_order_ids],
+  audits (assert_positive_order_ids),
 );
 
 @DEF(size, 1);
@@ -582,7 +582,7 @@ MODEL (
   name sqlmesh_example.full_model,
   kind FULL,
   cron '@daily',
-  audits [assert_positive_order_ids],
+  audits (assert_positive_order_ids),
 );
 
 @DEF(size, 1);
@@ -605,7 +605,7 @@ MODEL (
   name sqlmesh_example.full_model,
   kind FULL,
   cron '@daily',
-  audits [assert_positive_order_ids],
+  audits (assert_positive_order_ids),
 );
 
 @DEF(left_number, 1);

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -68,7 +68,7 @@ MODEL (
   kind FULL,
   cron '@daily',
   grain item_id,
-  audits [assert_positive_order_ids],
+  audits (assert_positive_order_ids),
 );
 
 SELECT
@@ -199,7 +199,7 @@ MODEL (
     ),
     start '2020-01-01',
     cron '@daily',
-    grain [id, ds]
+    grain (id, ds)
 );
 
 SELECT

--- a/docs/guides/notifications.md
+++ b/docs/guides/notifications.md
@@ -122,6 +122,7 @@ This example stops all notifications other than those for `User1`:
                     notification_target_2(...),
                 ],
             ),
+        ]
     )
     ```
 

--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -33,7 +33,7 @@ MODEL (
     ),
     start '2020-01-01',
     cron '@daily',
-    grain [id, ds]
+    grain (id, ds)
 );
 
 SELECT

--- a/docs/quickstart/cli.md
+++ b/docs/quickstart/cli.md
@@ -199,7 +199,7 @@ The `seed_model` date range begins on the same day the plan was made because `SE
             item_id INTEGER,
             ds VARCHAR
         ),
-        grain [id, ds]
+        grain (id, ds)
     );
     ```
 
@@ -217,7 +217,7 @@ The `seed_model` date range begins on the same day the plan was made because `SE
         ),
         start '2020-01-01',
         cron '@daily',
-        grain [id, ds]
+        grain (id, ds)
     );
 
     SELECT
@@ -238,7 +238,7 @@ The `seed_model` date range begins on the same day the plan was made because `SE
         kind FULL,
         cron '@daily',
         grain item_id,
-        audits [assert_positive_order_ids],
+        audits (assert_positive_order_ids),
     );
 
     SELECT
@@ -297,7 +297,7 @@ MODEL (
     ),
     start '2020-01-01',
     cron '@daily',
-    grain [id, ds]
+    grain (id, ds)
 );
 
 SELECT

--- a/docs/quickstart/notebook.md
+++ b/docs/quickstart/notebook.md
@@ -188,7 +188,7 @@ The `seed_model` date range begins on the same day the plan was made because `SE
             item_id INTEGER,
             ds VARCHAR
         ),
-        grain [id, ds]
+        grain (id, ds)
     );
     ```
 
@@ -206,7 +206,7 @@ The `seed_model` date range begins on the same day the plan was made because `SE
         ),
         start '2020-01-01',
         cron '@daily',
-        grain [id, ds]
+        grain (id, ds)
     );
 
     SELECT
@@ -227,7 +227,7 @@ The `seed_model` date range begins on the same day the plan was made because `SE
         kind FULL,
         cron '@daily',
         grain item_id,
-        audits [assert_positive_order_ids],
+        audits (assert_positive_order_ids),
     );
 
     SELECT

--- a/docs/quickstart/ui.md
+++ b/docs/quickstart/ui.md
@@ -238,7 +238,7 @@ The pane contains multiple pieces of information about the plan:
             item_id INTEGER,
             ds VARCHAR
         ),
-        grain [id, ds]
+        grain (id, ds)
     );
     ```
 
@@ -256,7 +256,7 @@ The pane contains multiple pieces of information about the plan:
         ),
         start '2020-01-01',
         cron '@daily',
-        grain [id, ds]
+        grain (id, ds)
     );
 
     SELECT
@@ -277,7 +277,7 @@ The pane contains multiple pieces of information about the plan:
         kind FULL,
         cron '@daily',
         grain item_id,
-        audits [assert_positive_order_ids],
+        audits (assert_positive_order_ids),
     );
 
     SELECT

--- a/examples/sushi/models/customer_revenue_by_day.sql
+++ b/examples/sushi/models/customer_revenue_by_day.sql
@@ -9,7 +9,7 @@ MODEL (
   cron '@daily',
   dialect hive,
   tags expensive,
-  grain [customer_id, event_date],
+  grain (customer_id, event_date),
 );
 
 WITH order_total AS (

--- a/examples/sushi/models/customer_revenue_lifetime.sql
+++ b/examples/sushi/models/customer_revenue_lifetime.sql
@@ -18,7 +18,7 @@ MODEL (
     revenue DOUBLE,
     event_date DATE
   ),
-  grain [customer_id, event_date],
+  grain (customer_id, event_date),
 );
 
 WITH order_total AS (

--- a/examples/sushi/models/top_waiters.sql
+++ b/examples/sushi/models/top_waiters.sql
@@ -3,7 +3,7 @@ MODEL (
   name sushi.top_waiters,
   owner jen,
   audits (
-    unique_values(columns=[waiter_id])
+    unique_values(columns=(waiter_id))
   ),
   grain waiter_id
 );

--- a/examples/sushi/models/waiter_as_customer_by_day.sql
+++ b/examples/sushi/models/waiter_as_customer_by_day.sql
@@ -7,8 +7,8 @@ MODEL (
   owner jen,
   cron '@daily',
   audits (
-    not_null(columns = [waiter_id]),
-    forall(criteria = [LENGTH(waiter_name) > 0])
+    not_null(columns = (waiter_id)),
+    forall(criteria = (LENGTH(waiter_name) > 0))
   )
 );
 

--- a/sqlmesh/cli/example_project.py
+++ b/sqlmesh/cli/example_project.py
@@ -65,7 +65,7 @@ EXAMPLE_FULL_MODEL_DEF = f"""MODEL (
   kind FULL,
   cron '@daily',
   grain item_id,
-  audits [assert_positive_order_ids],
+  audits (assert_positive_order_ids),
 );
 
 SELECT
@@ -84,7 +84,7 @@ EXAMPLE_INCREMENTAL_MODEL_DEF = f"""MODEL (
     ),
     start '2020-01-01',
     cron '@daily',
-    grain [id, ds]
+    grain (id, ds)
 );
 
 SELECT
@@ -107,7 +107,7 @@ EXAMPLE_SEED_MODEL_DEF = f"""MODEL (
         item_id INTEGER,
         ds TEXT
     ),
-    grain [id, ds]
+    grain (id, ds)
 );
 """
 

--- a/sqlmesh/core/audit/builtin.py
+++ b/sqlmesh/core/audit/builtin.py
@@ -4,7 +4,7 @@ from sqlglot import exp
 
 from sqlmesh.core.audit.definition import ModelAudit
 
-# not_null(columns=[column_1, column_2])
+# not_null(columns=(column_1, column_2))
 not_null_audit = ModelAudit(
     name="not_null",
     query="""
@@ -20,7 +20,7 @@ WHERE @REDUCE(
     """,
 )
 
-# unique_values(columns=[column_1, column_2])
+# unique_values(columns=(column_1, column_2))
 unique_values_audit = ModelAudit(
     name="unique_values",
     query="""
@@ -43,7 +43,7 @@ WHERE @REDUCE(
     """,
 )
 
-# accepted_values(column=column_name, is_in=[1, 2, 3])
+# accepted_values(column=column_name, is_in=(1, 2, 3))
 accepted_values_audit = ModelAudit(
     name="accepted_values",
     query="""
@@ -67,11 +67,11 @@ HAVING COUNT(*) <= @threshold
     """,
 )
 
-# forall(criteria=[
+# forall(criteria=(
 #   column_1 > 0,
 #   column_2 in (1, 2, 3),
 #   column_3 is not null
-# ]))
+# ))
 forall_audit = ModelAudit(
     name="forall",
     query="""
@@ -155,7 +155,7 @@ WHERE s.cnt_not_null <= s.cnt_tot * @threshold
     """,
 )
 
-# not_accepted_values(column=column_name, is_in=[1, 2, 3])
+# not_accepted_values(column=column_name, is_in=(1, 2, 3))
 not_accepted_values_audit = ModelAudit(
     name="not_accepted_values",
     query="""
@@ -189,7 +189,7 @@ FROM validation_errors
     """,
 )
 
-# unique_combination_of_columns(columns=[column_1, column_2])
+# unique_combination_of_columns(columns=(column_1, column_2))
 unique_combination_of_columns_audit = ModelAudit(
     name="unique_combination_of_columns",
     query="""
@@ -286,7 +286,7 @@ WHERE NOT REGEXP_LIKE(@column, '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$
     """,
 )
 
-# match_regex_pattern_list(column=column_name, patterns=['^pattern_1', 'pattern_2$'])
+# match_regex_pattern_list(column=column_name, patterns=('^pattern_1', 'pattern_2$'))
 match_regex_pattern_list_audit = ModelAudit(
     name="match_regex_pattern_list",
     query="""
@@ -302,7 +302,7 @@ WHERE @REDUCE(
     """,
 )
 
-# not_match_regex_pattern_list(column=column_name, patterns=['^pattern_1', 'pattern_2$'])
+# not_match_regex_pattern_list(column=column_name, patterns=('^pattern_1', 'pattern_2$'))
 not_match_regex_pattern_list_audit = ModelAudit(
     name="not_match_regex_pattern_list",
     query="""
@@ -318,7 +318,7 @@ WHERE @REDUCE(
     """,
 )
 
-# match_like_pattern_list(column=column_name, patterns=['%pattern_1%', 'pattern_2%'])
+# match_like_pattern_list(column=column_name, patterns=('%pattern_1%', 'pattern_2%'))
 match_like_pattern_list = ModelAudit(
     name="match_like_pattern_list",
     query="""
@@ -334,7 +334,7 @@ WHERE @REDUCE(
     """,
 )
 
-# not_match_like_pattern_list(column=column_name, patterns=['%pattern_1%', 'pattern_2%'])
+# not_match_like_pattern_list(column=column_name, patterns=('%pattern_1%', 'pattern_2%'))
 not_match_like_pattern_list_audit = ModelAudit(
     name="not_match_like_pattern_list",
     query="""
@@ -635,7 +635,7 @@ HAVING NOT @IF(@dependent, chi_square > @critical_value, chi_square <= @critical
 #     """,
 # )
 
-# equality(columns=[column_1, column_2], to=some.model)
+# equality(columns=(column_1, column_2), to=some.model)
 # equality_audit = ModelAudit(
 #     name="equality",
 #     query="""


### PR DESCRIPTION
Brackets `[]` are identifiers in tsql as of sqlglot v20.8.0, so models with the tsql dialect cannot parse MODEL DDL that uses brackets to define arrays. 

Arrays defined with parentheses can be parsed by all dialects. This PR changes all examples to use parentheses for array definition in MODEL DDL, including documentation, the SQLMesh example project, and the sushi project.