### PR TITLE
feat!: add tstz support

### DIFF
--- a/docs/concepts/macros/macro_variables.md
+++ b/docs/concepts/macros/macro_variables.md
@@ -51,7 +51,8 @@ Postfixes:
 
 * date - A python date object that converts into a native SQL Date.
 * ds - A date string with the format: '%Y-%m-%d'
-* ts - An ISO 8601 datetime formatted string: '%Y-%m-%d %H:%M:%S'.
+* ts - An ISO 8601 datetime formatted string: '%Y-%m-%dT%H:%M:%S'.
+* tstz - An ISO 8601 datetime formatted string with timezone: '%Y-%m-%dT%H:%M:%S%z'.
 * epoch - An integer representing seconds since Unix epoch.
 * millis - An integer representing milliseconds since Unix epoch.
 
@@ -76,6 +77,11 @@ All predefined macro variables:
     * @start_ts
     * @end_ts
     * @execution_ts
+
+* tstz
+    * @start_tstz
+    * @end_tstz
+    * @execution_tstz
 
 * epoch
     * @start_epoch

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -14,7 +14,6 @@ import itertools
 import logging
 import sys
 import typing as t
-from datetime import datetime, timezone
 from functools import partial
 
 import pandas as pd
@@ -152,23 +151,11 @@ class EngineAdapter:
         return isinstance(value, pd.DataFrame)
 
     @classmethod
