### PR TITLE
feat: Virtualized docs list, auto scroll to active item on refresh

### DIFF
--- a/web/client/src/library/components/sourceList/SourceList.tsx
+++ b/web/client/src/library/components/sourceList/SourceList.tsx
@@ -265,8 +265,8 @@ export function SourceListItem({
             ? variant === EnumVariant.Primary
               ? 'text-primary-500 bg-primary-10'
               : variant === EnumVariant.Danger
-                ? 'text-danger-500 bg-danger-5'
-                : 'text-neutral-500 bg-neutral-10'
+              ? 'text-danger-500 bg-danger-5'
+              : 'text-neutral-500 bg-neutral-10'
             : 'hover:bg-neutral-10 text-neutral-400 dark:text-neutral-300',
         )
       }

--- a/web/client/src/library/components/sourceList/SourceList.tsx
+++ b/web/client/src/library/components/sourceList/SourceList.tsx
@@ -259,8 +259,8 @@ export function SourceListItem({
             ? variant === EnumVariant.Primary
               ? 'text-primary-500 bg-primary-10'
               : variant === EnumVariant.Danger
-                ? 'text-danger-500 bg-danger-5'
-                : 'text-neutral-500 bg-neutral-10'
+              ? 'text-danger-500 bg-danger-5'
+              : 'text-neutral-500 bg-neutral-10'
             : 'hover:bg-neutral-10 text-neutral-400 dark:text-neutral-300',
         )
       }

--- a/web/client/src/library/components/sourceList/SourceList.tsx
+++ b/web/client/src/library/components/sourceList/SourceList.tsx
@@ -81,9 +81,9 @@ export default function SourceList<
   useEffect(() => {
     console.log({ activeItemIndex })
     if (activeItemIndex > -1) {
-      console.log('scrolling to the index')
       rowVirtualizer.scrollToIndex(activeItemIndex, {
         align: 'center',
+        behavior: 'smooth',
       })
     }
   }, [activeItemIndex])

--- a/web/client/src/library/components/sourceList/SourceList.tsx
+++ b/web/client/src/library/components/sourceList/SourceList.tsx
@@ -283,8 +283,8 @@ export function SourceListItem({
             ? variant === EnumVariant.Primary
               ? 'text-primary-500 bg-primary-10'
               : variant === EnumVariant.Danger
-                ? 'text-danger-500 bg-danger-5'
-                : 'text-neutral-500 bg-neutral-10'
+              ? 'text-danger-500 bg-danger-5'
+              : 'text-neutral-500 bg-neutral-10'
             : 'hover:bg-neutral-10 text-neutral-400 dark:text-neutral-300',
         )
       }

--- a/web/client/src/library/components/sourceList/SourceList.tsx
+++ b/web/client/src/library/components/sourceList/SourceList.tsx
@@ -27,7 +27,7 @@ export default function SourceList<
   items = [],
   types,
   by = 'id',
-  activeItemIndex,
+  activeItemIndex = -1,
   byName,
   byDescription,
   to,
@@ -39,7 +39,7 @@ export default function SourceList<
   to: string
   items?: TItem[]
   types?: TType
-  activeItemIndex: number
+  activeItemIndex?: number
   byName?: string
   disabled?: boolean
   byDescription?: string

--- a/web/client/src/library/components/sourceList/SourceList.tsx
+++ b/web/client/src/library/components/sourceList/SourceList.tsx
@@ -73,10 +73,16 @@ export default function SourceList<
     estimateSize: () => 28,
   })
 
-  const scrollToItem = (itemIndex: number): void => {
+  const scrollToItem = ({
+    itemIndex,
+    isSmoothScroll = true,
+  }: {
+    itemIndex: number
+    isSmoothScroll?: boolean
+  }): void => {
     rowVirtualizer.scrollToIndex(itemIndex, {
       align: 'center',
-      behavior: 'smooth',
+      behavior: isSmoothScroll ? 'smooth' : 'auto',
     })
   }
 
@@ -120,7 +126,7 @@ export default function SourceList<
       (rowVirtualizer.range.startIndex > filteredItemIndex ||
         rowVirtualizer.range.endIndex < filteredItemIndex)
     ) {
-      scrollToItem(filteredItemIndex)
+      scrollToItem({ itemIndex: filteredItemIndex, isSmoothScroll: false })
     }
   }, [activeItemIndex])
 
