### PR TITLE
Feat!: Automatically compute previews for changed forward-only models in dev

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -327,7 +327,7 @@ If no match is found, the catalog defined in the model or the default catalog de
 
 SQLMesh compares the current state of project files to an environment when `sqlmesh plan` is run. It detects changes to models, which can be classified as breaking or non-breaking.
 
-SQLMesh can  attempt to automatically [categorize](../concepts/plans.md#change-categories) the changes it detects. The `auto_categorize_changes` option determines whether SQLMesh should attempt automatic change categorization. This option is in the [environments](../reference/configuration.md#environments) section of the configuration reference page.
+SQLMesh can  attempt to automatically [categorize](../concepts/plans.md#change-categories) the changes it detects. The `plan.auto_categorize_changes` option determines whether SQLMesh should attempt automatic change categorization. This option is in the [environments](../reference/configuration.md#environments) section of the configuration reference page.
 
 Supported values:
 
@@ -340,11 +340,12 @@ Example showing default values:
 === "YAML"
 
     ```yaml linenums="1"
-    auto_categorize_changes:
-        external: full
-        python: off
-        sql: full
-        seed: full
+    plan:
+        auto_categorize_changes:
+            external: full
+            python: off
+            sql: full
+            seed: full
     ```
 
 === "Python"
@@ -357,15 +358,18 @@ Example showing default values:
         ModelDefaultsConfig,
         AutoCategorizationMode,
         CategorizerConfig,
+        PlanConfig,
     )
 
     config = Config(
         model_defaults=ModelDefaultsConfig(dialect=<dialect>),
-        auto_categorize_changes=CategorizerConfig(
-            external=AutoCategorizationMode.FULL,
-            python=AutoCategorizationMode.OFF,
-            sql=AutoCategorizationMode.FULL,
-            seed=AutoCategorizationMode.FULL,
+        plan=PlanConfig(
+            auto_categorize_changes=CategorizerConfig(
+                external=AutoCategorizationMode.FULL,
+                python=AutoCategorizationMode.OFF,
+                sql=AutoCategorizationMode.FULL,
+                seed=AutoCategorizationMode.FULL,
+            )
         ),
     )
     ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -238,6 +238,8 @@ Options:
   --no-diff                 Hide text differences for changed models.
   --run                     Run latest intervals as part of the plan
                             application (prod environment only).
+  --enable-preview          Enable preview for forward-only models when
+                            targeting a development environment.
   -v, --verbose             Verbose output.
   --help                    Show this message and exit.
 ```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,9 +29,7 @@ Configuration options for SQLMesh environment creation and promotion.
 | `snapshot_ttl`               | The period of time that a model snapshot not a part of any environment should exist before being deleted. This is defined as a string with the default `in 1 week`. Other [relative dates](https://dateparser.readthedocs.io/en/latest/) can be used, such as `in 30 days`. (Default: `in 1 week`) | string               | N        |
 | `environment_ttl`            | The period of time that a development environment should exist before being deleted. This is defined as a string with the default `in 1 week`. Other [relative dates](https://dateparser.readthedocs.io/en/latest/) can be used, such as `in 30 days`. (Default: `in 1 week`)                      | string               | N        |
 | `pinned_environments`        | The list of development environments that are exempt from deletion due to expiration                                                                                                                                                                                                               | list[string]         | N        |
-| `include_unmodified`         | Indicates whether to create views for all models in the target development environment or only for modified ones                                                                                                                                                                                   | boolean              | N        |
 | `time_column_format`         | The default format to use for all model time columns. This time format uses [python format codes](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes) (Default: `%Y-%m-%d`)                                                                                        | string               | N        |
-| `auto_categorize_changes`    | Indicates whether SQLMesh should attempt to automatically [categorize](../concepts/plans.md#change-categories) model changes during plan creation per each model source type ([additional details](../guides/configuration.md#auto-categorize-changes))                                                                      | dict[string, string] | N        |
 | `default_target_environment` | The name of the environment that will be the default target for the `sqlmesh plan` and `sqlmesh run` commands. (Default: `prod`)                                                                                                                                                                   | string               | N        |
 | `physical_schema_override`   | A mapping from model schema names to names of schemas in which physical tables for the corresponding models will be placed - [addition details](../guides/configuration.md#physical-schema-override). (Default physical schema name: `sqlmesh__[model schema]`)                                                                                                                                                                   | string               | N        |
 | `environment_suffix_target`  | Whether SQLMesh views should append their environment name to the `schema` or `table` - [additional details](../guides/configuration.md#view-schema-override). (Default: `schema`)                                                                                                                                                                   | string               | N        |
@@ -43,7 +41,21 @@ The `model_defaults` key is **required** and must contain a value for the `diale
 
 See all the keys allowed in `model_defaults` at the [model configuration reference page](./model_configuration.md#model-defaults).
 
-### Run
+## Plan
+
+Configuration for the `sqlmesh plan` command.
+
+| Option                    | Description                                                                                                                                                                                                                                             | Type                 | Required |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------:|:--------:|
+| `auto_categorize_changes` | Indicates whether SQLMesh should attempt to automatically [categorize](../concepts/plans.md#change-categories) model changes during plan creation per each model source type ([additional details](../guides/configuration.md#auto-categorize-changes)) | dict[string, string] | N        |
+| `include_unmodified`      | Indicates whether to create views for all models in the target development environment or only for modified ones (Default: False)                                                                                                                       | boolean              | N        |
+| `auto_apply`              | Indicates whether to automatically apply a new plan after creation (Default: False)                                                                                                                                                                     | boolean              | N        |
+| `forward_only`            | Indicates whether the plan should be [forward-only](../concepts/plans.md#forward-only-plans) (Default: False)                                                                                                                                           | boolean              | N        |
+| `enable_preview`         | Indicates whether to enable [data preview](../concepts/plans.md#data-preview) for forward-only models when targeting a development environment (Default: False)                                                                                         | boolean              | N        |
+| `no_diff`                 | Don't show diffs for changed models (Default: False)                                                                                                                                                                                                    | boolean              | N        |
+| `no_prompts`              | Disables interactive prompts in CLI (Default: False)                                                                                                                                                                                                    | boolean              | N        |
+
+## Run
 
 Configuration for the `sqlmesh run` command. Please note that this is only applicable when configured with the [builtin](#builtin) scheduler.
 
@@ -51,6 +63,28 @@ Configuration for the `sqlmesh run` command. Please note that this is only appli
 |------------------------------|--------------------------------------------------------------------------------------------------------------------|:----:|:--------:|
 | `environment_check_interval` | The number of seconds to wait between attempts to check the target environment for readiness (Default: 30 seconds) | int  | N        |
 | `environment_check_max_wait` | The maximum number of seconds to wait for the target environment to be ready (Default: 6 hours)                    | int  | N        |
+
+## Format
+
+Formatting settings for the `sqlmesh format` command and UI.
+
+| Option                | Description                                                                                    | Type    | Required |
+|-----------------------|------------------------------------------------------------------------------------------------|:-------:|:--------:|
+| `normailize`          | Whether to normalize SQL (Default: False)                                                      | boolean | N        |
+| `pad`                 | The number of spaces to use for padding (Default: 2)                                           | int     | N        |
+| `indent`              | The number of spaces to use for indentation (Default: 2)                                       | int     | N        |
+| `normalize_functions` | Whether to normalize function names. Supported values are: 'upper' and 'lower' (Default: None) | string  | N        |
+| `leading_comma`       | Whether to use leading commas (Default: False)                                                 | boolean | N        |
+| `max_text_width`      | The maximum text width in a segment before creating new lines (Default: 80)                    | int     | N        |
+| `append_newline`      | Whether to append a newline to the end of the file (Default: False)                            | boolean | N        |
+
+## UI
+
+SQLMesh UI settings.
+
+| Option   | Description                                                                                   | Type    | Required |
+|----------|-----------------------------------------------------------------------------------------------|:-------:|:--------:|
+| `format` | Whether to automatically format model definitions upon saving them to a file (Default: False) | boolean | N        |
 
 ## Gateways
 

--- a/examples/sushi/config.py
+++ b/examples/sushi/config.py
@@ -9,6 +9,7 @@ from sqlmesh.core.config import (
     EnvironmentSuffixTarget,
     GatewayConfig,
     ModelDefaultsConfig,
+    PlanConfig,
     SparkConnectionConfig,
 )
 from sqlmesh.core.notification_target import (
@@ -33,7 +34,7 @@ config = Config(
 test_config = Config(
     gateways={"in_memory": GatewayConfig(connection=DuckDBConnectionConfig())},
     default_gateway="in_memory",
-    auto_categorize_changes=CategorizerConfig(sql=AutoCategorizationMode.SEMI),
+    plan=PlanConfig(auto_categorize_changes=CategorizerConfig(sql=AutoCategorizationMode.SEMI)),
     model_defaults=ModelDefaultsConfig(dialect="duckdb"),
 )
 

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -290,6 +290,7 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
     "--forward-only",
     is_flag=True,
     help="Create a plan for forward-only changes.",
+    default=None,
 )
 @click.option(
     "--effective-from",
@@ -301,11 +302,13 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
     "--no-prompts",
     is_flag=True,
     help="Disable interactive prompts for the backfill time range. Please note that if this flag is set and there are uncategorized changes, plan creation will fail.",
+    default=None,
 )
 @click.option(
     "--auto-apply",
     is_flag=True,
     help="Automatically apply the new plan after creation.",
+    default=None,
 )
 @click.option(
     "--no-auto-categorization",
@@ -335,11 +338,18 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
     "--no-diff",
     is_flag=True,
     help="Hide text differences for changed models.",
+    default=None,
 )
 @click.option(
     "--run",
     is_flag=True,
     help="Run latest intervals as part of the plan application (prod environment only).",
+)
+@click.option(
+    "--enable-preview",
+    is_flag=True,
+    help="Enable preview for forward-only models when targeting a development environment.",
+    default=None,
 )
 @opt.verbose
 @click.pass_context

--- a/sqlmesh/core/config/__init__.py
+++ b/sqlmesh/core/config/__init__.py
@@ -22,6 +22,7 @@ from sqlmesh.core.config.loader import (
     load_configs,
 )
 from sqlmesh.core.config.model import ModelDefaultsConfig
+from sqlmesh.core.config.plan import PlanConfig
 from sqlmesh.core.config.root import Config
 from sqlmesh.core.config.run import RunConfig
 from sqlmesh.core.config.scheduler import (

--- a/sqlmesh/core/config/plan.py
+++ b/sqlmesh/core/config/plan.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from sqlmesh.core.config.base import BaseConfig
+from sqlmesh.core.config.categorizer import CategorizerConfig
+
+
+class PlanConfig(BaseConfig):
+    """Configuration for a plan.
+
+    Args:
+        forward_only: Whether the plan should be forward-only.
+        auto_categorize_changes: Whether SQLMesh should attempt to automatically categorize model changes (breaking / non-breaking)
+            during plan creation.
+        include_unmodified: Whether to include unmodified models in the target development environment.
+        enable_preview: Whether to enable preview for forward-only models in development environments.
+        no_diff: Hide text differences for changed models.
+        no_prompts: Whether to disable interactive prompts for the backfill time range. Please note that
+        auto_apply: Whether to automatically apply the new plan after creation.
+    """
+
+    forward_only: bool = False
+    auto_categorize_changes: CategorizerConfig = CategorizerConfig()
+    include_unmodified: bool = False
+    enable_preview: bool = False
+    no_diff: bool = False
+    no_prompts: bool = False
+    auto_apply: bool = False

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -829,7 +829,10 @@ class TerminalConsole(Console):
                         blank_meaning = "to preview starting from yesterday"
                         default_start = yesterday_ds()
                 else:
-                    blank_meaning = "to backfill from the beginning of history"
+                    if plan.provided_start:
+                        blank_meaning = f"to backfill starting from '{plan.provided_start}'"
+                    else:
+                        blank_meaning = "to backfill from the beginning of history"
                     default_start = None
 
                 start = self._prompt(

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -309,6 +309,7 @@ class SQLMeshMagics(Magics):
         "--forward-only",
         action="store_true",
         help="Create a plan for forward-only changes.",
+        default=None,
     )
     @argument(
         "--effective-from",
@@ -319,11 +320,13 @@ class SQLMeshMagics(Magics):
         "--no-prompts",
         action="store_true",
         help="Disables interactive prompts for the backfill time range. Please note that if this flag is set and there are uncategorized changes, plan creation will fail.",
+        default=None,
     )
     @argument(
         "--auto-apply",
         action="store_true",
         help="Automatically applies the new plan after creation.",
+        default=None,
     )
     @argument(
         "--no-auto-categorization",
@@ -353,11 +356,18 @@ class SQLMeshMagics(Magics):
         "--no-diff",
         action="store_true",
         help="Hide text differences for changed models.",
+        default=None,
     )
     @argument(
         "--run",
         action="store_true",
         help="Run latest intervals as part of the plan application (prod environment only).",
+    )
+    @argument(
+        "--enable-preview",
+        action="store_true",
+        help="Enable preview for forward-only models when targeting a development environment.",
+        default=None,
     )
     @line_magic
     @pass_sqlmesh_context
@@ -385,6 +395,7 @@ class SQLMeshMagics(Magics):
             select_models=args.select_model,
             no_diff=args.no_diff,
             run=args.run,
+            enable_preview=args.enable_preview,
         )
 
     @magic_arguments()


### PR DESCRIPTION
This introduces the additional `--enable-preview` flag (and a corresponding config option) to the plan command, which enables automatic computation of data previews for changes applied to forward-only models in development environments. 

Previously, to achieve the same outcome (compute previews), users had to run two plan commands: 1) to apply forward-only changes, and 2) to restate affected models in dev so that the portion of data is recomputed to make the preview available.