### PR TITLE
Feat!: Keep track of the previous finalized snapshots in the environment

### DIFF
--- a/sqlmesh/core/config/plan.py
+++ b/sqlmesh/core/config/plan.py
@@ -16,6 +16,8 @@ class PlanConfig(BaseConfig):
         no_diff: Hide text differences for changed models.
         no_prompts: Whether to disable interactive prompts for the backfill time range. Please note that
         auto_apply: Whether to automatically apply the new plan after creation.
+        use_finalized_state: Whether to compare against the latest finalized environment state, or to use
+            whatever state the target environment is currently in.
     """
 
     forward_only: bool = False
@@ -25,3 +27,4 @@ class PlanConfig(BaseConfig):
     no_diff: bool = False
     no_prompts: bool = False
     auto_apply: bool = False
+    use_finalized_state: bool = False

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -186,6 +186,12 @@ class Plan(PydanticModel, frozen=True):
                 s.snapshot_id for s in snapshots if s.snapshot_id in promotable_snapshot_ids
             ]
 
+        previous_finalized_snapshots = (
+            self.context_diff.environment_snapshots
+            if not self.context_diff.is_unfinalized_environment
+            else self.context_diff.previous_finalized_snapshots
+        )
+
         return Environment(
             snapshots=snapshots,
             start_at=self.provided_start or self._earliest_interval_start,
@@ -194,6 +200,7 @@ class Plan(PydanticModel, frozen=True):
             previous_plan_id=self.previous_plan_id,
             expiration_ts=expiration_ts,
             promoted_snapshot_ids=promoted_snapshot_ids,
+            previous_finalized_snapshots=previous_finalized_snapshots,
             **self.environment_naming_info.dict(),
         )
 

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -138,23 +138,31 @@ class StateReader(abc.ABC):
         """
 
     @abc.abstractmethod
-    def max_interval_end_for_environment(self, environment: str) -> t.Optional[int]:
+    def max_interval_end_for_environment(
+        self, environment: str, ensure_finalized_snapshots: bool = False
+    ) -> t.Optional[int]:
         """Returns the max interval end for the given environment.
 
         Args:
             environment: The environment.
+            ensure_finalized_snapshots: Whether to use snapshots from the latest finalized environment state,
+                or to use whatever snapshots are in the current environment state even if the environment is not finalized.
 
         Returns:
             A timestamp or None if no interval or environment exists.
         """
 
     @abc.abstractmethod
