### PR TITLE
Fix: allow comments in audit file

### DIFF
--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -485,8 +485,6 @@ def load_audit(
         raise
 
     meta_fields = {p.name: p.args.get("value") for p in meta.expressions if p}
-    if meta.comments:
-        meta_fields["description"] = "\n".join(comment.strip() for comment in meta.comments)
 
     standalone_field = meta_fields.pop("standalone", None)
     if standalone_field and not isinstance(standalone_field, exp.Boolean):

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -37,6 +37,7 @@ def model_default_catalog() -> Model:
 def test_load(assert_exp_eq):
     expressions = parse(
         """
+        -- Audit comment
         Audit (
             name my_audit,
             dialect spark,


### PR DESCRIPTION
Currently, the audit loader assigns any SQL comments above the audit DDL to the audit's `description` field. That field does not have first-class support, so audits with a comment present errored out.

This PR allows comments to be present by removing the assignment of the comment to the description field.

Closes #2054 