### PR TITLE
feat: add dbt scd type 2 feature flag

### DIFF
--- a/sqlmesh/core/config/feature_flag.py
+++ b/sqlmesh/core/config/feature_flag.py
@@ -1,0 +1,9 @@
+from sqlmesh.utils.pydantic import PydanticModel
+
+
+class DbtFeatureFlag(PydanticModel):
+    scd_type_2_support: bool = True
+
+
+class FeatureFlag(PydanticModel):
+    dbt: DbtFeatureFlag = DbtFeatureFlag()

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -19,6 +19,7 @@ from sqlmesh.core.config.connection import (
     DuckDBConnectionConfig,
     connection_config_validator,
 )
+from sqlmesh.core.config.feature_flag import FeatureFlag
 from sqlmesh.core.config.format import FormatConfig
 from sqlmesh.core.config.gateway import GatewayConfig
 from sqlmesh.core.config.model import ModelDefaultsConfig
@@ -68,6 +69,7 @@ class Config(BaseConfig):
         log_limit: The default number of logs to keep.
         format: The formatting options for SQL code.
         ui: The UI configuration for SQLMesh.
+        feature_flags: Feature flags to enable/disable certain features.
     """
 
     gateways: t.Dict[str, GatewayConfig] = {"": GatewayConfig()}
@@ -103,6 +105,7 @@ class Config(BaseConfig):
     run: RunConfig = RunConfig()
     format: FormatConfig = FormatConfig()
     ui: UIConfig = UIConfig()
+    feature_flags: FeatureFlag = FeatureFlag()
 
     _FIELD_UPDATE_STRATEGY: t.ClassVar[t.Dict[str, UpdateStrategy]] = {
         "gateways": UpdateStrategy.KEY_UPDATE,

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -17,6 +17,7 @@ from sqlmesh.core.macros import MacroRegistry
 from sqlmesh.core.model import Model, ModelCache
 from sqlmesh.dbt.basemodel import BMC, BaseModelConfig
 from sqlmesh.dbt.context import DbtContext
+from sqlmesh.dbt.model import ModelConfig
 from sqlmesh.dbt.profile import Profile
 from sqlmesh.dbt.project import Project
 from sqlmesh.dbt.target import TargetConfig
@@ -99,9 +100,19 @@ class DbtLoader(Loader):
             package_models: t.Dict[str, BaseModelConfig] = {**package.models, **package.seeds}
 
             for model in package_models.values():
+                if (
+                    not context.sqlmesh_config.feature_flags.dbt.scd_type_2_support
+                    and isinstance(model, ModelConfig)
+                    and model.model_kind(context).is_scd_type_2
+                ):
+                    logger.info(
+                        "Skipping loading Snapshot (SCD Type 2) models due to the feature flag disabling this feature"
+                    )
+                    continue
                 sqlmesh_model = cache.get_or_load_model(
                     model.path, loader=lambda: self._to_sqlmesh(model, context)
                 )
+
                 models[sqlmesh_model.fqn] = sqlmesh_model
 
         models.update(self._load_external_models())


### PR DESCRIPTION
Adds a feature flag for disabling SCD Type 2 Support (or called "Snapshots" in dbt) using the dbt adapter. This would disable all Snapshot models. The plan is to remove this in a few weeks if we find it is not needed as we continue to rollout full Snapshot support to dbt models. 