### PR TITLE
Feat: Add support for Trino Iceberg tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,9 @@ dmypy.json
 # PyCharm
 .idea/
 
+# VSCode
+.vscode/
+
 # Emacs
 *~
 *#

--- a/Makefile
+++ b/Makefile
@@ -167,4 +167,4 @@ spark-pyspark-test:
 	pytest -n auto -m "spark_pyspark"
 
 trino-test:
-	pytest -n auto -m "trino"
+	pytest -n auto -m "trino or trino_iceberg"

--- a/docs/integrations/engines/trino.md
+++ b/docs/integrations/engines/trino.md
@@ -17,10 +17,11 @@ pip install "trino[external-authentication-token-cache]"
 
 ### Trino Connector Support
 
-The trino engine adapter has been tested against the [Hive Connector](https://trino.io/docs/current/connector/hive.html).
+The trino engine adapter has been tested against the [Hive Connector](https://trino.io/docs/current/connector/hive.html) and the [Iceberg Connector](https://trino.io/docs/current/connector/iceberg.html).
+
 Please let us know on [Slack](https://tobikodata.com/slack) if you are wanting to use another connector or have tried another connector.
 
-### Hive Connector Configuration
+#### Hive Connector Configuration
 
 Recommended hive catalog properties configuration (`<catalog_name>.properties`):
 
@@ -34,6 +35,19 @@ hive.allow-drop-column=true
 hive.allow-rename-column=true
 hive.allow-rename-table=true
 ```
+
+#### Iceberg Connector Configuration
+
+If you're using a hive metastore for the Iceberg catalog, the [properties](https://trino.io/docs/current/connector/metastores.html#general-metastore-configuration-properties) are mostly the same as the Hive connector.
+
+```properties linenums="1"
+iceberg.catalog.type=hive_metastore
+# metastore properties as per the Hive Connector Configuration above
+```
+
+**Note**: The Trino Iceberg Connector must be configured with an `iceberg.catalog.type` that supports views. At the time of this writing, this is only `hive_metastore` and `glue`.
+
+The `jdbc`, `rest` and `nessie` catalogs do not support views and are thus incompatible with SQLMesh.
 
 ### Connection options
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,7 +28,8 @@ markers =
     redshift: test for Redshift
     snowflake: test for Snowflake
     spark: test for Spark
-    trino: test for Trino
+    trino: test for Trino (Hive connector)
+    trino_iceberg: test for Trino (Iceberg connector)
 addopts = -n 0 --dist=worksteal
 
 # Set this to True to enable logging during tests

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -95,6 +95,7 @@ class EngineAdapter:
     SUPPORTS_ROW_LEVEL_OP = True
     HAS_VIEW_BINDING = False
     SUPPORTS_REPLACE_TABLE = True
+    DEFAULT_CATALOG_TYPE = DIALECT
 
     def __init__(
         self,
@@ -260,6 +261,16 @@ class EngineAdapter:
     def set_current_catalog(self, catalog: str) -> None:
         """Sets the catalog name of the current connection."""
         raise NotImplementedError()
+
+    def get_catalog_type(self, catalog: t.Optional[str]) -> str:
+        """Intended to be overridden for data virtualization systems like Trino that,
+        depending on the target catalog, require slightly different properties to be set when creating / updating tables
+        """
+        return self.DEFAULT_CATALOG_TYPE
+
+    @property
+    def current_catalog_type(self) -> str:
+        return self.get_catalog_type(self.get_current_catalog())
 
     def replace_query(
         self,

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -459,6 +459,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
 
     def _build_table_properties_exp(
         self,
+        table: exp.Table,
         storage_format: t.Optional[str] = None,
         partitioned_by: t.Optional[t.List[exp.Expression]] = None,
         partition_interval_unit: t.Optional[IntervalUnit] = None,

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -149,8 +149,7 @@ class HiveMetastoreTablePropertiesMixin(EngineAdapter):
                         f"PARTITIONED BY contains non-column value '{expr.sql(dialect='spark')}'."
                     )
 
-            property: exp.Property
-            property = exp.PartitionedByProperty(
+            property: exp.Property = exp.PartitionedByProperty(
                 this=exp.Schema(expressions=partitioned_by),
             )
 

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -128,6 +128,7 @@ class InsertOverwriteWithMergeMixin(EngineAdapter):
 class HiveMetastoreTablePropertiesMixin(EngineAdapter):
     def _build_table_properties_exp(
         self,
+        table: exp.Table,
         storage_format: t.Optional[str] = None,
         partitioned_by: t.Optional[t.List[exp.Expression]] = None,
         partition_interval_unit: t.Optional[IntervalUnit] = None,
@@ -148,18 +149,23 @@ class HiveMetastoreTablePropertiesMixin(EngineAdapter):
                         f"PARTITIONED BY contains non-column value '{expr.sql(dialect='spark')}'."
                     )
 
-            if self.dialect == "trino" and self.current_catalog_type == "iceberg":
+            property: exp.Property
+            property = exp.PartitionedByProperty(
+                this=exp.Schema(expressions=partitioned_by),
+            )
+
+            if (
+                self.dialect == "trino"
+                and self.get_catalog_type(table.catalog or self.get_current_catalog()) == "iceberg"
+            ):
                 # On the Trino Iceberg catalog, the table property is called "partitioning" - not "partitioned_by"
+                # In addition, partition column transform expressions like `day(col)` or `bucket(col, 5)` are allowed
                 # ref: https://trino.io/docs/current/connector/iceberg.html#table-properties
-                properties.append(
-                    exp.Property(this="partitioning", value=exp.Schema(expressions=partitioned_by))
+                property = exp.Property(
+                    this=exp.var("PARTITIONING"), value=exp.Schema(expressions=partitioned_by)
                 )
-            else:
-                properties.append(
-                    exp.PartitionedByProperty(
-                        this=exp.Schema(expressions=partitioned_by),
-                    )
-                )
+
+            properties.append(property)
 
         if table_description:
             properties.append(exp.SchemaCommentProperty(this=exp.Literal.string(table_description)))

--- a/tests/core/engine_adapter/config.yaml
+++ b/tests/core/engine_adapter/config.yaml
@@ -18,6 +18,18 @@ gateways:
       register_comments: true
     state_connection:
       type: duckdb
+  inttest_trino_iceberg:
+    connection:
+      type: trino
+      host: localhost
+      port: 8080
+      user: admin
+      catalog: datalake_iceberg
+      http_scheme: http
+      retries: 20
+      register_comments: true
+    state_connection:
+      type: duckdb
   inttest_spark:
     connection:
       type: spark

--- a/tests/core/engine_adapter/docker-compose.yaml
+++ b/tests/core/engine_adapter/docker-compose.yaml
@@ -40,6 +40,7 @@ services:
     environment:
         SA_PASSWORD: 1StrongPwd@@
         ACCEPT_EULA: Y
+
   # Trino Stack
   trino:
     hostname: trino

--- a/tests/core/engine_adapter/docker-compose.yaml
+++ b/tests/core/engine_adapter/docker-compose.yaml
@@ -50,47 +50,54 @@ services:
     volumes:
       - ./trino/catalog:/etc/trino/catalog
 
-  trino_datalake_metastore_db:
+  trino_metastore_db:
     image: postgres
-    hostname: trino_datalake_metastore_db
+    hostname: trino_metastore_db
     environment:
       POSTGRES_USER: hive
       POSTGRES_PASSWORD: hive
-      POSTGRES_DB: metastore
+    volumes:
+      - ./trino/initdb.sql:/docker-entrypoint-initdb.d/initdb.sql
 
   trino-datalake-hive-metastore:
     hostname: trino-datalake-hive-metastore
     image: 'starburstdata/hive:3.1.2-e.15'
     environment:
       HIVE_METASTORE_DRIVER: org.postgresql.Driver
-      HIVE_METASTORE_JDBC_URL: jdbc:postgresql://trino_datalake_metastore_db:5432/metastore
+      HIVE_METASTORE_JDBC_URL: jdbc:postgresql://trino_metastore_db:5432/datalake_metastore
       HIVE_METASTORE_USER: hive
       HIVE_METASTORE_PASSWORD: hive
       HIVE_METASTORE_WAREHOUSE_DIR: s3://trino/datalake
       <<: *hive_metastore_environments
     depends_on:
-      - trino_datalake_metastore_db
-
-  trino_testing_metastore_db:
-    image: postgres
-    hostname: trino_testing_metastore_db
-    environment:
-      POSTGRES_USER: hive
-      POSTGRES_PASSWORD: hive
-      POSTGRES_DB: metastore
+      - trino_metastore_db
 
   trino-testing-hive-metastore:
     hostname: trino-testing-hive-metastore
     image: 'starburstdata/hive:3.1.2-e.15'
     environment:
       HIVE_METASTORE_DRIVER: org.postgresql.Driver
-      HIVE_METASTORE_JDBC_URL: jdbc:postgresql://trino_testing_metastore_db:5432/metastore
+      HIVE_METASTORE_JDBC_URL: jdbc:postgresql://trino_metastore_db:5432/testing_metastore
       HIVE_METASTORE_USER: hive
       HIVE_METASTORE_PASSWORD: hive
       HIVE_METASTORE_WAREHOUSE_DIR: s3://trino/testing
       <<: *hive_metastore_environments
     depends_on:
-      - trino_testing_metastore_db
+      - trino_metastore_db
+
+  trino-datalake-iceberg-hive-metastore:
+    hostname: trino-datalake-iceberg-hive-metastore
+    image: 'starburstdata/hive:3.1.2-e.15'
+    environment:
+      HIVE_METASTORE_DRIVER: org.postgresql.Driver
+      HIVE_METASTORE_JDBC_URL: jdbc:postgresql://trino_metastore_db:5432/datalake_iceberg_metastore
+      HIVE_METASTORE_USER: hive
+      HIVE_METASTORE_PASSWORD: hive
+      HIVE_METASTORE_WAREHOUSE_DIR: s3://trino/datalake_iceberg
+      <<: *hive_metastore_environments
+    depends_on:
+      - trino_metastore_db
+
   # Spark Stack
   spark:
     build:
@@ -125,7 +132,7 @@ services:
     depends_on:
       - spark_metastore_db
 
-  # Shared Spark/Truno S3 Storage
+  # Shared Spark/Trino S3 Storage
   minio:
     hostname: minio
     image: 'minio/minio:RELEASE.2022-05-26T05-48-41Z'
@@ -145,7 +152,9 @@ services:
       sleep 5;
       /usr/bin/mc config --quiet host add myminio http://minio:9000 minio minio123;
       /usr/bin/mc mb --quiet myminio/trino/datalake;
+      /usr/bin/mc mb --quiet myminio/trino/datalake_iceberg;
       /usr/bin/mc mb --quiet myminio/trino/testing;
+      /usr/bin/mc mb --quiet myminio/trino/testing_iceberg;
       /usr/bin/mc mb --quiet myminio/spark/datalake;
       /usr/bin/mc mb --quiet myminio/spark/testing
       "

--- a/tests/core/engine_adapter/test_trino.py
+++ b/tests/core/engine_adapter/test_trino.py
@@ -1,6 +1,8 @@
 import typing as t
 
 import pytest
+from pytest_mock.plugin import MockerFixture
+from sqlglot import exp
 
 from sqlmesh.core.engine_adapter import TrinoEngineAdapter
 from tests.core.engine_adapter import to_sql_calls
@@ -8,10 +10,144 @@ from tests.core.engine_adapter import to_sql_calls
 pytestmark = [pytest.mark.engine, pytest.mark.trino]
 
 
-def test_set_current_catalog(make_mocked_engine_adapter: t.Callable, duck_conn):
-    adapter = make_mocked_engine_adapter(TrinoEngineAdapter)
+@pytest.fixture
+def trino_mocked_engine_adapter(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+) -> TrinoEngineAdapter:
+    def mock_catalog_type(catalog_name):
+        if "iceberg" in catalog_name:
+            return "iceberg"
+        return "hive"
+
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.trino.TrinoEngineAdapter.get_catalog_type",
+        side_effect=mock_catalog_type,
+    )
+
+    return make_mocked_engine_adapter(TrinoEngineAdapter)
+
+
+def test_set_current_catalog(trino_mocked_engine_adapter: TrinoEngineAdapter):
+    adapter = trino_mocked_engine_adapter
     adapter.set_current_catalog("test_catalog")
 
     assert to_sql_calls(adapter) == [
         'USE "test_catalog"."information_schema"',
+    ]
+
+
+def test_get_catalog_type(trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: MockerFixture):
+    adapter = trino_mocked_engine_adapter
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.trino.TrinoEngineAdapter.get_current_catalog",
+        return_value="system",
+    )
+
+    assert adapter.current_catalog_type == "hive"
+    assert adapter.get_catalog_type("foo") == TrinoEngineAdapter.DEFAULT_CATALOG_TYPE
+    assert adapter.get_catalog_type("datalake_hive") == "hive"
+    assert adapter.get_catalog_type("datalake_iceberg") == "iceberg"
+
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.trino.TrinoEngineAdapter.get_current_catalog",
+        return_value="system_iceberg",
+    )
+    assert adapter.current_catalog_type == "iceberg"
+
+
+def test_partitioned_by_hive(
+    trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: MockerFixture
+):
+    adapter = trino_mocked_engine_adapter
+
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.trino.TrinoEngineAdapter.get_current_catalog",
+        return_value="datalake_hive",
+    )
+    assert adapter.get_catalog_type("datalake_hive") == "hive"
+
+    columns_to_types = {
+        "cola": exp.DataType.build("INT"),
+        "colb": exp.DataType.build("TEXT"),
+    }
+
+    adapter.create_table("test_table", columns_to_types, partitioned_by=[exp.to_column("colb")])
+
+    assert to_sql_calls(adapter) == [
+        """CREATE TABLE IF NOT EXISTS "test_table" ("cola" INTEGER, "colb" VARCHAR) WITH (PARTITIONED_BY=ARRAY['colb'])"""
+    ]
+
+
+def test_partitioned_by_iceberg(
+    trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: MockerFixture
+):
+    adapter = trino_mocked_engine_adapter
+
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.trino.TrinoEngineAdapter.get_current_catalog",
+        return_value="datalake_iceberg",
+    )
+    assert adapter.get_catalog_type("datalake_iceberg") == "iceberg"
+
+    columns_to_types = {
+        "cola": exp.DataType.build("INT"),
+        "colb": exp.DataType.build("TEXT"),
+    }
+
+    adapter.create_table("test_table", columns_to_types, partitioned_by=[exp.to_column("colb")])
+
+    assert to_sql_calls(adapter) == [
+        """CREATE TABLE IF NOT EXISTS "test_table" ("cola" INTEGER, "colb" VARCHAR) WITH (PARTITIONING=ARRAY['colb'])"""
+    ]
+
+
+def test_partitioned_by_iceberg_transforms(
+    trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: MockerFixture
+):
+    adapter = trino_mocked_engine_adapter
+
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.trino.TrinoEngineAdapter.get_current_catalog",
+        return_value="datalake_iceberg",
+    )
+
+    columns_to_types = {
+        "cola": exp.DataType.build("INT"),
+        "colb": exp.DataType.build("TEXT"),
+    }
+
+    adapter.create_table(
+        "test_table",
+        columns_to_types,
+        partitioned_by=[exp.to_column("day(cola)"), exp.to_column("truncate(colb, 8)")],
+    )
+
+    assert to_sql_calls(adapter) == [
+        """CREATE TABLE IF NOT EXISTS "test_table" ("cola" INTEGER, "colb" VARCHAR) WITH (PARTITIONING=ARRAY['day(cola)', 'truncate(colb, 8)'])"""
+    ]
+
+
+def test_partitioned_by_with_multiple_catalogs_same_server(
+    trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: MockerFixture
+):
+    adapter = trino_mocked_engine_adapter
+
+    columns_to_types = {
+        "cola": exp.DataType.build("INT"),
+        "colb": exp.DataType.build("TEXT"),
+    }
+
+    adapter.create_table(
+        "datalake.test_schema.test_table", columns_to_types, partitioned_by=[exp.to_column("colb")]
+    )
+
+    adapter.create_table(
+        "datalake_iceberg.test_schema.test_table",
+        columns_to_types,
+        partitioned_by=[exp.to_column("colb")],
+    )
+
+    assert to_sql_calls(adapter) == [
+        """CREATE TABLE IF NOT EXISTS "datalake"."test_schema"."test_table" ("cola" INTEGER, "colb" VARCHAR) WITH (PARTITIONED_BY=ARRAY['colb'])""",
+        """CREATE TABLE IF NOT EXISTS "datalake_iceberg"."test_schema"."test_table" ("cola" INTEGER, "colb" VARCHAR) WITH (PARTITIONING=ARRAY['colb'])""",
     ]

--- a/tests/core/engine_adapter/trino/catalog/datalake_iceberg.properties
+++ b/tests/core/engine_adapter/trino/catalog/datalake_iceberg.properties
@@ -1,0 +1,13 @@
+connector.name=iceberg
+# note: we have to use a Hive metastore instead of the REST catalog because
+# as at 2024-02-16 its the only one that supports views
+iceberg.catalog.type=hive_metastore
+iceberg.file-format=PARQUET
+hive.metastore.uri=thrift://trino-datalake-iceberg-hive-metastore:9083
+hive.metastore-cache-ttl=0s
+hive.metastore-refresh-interval=5s
+hive.metastore-timeout=10s
+hive.s3.endpoint=http://minio:9000
+hive.s3.path-style-access=true
+hive.s3.aws-access-key=minio
+hive.s3.aws-secret-key=minio123

--- a/tests/core/engine_adapter/trino/initdb.sql
+++ b/tests/core/engine_adapter/trino/initdb.sql
@@ -1,0 +1,4 @@
+create database datalake_metastore;
+create database datalake_iceberg_metastore;
+create database testing_metastore;
+create database testing_iceberg_metastore;


### PR DESCRIPTION
- Add the Iceberg connector to the integration test Trino instance
- Add a configuration to run the integration tests against the Iceberg connector
- Add the ability to probe the type of a catalog within an EngineAdapter
- Use this ability to change how table properties are generated in the Trino adapter so it can use `partitioned_by` for Hive tables and `partitioning` for Iceberg tables

ref: Issue #1998 