### PR TITLE
Feat: Add support for the synchronous mode to the 'invalidate' CLI command

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -176,7 +176,11 @@ Usage: sqlmesh invalidate [OPTIONS] ENVIRONMENT
   of the janitor process.
 
 Options:
-  --help  Show this message and exit.
+  -s, --sync  Wait for the environment to be deleted before returning. If not
+              specified, the environment will be deleted asynchronously by the
+              janitor process. This option requires a connection to the data
+              warehouse.
+  --help      Show this message and exit.
 ```
 
 ## migrate

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -384,12 +384,18 @@ def run(ctx: click.Context, environment: t.Optional[str] = None, **kwargs: t.Any
 
 @cli.command("invalidate")
 @click.argument("environment", required=True)
+@click.option(
+    "--sync",
+    "-s",
+    is_flag=True,
+    help="Wait for the environment to be deleted before returning. If not specified, the environment will be deleted asynchronously by the janitor process. This option requires a connection to the data warehouse.",
+)
 @click.pass_context
 @error_handler
-def invalidate(ctx: click.Context, environment: str) -> None:
+def invalidate(ctx: click.Context, environment: str, **kwargs: t.Any) -> None:
     """Invalidate the target environment, forcing its removal during the next run of the janitor process."""
     context = ctx.obj
-    context.invalidate_environment(environment)
+    context.invalidate_environment(environment, **kwargs)
 
 
 @cli.command("dag")


### PR DESCRIPTION
The new mode allows to block the `sqlmesh invalidate` command until the environment record and associated views are actually deleted. 

The mode requires a connection to data warehouse, which means that it's presently not supported when using Airflow unless the data warehouse connection configured separately.