-    def greatest_common_interval_end(self, environment: str, models: t.Set[str]) -> t.Optional[int]:
+    def greatest_common_interval_end(
+        self, environment: str, models: t.Set[str], ensure_finalized_snapshots: bool = False
+    ) -> t.Optional[int]:
         """Returns the greatest common interval end for given models in the target environment.
 
         Args:
             environment: The environment.
             models: The model FQNs to select intervals from.
+            ensure_finalized_snapshots: Whether to use snapshots from the latest finalized environment state,
+                or to use whatever snapshots are in the current environment state even if the environment is not finalized.
 
         Returns:
             A timestamp or None if no interval or environment exists.

--- a/sqlmesh/migrations/v0040_add_previous_finalized_snapshots.py
+++ b/sqlmesh/migrations/v0040_add_previous_finalized_snapshots.py
@@ -1,0 +1,21 @@
+"""Add support for environment previous finalized snapshots."""
+
+from sqlglot import exp
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    environments_table = "_environments"
+    if state_sync.schema:
+        environments_table = f"{state_sync.schema}.{environments_table}"
+
+    alter_table_exp = exp.AlterTable(
+        this=exp.to_table(environments_table),
+        actions=[
+            exp.ColumnDef(
+                this=exp.to_column("previous_finalized_snapshots"),
+                kind=exp.DataType.build("text"),
+            )
+        ],
+    )
+    engine_adapter.execute(alter_table_exp)

--- a/sqlmesh/schedulers/airflow/api.py
+++ b/sqlmesh/schedulers/airflow/api.py
@@ -75,7 +75,10 @@ def get_environments() -> Response:
 @check_authentication
 def get_max_interval_end(name: str) -> Response:
     with util.scoped_state_sync() as state_sync:
-        max_interval_end = state_sync.max_interval_end_for_environment(name)
+        ensure_finalized_snapshots = "ensure_finalized_snapshots" in request.args
+        max_interval_end = state_sync.max_interval_end_for_environment(
+            name, ensure_finalized_snapshots=ensure_finalized_snapshots
+        )
         response = common.IntervalEndResponse(environment=name, max_interval_end=max_interval_end)
         return _success(response)
 
@@ -86,7 +89,10 @@ def get_max_interval_end(name: str) -> Response:
 def get_greatest_common_interval_end(name: str) -> Response:
     with util.scoped_state_sync() as state_sync:
         models = json.loads(request.args["models"]) if "models" in request.args else []
-        max_interval_end = state_sync.greatest_common_interval_end(name, set(models))
+        ensure_finalized_snapshots = "ensure_finalized_snapshots" in request.args
+        max_interval_end = state_sync.greatest_common_interval_end(
+            name, set(models), ensure_finalized_snapshots=ensure_finalized_snapshots
+        )
         response = common.IntervalEndResponse(environment=name, max_interval_end=max_interval_end)
         return _success(response)
 

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -271,15 +271,20 @@ class AirflowClient(BaseAirflowClient):
         response = self._get(ENVIRONMENTS_PATH)
         return common.EnvironmentsResponse.parse_obj(response).environments
 
-    def max_interval_end_for_environment(self, environment: str) -> t.Optional[int]:
-        response = self._get(f"{ENVIRONMENTS_PATH}/{environment}/max_interval_end")
+    def max_interval_end_for_environment(
+        self, environment: str, ensure_finalized_snapshots: bool
+    ) -> t.Optional[int]:
+        flags = ["ensure_finalized_snapshots"] if ensure_finalized_snapshots else []
+        response = self._get(f"{ENVIRONMENTS_PATH}/{environment}/max_interval_end", *flags)
         return common.IntervalEndResponse.parse_obj(response).max_interval_end
 
     def greatest_common_interval_end(
-        self, environment: str, models: t.Collection[str]
+        self, environment: str, models: t.Collection[str], ensure_finalized_snapshots: bool
     ) -> t.Optional[int]:
+        flags = ["ensure_finalized_snapshots"] if ensure_finalized_snapshots else []
         response = self._get(
             f"{ENVIRONMENTS_PATH}/{environment}/greatest_common_interval_end",
+            *flags,
             models=_json_query_param(list(models)),
         )
         return common.IntervalEndResponse.parse_obj(response).max_interval_end

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -67,28 +67,40 @@ class HttpStateSync(StateSync):
         """
         return self._client.get_environments()
 
-    def max_interval_end_for_environment(self, environment: str) -> t.Optional[int]:
+    def max_interval_end_for_environment(
+        self, environment: str, ensure_finalized_snapshots: bool = False
+    ) -> t.Optional[int]:
         """Returns the max interval end for the given environment.
 
         Args:
             environment: The environment.
+            ensure_finalized_snapshots: Whether to use snapshots from the latest finalized environment state,
+                or to use whatever snapshots are in the current environment state even if the environment is not finalized.
 
         Returns:
             A timestamp or None if no interval or environment exists.
         """
-        return self._client.max_interval_end_for_environment(environment)
+        return self._client.max_interval_end_for_environment(
+            environment, ensure_finalized_snapshots
+        )
 
-    def greatest_common_interval_end(self, environment: str, models: t.Set[str]) -> t.Optional[int]:
+    def greatest_common_interval_end(
+        self, environment: str, models: t.Set[str], ensure_finalized_snapshots: bool = False
+    ) -> t.Optional[int]:
         """Returns the greatest common interval end for given models in the target environment.
 
         Args:
             environment: The environment.
             models: The model FQNs to select intervals from.
+            ensure_finalized_snapshots: Whether to use snapshots from the latest finalized environment state,
+                or to use whatever snapshots are in the current environment state even if the environment is not finalized.
 
         Returns:
             A timestamp or None if no interval or environment exists.
         """
