### PR TITLE
Fix: transpile default catalog name for default DuckDB test connection

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -291,7 +291,9 @@ class Context(BaseContext):
         self.concurrent_tasks = concurrent_tasks or self._connection_config.concurrent_tasks
         self._engine_adapter = engine_adapter or self._connection_config.create_engine_adapter()
 
-        test_connection_config = self.config.get_test_connection(self.gateway, self.default_catalog)
+        test_connection_config = self.config.get_test_connection(
+            self.gateway, self.default_catalog, default_catalog_dialect=self.engine_adapter.DIALECT
+        )
         self._test_engine_adapter = test_connection_config.create_engine_adapter(
             register_comments_override=False
         )


### PR DESCRIPTION
SQLMesh currently assumes the default DuckDB test connection can execute queries containing the main connection's default catalog name, which is not always true due to different identifier quotes across engines. 

This PR transpiles the default catalog name from the main connection dialect to the DuckDB dialect so DuckDB can accommodate default catalogs from all engines.

Background
- A SQLMesh project's main connection may specify a default catalog. If the catalog name is quoted, it will use the identifier quotes of the connection's own SQL dialect. 
- By default, SQLMesh executes model unit tests on a local DuckDB connection.
- The catalog name is part of a model's fully qualified name, which must be usable by DuckDB when it runs the test queries.