### PR TITLE
fix: use space instead of T for timestamp format

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -34,7 +34,7 @@ from sqlmesh.core.model.meta import ModelMeta
 from sqlmesh.core.model.seed import CsvSeedReader, Seed, create_seed
 from sqlmesh.core.renderer import ExpressionRenderer, QueryRenderer
 from sqlmesh.utils import columns_to_types_all_known, str_to_bool
-from sqlmesh.utils.date import TimeLike, make_inclusive, to_datetime, to_ds, to_ts
+from sqlmesh.utils.date import TimeLike, make_inclusive, to_datetime, to_time_column
 from sqlmesh.utils.errors import ConfigError, SQLMeshError, raise_config_error
 from sqlmesh.utils.hashing import hash_data
 from sqlmesh.utils.jinja import JinjaMacroRegistry, extract_macro_references
@@ -512,17 +512,7 @@ class _Model(ModelMeta, frozen=True):
 
             time_column_type = columns_to_types[self.time_column.column]
 
-            if time_column_type.is_type(exp.DataType.Type.DATE):
-                return exp.cast(exp.Literal.string(to_ds(time)), to="date")
-            if time_column_type.this in exp.DataType.TEMPORAL_TYPES:
-                return exp.cast(exp.Literal.string(to_ts(time)), to=time_column_type.this)
-
-            if self.time_column.format:
-                time = to_datetime(time).strftime(self.time_column.format)
-            if time_column_type.this in exp.DataType.TEXT_TYPES:
-                return exp.Literal.string(time)
-            if time_column_type.this in exp.DataType.NUMERIC_TYPES:
-                return exp.Literal.number(time)
+            return to_time_column(time, time_column_type, self.time_column.format)
         return exp.convert(time)
 
     def update_schema(

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -29,6 +29,7 @@ from sqlmesh.utils.date import (
     to_datetime,
     to_ds,
     to_timestamp,
+    to_ts,
     validate_date_range,
     yesterday,
 )
@@ -1349,7 +1350,8 @@ def merge_intervals(intervals: Intervals) -> Intervals:
 def _format_date_time(time_like: TimeLike, unit: t.Optional[IntervalUnit]) -> str:
     if unit is None or unit.is_date_granularity:
         return to_ds(time_like)
-    return to_datetime(time_like).isoformat()[:19]
+    # TODO: Remove `[0:19]` once `to_ts` always returns a timestamp without timezone
+    return to_ts(time_like)[0:19]
 
 
 def format_intervals(intervals: Intervals, unit: t.Optional[IntervalUnit]) -> str:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1338,7 +1338,7 @@ def test_convert_to_time_column():
     )
     model = load_sql_based_model(expressions)
     assert model.convert_to_time_column("2022-01-01") == d.parse_one(
-        "CAST('2022-01-01T00:00:00+00:00' AS TIMESTAMP)"
+        "CAST('2022-01-01 00:00:00+00:00' AS TIMESTAMP)"
     )
 
 

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -1131,7 +1131,7 @@ def test_environment_start_as_timestamp(
 
     stored_env = state_sync.get_environment(env.name)
     assert stored_env
-    assert stored_env.start_at == to_datetime(now_ts).isoformat()
+    assert stored_env.start_at == to_datetime(now_ts).isoformat(sep=" ")
 
 
 def test_unpause_snapshots(state_sync: EngineAdapterStateSync, make_snapshot: t.Callable):

--- a/tests/utils/test_date.py
+++ b/tests/utils/test_date.py
@@ -9,6 +9,7 @@ from sqlmesh.utils.date import (
     make_inclusive,
     to_datetime,
     to_timestamp,
+    to_ts,
 )
 
 
@@ -114,3 +115,8 @@ def test_make_inclusive(start_in, end_in, start_out, end_out) -> None:
 )
 def test_is_catagorical_relative_expression(expression, result):
     assert is_catagorical_relative_expression(expression) == result
+
+
+def test_to_ts():
+    assert to_ts(datetime(2020, 1, 1).replace(tzinfo=UTC)) == "2020-01-01 00:00:00+00:00"
+    assert to_ts(datetime(2020, 1, 1).replace(tzinfo=None)) == "2020-01-01 00:00:00+00:00"


### PR DESCRIPTION
Prior to this PR, Trino would error if we provided a timestamp since it expects the format to have a space between date and time instead of a `T`. I tested across all engines and they all accept the space so switching to that instead. 

Note that this PR does not address the issue that `ts` includes timezone but we assign it to a datatype that does not support TIMEZONE. That is being addressed in this PR: https://github.com/TobikoData/sqlmesh/pull/2112