### PR TITLE
feat!: add tstz support

### DIFF
--- a/docs/concepts/macros/macro_variables.md
+++ b/docs/concepts/macros/macro_variables.md
@@ -52,6 +52,7 @@ Postfixes:
 * date - A python date object that converts into a native SQL Date.
 * ds - A date string with the format: '%Y-%m-%d'
 * ts - An ISO 8601 datetime formatted string: '%Y-%m-%d %H:%M:%S'.
+* tstz - An ISO 8601 datetime formatted string with timezone: '%Y-%m-%d %H:%M:%S%z'.
 * epoch - An integer representing seconds since Unix epoch.
 * millis - An integer representing milliseconds since Unix epoch.
 
@@ -76,6 +77,11 @@ All predefined macro variables:
     * @start_ts
     * @end_ts
     * @execution_ts
+
+* tstz
+    * @start_tstz
+    * @end_tstz
+    * @execution_tstz
 
 * epoch
     * @start_epoch

--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -32,6 +32,11 @@ freshness_date_parser_module.PATTERN = re.compile(
 )
 DAY_SHORTCUT_EXPRESSIONS = {"today", "yesterday", "tomorrow"}
 TIME_UNITS = {"hours", "minutes", "seconds"}
+TEMPORAL_TZ_TYPES = {
+    exp.DataType.Type.TIMETZ,
+    exp.DataType.Type.TIMESTAMPTZ,
+    exp.DataType.Type.TIMESTAMPLTZ,
+}
 
 
 def now(minute_floor: bool = True) -> datetime:
@@ -228,6 +233,11 @@ def to_ds(obj: TimeLike) -> str:
 
 def to_ts(obj: TimeLike) -> str:
     """Converts a TimeLike object into YYYY-MM-DD HH:MM:SS formatted string."""
+    return to_datetime(obj).replace(tzinfo=None).isoformat(sep=" ")
+
+
+def to_tstz(obj: TimeLike) -> str:
+    """Converts a TimeLike object into YYYY-MM-DD HH:MM:SS+00:00 formatted string."""
     return to_datetime(obj).isoformat(sep=" ")
 
 
