### PR TITLE
chore: fix pydantic 1 support with new type

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -93,7 +93,7 @@ jobs:
           command: make install-dev
       - run:
           name: Install Pydantic v1
-          command: pip install --upgrade "pydantic<2.0.0"
+          command: pip install --upgrade "pydantic<2.0.0" && pip uninstall pydantic_core -y
       - run:
           name: Run linters and code style checks
           command: make py-style

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,6 +99,9 @@ ignore_missing_imports = True
 [mypy-bs4.*]
 ignore_missing_imports = True
 
+[mypy-pydantic_core.*]
+ignore_missing_imports = True
+
 [autoflake]
 in-place = True
 expand-star-imports = True

--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -33,9 +33,6 @@ PYDANTIC_MAJOR_VERSION, PYDANTIC_MINOR_VERSION = [int(p) for p in pydantic.__ver
 
 if PYDANTIC_MAJOR_VERSION >= 2:
 
-    if t.TYPE_CHECKING:
-        from pydantic_core.core_schema import ValidationInfo
-
     def field_validator(*args: t.Any, **kwargs: t.Any) -> t.Callable[[t.Any], t.Any]:
         # Pydantic v2 doesn't support "always" argument. The validator behaves as if "always" is True.
         kwargs.pop("always", None)
@@ -50,8 +47,6 @@ if PYDANTIC_MAJOR_VERSION >= 2:
         return pydantic.field_serializer(*args, **kwargs)  # type: ignore
 
 else:
-    if t.TYPE_CHECKING:
-        ValidationInfo = t.Dict[str, t.Any]
 
     def field_validator(*args: t.Any, **kwargs: t.Any) -> t.Callable[[t.Any], t.Any]:
         mode = kwargs.pop("mode", "after")
@@ -297,7 +292,7 @@ def positive_int_validator(v: t.Any) -> int:
 
 def _get_fields(
     v: t.Any,
-    values: ValidationInfo,
+    values: t.Any,
 ) -> t.List[exp.Expression]:
     values = values if isinstance(values, dict) else values.data
     dialect = values.get("dialect")
@@ -325,11 +320,11 @@ def _get_fields(
     return results
 
 
-def list_of_fields_validator(v: t.Any, values: ValidationInfo) -> t.List[exp.Expression]:
+def list_of_fields_validator(v: t.Any, values: t.Any) -> t.List[exp.Expression]:
     return _get_fields(v, values)
 
 
-def list_of_columns_validator(v: t.Any, values: ValidationInfo) -> t.List[exp.Column]:
+def list_of_columns_validator(v: t.Any, values: t.Any) -> t.List[exp.Column]:
     expressions = _get_fields(v, values)
     for expression in expressions:
         if not isinstance(expression, exp.Column):
@@ -338,7 +333,7 @@ def list_of_columns_validator(v: t.Any, values: ValidationInfo) -> t.List[exp.Co
 
 
 def list_of_columns_or_star_validator(
-    v: t.Any, values: ValidationInfo
+    v: t.Any, values: t.Any
 ) -> t.Union[exp.Star, t.List[exp.Column]]:
     expressions = _get_fields(v, values)
     if len(expressions) == 1 and isinstance(expressions[0], exp.Star):

--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -7,7 +7,6 @@ from functools import cached_property, wraps
 
 import pydantic
 from pydantic.fields import FieldInfo
-from pydantic_core.core_schema import ValidationInfo
 from sqlglot import exp, parse_one
 from sqlglot.helper import ensure_list
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
@@ -34,6 +33,9 @@ PYDANTIC_MAJOR_VERSION, PYDANTIC_MINOR_VERSION = [int(p) for p in pydantic.__ver
 
 if PYDANTIC_MAJOR_VERSION >= 2:
 
+    if t.TYPE_CHECKING:
+        from pydantic_core.core_schema import ValidationInfo
+
     def field_validator(*args: t.Any, **kwargs: t.Any) -> t.Callable[[t.Any], t.Any]:
         # Pydantic v2 doesn't support "always" argument. The validator behaves as if "always" is True.
         kwargs.pop("always", None)
@@ -48,6 +50,8 @@ if PYDANTIC_MAJOR_VERSION >= 2:
         return pydantic.field_serializer(*args, **kwargs)  # type: ignore
 
 else:
+    if t.TYPE_CHECKING:
+        ValidationInfo = t.Dict[str, t.Any]
 
     def field_validator(*args: t.Any, **kwargs: t.Any) -> t.Callable[[t.Any], t.Any]:
         mode = kwargs.pop("mode", "after")
@@ -293,7 +297,7 @@ def positive_int_validator(v: t.Any) -> int:
 
 def _get_fields(
     v: t.Any,
-    values: t.Union[t.Dict, ValidationInfo],
+    values: ValidationInfo,
 ) -> t.List[exp.Expression]:
     values = values if isinstance(values, dict) else values.data
     dialect = values.get("dialect")
@@ -321,15 +325,11 @@ def _get_fields(
     return results
 
 
-def list_of_fields_validator(
-    v: t.Any, values: t.Union[t.Dict, ValidationInfo]
-) -> t.List[exp.Expression]:
+def list_of_fields_validator(v: t.Any, values: ValidationInfo) -> t.List[exp.Expression]:
     return _get_fields(v, values)
 
 
-def list_of_columns_validator(
-    v: t.Any, values: t.Union[t.Dict, ValidationInfo]
-) -> t.List[exp.Column]:
+def list_of_columns_validator(v: t.Any, values: ValidationInfo) -> t.List[exp.Column]:
     expressions = _get_fields(v, values)
     for expression in expressions:
         if not isinstance(expression, exp.Column):
@@ -338,7 +338,7 @@ def list_of_columns_validator(
 
 
 def list_of_columns_or_star_validator(
-    v: t.Any, values: t.Union[t.Dict, ValidationInfo]
+    v: t.Any, values: ValidationInfo
 ) -> t.Union[exp.Star, t.List[exp.Column]]:
     expressions = _get_fields(v, values)
     if len(expressions) == 1 and isinstance(expressions[0], exp.Star):


### PR DESCRIPTION
Recent PR referenced a class that is not part of Pydantic 1 and therefore led to an error in Airflow tests that use Pydantic 1.

The reason why our Pydantic 1 CI test didn't catch it is because we downgrade pydantic 2 to pydantic 1 in CI but then leave pydantic_core behind which allowed the tests to pass. So updated CI too in order to catch this earlier in the future. 