@@ -129,7 +135,7 @@ export default function SourceList<
       {shouldShowReturnButton && (
         <Button
           className="absolute right-0 top-0 z-10 text-ellipsis !block overflow-hidden no-wrap max-w-[90%]"
-          onClick={() => scrollToItem(filteredItemIndex)}
+          onClick={() => scrollToItem({ itemIndex: filteredItemIndex })}
           size="sm"
           variant="neutral"
         >
@@ -259,8 +265,8 @@ export function SourceListItem({
             ? variant === EnumVariant.Primary
               ? 'text-primary-500 bg-primary-10'
               : variant === EnumVariant.Danger
-              ? 'text-danger-500 bg-danger-5'
-              : 'text-neutral-500 bg-neutral-10'
+                ? 'text-danger-500 bg-danger-5'
+                : 'text-neutral-500 bg-neutral-10'
             : 'hover:bg-neutral-10 text-neutral-400 dark:text-neutral-300',
         )
       }

--- a/web/client/src/library/components/sourceList/SourceList.tsx
+++ b/web/client/src/library/components/sourceList/SourceList.tsx
@@ -49,13 +49,7 @@ export default function SourceList<
 
   const scrollableAreaRef = useRef<HTMLDivElement>(null)
 
-  const getActiveIndex = (itemsList: TItem[]): number =>
-    itemsList.findIndex(item => isNotNil(isActive) && isActive(item[by]))
-
   const [activeItemIndex, filtered] = useMemo(() => {
-    if (filter === '') {
-      return [getActiveIndex(items), items]
-    }
     let activeIndex = -1
     const filteredList: TItem[] = []
     items.forEach((item, index) => {
@@ -76,24 +70,9 @@ export default function SourceList<
         }
       }
     })
-    // const filteredList = items.filter(item => {
-    //   const id = item[by] ?? ''
-    //   const description = String(
-    //     isNil(byDescription) ? '' : item?.[byDescription] ?? '',
-    //   )
-    //   const name = String(isNil(byName) ? '' : item?.[byName] ?? '')
-    //   const type = String(types?.[id] ?? '')
 
-    //   return (
-    //     name.includes(filter) ||
-    //     description.includes(filter) ||
-    //     type.includes(filter)
-    //   )
-    // })
     return [activeIndex, filteredList]
   }, [items, filter])
