### PR TITLE
fix: replace query unknown self-reference

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -495,6 +495,17 @@ class EngineAdapter:
             kwargs: Optional create table properties.
         """
         table = exp.to_table(table_name)
+
+        if not columns_to_types_all_known(columns_to_types):
+            # It is ok if the columns types are not known if the table already exists and IF NOT EXISTS is set
+            if exists and self.table_exists(table_name):
+                return
+            raise SQLMeshError(
+                "Cannot create a table without knowing the column types. "
+                "Try casting the columns to an expected type or defining the columns in the model metadata. "
+                f"Columns to types: {columns_to_types}"
+            )
+
         primary_key_expression = (
             [exp.PrimaryKey(expressions=[exp.to_column(k) for k in primary_key])]
             if primary_key and self.SUPPORTS_INDEXES

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -317,7 +317,7 @@ def test_create_table_date_partition(
     )
     adapter.create_table(
         "test_table",
-        {"a": "int", "b": "int"},
+        {"a": exp.DataType.build("int"), "b": exp.DataType.build("int")},
         partitioned_by=partition_by_cols,
         partition_interval_unit=IntervalUnit.DAY,
         clustered_by=["b"],
@@ -325,7 +325,7 @@ def test_create_table_date_partition(
 
     sql_calls = _to_sql_calls(execute_mock)
     assert sql_calls == [
-        f"CREATE TABLE IF NOT EXISTS `test_table` (`a` int, `b` int) PARTITION BY {partition_by_statement} CLUSTER BY `b`"
+        f"CREATE TABLE IF NOT EXISTS `test_table` (`a` INT64, `b` INT64) PARTITION BY {partition_by_statement} CLUSTER BY `b`"
     ]
 
 
@@ -572,7 +572,7 @@ def test_create_table_table_options(make_mocked_engine_adapter: t.Callable, mock
 
     adapter.create_table(
         "test_table",
-        {"a": "int", "b": "int"},
+        {"a": exp.DataType.build("int"), "b": exp.DataType.build("int")},
         table_properties={
             "partition_expiration_days": exp.convert(7),
         },
@@ -580,7 +580,7 @@ def test_create_table_table_options(make_mocked_engine_adapter: t.Callable, mock
 
     sql_calls = _to_sql_calls(execute_mock)
     assert sql_calls == [
-        "CREATE TABLE IF NOT EXISTS `test_table` (`a` int, `b` int) OPTIONS (partition_expiration_days=7)"
+        "CREATE TABLE IF NOT EXISTS `test_table` (`a` INT64, `b` INT64) OPTIONS (partition_expiration_days=7)"
     ]
 
 


### PR DESCRIPTION
Prior to this change if you had a self-referencing query that is full refresh (SCD Type 2 is this) then we would always do a create table if not exists since we need a table to reference if one doesn't exist. If a column was unknown then we would get an error trying to create the table.

Now we check if column types are all known in create table and if they aren't then we raise an error. The exception is if the table already exists and we get IF NOT EXISTS then we just return since we aren't creating the table anyways. This addresses the error case here since even though we have an unknown it is ok since the table is already created. 