### PR TITLE
Fix: do not include a schema def in CTAS unless all column types are known

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -604,9 +604,14 @@ class EngineAdapter:
         # types, and for evaluation methods like `LogicalReplaceQueryMixin.replace_query()`
         # calls and SCD Type 2 model calls.
         schema = None
+        columns_to_types_all_known = columns_to_types and all(
+            not column_type.is_type(exp.DataType.Type.UNKNOWN, exp.DataType.Type.NULL)
+            for column_type in columns_to_types.values()
+        )
         if (
             column_descriptions
             and columns_to_types
+            and columns_to_types_all_known
             and self.COMMENT_CREATION_TABLE.is_in_schema_def_ctas
             and self.comments_enabled
         ):

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -33,7 +33,7 @@ from sqlmesh.core.model.kind import (
 from sqlmesh.core.model.meta import ModelMeta
 from sqlmesh.core.model.seed import CsvSeedReader, Seed, create_seed
 from sqlmesh.core.renderer import ExpressionRenderer, QueryRenderer
-from sqlmesh.utils import str_to_bool
+from sqlmesh.utils import columns_to_types_all_known, str_to_bool
 from sqlmesh.utils.date import TimeLike, make_inclusive, to_datetime, to_ds, to_ts
 from sqlmesh.utils.errors import ConfigError, SQLMeshError, raise_config_error
 from sqlmesh.utils.hashing import hash_data
@@ -575,10 +575,7 @@ class _Model(ModelMeta, frozen=True):
         }
         if not columns_to_types:
             return False
-        return all(
-            not column_type.is_type(exp.DataType.Type.UNKNOWN, exp.DataType.Type.NULL)
-            for column_type in columns_to_types.values()
-        )
+        return columns_to_types_all_known(columns_to_types)
 
     @property
     def sorted_python_env(self) -> t.List[t.Tuple[str, Executable]]:

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -19,6 +19,7 @@ from copy import deepcopy
 from functools import lru_cache, reduce, wraps
 from pathlib import Path
 
+from sqlglot import exp
 from sqlglot.dialects.dialect import Dialects
 
 logger = logging.getLogger(__name__)
