### PR TITLE
feat!: include sqlmesh in version check

### DIFF
--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -210,38 +210,32 @@ class StateReader(abc.ABC):
                     f"{lib} (local) is using version '{local}' which is behind '{remote}' (remote).{upgrade_suggestion}"
                 )
 
-            if SCHEMA_VERSION < versions.schema_version:
+            if SCHEMA_VERSION != versions.schema_version:
                 raise_error(
                     "SQLMesh",
                     SCHEMA_VERSION,
                     versions.schema_version,
                     remote_package_version=versions.sqlmesh_version,
+                    ahead=SCHEMA_VERSION > versions.schema_version,
                 )
 
-            if major_minor(SQLGLOT_VERSION) < major_minor(versions.sqlglot_version):
+            if major_minor(SQLGLOT_VERSION) != major_minor(versions.sqlglot_version):
                 raise_error(
                     "SQLGlot",
                     SQLGLOT_VERSION,
                     versions.sqlglot_version,
                     remote_package_version=versions.sqlglot_version,
+                    ahead=major_minor(SQLGLOT_VERSION) > major_minor(versions.sqlglot_version),
                 )
 
-            if major_minor(SQLMESH_VERSION) < major_minor(versions.sqlmesh_version):
+            if major_minor(SQLMESH_VERSION) != major_minor(versions.sqlmesh_version):
                 raise_error(
                     "SQLMesh",
                     SQLMESH_VERSION,
                     versions.sqlmesh_version,
                     remote_package_version=versions.sqlmesh_version,
+                    ahead=major_minor(SQLMESH_VERSION) > major_minor(versions.sqlmesh_version),
                 )
-
-            if SCHEMA_VERSION > versions.schema_version:
-                raise_error("SQLMesh", SCHEMA_VERSION, versions.schema_version, ahead=True)
-
-            if major_minor(SQLGLOT_VERSION) > major_minor(versions.sqlglot_version):
-                raise_error("SQLGlot", SQLGLOT_VERSION, versions.sqlglot_version, ahead=True)
-
-            if major_minor(SQLMESH_VERSION) > major_minor(versions.sqlmesh_version):
-                raise_error("SQLMesh", SQLMESH_VERSION, versions.sqlmesh_version, ahead=True)
 
         return versions
 

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -898,7 +898,11 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         versions = self.get_versions(validate=False)
         migrations = MIGRATIONS[versions.schema_version :]
 
-        if not migrations and major_minor(SQLGLOT_VERSION) == versions.minor_sqlglot_version:
+        if (
+            not migrations
+            and major_minor(SQLGLOT_VERSION) == versions.minor_sqlglot_version
+            and major_minor(SQLMESH_VERSION) == versions.minor_sqlmesh_version
+        ):
             return
 
         if not skip_backup:


### PR DESCRIPTION
Prior to this change we considered SQLMesh versions "compatible", or that they could be run together, if they shared a common sqlglot minor version and were on the same migration release. Sometimes though we introduce incompatibility that doesn't require a migration and we represent this with a minor version bump. Therefore this change now considers SQLMesh's minor version too when deciding if releases are compatible. 