@@ -314,6 +324,8 @@ def to_time_column(
         return exp.cast(time_column, to=time_column_type)
     if time_column_type.is_type(exp.DataType.Type.DATE):
         return exp.cast(exp.Literal.string(to_ds(time_column)), to="date")
+    if time_column_type.this in TEMPORAL_TZ_TYPES:
+        return exp.cast(exp.Literal.string(to_tstz(time_column)), to=time_column_type.this)
     if time_column_type.this in exp.DataType.TEMPORAL_TYPES:
         return exp.cast(exp.Literal.string(to_ts(time_column)), to=time_column_type.this)
 

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -1102,14 +1102,14 @@ WITH "source" AS (
         ELSE "test_updated_at"
       END
       WHEN "t_test_valid_from" IS NULL
-      THEN CAST(CAST('1970-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)
+      THEN CAST('1970-01-01 00:00:00' AS TIMESTAMP)
       ELSE "t_test_valid_from"
     END AS "test_valid_from",
     CASE
       WHEN "test_updated_at" > "t_test_updated_at"
       THEN "test_updated_at"
       WHEN "joined"."_exists" IS NULL
-      THEN CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)
+      THEN CAST('2020-01-01 00:00:00' AS TIMESTAMP)
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
   FROM "joined"
@@ -1122,7 +1122,7 @@ WITH "source" AS (
     "price",
     "test_updated_at",
     "test_updated_at" AS "test_valid_from",
-    CAST(CAST(NULL AS TIMESTAMP) AS TIMESTAMP) AS "test_valid_to"
+    CAST(NULL AS TIMESTAMP) AS "test_valid_to"
   FROM "joined"
   WHERE
     "test_updated_at" > "t_test_updated_at"
@@ -1300,14 +1300,14 @@ WITH "source" AS (
         ELSE "test_updated_at"
       END
       WHEN "t_test_valid_from" IS NULL
-      THEN CAST(CAST('1970-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMPTZ)
+      THEN CAST('1970-01-01 00:00:00+00:00' AS TIMESTAMPTZ)
       ELSE "t_test_valid_from"
     END AS "test_valid_from",
     CASE
       WHEN "test_updated_at" > "t_test_updated_at"
       THEN "test_updated_at"
       WHEN "joined"."_exists" IS NULL
-      THEN CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMPTZ)
+      THEN CAST('2020-01-01 00:00:00+00:00' AS TIMESTAMPTZ)
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
   FROM "joined"
@@ -1322,7 +1322,7 @@ WITH "source" AS (
     "price",
     "test_updated_at",
     "test_updated_at" AS "test_valid_from",
-    CAST(CAST(NULL AS TIMESTAMP) AS TIMESTAMPTZ) AS "test_valid_to"
+    CAST(NULL AS TIMESTAMPTZ) AS "test_valid_to"
   FROM "joined"
   WHERE
     "test_updated_at" > "t_test_updated_at"
@@ -1454,7 +1454,7 @@ WITH "source" AS (
     COALESCE("joined"."t_id", "joined"."id") AS "id",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
     COALESCE("joined"."t_price", "joined"."price") AS "price",
-    COALESCE("t_test_valid_from", CAST(CAST('1970-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)) AS "test_valid_from",
+    COALESCE("t_test_valid_from", CAST('1970-01-01 00:00:00' AS TIMESTAMP)) AS "test_valid_from",
     CASE
       WHEN "joined"."_exists" IS NULL
       OR (
@@ -1478,7 +1478,7 @@ WITH "source" AS (
           )
         )
       )
-      THEN CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)
+      THEN CAST('2020-01-01 00:00:00' AS TIMESTAMP)
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
   FROM "joined"
@@ -1489,8 +1489,8 @@ WITH "source" AS (
     "id",
     "name",
     "price",
-    CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP) AS "test_valid_from",
-    CAST(CAST(NULL AS TIMESTAMP) AS TIMESTAMP) AS "test_valid_to"
+    CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS "test_valid_from",
+    CAST(NULL AS TIMESTAMP) AS "test_valid_to"
   FROM "joined"
   WHERE
     (
@@ -1640,7 +1640,7 @@ WITH "source" AS (
     COALESCE("joined"."t_id", "joined"."id") AS "id",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
     COALESCE("joined"."t_price", "joined"."price") AS "price",
-    COALESCE("t_test_valid_from", CAST(CAST('1970-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)) AS "test_valid_from",
+    COALESCE("t_test_valid_from", CAST('1970-01-01 00:00:00' AS TIMESTAMP)) AS "test_valid_from",
     CASE
       WHEN "joined"."_exists" IS NULL
       OR (
@@ -1671,7 +1671,7 @@ WITH "source" AS (
           )
         )
       )
-      THEN CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)
+      THEN CAST('2020-01-01 00:00:00' AS TIMESTAMP)
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
   FROM "joined"
@@ -1682,8 +1682,8 @@ WITH "source" AS (
     "id",
     "name",
     "price",
-    CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP) AS "test_valid_from",
-    CAST(CAST(NULL AS TIMESTAMP) AS TIMESTAMP) AS "test_valid_to"
+    CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS "test_valid_from",
+    CAST(NULL AS TIMESTAMP) AS "test_valid_to"
   FROM "joined"
   WHERE
     (

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -719,14 +719,14 @@ def test_scd_type_2_by_time(
         ELSE `test_updated_at`
       END
       WHEN `t_test_valid_from` IS NULL
-      THEN CAST(CAST('1970-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)
+      THEN CAST('1970-01-01 00:00:00' AS TIMESTAMP)
       ELSE `t_test_valid_from`
     END AS `test_valid_from`,
     CASE
       WHEN `test_updated_at` > `t_test_updated_at`
       THEN `test_updated_at`
       WHEN `joined`.`_exists` IS NULL
-      THEN CAST(CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP)
+      THEN CAST('2020-01-01 00:00:00' AS TIMESTAMP)
       ELSE `t_test_valid_to`
     END AS `test_valid_to`
   FROM `joined`
@@ -739,7 +739,7 @@ def test_scd_type_2_by_time(
     `price`,
     `test_updated_at`,
     `test_updated_at` AS `test_valid_from`,
-    CAST(CAST(NULL AS TIMESTAMP) AS TIMESTAMP) AS `test_valid_to`
+    CAST(NULL AS TIMESTAMP) AS `test_valid_to`
   FROM `joined`
   WHERE
     `test_updated_at` > `t_test_updated_at`

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1338,7 +1338,7 @@ def test_convert_to_time_column():
     )
     model = load_sql_based_model(expressions)
     assert model.convert_to_time_column("2022-01-01") == d.parse_one(
-        "CAST('2022-01-01 00:00:00+00:00' AS TIMESTAMP)"
+        "CAST('2022-01-01 00:00:00' AS TIMESTAMP)"
     )
 
 

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -1131,7 +1131,7 @@ def test_environment_start_as_timestamp(
 
     stored_env = state_sync.get_environment(env.name)
     assert stored_env
-    assert stored_env.start_at == to_datetime(now_ts).isoformat(sep=" ")
+    assert stored_env.start_at == to_datetime(now_ts).replace(tzinfo=None).isoformat(sep=" ")
 
 
 def test_unpause_snapshots(state_sync: EngineAdapterStateSync, make_snapshot: t.Callable):


### PR DESCRIPTION
Prior to this change `ts` could contain timezone information if that was passed in and would cause issues for some engines. Now we make sure that `ts` does not contain timezone and `tstz` does. 

Took the opportunity to reduce some extra code in engine adapter and write some tests to ensure we could cast the values correctly across all engines. Also ran the engine adapter integration tests across all engines (including remote) to ensure it works. 