### PR TITLE
Feat: ignore SQL model unit test row order unless query contains ORDER BY

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -101,7 +101,7 @@ class ModelTest(unittest.TestCase):
                 else table
             )
 
-    def assert_equal(self, expected: pd.DataFrame, actual: pd.DataFrame) -> None:
+    def assert_equal(self, expected: pd.DataFrame, actual: pd.DataFrame, sort: bool) -> None:
         """Compare two DataFrames"""
 
         # Two astypes are necessary, pandas converts strings to times as NS,
@@ -116,10 +116,19 @@ class ModelTest(unittest.TestCase):
 
         try:
             pd.testing.assert_frame_equal(
-                expected.sort_index(axis=1),
-                actual.sort_index(axis=1),
+                (
+                    expected.sort_values(by=expected.columns.to_list()).reset_index(drop=True)
+                    if sort
+                    else expected
+                ),
+                (
+                    actual.sort_values(by=actual.columns.to_list()).reset_index(drop=True)
+                    if sort
+                    else actual
+                ),
                 check_dtype=False,
                 check_datetimelike_compat=True,
+                check_like=True,  # ignore column order
             )
         except AssertionError as e:
             if expected.empty and actual.empty and all(expected.columns == actual.columns):
@@ -241,12 +250,13 @@ class SqlModelTest(ModelTest):
                     )
 
                 cte_query = ctes[cte_name].this
+                query_has_orderby = any(cte_query.find_all(exp.Order))
                 for alias, cte in ctes.items():
                     cte_query = cte_query.with_(alias, cte.this)
 
                 expected_df = pd.DataFrame.from_records(rows, columns=cte_query.named_selects)
                 actual_df = self._execute(cte_query)
-                self.assert_equal(expected_df, actual_df)
+                self.assert_equal(expected_df, actual_df, sort=not query_has_orderby)
 
     def runTest(self) -> None:
         # For tests we just use the model name for the table reference and we don't want to expand
@@ -262,6 +272,7 @@ class SqlModelTest(ModelTest):
             engine_adapter=self.engine_adapter,
             table_mapping=mapping,
         )
