### PR TITLE
Fix: When plan running dont error and just wait

### DIFF
--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -401,8 +401,7 @@ async def test_cancel() -> None:
 
 def test_cancel_no_task() -> None:
     response = client.post("/api/plan/cancel")
-    assert response.status_code == 422
-    assert response.json()["message"] == "Plan/apply is not running"
+    assert response.status_code == 204
 
 
 def test_evaluate(web_sushi_context: Context) -> None:

--- a/web/client/openapi.json
+++ b/web/client/openapi.json
@@ -1450,6 +1450,8 @@
           "INCREMENTAL_UNMANAGED",
           "FULL",
           "SCD_TYPE_2",
+          "SCD_TYPE_2_BY_TIME",
+          "SCD_TYPE_2_BY_COLUMN",
           "VIEW",
           "EMBEDDED",
           "SEED",


### PR DESCRIPTION
When have `running task` there maybe some API calls to `/plan` endpoint and in case when multiple browser tabs opened, requests are coming form all the  tabes pretty much at the same time. So instead of `error and drop` request, it just `wait and re-tries` 