### PR TITLE
chore: scope log handlers to modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 import typing as t
 import uuid
 from pathlib import Path
@@ -180,6 +181,12 @@ def rescope_global_models(request):
 @pytest.fixture(scope="function", autouse=True)
 def rescope_duckdb_classvar(request):
     DuckDBConnectionConfig._data_file_to_adapter = {}
+    yield
+
+
+@pytest.fixture(scope="module", autouse=True)
+def rescope_log_handlers():
+    logging.getLogger().handlers.clear()
     yield
 
 


### PR DESCRIPTION
Handlers are shared globally which was causing an issue where Airflow tests would add handlers and those handlers would then affect the results of other tests (like upcoming CLI tests: https://github.com/TobikoData/sqlmesh/pull/2091)

I initially tried fixing Airflow directly by setting `_AIRFLOW__AS_LIBRARY` within a autouse fixture but that broke some tests and also required that imports for Airflow be within the scope of functions which was annoying. This solution though helps rescope logger to not share state across modules which seems more broadly useful. I decided to scope it to modules instead of functions because I want to make it easy for future tests to configure logging at the module level and not have this override it. 