+        query_has_orderby = any(query.find_all(exp.Order))
 
         self.test_ctes(
             {normalize_model_name(cte.alias, None, self.dialect): cte for cte in query.ctes}
@@ -272,7 +283,7 @@ class SqlModelTest(ModelTest):
         if query_rows is not None:
             expected_df = pd.DataFrame.from_records(query_rows, columns=self.model.columns_to_types)  # type: ignore
             actual_df = self._execute(query)
-            self.assert_equal(expected_df, actual_df)
+            self.assert_equal(expected_df, actual_df, sort=not query_has_orderby)
 
 
 class PythonModelTest(ModelTest):
@@ -324,7 +335,7 @@ class PythonModelTest(ModelTest):
             expected_df = pd.DataFrame.from_records(query_rows, columns=self.model.columns_to_types)  # type: ignore
             actual_df = self._execute_model()
             actual_df.reset_index(drop=True, inplace=True)
-            self.assert_equal(expected_df, actual_df)
+            self.assert_equal(expected_df, actual_df, sort=False)
 
 
 def generate_test(

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -234,6 +234,74 @@ test_foo:
     assert result and result.wasSuccessful()
 
 
+def test_row_order_orderby(sushi_context: Context, full_model_without_ctes: SqlModel) -> None:
+    # add ORDER BY to model query
+    full_model_without_ctes_dict = full_model_without_ctes.dict()
+    full_model_without_ctes_dict["query"] = full_model_without_ctes.query.order_by("id")  # type: ignore
+    full_model_without_ctes_orderby = SqlModel(**full_model_without_ctes_dict)
+
+    model = t.cast(SqlModel, sushi_context.upsert_model(full_model_without_ctes_orderby))
+
+    body = load_yaml(
+        """
+test_foo:
+  model: sushi.foo
+  inputs:
+    raw:
+      - id: 1
+        value: 2
+        ds: 3
+      - id: 2
+        value: 3
+        ds: 4
+  outputs:
+    query:
+      - id: 2
+        value: 3
+        ds: 4
+      - id: 1
+        value: 2
+        ds: 3
+  vars:
+    start: 2022-01-01
+    end: 2022-01-01
+        """
+    )
+    result = _create_test(body, "test_foo", model, sushi_context).run()
+    assert result and not result.wasSuccessful()
+
+
+def test_row_order_no_orderby(sushi_context: Context, full_model_without_ctes: SqlModel) -> None:
+    model = t.cast(SqlModel, sushi_context.upsert_model(full_model_without_ctes))
+    body = load_yaml(
+        """
+test_foo:
+  model: sushi.foo
+  inputs:
+    raw:
+      - id: 1
+        value: 2
+        ds: 3
+      - id: 2
+        value: 3
+        ds: 4
+  outputs:
+    query:
+      - id: 2
+        value: 3
+        ds: 4
+      - id: 1
+        value: 2
+        ds: 3
+  vars:
+    start: 2022-01-01
+    end: 2022-01-01
+        """
+    )
+    result = _create_test(body, "test_foo", model, sushi_context).run()
+    assert result and result.wasSuccessful()
+
+
 def test_partial_data(sushi_context: Context) -> None:
     model = _create_model(
         "WITH source AS (SELECT id, name FROM sushi.waiter_names) SELECT id, name, 'nan' as str FROM source",

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -234,72 +234,49 @@ test_foo:
     assert result and result.wasSuccessful()
 
 
-def test_row_order_orderby(sushi_context: Context, full_model_without_ctes: SqlModel) -> None:
-    # add ORDER BY to model query
+def test_row_order(sushi_context: Context, full_model_without_ctes: SqlModel) -> None:
+    model = t.cast(SqlModel, sushi_context.upsert_model(full_model_without_ctes))
+
+    # input and output rows are in different orders
+    body = load_yaml(
+        """
+test_foo:
+  model: sushi.foo
+  inputs:
+    raw:
+      - id: 1
+        value: 2
+        ds: 3
+      - id: 2
+        value: 3
+        ds: 4
+  outputs:
+    query:
+      - id: 2
+        value: 3
+        ds: 4
+      - id: 1
+        value: 2
+        ds: 3
+  vars:
+    start: 2022-01-01
+    end: 2022-01-01
+        """
+    )
+
+    # model query without ORDER BY should pass unit test
+    result = _create_test(body, "test_foo", model, sushi_context).run()
+    assert result and result.wasSuccessful()
+
+    # model query with ORDER BY should fail unit test
     full_model_without_ctes_dict = full_model_without_ctes.dict()
     full_model_without_ctes_dict["query"] = full_model_without_ctes.query.order_by("id")  # type: ignore
     full_model_without_ctes_orderby = SqlModel(**full_model_without_ctes_dict)
 
     model = t.cast(SqlModel, sushi_context.upsert_model(full_model_without_ctes_orderby))
 
-    body = load_yaml(
-        """
-test_foo:
-  model: sushi.foo
-  inputs:
-    raw:
-      - id: 1
-        value: 2
-        ds: 3
-      - id: 2
-        value: 3
-        ds: 4
-  outputs:
-    query:
-      - id: 2
-        value: 3
-        ds: 4
-      - id: 1
-        value: 2
-        ds: 3
-  vars:
-    start: 2022-01-01
-    end: 2022-01-01
-        """
-    )
     result = _create_test(body, "test_foo", model, sushi_context).run()
     assert result and not result.wasSuccessful()
-
-
-def test_row_order_no_orderby(sushi_context: Context, full_model_without_ctes: SqlModel) -> None:
-    model = t.cast(SqlModel, sushi_context.upsert_model(full_model_without_ctes))
-    body = load_yaml(
-        """
-test_foo:
-  model: sushi.foo
-  inputs:
-    raw:
-      - id: 1
-        value: 2
-        ds: 3
-      - id: 2
-        value: 3
-        ds: 4
-  outputs:
-    query:
-      - id: 2
-        value: 3
-        ds: 4
-      - id: 1
-        value: 2
-        ds: 3
-  vars:
-    start: 2022-01-01
-    end: 2022-01-01
-        """
-    )
-    result = _create_test(body, "test_foo", model, sushi_context).run()
-    assert result and result.wasSuccessful()
 
 
 def test_partial_data(sushi_context: Context) -> None:


### PR DESCRIPTION
SQLMesh unit tests currently require the rows returned by the test query to be in the same order as the output rows specified in the test definition. Different engines may return query rows in different orders, meaning the same unit test will pass on some engines and fail on others.

This PR makes SQL model unit tests row-order agnostic unless the model outer SELECT contains an `ORDER BY` clause (or a CTE's outer SELECT for CTE-specific tests).

Python model tests are order-dependent because there is no universally reliable way to determine whether the model orders the rows.