### PR TITLE
Docs: expand external model documentation

### DIFF
--- a/docs/concepts/models/external_models.md
+++ b/docs/concepts/models/external_models.md
@@ -1,12 +1,26 @@
 # External models
-Models may reference "external" tables that have been created outside SQLMesh. These external tables are captured in SQLMesh as models with a unique "external" kind. Each external model retains metadata about a table it represents.
 
-This metadata allows SQLMesh to provide column-level lineage and data type information for models that reference external tables.
+SQLMesh model queries may reference "external" tables that are created and managed outside the SQLMesh project. For example, a model might ingest data from a third party's read-only data system.
 
-## Generating external models schema
+SQLMesh does not manage external tables, but it can use information about the tables' columns and data types to make features more useful. For example, column information allows column-level lineage to include external tables' columns.
+
+SQLMesh stores external tables' column information as `EXTERNAL` models.
+
+## External models are not run
+
+`EXTERNAL` models consist solely of an external table's column information, so there is no query for SQLMesh to run.
+
+SQLMesh has no information about the data contained in the table represented by an `EXTERNAL` model. The table could be altered or have all its data deleted, and SQLMesh will not detect it. All SQLMesh knows about the table is that it contains the columns specified in the `EXTERNAL` model's `schema.yaml` file (more information below).
+
+SQLMesh will not take any actions based on an `EXTERNAL` model - its actions are solely determined by the model whose query selects from the `EXTERNAL` model.
+
+The querying model's [`kind`](./model_kinds.md), [`cron`](./overview.md#cron), and previously loaded time intervals determine when SQLMesh will query the `EXTERNAL` model.
+
+## Generating an external models schema file
+
 External models are defined in the `schema.yaml` file in the SQLMesh project's root folder.
 
-You can create this file by either (i) allowing SQLMesh to fetch information about external tables with the `create_external_models` CLI command or (ii) writing the YAML by hand.
+You can create this file by either writing the YAML by hand or allowing SQLMesh to fetch information about external tables with the `create_external_models` CLI command.
 
 Consider this example model that queries an external table `external_db.external_table`:
 
@@ -22,15 +36,13 @@ FROM
   external_db.external_table;
 ```
 
-The following sections demonstrate how to create an external model containing metadata about `external_db.external_table`, which contains columns `column_a` and `column_b`.
+The following sections demonstrate how to create an external model containing `external_db.external_table`'s column information.
 
-### Using CLI
-Instead of creating the `schema.yaml` file manually, SQLMesh can generate it for you. The [create_external_models](../../reference/cli.md#create_external_models) CLI command does exactly this.
-
-The command locates all external tables referenced in your SQLMesh project, fetches their schemas (column names and types), and then stores them in the `schema.yaml` file.
+All of a SQLMesh project's external models are defined in a single `schema.yaml` file, so the files created below might also include column information for other external models.
 
 ### Writing YAML by hand
-The following example demonstrates a typical content of the `schema.yaml` file:
+
+This example demonstrates the structure of a `schema.yaml` file:
 
 ```yaml
 - name: external_db.external_table
@@ -45,4 +57,16 @@ The following example demonstrates a typical content of the `schema.yaml` file:
     column_d: float
 ```
 
-All the external models in a SQLMesh project are stored in a single `schema.yaml` file.
+It contains each `EXTERNAL` model's name, an optional description, and each of the external table's columns' name and data type.
+
+The file can be constructed by hand using a standard text editor or IDE.
+
+### Using CLI
+
+Instead of creating the `schema.yaml` file manually, SQLMesh can generate it for you with the [create_external_models](../../reference/cli.md#create_external_models) CLI command.
+
+The command identifies all external tables referenced in your SQLMesh project, fetches their column information from the SQL engine's metadata, and then stores the information in the `schema.yaml` file.
+
+If SQLMesh does not have access to an external table's metadata, the table will be omitted from the file and SQLMesh will issue a warning.
+
+`create_external_models` solely queries SQL engine metadata and does not query external tables themselves.

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -103,9 +103,14 @@
 
     A SQLMesh [`audit`](../concepts/audits.md) validates that transformed *data* meet some criteria. For example, an `audit` might verify that a column contains no `NULL` values or has no duplicated values. SQLMesh automatically runs audits when a `sqlmesh plan` is executed and the plan is applied or when `sqlmesh run` is executed.
 
+??? question "How does a model know when to run?"
+    A SQLMesh model determines when to run based on its [`cron`](#cron-question) parameter and how much time has elapsed since its previous run.
+
+    Models are not aware of upstream data updates and do not run based on what has happened in an upstream data source.
+
 <a id="cron-question"></a>
 ??? question "What is the model `cron` parameter?"
-    SQLMesh does not fully refresh models when a project is run. Instead, you specify how frequently each model should run with its [`cron` parameter](../concepts/models/overview.md#cron) (defaults to daily).
+    SQLMesh does not fully refresh models every time a project is run. Instead, you specify how frequently each model should run with its [`cron` parameter](../concepts/models/overview.md#cron) (defaults to daily).
 
     When you execute `sqlmesh run`, SQLMesh compares each model's `cron` value to its record of when the model was last run. If enough time has elapsed it will run the model, otherwise it does nothing.
 
@@ -137,14 +142,6 @@
 
     You can retroactively apply the forward-only plan's changes to existing data in the production environment with [`plan`'s `--effective-from` option](../reference/cli.md#plan).
 
-??? question "How does an `EXTERNAL` model know when to update?"
-    SQLMesh model queries sometimes reference "external" tables that are created and managed outside the SQLMesh project. For example, a model might ingest data from a third party's read-only data system.
-
-    SQLMesh stores information about the columns contained in an external table as an `EXTERNAL` model. `EXTERNAL` models consist solely of an external table's column information and contain no query for SQLMesh to run.
-
-    SQLMesh will not take any actions based on an `EXTERNAL` model - its actions are solely determined by the model whose query selects from the `EXTERNAL` model. The querying model's [`kind`](../concepts/models/model_kinds.md), [`cron`](../concepts/models/overview.md#cron), and previously loaded time intervals determine when SQLMesh will query the `EXTERNAL` model.
-
-    Learn more about `EXTERNAL` models [here](../concepts/models/external_models.md).
 
 ## Databases/Engines
 

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -137,6 +137,15 @@
 
     You can retroactively apply the forward-only plan's changes to existing data in the production environment with [`plan`'s `--effective-from` option](../reference/cli.md#plan).
 
+??? question "How does an `EXTERNAL` model know when to update?"
+    SQLMesh model queries sometimes reference "external" tables that are created and managed outside the SQLMesh project. For example, a model might ingest data from a third party's read-only data system.
+
+    SQLMesh stores information about the columns contained in an external table as an `EXTERNAL` model. `EXTERNAL` models consist solely of an external table's column information and contain no query for SQLMesh to run.
+
+    SQLMesh will not take any actions based on an `EXTERNAL` model - its actions are solely determined by the model whose query selects from the `EXTERNAL` model. The querying model's [`kind`](../concepts/models/model_kinds.md), [`cron`](../concepts/models/overview.md#cron), and previously loaded time intervals determine when SQLMesh will query the `EXTERNAL` model.
+
+    Learn more about `EXTERNAL` models [here](../concepts/models/external_models.md).
+
 ## Databases/Engines
 
 ??? question "What databases/engines does SQLMesh work with?"


### PR DESCRIPTION
Clarify that:
- They consist solely of the external table's column metadata
- SQLMesh's actions are determined by the model(s) querying the `EXTERNAL` model, not the external model itself