### PR TITLE
Chore!: bump sqlglot to v21.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=20.11.0",
+        "sqlglot[rs]~=21.0.0",
     ],
     extras_require={
         "bigquery": [

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -356,8 +356,10 @@ def _parse_types(
 # MacroVar, it'll render into @<path>, so it won't break staged file path references.
 #
 # See: https://docs.snowflake.com/en/user-guide/querying-stage
-def _parse_table_parts(self: Parser, schema: bool = False) -> exp.Table:
-    table = self.__parse_table_parts(schema=schema)  # type: ignore
+def _parse_table_parts(
+    self: Parser, schema: bool = False, is_db_reference: bool = False
+) -> exp.Table:
+    table = self.__parse_table_parts(schema=schema, is_db_reference=is_db_reference)  # type: ignore
     table_arg = table.this
 
     if isinstance(table_arg, exp.Var) and table_arg.name.startswith(SQLMESH_MACRO_PREFIX):

--- a/sqlmesh/core/schema_diff.py
+++ b/sqlmesh/core/schema_diff.py
@@ -453,7 +453,9 @@ class SchemaDiffer(PydanticModel):
         root_struct: exp.DataType,
         new_kwarg: exp.ColumnDef,
     ) -> t.List[TableAlterOperation]:
-        current_type = exp.DataType.build(current_type)
+        # We don't copy on purpose here because current_type may need to be mutated inside
+        # _get_operations (struct.expressions.pop and struct.expressions.insert)
+        current_type = exp.DataType.build(current_type, copy=False)
         if self.support_nested_operations:
             if new_type.this == current_type.this == exp.DataType.Type.STRUCT:
                 return self._get_operations(


### PR DESCRIPTION
Was super annoying to detect the need for the L458 change in schema_diff.py (triggered by a recent [change](https://github.com/tobymao/sqlglot/commit/b4e886877ecfbafdd64c515c765c3c54764bd987#diff-7857fedd1d1451b1b9a5b8efaa1cc292c02e7ee4f0d04d7e2f9d5bfb9565802cR3837) in sqlglot), may need to refactor this at some point to avoid the mutations if possible.