### PR TITLE
test: add test to reproduce missing documentation on bigquery `STRUCT` fields

### DIFF
--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -593,9 +593,17 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
 
     adapter.create_table(
         "test_table",
-        {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
+        {
+            "a": exp.DataType.build("INT"),
+            "b": exp.DataType.build("INT"),
+            "s": exp.DataType.build("STRUCT<foo STRING>"),
+        },
         table_description="test description",
-        column_descriptions={"a": "a description"},
+        column_descriptions={
+            "a": "a description",
+            "s": "s description",
+            "s.foo": "foo description",
+        },
     )
 
     adapter.ctas(
@@ -619,7 +627,7 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
 
     sql_calls = _to_sql_calls(execute_mock)
     assert sql_calls == [
-        "CREATE TABLE IF NOT EXISTS `test_table` (`a` INT64 OPTIONS (description='a description'), `b` INT64) OPTIONS (description='test description')",
+        "CREATE TABLE IF NOT EXISTS `test_table` (`a` INT64 OPTIONS (description='a description'), `b` INT64, `s` STRUCT<foo STRING OPTIONS (description='foo description')> OPTIONS (description='s description')) OPTIONS (description='test description')",
         "CREATE TABLE IF NOT EXISTS `test_table` (`a` INT64 OPTIONS (description='a description'), `b` INT64) OPTIONS (description='test description') AS SELECT `a`, `b` FROM `source_table`",
         "CREATE OR REPLACE VIEW `test_table` OPTIONS (description='test description') AS SELECT `a`, `b` FROM `source_table`",
         "ALTER TABLE `test_table` SET OPTIONS(description = 'test description')",

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -463,6 +463,28 @@ def test_column_descriptions(sushi_context, assert_exp_eq):
     """,
     )
 
+    expressions = d.parse(
+        """
+        MODEL (
+            name db.table,
+            kind FULL,
+        );
+
+        SELECT
+          STRUCT<
+            a STRING, -- a description
+            b INT, -- b description
+          > AS s, -- s description
+        FROM table
+    """
+    )
+    model = load_sql_based_model(expressions, dialect="bigquery", default_catalog="memory")
+
+    assert_exp_eq(
+        model.column_descriptions,
+        {"s": "s description", "s.a": "a description", "s.b": "b description"},
+    )
+
 
 def test_model_jinja_macro_reference_extraction():
     @macro()


### PR DESCRIPTION
I noticed that BigQuery `STRUCT` fields do not get their comment added as their "description", e.g.:

```sql
MODEL(
 name foo
);
SELECT
  STRUCT<
     a INT, -- this comment will not be added
  > s, -- this comment will be added
FROM bar
```

This adds a test to reproduce the issue. I'm not sure how to refer to struct inner fields in the dict of field comments (i.e.: `Dict[str, str]`), but it should be close enough to understand.