### PR TITLE
Feat: Support config class overriding in the loader and context

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email="engineering@tobikodata.com",
     license="Apache License 2.0",
     packages=find_packages(include=["sqlmesh", "sqlmesh.*", "web*"]),
-    package_data={"web": ["client/dist/**"]},
+    package_data={"web": ["client/dist/**"], "": ["py.typed"]},
     entry_points={
         "console_scripts": [
             "sqlmesh = sqlmesh.cli.main:cli",

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -11,7 +11,7 @@ from sqlmesh import configure_logging
 from sqlmesh.cli import error_handler
 from sqlmesh.cli import options as opt
 from sqlmesh.cli.example_project import ProjectTemplate, init_example_project
-from sqlmesh.core.config import load_configs
+from sqlmesh.core.config import Config, load_configs
 from sqlmesh.core.context import Context
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.errors import MissingDependencyError
@@ -77,7 +77,7 @@ def cli(
         elif ctx.invoked_subcommand in ("create_external_models", "migrate", "rollback", "ui"):
             load = False
 
-    configs = load_configs(config, paths)
+    configs = load_configs(config, Config, paths)
     log_limit = list(configs.values())[0].log_limit
     configure_logging(debug, ignore_warnings, log_to_stdout, log_limit=log_limit)
 

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -77,7 +77,7 @@ def cli(
         elif ctx.invoked_subcommand in ("create_external_models", "migrate", "rollback", "ui"):
             load = False
 
-    configs = load_configs(config, paths, config_type=Config)
+    configs = load_configs(config, Config, paths)
     log_limit = list(configs.values())[0].log_limit
     configure_logging(debug, ignore_warnings, log_to_stdout, log_limit=log_limit)
 

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -77,7 +77,7 @@ def cli(
         elif ctx.invoked_subcommand in ("create_external_models", "migrate", "rollback", "ui"):
             load = False
 
-    configs = load_configs(config, Config, paths)
+    configs = load_configs(config, paths, config_type=Config)
     log_limit = list(configs.values())[0].log_limit
     configure_logging(debug, ignore_warnings, log_to_stdout, log_limit=log_limit)
 

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -42,6 +42,8 @@ class ConnectionConfig(abc.ABC, BaseConfig):
     concurrent_tasks: int
     register_comments: bool
 
+    type_: str = Field(alias="type", default="none")
+
     @property
     @abc.abstractmethod
     def _connection_kwargs_keys(self) -> t.Set[str]:

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -42,6 +42,7 @@ class ConnectionConfig(abc.ABC, BaseConfig):
     concurrent_tasks: int
     register_comments: bool
 
+    # Pydantic V2 does not include type field in dict unless also in base class
     type_: str = Field(alias="type", default="none")
 
     @property

--- a/sqlmesh/core/config/loader.py
+++ b/sqlmesh/core/config/loader.py
@@ -17,19 +17,20 @@ C = t.TypeVar("C", bound=Config)
 
 
 def load_configs(
-    config: t.Optional[str | t.Union[Config, C]],
-    config_type: t.Type[C],
+    config: t.Optional[t.Union[str, Config]],
     paths: t.Union[str | Path, t.Iterable[str | Path]],
     sqlmesh_path: t.Optional[Path] = None,
+    config_type: t.Optional[t.Type[C]] = None,
 ) -> t.Dict[Path, C]:
     sqlmesh_path = sqlmesh_path or c.SQLMESH_PATH
     config = config or "config"
+    config_type = config_type or t.cast(t.Type[C], Config)
 
     absolute_paths = [
         Path(t.cast(t.Union[str, Path], path)).absolute() for path in ensure_list(paths)
     ]
 
-    if isinstance(config, Config):
+    if not isinstance(config, str):
         if type(config) != config_type:
             config = convert_config_type(config, config_type)
         return {path: config for path in absolute_paths}
@@ -48,24 +49,25 @@ def load_configs(
     with env_vars(config_env_vars if config_env_vars else {}):
         return {
             path: load_config_from_paths(
-                config_type=config_type,
                 project_paths=[path / "config.py", path / "config.yml", path / "config.yaml"],
                 personal_paths=personal_paths,
                 config_name=config,
+                config_type=config_type,
             )
             for path in absolute_paths
         }
 
 
 def load_config_from_paths(
-    config_type: t.Type[C],
     project_paths: t.Optional[t.List[Path]] = None,
     personal_paths: t.Optional[t.List[Path]] = None,
     config_name: str = "config",
     load_from_env: bool = True,
+    config_type: t.Optional[t.Type[C]] = None,
 ) -> C:
     project_paths = project_paths or []
     personal_paths = personal_paths or []
+    config_type = config_type or t.cast(t.Type[C], Config)
     visited_folders: t.Set[Path] = set()
     python_config: t.Optional[C] = None
     non_python_configs = []
@@ -96,7 +98,7 @@ def load_config_from_paths(
             non_python_configs.append(load_config_from_yaml(path))
         elif extension == "py":
             python_config = load_config_from_python_module(
-                config_type, path, config_name=config_name
+                path, config_name=config_name, config_type=config_type
             )
         else:
             raise ConfigError(
@@ -133,8 +135,12 @@ def load_config_from_yaml(path: Path) -> t.Dict[str, t.Any]:
 
 
 def load_config_from_python_module(
-    config_type: t.Type[C], module_path: Path, config_name: str = "config"
+    module_path: Path,
+    config_name: str = "config",
+    config_type: t.Optional[t.Type[C]] = None,
 ) -> C:
+    config_type = config_type or t.cast(t.Type[C], Config)
+
     with sys_path(module_path.parent):
         config_module = import_python_file(module_path, module_path.parent)
 
@@ -175,5 +181,9 @@ def load_config_from_env() -> t.Dict[str, t.Any]:
     return config_dict
 
 
-def convert_config_type(config_obj: Config, config_type: t.Type[C]) -> C:
+def convert_config_type(
+    config_obj: Config,
+    config_type: t.Optional[t.Type[C]] = None,
+) -> C:
+    config_type = config_type or t.cast(t.Type[C], Config)
     return config_type.parse_obj(config_obj.dict())

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -119,6 +119,7 @@ if t.TYPE_CHECKING:
     ModelOrSnapshot = t.Union[str, Model, Snapshot]
     NodeOrSnapshot = t.Union[str, Model, StandaloneAudit, Snapshot]
 
+C = t.TypeVar("C", bound=Config)
 
 logger = logging.getLogger(__name__)
 
@@ -250,6 +251,7 @@ class Context(BaseContext):
         load: Whether or not to automatically load all models and macros (default True).
         console: The rich instance used for printing out CLI command results.
         users: A list of users to make known to SQLMesh.
+        config_type: The type of config object to use (default Config).
     """
 
     def __init__(
@@ -265,9 +267,12 @@ class Context(BaseContext):
         load: bool = True,
         console: t.Optional[Console] = None,
         users: t.Optional[t.List[User]] = None,
+        config_type: t.Union[t.Type[C], t.Type[Config]] = Config,
     ):
         self.console = console or get_console()
-        self.configs = config if isinstance(config, dict) else load_configs(config, paths)
+        self.configs = (
+            config if isinstance(config, dict) else load_configs(config, config_type, paths)
+        )
         self.dag: DAG[str] = DAG()
         self._models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")
         self._audits: UniqueKeyDict[str, Audit] = UniqueKeyDict("audits")

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -267,11 +267,13 @@ class Context(BaseContext):
         load: bool = True,
         console: t.Optional[Console] = None,
         users: t.Optional[t.List[User]] = None,
-        config_type: t.Union[t.Type[C], t.Type[Config]] = Config,
+        config_type: t.Optional[t.Type[C]] = None,
     ):
         self.console = console or get_console()
         self.configs = (
-            config if isinstance(config, dict) else load_configs(config, config_type, paths)
+            config
+            if isinstance(config, dict)
+            else load_configs(config, paths, config_type=config_type or t.cast(t.Type[C], Config))
         )
         self.dag: DAG[str] = DAG()
         self._models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -283,7 +283,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         self._jinja_macros = JinjaMacroRegistry()
         self._default_catalog: t.Optional[str] = None
 
-        self.path, self.config = t.cast(t.Tuple[Path, Config], next(iter(self.configs.items())))
+        self.path, self.config = t.cast(t.Tuple[Path, C], next(iter(self.configs.items())))
 
         self.gateway = gateway
         self._scheduler = self.config.get_scheduler(self.gateway)

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -35,7 +35,7 @@ from sqlmesh.utils.yaml import YAML
 
 if t.TYPE_CHECKING:
     from sqlmesh.core.config import Config
-    from sqlmesh.core.context import Context
+    from sqlmesh.core.context import GenericContext
 
 
 logger = logging.getLogger(__name__)
@@ -91,7 +91,7 @@ class Loader(abc.ABC):
         self._path_mtimes: t.Dict[Path, float] = {}
         self._dag: DAG[str] = DAG()
 
-    def load(self, context: Context, update_schemas: bool = True) -> LoadedProject:
+    def load(self, context: GenericContext, update_schemas: bool = True) -> LoadedProject:
         """
         Loads all macros and models in the context's path.
 

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -28,7 +28,7 @@ from sqlmesh.utils.jinja import JinjaMacroRegistry
 logger = logging.getLogger(__name__)
 
 if t.TYPE_CHECKING:
-    from sqlmesh.core.context import Context
+    from sqlmesh.core.context import GenericContext
 
 
 def sqlmesh_config(
@@ -65,7 +65,7 @@ class DbtLoader(Loader):
         self._macros_max_mtime: t.Optional[float] = None
         super().__init__()
 
-    def load(self, context: Context, update_schemas: bool = True) -> LoadedProject:
+    def load(self, context: GenericContext, update_schemas: bool = True) -> LoadedProject:
         self._project = None
         return super().load(context, update_schemas)
 

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -19,7 +19,7 @@ from rich.jupyter import JupyterRenderable
 
 from sqlmesh.cli.example_project import ProjectTemplate, init_example_project
 from sqlmesh.core import constants as c
-from sqlmesh.core.config import load_configs
+from sqlmesh.core.config import Config, load_configs
 from sqlmesh.core.console import get_console
 from sqlmesh.core.context import Context
 from sqlmesh.core.dialect import format_model_expressions, parse
@@ -97,7 +97,7 @@ class SQLMeshMagics(Magics):
         from sqlmesh import configure_logging
 
         args = parse_argstring(self.context, line)
-        configs = load_configs(args.config, args.paths)
+        configs = load_configs(args.config, Config, args.paths)
         log_limit = list(configs.values())[0].log_limit
         configure_logging(args.debug, args.ignore_warnings, log_limit=log_limit)
         try:

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -97,7 +97,7 @@ class SQLMeshMagics(Magics):
         from sqlmesh import configure_logging
 
         args = parse_argstring(self.context, line)
-        configs = load_configs(args.config, Config, args.paths)
+        configs = load_configs(args.config, args.paths, config_type=Config)
         log_limit = list(configs.values())[0].log_limit
         configure_logging(args.debug, args.ignore_warnings, log_limit=log_limit)
         try:

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -97,7 +97,7 @@ class SQLMeshMagics(Magics):
         from sqlmesh import configure_logging
 
         args = parse_argstring(self.context, line)
-        configs = load_configs(args.config, args.paths, config_type=Config)
+        configs = load_configs(args.config, Config, args.paths)
         log_limit = list(configs.values())[0].log_limit
         configure_logging(args.debug, args.ignore_warnings, log_limit=log_limit)
         try:

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -13,7 +13,7 @@ import pytest
 from sqlglot import exp, parse_one
 
 from sqlmesh import Config, Context, EngineAdapter
-from sqlmesh.core.config import Config, load_config_from_paths
+from sqlmesh.core.config import load_config_from_paths
 from sqlmesh.core.dialect import normalize_model_name
 from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 from sqlmesh.utils import random_id
@@ -380,7 +380,6 @@ def test_type(request):
 @pytest.fixture(scope="session")
 def config() -> Config:
     return load_config_from_paths(
-        config_type=Config,
         project_paths=[
             pathlib.Path("examples/wursthall/config.yaml"),
             pathlib.Path(os.path.join(os.path.dirname(__file__), "config.yaml")),
@@ -1569,7 +1568,6 @@ def test_sushi(ctx: TestContext):
         pytest.skip("Sushi end-to-end tests only need to run for query")
 
     config = load_config_from_paths(
-        config_type=Config,
         project_paths=[
             pathlib.Path(os.path.join(os.path.dirname(__file__), "config.yaml")),
         ],

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -13,7 +13,7 @@ import pytest
 from sqlglot import exp, parse_one
 
 from sqlmesh import Config, Context, EngineAdapter
-from sqlmesh.core.config import load_config_from_paths
+from sqlmesh.core.config import Config, load_config_from_paths
 from sqlmesh.core.dialect import normalize_model_name
 from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 from sqlmesh.utils import random_id
@@ -380,6 +380,7 @@ def test_type(request):
 @pytest.fixture(scope="session")
 def config() -> Config:
     return load_config_from_paths(
+        config_type=Config,
         project_paths=[
             pathlib.Path("examples/wursthall/config.yaml"),
             pathlib.Path(os.path.join(os.path.dirname(__file__), "config.yaml")),
@@ -1568,6 +1569,7 @@ def test_sushi(ctx: TestContext):
         pytest.skip("Sushi end-to-end tests only need to run for query")
 
     config = load_config_from_paths(
+        config_type=Config,
         project_paths=[
             pathlib.Path(os.path.join(os.path.dirname(__file__), "config.yaml")),
         ],

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -380,6 +380,7 @@ def test_type(request):
 @pytest.fixture(scope="session")
 def config() -> Config:
     return load_config_from_paths(
+        Config,
         project_paths=[
             pathlib.Path("examples/wursthall/config.yaml"),
             pathlib.Path(os.path.join(os.path.dirname(__file__), "config.yaml")),
@@ -1568,6 +1569,7 @@ def test_sushi(ctx: TestContext):
         pytest.skip("Sushi end-to-end tests only need to run for query")
 
     config = load_config_from_paths(
+        Config,
         project_paths=[
             pathlib.Path(os.path.join(os.path.dirname(__file__), "config.yaml")),
         ],

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -146,8 +146,7 @@ def test_default_gateway():
 
 
 def test_load_config_from_paths(yaml_config_path: Path, python_config_path: Path):
-    config = load_config_from_paths(
-        Config,
+    config: Config = load_config_from_paths(
         project_paths=[yaml_config_path, python_config_path],
     )
 
@@ -170,12 +169,12 @@ def test_load_config_multiple_config_files_in_folder(tmp_path):
         fd.write("project: project_b")
 
     with pytest.raises(ConfigError, match=r"^Multiple configuration files found in folder.*"):
-        load_config_from_paths(Config, project_paths=[config_a_path, config_b_path])
+        load_config_from_paths(project_paths=[config_a_path, config_b_path])
 
 
 def test_load_config_no_config():
     with pytest.raises(ConfigError, match=r"^SQLMesh project config could not be found.*"):
-        load_config_from_paths(Config, load_from_env=False)
+        load_config_from_paths(load_from_env=False)
 
 
 def test_load_config_no_dialect(tmp_path):
@@ -204,12 +203,12 @@ config = Config(default_connection=DuckDBConnectionConfig())
     with pytest.raises(
         ConfigError, match=r"^Default model SQL dialect is a required configuration parameter.*"
     ):
-        load_config_from_paths(Config, project_paths=[tmp_path / "config.yaml"])
+        load_config_from_paths(project_paths=[tmp_path / "config.yaml"])
 
     with pytest.raises(
         ConfigError, match=r"^Default model SQL dialect is a required configuration parameter.*"
     ):
-        load_config_from_paths(Config, project_paths=[tmp_path / "config.py"])
+        load_config_from_paths(project_paths=[tmp_path / "config.py"])
 
 
 def test_load_config_unsupported_extension(tmp_path):
@@ -217,7 +216,7 @@ def test_load_config_unsupported_extension(tmp_path):
     config_path.touch()
 
     with pytest.raises(ConfigError, match=r"^Unsupported config file extension 'txt'.*"):
-        load_config_from_paths(Config, project_paths=[config_path])
+        load_config_from_paths(project_paths=[config_path])
 
 
 def test_load_python_config_with_personal_config(tmp_path):
@@ -243,7 +242,6 @@ custom_config = Config(default_connection=DuckDBConnectionConfig(), model_defaul
 """,
     )
     config = load_config_from_paths(
-        Config,
         project_paths=[tmp_path / "config.py"],
         personal_paths=[tmp_path / "personal" / "config.yaml"],
         config_name="custom_config",
@@ -288,7 +286,7 @@ def test_load_config_from_python_module_missing_config(tmp_path):
         fd.write("from sqlmesh.core.config import Config")
 
     with pytest.raises(ConfigError, match="Config 'config' was not found."):
-        load_config_from_python_module(Config, config_path)
+        load_config_from_python_module(config_path)
 
 
 def test_load_config_from_python_module_invalid_config_object(tmp_path):
@@ -300,7 +298,7 @@ def test_load_config_from_python_module_invalid_config_object(tmp_path):
         ConfigError,
         match=r"^Config needs to be a valid object.*",
     ):
-        load_config_from_python_module(Config, config_path)
+        load_config_from_python_module(config_path)
 
 
 def test_cloud_composer_scheduler_config(tmp_path_factory):
@@ -323,7 +321,6 @@ model_defaults:
         )
 
     assert load_config_from_paths(
-        Config,
         project_paths=[config_path],
     )
 
@@ -382,12 +379,11 @@ environment_catalog_mapping:
     if raise_error:
         with pytest.raises(ConfigError, match=raise_error):
             load_config_from_paths(
-                Config,
                 project_paths=[config_path],
             )
     else:
         assert (
-            load_config_from_paths(Config, project_paths=[config_path]).environment_catalog_mapping
+            load_config_from_paths(project_paths=[config_path]).environment_catalog_mapping
             == expected
         )
 
@@ -410,7 +406,6 @@ feature_flags:
         )
 
     assert load_config_from_paths(
-        Config,
         project_paths=[config_path],
     ) == Config(
         gateways={
@@ -426,8 +421,8 @@ def test_load_alternative_config_type(yaml_config_path: Path, python_config_path
         pass
 
     config = load_config_from_paths(
-        DerivedConfig,
         project_paths=[yaml_config_path, python_config_path],
+        config_type=DerivedConfig,
     )
 
     assert config == DerivedConfig(

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -147,6 +147,7 @@ def test_default_gateway():
 
 def test_load_config_from_paths(yaml_config_path: Path, python_config_path: Path):
     config: Config = load_config_from_paths(
+        Config,
         project_paths=[yaml_config_path, python_config_path],
     )
 
@@ -169,12 +170,12 @@ def test_load_config_multiple_config_files_in_folder(tmp_path):
         fd.write("project: project_b")
 
     with pytest.raises(ConfigError, match=r"^Multiple configuration files found in folder.*"):
-        load_config_from_paths(project_paths=[config_a_path, config_b_path])
+        load_config_from_paths(Config, project_paths=[config_a_path, config_b_path])
 
 
 def test_load_config_no_config():
     with pytest.raises(ConfigError, match=r"^SQLMesh project config could not be found.*"):
-        load_config_from_paths(load_from_env=False)
+        load_config_from_paths(Config, load_from_env=False)
 
 
 def test_load_config_no_dialect(tmp_path):
@@ -203,12 +204,12 @@ config = Config(default_connection=DuckDBConnectionConfig())
     with pytest.raises(
         ConfigError, match=r"^Default model SQL dialect is a required configuration parameter.*"
     ):
-        load_config_from_paths(project_paths=[tmp_path / "config.yaml"])
+        load_config_from_paths(Config, project_paths=[tmp_path / "config.yaml"])
 
     with pytest.raises(
         ConfigError, match=r"^Default model SQL dialect is a required configuration parameter.*"
     ):
-        load_config_from_paths(project_paths=[tmp_path / "config.py"])
+        load_config_from_paths(Config, project_paths=[tmp_path / "config.py"])
 
 
 def test_load_config_unsupported_extension(tmp_path):
@@ -216,7 +217,7 @@ def test_load_config_unsupported_extension(tmp_path):
     config_path.touch()
 
     with pytest.raises(ConfigError, match=r"^Unsupported config file extension 'txt'.*"):
-        load_config_from_paths(project_paths=[config_path])
+        load_config_from_paths(Config, project_paths=[config_path])
 
 
 def test_load_python_config_with_personal_config(tmp_path):
@@ -242,6 +243,7 @@ custom_config = Config(default_connection=DuckDBConnectionConfig(), model_defaul
 """,
     )
     config = load_config_from_paths(
+        Config,
         project_paths=[tmp_path / "config.py"],
         personal_paths=[tmp_path / "personal" / "config.yaml"],
         config_name="custom_config",
@@ -286,7 +288,7 @@ def test_load_config_from_python_module_missing_config(tmp_path):
         fd.write("from sqlmesh.core.config import Config")
 
     with pytest.raises(ConfigError, match="Config 'config' was not found."):
-        load_config_from_python_module(config_path)
+        load_config_from_python_module(Config, config_path)
 
 
 def test_load_config_from_python_module_invalid_config_object(tmp_path):
@@ -298,7 +300,7 @@ def test_load_config_from_python_module_invalid_config_object(tmp_path):
         ConfigError,
         match=r"^Config needs to be a valid object.*",
     ):
-        load_config_from_python_module(config_path)
+        load_config_from_python_module(Config, config_path)
 
 
 def test_cloud_composer_scheduler_config(tmp_path_factory):
@@ -321,6 +323,7 @@ model_defaults:
         )
 
     assert load_config_from_paths(
+        Config,
         project_paths=[config_path],
     )
 
@@ -379,11 +382,12 @@ environment_catalog_mapping:
     if raise_error:
         with pytest.raises(ConfigError, match=raise_error):
             load_config_from_paths(
+                Config,
                 project_paths=[config_path],
             )
     else:
         assert (
-            load_config_from_paths(project_paths=[config_path]).environment_catalog_mapping
+            load_config_from_paths(Config, project_paths=[config_path]).environment_catalog_mapping
             == expected
         )
 
@@ -406,6 +410,7 @@ feature_flags:
         )
 
     assert load_config_from_paths(
+        Config,
         project_paths=[config_path],
     ) == Config(
         gateways={
@@ -421,8 +426,8 @@ def test_load_alternative_config_type(yaml_config_path: Path, python_config_path
         pass
 
     config = load_config_from_paths(
+        DerivedConfig,
         project_paths=[yaml_config_path, python_config_path],
-        config_type=DerivedConfig,
     )
 
     assert config == DerivedConfig(

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -147,6 +147,7 @@ def test_default_gateway():
 
 def test_load_config_from_paths(yaml_config_path: Path, python_config_path: Path):
     config = load_config_from_paths(
+        Config,
         project_paths=[yaml_config_path, python_config_path],
     )
 
@@ -169,12 +170,12 @@ def test_load_config_multiple_config_files_in_folder(tmp_path):
         fd.write("project: project_b")
 
     with pytest.raises(ConfigError, match=r"^Multiple configuration files found in folder.*"):
-        load_config_from_paths(project_paths=[config_a_path, config_b_path])
+        load_config_from_paths(Config, project_paths=[config_a_path, config_b_path])
 
 
 def test_load_config_no_config():
     with pytest.raises(ConfigError, match=r"^SQLMesh project config could not be found.*"):
-        load_config_from_paths(load_from_env=False)
+        load_config_from_paths(Config, load_from_env=False)
 
 
 def test_load_config_no_dialect(tmp_path):
@@ -203,12 +204,12 @@ config = Config(default_connection=DuckDBConnectionConfig())
     with pytest.raises(
         ConfigError, match=r"^Default model SQL dialect is a required configuration parameter.*"
     ):
-        load_config_from_paths(project_paths=[tmp_path / "config.yaml"])
+        load_config_from_paths(Config, project_paths=[tmp_path / "config.yaml"])
 
     with pytest.raises(
         ConfigError, match=r"^Default model SQL dialect is a required configuration parameter.*"
     ):
-        load_config_from_paths(project_paths=[tmp_path / "config.py"])
+        load_config_from_paths(Config, project_paths=[tmp_path / "config.py"])
 
 
 def test_load_config_unsupported_extension(tmp_path):
@@ -216,7 +217,7 @@ def test_load_config_unsupported_extension(tmp_path):
     config_path.touch()
 
     with pytest.raises(ConfigError, match=r"^Unsupported config file extension 'txt'.*"):
-        load_config_from_paths(project_paths=[config_path])
+        load_config_from_paths(Config, project_paths=[config_path])
 
 
 def test_load_python_config_with_personal_config(tmp_path):
@@ -242,6 +243,7 @@ custom_config = Config(default_connection=DuckDBConnectionConfig(), model_defaul
 """,
     )
     config = load_config_from_paths(
+        Config,
         project_paths=[tmp_path / "config.py"],
         personal_paths=[tmp_path / "personal" / "config.yaml"],
         config_name="custom_config",
@@ -286,7 +288,7 @@ def test_load_config_from_python_module_missing_config(tmp_path):
         fd.write("from sqlmesh.core.config import Config")
 
     with pytest.raises(ConfigError, match="Config 'config' was not found."):
-        load_config_from_python_module(config_path)
+        load_config_from_python_module(Config, config_path)
 
 
 def test_load_config_from_python_module_invalid_config_object(tmp_path):
@@ -298,7 +300,7 @@ def test_load_config_from_python_module_invalid_config_object(tmp_path):
         ConfigError,
         match=r"^Config needs to be a valid object.*",
     ):
-        load_config_from_python_module(config_path)
+        load_config_from_python_module(Config, config_path)
 
 
 def test_cloud_composer_scheduler_config(tmp_path_factory):
@@ -321,6 +323,7 @@ model_defaults:
         )
 
     assert load_config_from_paths(
+        Config,
         project_paths=[config_path],
     )
 
@@ -379,11 +382,12 @@ environment_catalog_mapping:
     if raise_error:
         with pytest.raises(ConfigError, match=raise_error):
             load_config_from_paths(
+                Config,
                 project_paths=[config_path],
             )
     else:
         assert (
-            load_config_from_paths(project_paths=[config_path]).environment_catalog_mapping
+            load_config_from_paths(Config, project_paths=[config_path]).environment_catalog_mapping
             == expected
         )
 
@@ -406,6 +410,7 @@ feature_flags:
         )
 
     assert load_config_from_paths(
+        Config,
         project_paths=[config_path],
     ) == Config(
         gateways={
@@ -413,4 +418,22 @@ feature_flags:
         },
         model_defaults=ModelDefaultsConfig(dialect="bigquery"),
         feature_flags=FeatureFlag(dbt=DbtFeatureFlag(scd_type_2_support=False)),
+    )
+
+
+def test_load_alternative_config_type(yaml_config_path: Path, python_config_path: Path):
+    class DerivedConfig(Config):
+        pass
+
+    config = load_config_from_paths(
+        DerivedConfig,
+        project_paths=[yaml_config_path, python_config_path],
+    )
+
+    assert config == DerivedConfig(
+        gateways={  # type: ignore
+            "another_gateway": GatewayConfig(connection=DuckDBConnectionConfig(database="test_db")),
+            "": GatewayConfig(connection=DuckDBConnectionConfig()),
+        },
+        model_defaults=ModelDefaultsConfig(dialect=""),
     )

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -340,8 +340,10 @@ model_defaults:
             ConfigError,
             match="User and password must be provided if using default authentication",
         ):
-            load_configs("config", paths=project_config.parent)
-        loaded_configs = load_configs("config", paths=project_config.parent, sqlmesh_path=home_path)
+            load_configs("config", Config, paths=project_config.parent)
+        loaded_configs = load_configs(
+            "config", Config, paths=project_config.parent, sqlmesh_path=home_path
+        )
         assert len(loaded_configs) == 1
         snowflake_connection = list(loaded_configs.values())[0].gateways["snowflake"].connection  # type: ignore
         assert isinstance(snowflake_connection, SnowflakeConnectionConfig)

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1,5 +1,6 @@
 import logging
 import pathlib
+import typing as t
 from datetime import date, timedelta
 from tempfile import TemporaryDirectory
 from unittest.mock import PropertyMock, call, patch
@@ -340,9 +341,9 @@ model_defaults:
             ConfigError,
             match="User and password must be provided if using default authentication",
         ):
-            load_configs("config", Config, paths=project_config.parent)
-        loaded_configs = load_configs(
-            "config", Config, paths=project_config.parent, sqlmesh_path=home_path
+            load_configs("config", paths=project_config.parent)
+        loaded_configs: t.Dict[pathlib.Path, Config] = load_configs(
+            "config", paths=project_config.parent, sqlmesh_path=home_path
         )
         assert len(loaded_configs) == 1
         snowflake_connection = list(loaded_configs.values())[0].gateways["snowflake"].connection  # type: ignore

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -341,9 +341,9 @@ model_defaults:
             ConfigError,
             match="User and password must be provided if using default authentication",
         ):
-            load_configs("config", paths=project_config.parent)
+            load_configs("config", Config, paths=project_config.parent)
         loaded_configs: t.Dict[pathlib.Path, Config] = load_configs(
-            "config", paths=project_config.parent, sqlmesh_path=home_path
+            "config", Config, paths=project_config.parent, sqlmesh_path=home_path
         )
         assert len(loaded_configs) == 1
         snowflake_connection = list(loaded_configs.values())[0].gateways["snowflake"].connection  # type: ignore

--- a/tests/integrations/github/cicd/test_config.py
+++ b/tests/integrations/github/cicd/test_config.py
@@ -5,7 +5,6 @@ import pytest
 from sqlmesh.core.config import (
     AutoCategorizationMode,
     CategorizerConfig,
-    Config,
     load_config_from_paths,
 )
 from sqlmesh.integrations.github.cicd.config import MergeMethod
@@ -26,7 +25,6 @@ model_defaults:
 """,
     )
     config = load_config_from_paths(
-        Config,
         project_paths=[tmp_path / "config.yaml"],
     )
     assert config.cicd_bot.type_ == "github"
@@ -64,7 +62,6 @@ model_defaults:
 """,
     )
     config = load_config_from_paths(
-        Config,
         project_paths=[tmp_path / "config.yaml"],
     )
     assert config.cicd_bot.type_ == "github"
@@ -98,7 +95,6 @@ config = Config(
 """,
     )
     config = load_config_from_paths(
-        Config,
         project_paths=[tmp_path / "config.py"],
     )
     assert config.cicd_bot.type_ == "github"
@@ -142,7 +138,6 @@ config = Config(
     )
 
     config = load_config_from_paths(
-        Config,
         project_paths=[tmp_path / "config.py"],
     )
     assert config.cicd_bot.type_ == "github"
@@ -177,7 +172,7 @@ model_defaults:
     with pytest.raises(
         ValueError, match="enable_deploy_command must be set if command_namespace is set"
     ):
-        load_config_from_paths(Config, project_paths=[tmp_path / "config.yaml"])
+        load_config_from_paths(project_paths=[tmp_path / "config.yaml"])
 
     create_temp_file(
         tmp_path,
@@ -193,4 +188,4 @@ model_defaults:
     with pytest.raises(
         ValueError, match="merge_method must be set if enable_deploy_command is True"
     ):
-        load_config_from_paths(Config, project_paths=[tmp_path / "config.yaml"])
+        load_config_from_paths(project_paths=[tmp_path / "config.yaml"])

--- a/tests/integrations/github/cicd/test_config.py
+++ b/tests/integrations/github/cicd/test_config.py
@@ -5,6 +5,7 @@ import pytest
 from sqlmesh.core.config import (
     AutoCategorizationMode,
     CategorizerConfig,
+    Config,
     load_config_from_paths,
 )
 from sqlmesh.integrations.github.cicd.config import MergeMethod
@@ -25,6 +26,7 @@ model_defaults:
 """,
     )
     config = load_config_from_paths(
+        Config,
         project_paths=[tmp_path / "config.yaml"],
     )
     assert config.cicd_bot.type_ == "github"
@@ -62,6 +64,7 @@ model_defaults:
 """,
     )
     config = load_config_from_paths(
+        Config,
         project_paths=[tmp_path / "config.yaml"],
     )
     assert config.cicd_bot.type_ == "github"
@@ -95,6 +98,7 @@ config = Config(
 """,
     )
     config = load_config_from_paths(
+        Config,
         project_paths=[tmp_path / "config.py"],
     )
     assert config.cicd_bot.type_ == "github"
@@ -138,6 +142,7 @@ config = Config(
     )
 
     config = load_config_from_paths(
+        Config,
         project_paths=[tmp_path / "config.py"],
     )
     assert config.cicd_bot.type_ == "github"
@@ -172,7 +177,7 @@ model_defaults:
     with pytest.raises(
         ValueError, match="enable_deploy_command must be set if command_namespace is set"
     ):
-        load_config_from_paths(project_paths=[tmp_path / "config.yaml"])
+        load_config_from_paths(Config, project_paths=[tmp_path / "config.yaml"])
 
     create_temp_file(
         tmp_path,
@@ -188,4 +193,4 @@ model_defaults:
     with pytest.raises(
         ValueError, match="merge_method must be set if enable_deploy_command is True"
     ):
-        load_config_from_paths(project_paths=[tmp_path / "config.yaml"])
+        load_config_from_paths(Config, project_paths=[tmp_path / "config.yaml"])


### PR DESCRIPTION
This PR enables loading a different Config class that is derived from `Config` into the SQLMesh context, which enables storage of additional config parameters that are not directly used by SQLMesh.