### PR TITLE
Revert "Feat: Macro typing coercion (#2041)"

### DIFF
--- a/examples/sushi/macros/macros.py
+++ b/examples/sushi/macros/macros.py
@@ -1,9 +1,8 @@
 from macros.utils import between  # type: ignore
-from sqlglot import exp
 
 from sqlmesh import macro
 
 
 @macro()
-def incremental_by_ds(evaluator, column: exp.Column):
+def incremental_by_ds(evaluator, column):
     return between(evaluator, column, evaluator.locals["start_date"], evaluator.locals["end_date"])

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-import inspect
-import logging
 import typing as t
 from enum import Enum
-from functools import reduce, wraps
+from functools import reduce
 from string import Template
 
 import sqlglot
 from jinja2 import Environment
-from sqlglot import Generator, exp, parse_one
+from sqlglot import Generator, exp
 from sqlglot.executor.env import ENV
 from sqlglot.executor.python import Python
 from sqlglot.helper import csv, ensure_collection
@@ -17,7 +15,6 @@ from sqlglot.schema import MappingSchema
 
 from sqlmesh.core.dialect import (
     SQLMESH_MACRO_PREFIX,
-    Dialect,
     MacroDef,
     MacroFunc,
     MacroSQL,
@@ -35,8 +32,6 @@ if t.TYPE_CHECKING:
     from sqlmesh.core._typing import TableName
     from sqlmesh.core.engine_adapter import EngineAdapter
     from sqlmesh.core.snapshot import Snapshot
-
-logger = logging.getLogger(__name__)
 
 
 class RuntimeStage(Enum):
@@ -354,75 +349,6 @@ class MacroEvaluator:
             )
         return self.locals["engine_adapter"]
 