-    def _to_utc_timestamp(
-        cls, col: t.Union[str, exp.Literal, exp.Column, exp.Null], time_data_type: exp.DataType
+    def _to_timestamp(
+        cls, col: t.Union[TimeLike, exp.Null], time_data_type: exp.DataType
     ) -> exp.Cast:
-        def ensure_utc_exp(
-            ts: t.Union[str, exp.Literal, exp.Column, exp.Null]
-        ) -> t.Union[exp.Literal, exp.Column, exp.Null]:
-            if not isinstance(ts, (str, exp.Literal)):
-                return ts
-            if isinstance(ts, exp.Literal):
-                if not ts.is_string:
-                    raise SQLMeshError("Timestamp literal must be a string")
-                ts = ts.name
-            return exp.Literal.string(
-                datetime.fromisoformat(ts).astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
-            )
-
-        return exp.cast(exp.cast(ensure_utc_exp(col), "TIMESTAMP"), time_data_type)
+        column_to_cast = col if isinstance(col, exp.Null) else exp.Literal.string(to_ts(col))
+        return exp.cast(exp.cast(column_to_cast, "TIMESTAMP"), time_data_type)
 
     @classmethod
     def _casted_columns(cls, columns_to_types: t.Dict[str, exp.DataType]) -> t.List[exp.Alias]:
@@ -1305,7 +1292,7 @@ class EngineAdapter:
         # column names and then remove them from the unmanaged_columns
         if check_columns and check_columns == exp.Star():
             check_columns = [exp.column(col) for col in unmanaged_columns]
-        execution_ts = self._to_utc_timestamp(to_ts(execution_time), time_data_type)
+        execution_ts = self._to_timestamp(execution_time, time_data_type)
         if updated_at_as_valid_from:
             if not updated_at_name:
                 raise SQLMeshError(
@@ -1315,7 +1302,7 @@ class EngineAdapter:
         elif execution_time_as_valid_from:
             update_valid_from_start = execution_ts
         else:
-            update_valid_from_start = self._to_utc_timestamp(
+            update_valid_from_start = self._to_timestamp(
                 "1970-01-01 00:00:00+00:00", time_data_type
             )
         insert_valid_from_start = execution_ts if check_columns else exp.column(updated_at_name)  # type: ignore
@@ -1521,7 +1508,7 @@ class EngineAdapter:
                     exp.select(
                         *unmanaged_columns,
                         insert_valid_from_start.as_(valid_from_name),
-                        self._to_utc_timestamp(exp.null(), time_data_type).as_(valid_to_name),
+                        self._to_timestamp(exp.null(), time_data_type).as_(valid_to_name),
                     )
                     .from_("joined")
                     .where(updated_row_filter),

--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -214,7 +214,8 @@ def date_dict(
         kwargs[f"{prefix}_dt"] = dt
         kwargs[f"{prefix}_date"] = to_date(dt)
         kwargs[f"{prefix}_ds"] = to_ds(time_like)
-        kwargs[f"{prefix}_ts"] = dt.isoformat()
+        kwargs[f"{prefix}_ts"] = to_ts(dt)
+        kwargs[f"{prefix}_tstz"] = to_tstz(dt)
         kwargs[f"{prefix}_epoch"] = millis / 1000
         kwargs[f"{prefix}_millis"] = millis
         kwargs[f"{prefix}_hour"] = dt.hour
@@ -227,7 +228,12 @@ def to_ds(obj: TimeLike) -> str:
 
 
 def to_ts(obj: TimeLike) -> str:
-    """Converts a TimeLike object into YYYY-MM-DD HH:MM:SS formatted string."""
+    """Converts a TimeLike object into YYYY-MM-DDTHH:MM:SS formatted string."""
+    return to_datetime(obj).replace(tzinfo=None).isoformat()
+
+
+def to_tstz(obj: TimeLike) -> str:
+    """Converts a TimeLike object into YYYY-MM-DDTHH:MM:SS+HH:MM formatted string."""
     return to_datetime(obj).isoformat()
 
 

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -1102,14 +1102,14 @@ WITH "source" AS (
         ELSE "test_updated_at"
       END
       WHEN "t_test_valid_from" IS NULL
-      THEN CAST(CAST('1970-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)
+      THEN CAST(CAST('1970-01-01T00:00:00' AS TIMESTAMP) AS TIMESTAMP)
       ELSE "t_test_valid_from"
     END AS "test_valid_from",
     CASE
       WHEN "test_updated_at" > "t_test_updated_at"
       THEN "test_updated_at"
       WHEN "joined"."_exists" IS NULL
-      THEN CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)
+      THEN CAST(CAST('2020-01-01T00:00:00' AS TIMESTAMP) AS TIMESTAMP)
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
   FROM "joined"
@@ -1300,14 +1300,14 @@ WITH "source" AS (
         ELSE "test_updated_at"
       END
       WHEN "t_test_valid_from" IS NULL
-      THEN CAST(CAST('1970-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMPTZ)
+      THEN CAST(CAST('1970-01-01T00:00:00' AS TIMESTAMP) AS TIMESTAMPTZ)
       ELSE "t_test_valid_from"
     END AS "test_valid_from",
     CASE
       WHEN "test_updated_at" > "t_test_updated_at"
       THEN "test_updated_at"
       WHEN "joined"."_exists" IS NULL
-      THEN CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMPTZ)
+      THEN CAST(CAST('2020-01-01T00:00:00' AS TIMESTAMP) AS TIMESTAMPTZ)
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
   FROM "joined"
@@ -1454,7 +1454,7 @@ WITH "source" AS (
     COALESCE("joined"."t_id", "joined"."id") AS "id",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
     COALESCE("joined"."t_price", "joined"."price") AS "price",
-    COALESCE("t_test_valid_from", CAST(CAST('1970-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)) AS "test_valid_from",
+    COALESCE("t_test_valid_from", CAST(CAST('1970-01-01T00:00:00' AS TIMESTAMP) AS TIMESTAMP)) AS "test_valid_from",
     CASE
       WHEN "joined"."_exists" IS NULL
       OR (
@@ -1478,7 +1478,7 @@ WITH "source" AS (
           )
         )
       )
-      THEN CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)
+      THEN CAST(CAST('2020-01-01T00:00:00' AS TIMESTAMP) AS TIMESTAMP)
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
   FROM "joined"
@@ -1489,7 +1489,7 @@ WITH "source" AS (
     "id",
     "name",
     "price",
-    CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP) AS "test_valid_from",
+    CAST(CAST('2020-01-01T00:00:00' AS TIMESTAMP) AS TIMESTAMP) AS "test_valid_from",
     CAST(CAST(NULL AS TIMESTAMP) AS TIMESTAMP) AS "test_valid_to"
   FROM "joined"
   WHERE
@@ -1640,7 +1640,7 @@ WITH "source" AS (
     COALESCE("joined"."t_id", "joined"."id") AS "id",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
     COALESCE("joined"."t_price", "joined"."price") AS "price",
-    COALESCE("t_test_valid_from", CAST(CAST('1970-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)) AS "test_valid_from",
+    COALESCE("t_test_valid_from", CAST(CAST('1970-01-01T00:00:00' AS TIMESTAMP) AS TIMESTAMP)) AS "test_valid_from",
     CASE
       WHEN "joined"."_exists" IS NULL
       OR (
@@ -1671,7 +1671,7 @@ WITH "source" AS (
           )
         )
       )
-      THEN CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)
+      THEN CAST(CAST('2020-01-01T00:00:00' AS TIMESTAMP) AS TIMESTAMP)
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
   FROM "joined"
@@ -1682,7 +1682,7 @@ WITH "source" AS (
     "id",
     "name",
     "price",
-    CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP) AS "test_valid_from",
+    CAST(CAST('2020-01-01T00:00:00' AS TIMESTAMP) AS TIMESTAMP) AS "test_valid_from",
     CAST(CAST(NULL AS TIMESTAMP) AS TIMESTAMP) AS "test_valid_to"
   FROM "joined"
   WHERE

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -719,14 +719,14 @@ def test_scd_type_2_by_time(
         ELSE `test_updated_at`
       END
       WHEN `t_test_valid_from` IS NULL
-      THEN CAST(CAST('1970-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)
+      THEN CAST(CAST('1970-01-01T00:00:00' AS TIMESTAMP) AS TIMESTAMP)
       ELSE `t_test_valid_from`
     END AS `test_valid_from`,
     CASE
       WHEN `test_updated_at` > `t_test_updated_at`
       THEN `test_updated_at`
       WHEN `joined`.`_exists` IS NULL
-      THEN CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)
+      THEN CAST(CAST('2020-01-01T00:00:00' AS TIMESTAMP) AS TIMESTAMP)
       ELSE `t_test_valid_to`
     END AS `test_valid_to`
   FROM `joined`

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1338,7 +1338,7 @@ def test_convert_to_time_column():
     )
     model = load_sql_based_model(expressions)
     assert model.convert_to_time_column("2022-01-01") == d.parse_one(
-        "CAST('2022-01-01T00:00:00+00:00' AS TIMESTAMP)"
+        "CAST('2022-01-01T00:00:00' AS TIMESTAMP)"
     )
 
 

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -1131,7 +1131,7 @@ def test_environment_start_as_timestamp(
 
     stored_env = state_sync.get_environment(env.name)
     assert stored_env
-    assert stored_env.start_at == to_datetime(now_ts).isoformat()
+    assert stored_env.start_at == to_datetime(now_ts).replace(tzinfo=None).isoformat()
 
 
 def test_unpause_snapshots(state_sync: EngineAdapterStateSync, make_snapshot: t.Callable):

--- a/tests/utils/test_date.py
+++ b/tests/utils/test_date.py
@@ -9,6 +9,8 @@ from sqlmesh.utils.date import (
     make_inclusive,
     to_datetime,
     to_timestamp,
+    to_ts,
+    to_tstz,
 )
 
 
@@ -114,3 +116,13 @@ def test_make_inclusive(start_in, end_in, start_out, end_out) -> None:
 )
 def test_is_catagorical_relative_expression(expression, result):
     assert is_catagorical_relative_expression(expression) == result
+
+
+def test_to_ts():
+    assert to_ts(datetime(2020, 1, 1).replace(tzinfo=UTC)) == "2020-01-01T00:00:00"
+    assert to_ts(datetime(2020, 1, 1).replace(tzinfo=None)) == "2020-01-01T00:00:00"
+
+
+def test_to_tstz():
+    assert to_tstz(datetime(2020, 1, 1).replace(tzinfo=UTC)) == "2020-01-01T00:00:00+00:00"
+    assert to_tstz(datetime(2020, 1, 1).replace(tzinfo=None)) == "2020-01-01T00:00:00+00:00"


### PR DESCRIPTION
TODO: Add more tests

Currently if you are using BigQuery then the `*_ts` macros will create `DATETIME` objects and therefore if you are using `TIMESTAMP` then you will run into errors. `*_tstz` is being introduced to allow users to have `TIMESTAMP` objects to use instead. 