-        return self._client.greatest_common_interval_end(environment, models)
+        return self._client.greatest_common_interval_end(
+            environment, models, ensure_finalized_snapshots
+        )
 
     def get_snapshots(
         self,

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -63,6 +63,7 @@ def test_forward_only_plan_sets_version(make_snapshot, mocker: MockerFixture):
         new_snapshots={snapshot_b.snapshot_id: snapshot_b},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     plan_builder = PlanBuilder(context_diff, forward_only=True)
@@ -100,6 +101,7 @@ def test_forward_only_dev(make_snapshot, mocker: MockerFixture):
         new_snapshots={snapshot_a.snapshot_id: snapshot_a},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     yesterday_ds_mock = mocker.patch("sqlmesh.core.plan.builder.yesterday_ds")
@@ -145,6 +147,7 @@ def test_forward_only_plan_added_models(make_snapshot, mocker: MockerFixture):
         },
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     PlanBuilder(context_diff, forward_only=True).build()
@@ -187,6 +190,7 @@ def test_paused_forward_only_parent(make_snapshot, mocker: MockerFixture):
         new_snapshots={snapshot_b.snapshot_id: snapshot_b},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     PlanBuilder(context_diff, forward_only=False).build()
@@ -218,6 +222,7 @@ def test_missing_intervals_lookback(make_snapshot, mocker: MockerFixture):
         new_snapshots={snapshot_a.snapshot_id: snapshot_a},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     plan = Plan(
@@ -365,6 +370,7 @@ def test_restate_model_with_merge_strategy(make_snapshot, mocker: MockerFixture)
         new_snapshots={},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     with pytest.raises(
@@ -389,6 +395,7 @@ def test_new_snapshots_with_restatements(make_snapshot, mocker: MockerFixture):
         new_snapshots={snapshot_a.snapshot_id: snapshot_a},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     with pytest.raises(
@@ -419,6 +426,7 @@ def test_end_validation(make_snapshot, mocker: MockerFixture):
         new_snapshots={snapshot_a.snapshot_id: snapshot_a},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     dev_plan_builder = PlanBuilder(context_diff, end="2022-01-03", is_dev=True)
@@ -479,6 +487,7 @@ def test_forward_only_revert_not_allowed(make_snapshot, mocker: MockerFixture):
         new_snapshots={},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     with pytest.raises(
@@ -533,6 +542,7 @@ def test_forward_only_plan_seed_models(make_snapshot, mocker: MockerFixture):
         new_snapshots={snapshot_a_updated.snapshot_id: snapshot_a},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     PlanBuilder(context_diff, forward_only=True).build()
@@ -564,6 +574,7 @@ def test_start_inference(make_snapshot, mocker: MockerFixture):
         new_snapshots={},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     snapshot_b.add_interval("2022-01-01", now())
@@ -598,6 +609,7 @@ def test_auto_categorization(make_snapshot, mocker: MockerFixture):
         new_snapshots={updated_snapshot.snapshot_id: updated_snapshot},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     PlanBuilder(context_diff).build()
@@ -641,6 +653,7 @@ def test_auto_categorization_missing_schema_downstream(make_snapshot, mocker: Mo
         new_snapshots={updated_snapshot.snapshot_id: updated_snapshot},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     PlanBuilder(context_diff).build()
@@ -670,6 +683,7 @@ def test_broken_references(make_snapshot, mocker: MockerFixture):
         new_snapshots={},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     with pytest.raises(
@@ -703,6 +717,7 @@ def test_effective_from(make_snapshot, mocker: MockerFixture):
         new_snapshots={updated_snapshot.snapshot_id: updated_snapshot},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     with pytest.raises(
@@ -758,6 +773,7 @@ def test_new_environment_no_changes(make_snapshot, mocker: MockerFixture):
         new_snapshots={},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     with pytest.raises(PlanError, match="No changes were detected.*"):
@@ -795,6 +811,7 @@ def test_new_environment_with_changes(make_snapshot, mocker: MockerFixture):
         new_snapshots={updated_snapshot_a.snapshot_id: updated_snapshot_a},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     # Modified the existing model.
@@ -860,6 +877,7 @@ def test_forward_only_models(make_snapshot, mocker: MockerFixture):
         new_snapshots={updated_snapshot.snapshot_id: updated_snapshot},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     PlanBuilder(context_diff, is_dev=True).build()
@@ -927,6 +945,7 @@ def test_indirectly_modified_forward_only_model(make_snapshot, mocker: MockerFix
         },
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     plan = PlanBuilder(context_diff, is_dev=True).build()
@@ -976,6 +995,7 @@ def test_added_model_with_forward_only_parent(make_snapshot, mocker: MockerFixtu
         new_snapshots={snapshot_b.snapshot_id: snapshot_b},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     PlanBuilder(context_diff, is_dev=True).build()
@@ -1011,6 +1031,7 @@ def test_added_forward_only_model(make_snapshot, mocker: MockerFixture):
         },
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     PlanBuilder(context_diff).build()
@@ -1040,6 +1061,7 @@ def test_disable_restatement(make_snapshot, mocker: MockerFixture):
         new_snapshots={},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     with pytest.raises(PlanError, match="""Cannot restate from '"a"'.*"""):
@@ -1095,6 +1117,7 @@ def test_revert_to_previous_value(make_snapshot, mocker: MockerFixture):
         new_snapshots={snapshot_a.snapshot_id: snapshot_a},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     plan_builder = PlanBuilder(context_diff)
@@ -1304,6 +1327,7 @@ def test_add_restatements(
         new_snapshots={},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     plan = PlanBuilder(
@@ -1377,6 +1401,7 @@ def test_dev_plan_depends_past(make_snapshot, mocker: MockerFixture):
         },
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     dev_plan_start_aligned = PlanBuilder(
@@ -1444,6 +1469,7 @@ def test_models_selected_for_backfill(make_snapshot, mocker: MockerFixture):
         new_snapshots={snapshot_b.snapshot_id: snapshot_b},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     with pytest.raises(
@@ -1492,11 +1518,12 @@ def test_categorized_uncategorized(make_snapshot, mocker: MockerFixture):
         create_from="prod",
         added=set(),
         removed_snapshots={},
-        modified_snapshots={new_snapshot.name: (snapshot, new_snapshot)},
+        modified_snapshots={new_snapshot.name: (new_snapshot, snapshot)},
         snapshots={new_snapshot.snapshot_id: new_snapshot},
         new_snapshots={new_snapshot.snapshot_id: new_snapshot},
         previous_plan_id=None,
         previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=None,
     )
 
     plan_builder = PlanBuilder(context_diff, auto_categorization_enabled=False)
@@ -1510,3 +1537,57 @@ def test_categorized_uncategorized(make_snapshot, mocker: MockerFixture):
     plan = plan_builder.build()
     assert not plan.uncategorized
     assert plan.categorized == [new_snapshot]
+
+
+def test_environment_previous_finalized_snapshots(make_snapshot, mocker: MockerFixture):
+    snapshot_a = make_snapshot(SqlModel(name="a", query=parse_one("select 1 as one, ds")))
+    snapshot_a.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    updated_snapshot_a = make_snapshot(SqlModel(name="a", query=parse_one("select 4 as four, ds")))
+    updated_snapshot_a.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    snapshot_b = make_snapshot(SqlModel(name="b", query=parse_one("select 2 as two, ds")))
+    snapshot_b.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    snapshot_c = make_snapshot(SqlModel(name="c", query=parse_one("select 3 as three, ds")))
+    snapshot_c.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    snapshot_d = make_snapshot(SqlModel(name="d", query=parse_one("select 5 as five, ds")))
+    snapshot_d.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    context_diff = ContextDiff(
+        environment="test_environment",
+        is_new_environment=False,
+        is_unfinalized_environment=True,
+        create_from="prod",
+        added={snapshot_b.snapshot_id},
+        removed_snapshots={snapshot_c.snapshot_id: snapshot_c.table_info},
+        modified_snapshots={snapshot_a.name: (updated_snapshot_a, snapshot_a)},
+        snapshots={
+            updated_snapshot_a.snapshot_id: updated_snapshot_a,
+            snapshot_b.snapshot_id: snapshot_b,
+            snapshot_d.snapshot_id: snapshot_d,
+        },
+        new_snapshots={
+            snapshot_b.snapshot_id: snapshot_b,
+            updated_snapshot_a.snapshot_id: updated_snapshot_a,
+        },
+        previous_plan_id=None,
+        previously_promoted_snapshot_ids=set(),
+        previous_finalized_snapshots=[snapshot_c.table_info, snapshot_d.table_info],
+    )
+
+    plan = PlanBuilder(context_diff).build()
+    assert set(plan.environment.previous_finalized_snapshots or []) == {
+        snapshot_c.table_info,
+        snapshot_d.table_info,
+    }
+
+    context_diff.is_unfinalized_environment = False
+
+    plan = PlanBuilder(context_diff).build()
+    assert set(plan.environment.previous_finalized_snapshots or []) == {
+        snapshot_a.table_info,
+        snapshot_c.table_info,
+        snapshot_d.table_info,
+    }

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -349,7 +349,10 @@ def test_get_environments(mocker: MockerFixture, snapshot: Snapshot):
     )
 
 
-def test_max_interval_end_for_environment(mocker: MockerFixture, snapshot: Snapshot):
+@pytest.mark.parametrize("ensure_finalized_snapshots", [True, False])
+def test_max_interval_end_for_environment(
+    mocker: MockerFixture, snapshot: Snapshot, ensure_finalized_snapshots: bool
+):
     response = common.IntervalEndResponse(
         environment="test_environment", max_interval_end=to_timestamp("2023-01-01")
     )
@@ -361,16 +364,20 @@ def test_max_interval_end_for_environment(mocker: MockerFixture, snapshot: Snaps
     max_interval_end_mock.return_value = max_interval_end_response_mock
 
     client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
-    result = client.max_interval_end_for_environment("test_environment")
+    result = client.max_interval_end_for_environment("test_environment", ensure_finalized_snapshots)
 
     assert result == response.max_interval_end
 
+    flags = "?ensure_finalized_snapshots" if ensure_finalized_snapshots else ""
     max_interval_end_mock.assert_called_once_with(
-        "http://localhost:8080/sqlmesh/api/v1/environments/test_environment/max_interval_end"
+        f"http://localhost:8080/sqlmesh/api/v1/environments/test_environment/max_interval_end{flags}"
     )
 
 
-def test_greatest_common_interval_end(mocker: MockerFixture, snapshot: Snapshot):
+@pytest.mark.parametrize("ensure_finalized_snapshots", [True, False])
+def test_greatest_common_interval_end(
+    mocker: MockerFixture, snapshot: Snapshot, ensure_finalized_snapshots: bool
+):
     response = common.IntervalEndResponse(
         environment="test_environment", max_interval_end=to_timestamp("2023-01-01")
     )
@@ -382,12 +389,15 @@ def test_greatest_common_interval_end(mocker: MockerFixture, snapshot: Snapshot)
     max_interval_end_mock.return_value = max_interval_end_response_mock
 
     client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
-    result = client.greatest_common_interval_end("test_environment", {"a.b.c"})
+    result = client.greatest_common_interval_end(
+        "test_environment", {"a.b.c"}, ensure_finalized_snapshots
+    )
 
     assert result == response.max_interval_end
 
+    flags = "ensure_finalized_snapshots&" if ensure_finalized_snapshots else ""
     max_interval_end_mock.assert_called_once_with(
-        "http://localhost:8080/sqlmesh/api/v1/environments/test_environment/greatest_common_interval_end?models=%5B%22a.b.c%22%5D"
+        f"http://localhost:8080/sqlmesh/api/v1/environments/test_environment/greatest_common_interval_end?{flags}models=%5B%22a.b.c%22%5D"
     )
 
 


### PR DESCRIPTION
Sometimes, when the main branch is ahead of production and changes are being deployed to production, other users iterating in their development environments might end up comparing their local state against a partial / unfinilized production state.

This may result in unnecessary evaluations, leading to a worse developer experience, even if comparing against the most recent state of production is technically more correct.

This update introduces an option to compare against the latest finalized state of the target environment and ignore the partial state.