-    def _coerce(self, expr: exp.Expression, typ: t.Any, strict: bool = False) -> t.Any:
-        """Coerces the given expression to the specified type on a best-effort basis."""
-        base_err_msg = f"Failed to coerce expression '{expr}' to type '{typ}'."
-        try:
-            if typ is None:
-                return expr
-            base = t.get_origin(typ) or typ
-            # We need to handle t.Union first since we cannot use isinstance with it
-            if base is t.Union:
-                for branch in t.get_args(typ):
-                    try:
-                        return self._coerce(expr, branch, True)
-                    except Exception:
-                        pass
-                raise SQLMeshError(base_err_msg)
-            if isinstance(expr, base):
-                return expr
-            if issubclass(base, exp.Expression):
-                d = Dialect.get_or_raise(self.dialect)
-                into = base if base in d.parser().EXPRESSION_PARSERS else None
-                if into is None:
-                    if isinstance(expr, exp.Literal):
-                        coerced = parse_one(expr.this)
-                    else:
-                        raise SQLMeshError(
-                            f"{base_err_msg} Coercion to {base} requires a literal expression."
-                        )
-                else:
-                    coerced = parse_one(
-                        expr.this if isinstance(expr, exp.Literal) else expr.sql(), into=into
-                    )
-                if isinstance(coerced, base):
-                    return coerced
-                else:
-                    raise SQLMeshError(base_err_msg)
-            if base in (int, float, str) and isinstance(expr, exp.Literal):
-                return base(expr.this)
-            if base is bool and isinstance(expr, exp.Boolean):
-                return expr.this
-            if base is str and isinstance(expr, exp.Expression):
-                return expr.sql(self.dialect)
-            if base is tuple and isinstance(expr, (exp.Tuple, exp.Array)):
-                generic = t.get_args(typ)
-                if not generic:
-                    return tuple(expr.expressions)
-                if generic[-1] is ...:
-                    return tuple(self._coerce(expr, generic[0]) for expr in expr.expressions)
-                elif len(generic) == len(expr.expressions):
-                    return tuple(
-                        self._coerce(expr, generic[i]) for i, expr in enumerate(expr.expressions)
-                    )
-                raise SQLMeshError(f"{base_err_msg} Expected {len(generic)} items.")
-            if base is list and isinstance(expr, (exp.Array, exp.Tuple)):
-                generic = t.get_args(typ)
-                if not generic:
-                    return expr.expressions
-                return [self._coerce(expr, generic[0]) for expr in expr.expressions]
-            raise SQLMeshError(base_err_msg)
-        except Exception:
-            if strict:
-                raise
-            logger.warning(
-                "Coercion of expression '%s' to type '%s' failed. Using non coerced expression.",
-                expr,
-                typ,
-                exc_info=True,
-            )
-            return expr
-
 
 class macro(registry_decorator):
     """Specifies a function is a macro and registers it the global MACROS registry.
@@ -446,31 +372,7 @@ class macro(registry_decorator):
     def __call__(
         self, func: t.Callable[..., DECORATOR_RETURN_TYPE]
     ) -> t.Callable[..., DECORATOR_RETURN_TYPE]:
-        @wraps(func)
-        def _typed_func(
-            evaluator: MacroEvaluator, *args_: t.Any, **kwargs_: t.Any
-        ) -> DECORATOR_RETURN_TYPE:
-            spec = inspect.getfullargspec(func)
-            annotations = t.get_type_hints(func)
-            kwargs = inspect.getcallargs(func, evaluator, *args_, **kwargs_)
-            for param, value in kwargs.items():
-                coercible_type = annotations.get(param)
-                if not coercible_type:
-                    continue
-                kwargs[param] = evaluator._coerce(value, coercible_type)
-            args = [kwargs.pop(k) for k in spec.args if k in kwargs]
-            if spec.varargs:
-                args.extend(kwargs.pop(spec.varargs, []))
-            return func(*args, **kwargs)
-
-        try:
-            annotated = any(t.get_type_hints(func).keys() - {"return"})
-        except TypeError:
-            annotated = False
-
-        wrapper = super().__call__(
-            func if not annotated else t.cast(t.Callable[..., DECORATOR_RETURN_TYPE], _typed_func)
-        )
+        wrapper = super().__call__(func)
 
         # This is useful to identify macros at runtime
         setattr(wrapper, "__sqlmesh_macro__", True)

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -27,41 +27,6 @@ def macro_evaluator() -> MacroEvaluator:
     def noop(evaluator: MacroEvaluator):
         return None
 
-    @macro()
-    def bitshift_square(evaluator: MacroEvaluator, x: int, y: int) -> int:
-        return (x >> y) ** 2
-
-    @macro()
-    def prefix_db(evaluator: MacroEvaluator, table: exp.Table, prefix: str) -> exp.Table:
-        table.set("db", prefix + table.db)
-        return table
-
-    @macro()
-    def repeated(evaluator: MacroEvaluator, expr: str, times: int = 2, multi: bool = False):
-        if multi is True:
-            return (expr,) * times
-        return expr * times
-
-    @macro()
-    def split(evaluator: MacroEvaluator, string: str, sep: str = ","):
-        return string.split(sep)
-
-    @macro()
-    def cte_tag_name(evaluator: MacroEvaluator, with_: exp.Select):
-        for cte in with_.find_all(exp.CTE):
-            name = cte.alias_or_name
-            for query in cte.find_all(exp.Select):
-                query.select(exp.Literal.string(name).as_("source"), copy=False)
-        return with_
-
-    @macro()
-    def suffix_idents(evaluator: MacroEvaluator, items: t.List[str], suffix: str):
-        return [item + suffix for item in items]
-
-    @macro()
-    def suffix_idents_2(evaluator: MacroEvaluator, items: t.Tuple[str, ...], suffix: str):
-        return [item + suffix for item in items]
-
     return MacroEvaluator(
         "hive",
         {"test": Executable(name="test", payload=f"def test(_):\n    return 'test'")},
@@ -327,131 +292,12 @@ def test_ast_correctness(macro_evaluator):
             "SELECT d",
             {},
         ),
-        (
-            """@BITSHIFT_SQUARE(50, '3')""",
-            "36",
-            {},
-        ),
-        (
-            """@PREFIX_DB(my.schema.table, 'dev_')""",
-            "my.dev_schema.table",
-            {},
-        ),
-        (
-            """select @REPEATED(test, 3)""",
-            "SELECT testtesttest",
-            {},
-        ),
-        (
-            """select @REPEATED(test, 3, true)""",
-            "SELECT test, test, test",
-            {},
-        ),
-        (
-            """select @SPLIT('a,b,c')""",
-            "SELECT a, b, c",
-            {},
-        ),
-        (
-            """@CTE_TAG_NAME(WITH step1 AS (SELECT 1) SELECT * FROM step1)""",
-            "WITH step1 AS (SELECT 1, 'step1' AS source) SELECT * FROM step1",
-            {},
-        ),
-        (
-            """@CTE_TAG_NAME('WITH step1 AS (SELECT 1) SELECT * FROM step1')""",
-            "WITH step1 AS (SELECT 1, 'step1' AS source) SELECT * FROM step1",
-            {},
-        ),
-        (
-            """SELECT @SUFFIX_IDENTS(['a', 'b', 'c'], 'z')""",
-            "SELECT az, bz, cz",
-            {},
-        ),
-        (
-            """SELECT @SUFFIX_IDENTS_2(['a', 'b', 'c'], 'z')""",
-            "SELECT az, bz, cz",
-            {},
-        ),
     ],
 )
-def test_macro_functions(macro_evaluator: MacroEvaluator, assert_exp_eq, sql, expected, args):
+def test_macro_functions(macro_evaluator, assert_exp_eq, sql, expected, args):
     macro_evaluator.locals = args or {}
     assert_exp_eq(macro_evaluator.transform(parse_one(sql)), expected)
 
 
-def test_macro_returns_none(macro_evaluator: MacroEvaluator):
+def test_macro_returns_none(macro_evaluator):
     assert macro_evaluator.transform(parse_one("@NOOP()")) is None
-
-
-def test_macro_coercion(macro_evaluator: MacroEvaluator, assert_exp_eq):
-    coerce = macro_evaluator._coerce
-    assert coerce(exp.Literal.number(1), int) == 1
-    assert coerce(exp.Literal.number(1.1), float) == 1.1
-    assert coerce(exp.Literal.string("Hi mom"), str) == "Hi mom"
-    assert coerce(exp.true(), bool) is True
-
-    # Coercing a string literal to a column should return a column with the same name
-    assert_exp_eq(coerce(exp.Literal.string("order"), exp.Column), exp.column("order"))
-    # Not possible to coerce this string literal Cast to an exp.Column node -- so it should just return the input
-    assert_exp_eq(
-        coerce(exp.Literal.string("order::date"), exp.Column), exp.Literal.string("order::date")
-    )
-    # This however, is correctly coercible since it's a cast
-    assert_exp_eq(
-        coerce(exp.Literal.string("order::date"), exp.Cast), exp.cast(exp.column("order"), "DATE")
-    )
-
-    # Here we resolve ambiguity via the user type hint
-    assert_exp_eq(coerce(exp.Literal.string("order"), exp.Identifier), exp.to_identifier("order"))
-    assert_exp_eq(coerce(exp.Literal.string("order"), exp.Table), exp.table_("order"))
-
-    # Resolve a union type hint by choosing the first one that works
-    assert_exp_eq(
-        coerce(exp.Literal.string("order::date"), t.Union[exp.Column, exp.Cast]),
-        exp.cast(exp.column("order"), "DATE"),
-    )
-
-    # Simply ask for a string, and always get a string
-    assert coerce(exp.column("order"), str) == "order"
-    assert (
-        coerce(parse_one("SELECT x FROM UNNEST(y) AS x WHERE 1 = 1"), str)
-        == "SELECT x FROM UNNEST(y) AS x WHERE 1 = 1"
-    )
-
-    # From a string literal to a Select should parse the string literal, and the inverse operation works as well
-    assert_exp_eq(
-        coerce(exp.Literal.string("SELECT 1 FROM a"), exp.Select), parse_one("SELECT 1 FROM a")
-    )
-    assert coerce(parse_one("SELECT 1 FROM a"), str) == "SELECT 1 FROM a"
-
-    # Get a list of exp directly instead of an exp.Array
-    assert coerce(parse_one("[1, 2, 3]"), list) == [
-        exp.Literal.number(1),
-        exp.Literal.number(2),
-        exp.Literal.number(3),
-    ]
-
-    # Generics work as well, recursively resolving inner types
-    assert coerce(parse_one("[1, 2, 3]"), t.List[int]) == [1, 2, 3]
-    assert coerce(parse_one("[1, 2, 3]"), t.Tuple[int, int, float]) == (1, 2, 3.0)
-    assert coerce(parse_one("[1, 2, 3]"), t.Tuple[int, ...]) == (1, 2, 3)
-    assert coerce(parse_one("[1, 2, 3]"), t.Tuple[int, str, float]) == (1, "2", 3.0)
-    assert coerce(
-        parse_one("[1, 2, [3]]"), t.Tuple[int, str, t.Union[float, t.Tuple[float, ...]]]
-    ) == (1, "2", (3.0,))
-
-    # Using exp.Expression will always return the input expression
-    assert coerce(parse_one("order", into=exp.Column), exp.Expression) == exp.column("order")
-    assert coerce(exp.Literal.string("OK"), exp.Expression) == exp.Literal.string("OK")
-
-    # Strict flag allows raising errors and is used when recursively coercing expressions
-    # otherwise, in general, we want to be lenient and just warn the user when something is not possible
-    with pytest.raises(SQLMeshError):
-        coerce(exp.Literal.string("order"), exp.Select, strict=True)
-
-    with pytest.raises(SQLMeshError):
-        _ = coerce(
-            exp.Literal.string("order::date"),
-            t.Union[exp.Column, exp.Identifier],
-            strict=True,
-        )


### PR DESCRIPTION
This reverts commit 61451e2838f04af016bf695699a793cf94fb0b44. PR: https://github.com/TobikoData/sqlmesh/pull/2041

The issue is that is breaks Airflow tests because the macros are not serialized properly to include type hints. 