@@ -305,3 +306,13 @@ def groupby(
     for item in items:
         grouped[func(item)].append(item)
     return grouped
+
+
+def columns_to_types_all_known(columns_to_types: t.Dict[str, exp.DataType]) -> bool:
+    """
+    Checks that all column types are known and not NULL.
+    """
+    return all(
+        not column_type.is_type(exp.DataType.Type.UNKNOWN, exp.DataType.Type.NULL)
+        for column_type in columns_to_types.values()
+    )

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -218,7 +218,9 @@ def test_replace_query(make_mocked_engine_adapter: t.Callable, mocker: MockerFix
     execute_mock = mocker.patch(
         "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.execute"
     )
-    adapter.replace_query("test_table", parse_one("SELECT a FROM tbl"), {"a": "int"})
+    adapter.replace_query(
+        "test_table", parse_one("SELECT a FROM tbl"), {"a": exp.DataType.build("INT")}
+    )
 
     sql_calls = _to_sql_calls(execute_mock)
     assert sql_calls == ["CREATE OR REPLACE TABLE `test_table` AS SELECT `a` FROM `tbl`"]
@@ -591,7 +593,7 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
 
     adapter.create_table(
         "test_table",
-        {"a": "int", "b": "int"},
+        {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
         table_description="test description",
         column_descriptions={"a": "a description"},
     )
@@ -599,7 +601,7 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
     adapter.ctas(
         "test_table",
         parse_one("SELECT a, b FROM source_table"),
-        {"a": "int", "b": "int"},
+        {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
         table_description="test description",
         column_descriptions={"a": "a description"},
     )
@@ -617,8 +619,8 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
 
     sql_calls = _to_sql_calls(execute_mock)
     assert sql_calls == [
-        "CREATE TABLE IF NOT EXISTS `test_table` (`a` int OPTIONS (description='a description'), `b` int) OPTIONS (description='test description')",
-        "CREATE TABLE IF NOT EXISTS `test_table` (`a` int OPTIONS (description='a description'), `b` int) OPTIONS (description='test description') AS SELECT `a`, `b` FROM `source_table`",
+        "CREATE TABLE IF NOT EXISTS `test_table` (`a` INT64 OPTIONS (description='a description'), `b` INT64) OPTIONS (description='test description')",
+        "CREATE TABLE IF NOT EXISTS `test_table` (`a` INT64 OPTIONS (description='a description'), `b` INT64) OPTIONS (description='test description') AS SELECT `a`, `b` FROM `source_table`",
         "CREATE OR REPLACE VIEW `test_table` OPTIONS (description='test description') AS SELECT `a`, `b` FROM `source_table`",
         "ALTER TABLE `test_table` SET OPTIONS(description = 'test description')",
     ]

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -4,7 +4,7 @@ import typing as t
 import pandas as pd
 import pytest
 from pytest_mock import MockFixture
-from sqlglot import parse_one
+from sqlglot import exp, parse_one
 
 from sqlmesh.core.engine_adapter import DatabricksEngineAdapter
 from tests.core.engine_adapter import to_sql_calls
@@ -18,7 +18,9 @@ def test_replace_query_not_exists(mocker: MockFixture, make_mocked_engine_adapte
         return_value=False,
     )
     adapter = make_mocked_engine_adapter(DatabricksEngineAdapter)
-    adapter.replace_query("test_table", parse_one("SELECT a FROM tbl"), {"a": "int"})
+    adapter.replace_query(
+        "test_table", parse_one("SELECT a FROM tbl"), {"a": exp.DataType.build("INT")}
+    )
 
     assert to_sql_calls(adapter) == [
         "CREATE TABLE IF NOT EXISTS `test_table` AS SELECT `a` FROM `tbl`",
@@ -47,7 +49,9 @@ def test_replace_query_pandas_not_exists(
     )
     adapter = make_mocked_engine_adapter(DatabricksEngineAdapter)
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    adapter.replace_query("test_table", df, {"a": "int", "b": "int"})
+    adapter.replace_query(
+        "test_table", df, {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")}
+    )
 
     assert to_sql_calls(adapter) == [
         "CREATE TABLE IF NOT EXISTS `test_table` AS SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `t`(`a`, `b`)",

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -171,7 +171,9 @@ def test_replace_query_not_exists(mocker: MockerFixture, make_mocked_engine_adap
         return_value=False,
     )
     adapter = make_mocked_engine_adapter(SparkEngineAdapter)
-    adapter.replace_query("test_table", parse_one("SELECT a FROM tbl"), {"a": "int"})
+    adapter.replace_query(
+        "test_table", parse_one("SELECT a FROM tbl"), {"a": exp.DataType.build("INT")}
+    )
 
     assert to_sql_calls(adapter) == [
         "CREATE TABLE IF NOT EXISTS `test_table` AS SELECT `a` FROM `tbl`",
@@ -867,13 +869,13 @@ def test_replace_query_with_wap_self_reference(
     adapter.replace_query(
         "catalog.schema.table.branch_wap_12345",
         parse_one("SELECT 1 as a FROM catalog.schema.table.branch_wap_12345"),
-        columns_to_types={"a": "int"},
+        columns_to_types={"a": exp.DataType.build("INT")},
         storage_format="ICEBERG",
     )
 
     sql_calls = to_sql_calls(adapter)
     assert sql_calls == [
-        "CREATE TABLE IF NOT EXISTS `catalog`.`schema`.`table` (`a` int)",
+        "CREATE TABLE IF NOT EXISTS `catalog`.`schema`.`table` (`a` INT)",
         "CREATE SCHEMA IF NOT EXISTS `schema`",
         "CREATE TABLE IF NOT EXISTS `catalog`.`schema`.`temp_branch_wap_12345_abcdefgh` USING ICEBERG AS SELECT `a` FROM `catalog`.`schema`.`table`.`branch_wap_12345`",
         "INSERT OVERWRITE TABLE `catalog`.`schema`.`table`.`branch_wap_12345` (`a`) SELECT 1 AS `a` FROM `catalog`.`schema`.`temp_branch_wap_12345_abcdefgh`",

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,0 +1,18 @@
+from sqlglot import expressions
+
+from sqlmesh.utils import columns_to_types_all_known
+
+
+def test_columns_to_types_all_known() -> None:
+    assert (
+        columns_to_types_all_known(
+            {"a": expressions.DataType.build("INT"), "b": expressions.DataType.build("INT")}
+        )
+        == True
+    )
+    assert (
+        columns_to_types_all_known(
+            {"a": expressions.DataType.build("UNKNOWN"), "b": expressions.DataType.build("INT")}
+        )
+        == False
+    )

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -16,3 +16,9 @@ def test_columns_to_types_all_known() -> None:
         )
         == False
     )
+    assert (
+        columns_to_types_all_known(
+            {"a": expressions.DataType.build("NULL"), "b": expressions.DataType.build("INT")}
+        )
+        == False
+    )


### PR DESCRIPTION
CTAS calls include a schema definition if column comments are present and columns_to_types are available. Currently, the schema definition could include `UNKNOWN` or `NULL` data types, which cause the CTAS call to error out.

This PR ensures that the schema definition is only included if all column types are known.

Closes #2060 