-
-  console.log({ activeItemIndex, filtered })
 
   const rowVirtualizer = useVirtualizer({
     count: filtered.length,

--- a/web/client/src/library/pages/audits/Audits.tsx
+++ b/web/client/src/library/pages/audits/Audits.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom'
+import { Outlet, useLocation } from 'react-router-dom'
 import Page from '../root/Page'
 import { useStoreProject } from '@context/project'
 import SourceList, { SourceListItem } from '@components/sourceList/SourceList'
@@ -6,13 +6,21 @@ import { EnumSize, EnumVariant } from '~/types/enum'
 import { EnumRoutes } from '~/routes'
 import { Button } from '@components/button/Button'
 import { Divider } from '@components/divider/Divider'
+import { useMemo } from 'react'
 
 export default function PageAudits(): JSX.Element {
+  const { pathname } = useLocation()
   const files = useStoreProject(s => s.files)
 
   const items = Array.from(files.values()).filter(it =>
     it.path.endsWith('audits'),
   )
+
+  const activeItemIndex = useMemo((): number => {
+    return items.findIndex(item => {
+      return `${EnumRoutes.Audits}/${item.basename}` === pathname
+    })
+  }, [pathname, items])
 
   return (
     <Page
@@ -23,6 +31,7 @@ export default function PageAudits(): JSX.Element {
             byName="basename"
             to={EnumRoutes.Audits}
             items={items}
+            activeItemIndex={activeItemIndex}
             className="h-full"
             listItem={({ to, name, description, text, disabled = false }) => (
               <SourceListItem

--- a/web/client/src/library/pages/audits/Audits.tsx
+++ b/web/client/src/library/pages/audits/Audits.tsx
@@ -15,10 +15,6 @@ export default function PageAudits(): JSX.Element {
     it.path.endsWith('audits'),
   )
 
-  const isActive = (id: string): boolean => {
-    return `${EnumRoutes.Audits}/${id}` === pathname
-  }
-
   return (
     <Page
       sidebar={
@@ -28,7 +24,7 @@ export default function PageAudits(): JSX.Element {
             byName="basename"
             to={EnumRoutes.Audits}
             items={items}
-            isActive={isActive}
+            isActive={id => `${EnumRoutes.Audits}/${id}` === pathname}
             className="h-full"
             listItem={({ to, name, description, text, disabled = false }) => (
               <SourceListItem

--- a/web/client/src/library/pages/audits/Audits.tsx
+++ b/web/client/src/library/pages/audits/Audits.tsx
@@ -6,7 +6,6 @@ import { EnumSize, EnumVariant } from '~/types/enum'
 import { EnumRoutes } from '~/routes'
 import { Button } from '@components/button/Button'
 import { Divider } from '@components/divider/Divider'
-import { useMemo } from 'react'
 
 export default function PageAudits(): JSX.Element {
   const { pathname } = useLocation()
@@ -16,11 +15,9 @@ export default function PageAudits(): JSX.Element {
     it.path.endsWith('audits'),
   )
 
-  const activeItemIndex = useMemo((): number => {
-    return items.findIndex(item => {
-      return `${EnumRoutes.Audits}/${item.basename}` === pathname
-    })
-  }, [pathname, items])
+  const isActive = (id: string): boolean => {
+    return `${EnumRoutes.Audits}/${id}` === pathname
+  }
 
   return (
     <Page
@@ -31,7 +28,7 @@ export default function PageAudits(): JSX.Element {
             byName="basename"
             to={EnumRoutes.Audits}
             items={items}
-            activeItemIndex={activeItemIndex}
+            isActive={isActive}
             className="h-full"
             listItem={({ to, name, description, text, disabled = false }) => (
               <SourceListItem

--- a/web/client/src/library/pages/docs/Docs.tsx
+++ b/web/client/src/library/pages/docs/Docs.tsx
@@ -40,10 +40,6 @@ export default function PageDocs(): JSX.Element {
 
   const list = Array.from(new Set(models.values()))
 
-  const isActive = (id: string): boolean => {
-    return `${EnumRoutes.IdeDocsModels}/${id}` === pathname
-  }
-
   return (
     <Page
       sidebar={
@@ -52,7 +48,7 @@ export default function PageDocs(): JSX.Element {
           byName="displayName"
           to={EnumRoutes.IdeDocsModels}
           items={list}
-          isActive={isActive}
+          isActive={id => `${EnumRoutes.IdeDocsModels}/${id}` === pathname}
           types={list.reduce(
             (acc: Record<string, string>, it) =>
               Object.assign(acc, {

--- a/web/client/src/library/pages/docs/Docs.tsx
+++ b/web/client/src/library/pages/docs/Docs.tsx
@@ -40,8 +40,6 @@ export default function PageDocs(): JSX.Element {
 
   const list = Array.from(new Set(models.values()))
 
-  console.log(list, 'list')
-
   const activeItemIndex = useMemo((): number => {
     return list.findIndex(listItem => {
       return `/docs/models/${listItem.name}` === pathname

--- a/web/client/src/library/pages/docs/Docs.tsx
+++ b/web/client/src/library/pages/docs/Docs.tsx
@@ -13,7 +13,7 @@ import { type LineageNodeModelType } from '@components/graph/Graph'
 import { getModelNodeTypeTitle } from '@components/graph/help'
 
 export default function PageDocs(): JSX.Element {
-  const location = useLocation()
+  const { pathname } = useLocation()
   const navigate = useNavigate()
   const { modelName } = useParams()
 
@@ -40,15 +40,23 @@ export default function PageDocs(): JSX.Element {
 
   const list = Array.from(new Set(models.values()))
 
+  console.log(list, 'list')
+
+  const activeItemIndex = useMemo((): number => {
+    return list.findIndex(listItem => {
+      return `/docs/models/${listItem.name}` === pathname
+    })
+  }, [pathname, list])
+
   return (
     <Page
       sidebar={
         <SourceList
-          key={location.pathname}
           by="displayName"
           byName="displayName"
           to={EnumRoutes.IdeDocsModels}
           items={list}
+          activeItemIndex={activeItemIndex}
           types={list.reduce(
             (acc: Record<string, string>, it) =>
               Object.assign(acc, {

--- a/web/client/src/library/pages/docs/Docs.tsx
+++ b/web/client/src/library/pages/docs/Docs.tsx
@@ -40,11 +40,9 @@ export default function PageDocs(): JSX.Element {
 
   const list = Array.from(new Set(models.values()))
 
-  const activeItemIndex = useMemo((): number => {
-    return list.findIndex(listItem => {
-      return `/docs/models/${listItem.name}` === pathname
-    })
-  }, [pathname, list])
+  const isActive = (id: string): boolean => {
+    return `${EnumRoutes.IdeDocsModels}/${id}` === pathname
+  }
 
   return (
     <Page
@@ -54,7 +52,7 @@ export default function PageDocs(): JSX.Element {
           byName="displayName"
           to={EnumRoutes.IdeDocsModels}
           items={list}
-          activeItemIndex={activeItemIndex}
+          isActive={isActive}
           types={list.reduce(
             (acc: Record<string, string>, it) =>
               Object.assign(acc, {

--- a/web/client/src/library/pages/errors/Errors.tsx
+++ b/web/client/src/library/pages/errors/Errors.tsx
@@ -16,10 +16,6 @@ export default function PageErrors(): JSX.Element {
 
   const list = useMemo(() => Array.from(errors).reverse(), [errors])
 
-  const isActive = (id: string): boolean => {
-    return `${EnumRoutes.Errors}/${id}` === pathname
-  }
-
   useEffect(() => {
     if (isArrayEmpty(list)) {
       setTimeout(() => navigate(EnumRoutes.Ide))
@@ -63,7 +59,7 @@ export default function PageErrors(): JSX.Element {
             byDescription="message"
             to={EnumRoutes.Errors}
             items={list}
-            isActive={isActive}
+            isActive={id => `${EnumRoutes.Errors}/${id}` === pathname}
             types={list.reduce(
               (acc: Record<string, string>, it) =>
                 Object.assign(acc, { [it.id]: it.status }),

--- a/web/client/src/library/pages/errors/Errors.tsx
+++ b/web/client/src/library/pages/errors/Errors.tsx
@@ -2,24 +2,23 @@ import { useIDE } from '../ide/context'
 import Page from '../root/Page'
 import SourceList, { SourceListItem } from '@components/sourceList/SourceList'
 import { EnumRoutes } from '~/routes'
-import { Outlet, useNavigate } from 'react-router-dom'
+import { Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { EnumSize, EnumVariant } from '~/types/enum'
 import { useEffect, useMemo } from 'react'
 import { isArrayEmpty, isNil, isNotNil } from '@utils/index'
 import { Button } from '@components/button/Button'
 
 export default function PageErrors(): JSX.Element {
+  const { pathname } = useLocation()
   const navigate = useNavigate()
 
   const { errors, removeError, clearErrors } = useIDE()
 
   const list = useMemo(() => Array.from(errors).reverse(), [errors])
 
-  const activeItemIndex = useMemo((): number => {
-    return list.findIndex(item => {
-      return `${EnumRoutes.Errors}/${item.id}` === location.pathname
-    })
-  }, [location.pathname, list])
+  const isActive = (id: string): boolean => {
+    return `${EnumRoutes.Errors}/${id}` === pathname
+  }
 
   useEffect(() => {
     if (isArrayEmpty(list)) {
@@ -64,7 +63,7 @@ export default function PageErrors(): JSX.Element {
             byDescription="message"
             to={EnumRoutes.Errors}
             items={list}
-            activeItemIndex={activeItemIndex}
+            isActive={isActive}
             types={list.reduce(
               (acc: Record<string, string>, it) =>
                 Object.assign(acc, { [it.id]: it.status }),

--- a/web/client/src/library/pages/errors/Errors.tsx
+++ b/web/client/src/library/pages/errors/Errors.tsx
@@ -15,6 +15,12 @@ export default function PageErrors(): JSX.Element {
 
   const list = useMemo(() => Array.from(errors).reverse(), [errors])
 
+  const activeItemIndex = useMemo((): number => {
+    return list.findIndex(item => {
+      return `${EnumRoutes.Errors}/${item.id}` === location.pathname
+    })
+  }, [location.pathname, list])
+
   useEffect(() => {
     if (isArrayEmpty(list)) {
       setTimeout(() => navigate(EnumRoutes.Ide))
@@ -58,6 +64,7 @@ export default function PageErrors(): JSX.Element {
             byDescription="message"
             to={EnumRoutes.Errors}
             items={list}
+            activeItemIndex={activeItemIndex}
             types={list.reduce(
               (acc: Record<string, string>, it) =>
                 Object.assign(acc, { [it.id]: it.status }),

--- a/web/client/src/library/pages/plan/Plan.tsx
+++ b/web/client/src/library/pages/plan/Plan.tsx
@@ -3,7 +3,7 @@ import { useStoreContext } from '@context/context'
 import SourceList, { SourceListItem } from '@components/sourceList/SourceList'
 import { EnumRoutes } from '~/routes'
 import { Outlet, useLocation, useNavigate } from 'react-router-dom'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useStorePlan } from '@context/plan'
 import { isFalse, isNotNil } from '@utils/index'
 import { Modules } from '@api/client'
@@ -18,6 +18,14 @@ export default function PagePlan(): JSX.Element {
 
   const planAction = useStorePlan(s => s.planAction)
   const planApply = useStorePlan(s => s.planApply)
+
+  const environmentsArray = Array.from(environments)
+
+  const activeItemIndex = useMemo((): number => {
+    return environmentsArray.findIndex(env => {
+      return `${EnumRoutes.Plan}/environments/${env.name}` === location.pathname
+    })
+  }, [location.pathname, environments])
 
   useEffect(() => {
     if (planApply.isRunning && isNotNil(planApply.environment)) {
@@ -49,12 +57,13 @@ export default function PagePlan(): JSX.Element {
           by="name"
           byName="name"
           to={`${EnumRoutes.Plan}/environments`}
-          items={Array.from(environments)}
+          items={environmentsArray}
           disabled={
             isFalse(modules.includes(Modules.plans)) ||
             planAction.isProcessing ||
             environment.isInitialProd
           }
+          activeItemIndex={activeItemIndex}
           listItem={({
             to,
             name,

--- a/web/client/src/library/pages/plan/Plan.tsx
+++ b/web/client/src/library/pages/plan/Plan.tsx
@@ -3,7 +3,7 @@ import { useStoreContext } from '@context/context'
 import SourceList, { SourceListItem } from '@components/sourceList/SourceList'
 import { EnumRoutes } from '~/routes'
 import { Outlet, useLocation, useNavigate } from 'react-router-dom'
-import { useEffect, useMemo } from 'react'
+import { useEffect } from 'react'
 import { useStorePlan } from '@context/plan'
 import { isFalse, isNotNil } from '@utils/index'
 import { Modules } from '@api/client'
@@ -21,11 +21,9 @@ export default function PagePlan(): JSX.Element {
 
   const environmentsArray = Array.from(environments)
 
-  const activeItemIndex = useMemo((): number => {
-    return environmentsArray.findIndex(env => {
-      return `${EnumRoutes.Plan}/environments/${env.name}` === location.pathname
-    })
-  }, [location.pathname, environments])
+  const isActive = (id: string): boolean => {
+    return `${EnumRoutes.Plan}/environments/${id}` === location.pathname
+  }
 
   useEffect(() => {
     if (planApply.isRunning && isNotNil(planApply.environment)) {
@@ -63,7 +61,7 @@ export default function PagePlan(): JSX.Element {
             planAction.isProcessing ||
             environment.isInitialProd
           }
-          activeItemIndex={activeItemIndex}
+          isActive={isActive}
           listItem={({
             to,
             name,

--- a/web/client/src/library/pages/plan/Plan.tsx
+++ b/web/client/src/library/pages/plan/Plan.tsx
@@ -21,10 +21,6 @@ export default function PagePlan(): JSX.Element {
 
   const environmentsArray = Array.from(environments)
 
-  const isActive = (id: string): boolean => {
-    return `${EnumRoutes.Plan}/environments/${id}` === location.pathname
-  }
-
   useEffect(() => {
     if (planApply.isRunning && isNotNil(planApply.environment)) {
       const pathname = `${EnumRoutes.Plan}/environments/${planApply.environment}`
@@ -61,7 +57,9 @@ export default function PagePlan(): JSX.Element {
             planAction.isProcessing ||
             environment.isInitialProd
           }
-          isActive={isActive}
+          isActive={id =>
+            `${EnumRoutes.Plan}/environments/${id}` === location.pathname
+          }
           listItem={({
             to,
             name,

--- a/web/client/src/library/pages/tests/Tests.tsx
+++ b/web/client/src/library/pages/tests/Tests.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom'
+import { Outlet, useLocation } from 'react-router-dom'
 import Page from '../root/Page'
 import { useStoreProject } from '@context/project'
 import SourceList, { SourceListItem } from '@components/sourceList/SourceList'
@@ -6,20 +6,18 @@ import { EnumSize, EnumVariant } from '~/types/enum'
 import { EnumRoutes } from '~/routes'
 import { Button } from '@components/button/Button'
 import { Divider } from '@components/divider/Divider'
-import { useMemo } from 'react'
 
 export default function PageTests(): JSX.Element {
+  const { pathname } = useLocation()
   const files = useStoreProject(s => s.files)
 
   const items = Array.from(files.values()).filter(it =>
     it.path.endsWith('tests'),
   )
 
-  const activeItemIndex = useMemo((): number => {
-    return items.findIndex(item => {
-      return `${EnumRoutes.Tests}/${item.basename}` === location.pathname
-    })
-  }, [location.pathname, items])
+  const isActive = (id: string): boolean => {
+    return `${EnumRoutes.Tests}/${id}` === pathname
+  }
 
   return (
     <Page
@@ -30,7 +28,7 @@ export default function PageTests(): JSX.Element {
             byName="basename"
             to={EnumRoutes.Tests}
             items={items}
-            activeItemIndex={activeItemIndex}
+            isActive={isActive}
             listItem={({ to, name, description, text, disabled = false }) => (
               <SourceListItem
                 to={to}

--- a/web/client/src/library/pages/tests/Tests.tsx
+++ b/web/client/src/library/pages/tests/Tests.tsx
@@ -15,10 +15,6 @@ export default function PageTests(): JSX.Element {
     it.path.endsWith('tests'),
   )
 
-  const isActive = (id: string): boolean => {
-    return `${EnumRoutes.Tests}/${id}` === pathname
-  }
-
   return (
     <Page
       sidebar={
@@ -28,7 +24,7 @@ export default function PageTests(): JSX.Element {
             byName="basename"
             to={EnumRoutes.Tests}
             items={items}
-            isActive={isActive}
+            isActive={id => `${EnumRoutes.Tests}/${id}` === pathname}
             listItem={({ to, name, description, text, disabled = false }) => (
               <SourceListItem
                 to={to}

--- a/web/client/src/library/pages/tests/Tests.tsx
+++ b/web/client/src/library/pages/tests/Tests.tsx
@@ -6,6 +6,7 @@ import { EnumSize, EnumVariant } from '~/types/enum'
 import { EnumRoutes } from '~/routes'
 import { Button } from '@components/button/Button'
 import { Divider } from '@components/divider/Divider'
+import { useMemo } from 'react'
 
 export default function PageTests(): JSX.Element {
   const files = useStoreProject(s => s.files)
@@ -13,6 +14,12 @@ export default function PageTests(): JSX.Element {
   const items = Array.from(files.values()).filter(it =>
     it.path.endsWith('tests'),
   )
+
+  const activeItemIndex = useMemo((): number => {
+    return items.findIndex(item => {
+      return `${EnumRoutes.Tests}/${item.basename}` === location.pathname
+    })
+  }, [location.pathname, items])
 
   return (
     <Page
@@ -23,6 +30,7 @@ export default function PageTests(): JSX.Element {
             byName="basename"
             to={EnumRoutes.Tests}
             items={items}
+            activeItemIndex={activeItemIndex}
             listItem={({ to, name, description, text, disabled = false }) => (
               <SourceListItem
                 to={to}


### PR DESCRIPTION
Three main things being added here

- virtualizing the list of items in the docs list using tanstack react virtualizer
- when user refreshes the page, if the active item is not visible in the docs list, list will be scrolled until the active item is visible
- added a button so if you scroll away from the currently active item and want to return to it, it will be easy to do so

==

Video showing page refresh results in active item being visible, and the "scroll to" button when it is scrolled out of frame:

https://github.com/TobikoData/sqlmesh/assets/81378/469b7318-dd77-4d34-9865-9d97a26b8488