### PR TITLE
fix!: add missing tstz variable

### DIFF
--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -220,6 +220,7 @@ def date_dict(
         kwargs[f"{prefix}_date"] = to_date(dt)
         kwargs[f"{prefix}_ds"] = to_ds(time_like)
         kwargs[f"{prefix}_ts"] = to_ts(dt)
+        kwargs[f"{prefix}_tstz"] = to_tstz(dt)
         kwargs[f"{prefix}_epoch"] = millis / 1000
         kwargs[f"{prefix}_millis"] = millis
         kwargs[f"{prefix}_hour"] = dt.hour

--- a/tests/utils/test_date.py
+++ b/tests/utils/test_date.py
@@ -8,6 +8,7 @@ from sqlglot import exp
 from sqlmesh.utils.date import (
     UTC,
     TimeLike,
+    date_dict,
     is_catagorical_relative_expression,
     make_inclusive,
     to_datetime,
@@ -180,3 +181,41 @@ def test_to_time_column(
     result: str,
 ):
     assert to_time_column(time_column, time_column_type, time_column_format).sql() == result
+
+
+def test_date_dict():
+    resp = date_dict("2020-01-02 01:00:00", "2020-01-01 00:00:00", "2020-01-02 00:00:00")
+    assert resp == {
+        "latest_dt": datetime(2020, 1, 2, 1, 0, 0, tzinfo=UTC),
+        "execution_dt": datetime(2020, 1, 2, 1, 0, 0, tzinfo=UTC),
+        "start_dt": datetime(2020, 1, 1, 0, 0, 0, tzinfo=UTC),
+        "end_dt": datetime(2020, 1, 2, 0, 0, 0, tzinfo=UTC),
+        "latest_date": date(2020, 1, 2),
+        "execution_date": date(2020, 1, 2),
+        "start_date": date(2020, 1, 1),
+        "end_date": date(2020, 1, 2),
+        "latest_ds": "2020-01-02",
+        "execution_ds": "2020-01-02",
+        "start_ds": "2020-01-01",
+        "end_ds": "2020-01-02",
+        "latest_ts": "2020-01-02 01:00:00",
+        "execution_ts": "2020-01-02 01:00:00",
+        "start_ts": "2020-01-01 00:00:00",
+        "end_ts": "2020-01-02 00:00:00",
+        "latest_tstz": "2020-01-02 01:00:00+00:00",
+        "execution_tstz": "2020-01-02 01:00:00+00:00",
+        "start_tstz": "2020-01-01 00:00:00+00:00",
+        "end_tstz": "2020-01-02 00:00:00+00:00",
+        "latest_epoch": 1577926800.0,
+        "execution_epoch": 1577926800.0,
+        "start_epoch": 1577836800.0,
+        "end_epoch": 1577923200.0,
+        "latest_millis": 1577926800000,
+        "execution_millis": 1577926800000,
+        "start_millis": 1577836800000,
+        "end_millis": 1577923200000,
+        "latest_hour": 1,
+        "execution_hour": 1,
+        "start_hour": 0,
+        "end_hour": 0,
+    }


### PR DESCRIPTION
After refactoring old PR into two PRs, I forgot the most important part of actually adding `tstz` variable. 🤦 This adds it and then adds a test to make sure all expected variables are being set. 

Breaking since this is incompatible with previous release since someone could use the `_tstz` variable and someone on last release wouldn't recognize it. 