### PR TITLE
Fix: motherduck only supports duckdb==0.9.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install-doc:
 	pip3 install -r ./docs/requirements.txt
 
 install-engine-test:
-	pip3 install -e ".[dev,web,slack,mysql,postgres,databricks,redshift,bigquery,snowflake,trino,mssql]"
+	pip3 install -e ".[dev,web,slack,mysql,postgres,databricks,redshift,bigquery,snowflake,trino,mssql,motherduck]"
 
 install-pre-commit:
 	pre-commit install

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,9 @@ setup(
             "langchain",
             "openai",
         ],
+        "motherduck": [
+            "duckdb==0.9.2",
+        ],
         "mssql": [
             "pymssql",
         ],

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
             "openai",
         ],
         "motherduck": [
-            "duckdb==0.9.2",
+            "duckdb<0.10.0",
         ],
         "mssql": [
             "pymssql",


### PR DESCRIPTION
Motherduck only supports `duckdb==0.9.2` as of 2024-02-16

https://motherduck.com/docs/getting-started/connect-query-from-python/installation-authentication/#installing-duckdb

![image](https://github.com/TobikoData/sqlmesh/assets/1831878/bb380576-b8c0-4088-9c61-6a7b066d763c)