### PR TITLE
Fix: Make sure that missing intervals don't exceed the target end date when applying plan

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1045,6 +1045,7 @@ class Context(BaseContext):
             enable_preview=(
                 enable_preview if enable_preview is not None else self.config.plan.enable_preview
             ),
+            end_bounded=not run,
         )
 
     def apply(

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -56,6 +56,8 @@ class PlanBuilder:
         default_start: The default plan start to use if not specified.
         default_end: The default plan end to use if not specified.
         enable_preview: Whether to enable preview for forward-only models in development environments.
+        end_bounded: If set to true, the missing intervals will be bounded by the target end date, disregarding lookback,
+            allow_partials, and other attributes that could cause the intervals to exceed the target end date.
     """
 
     def __init__(
@@ -81,6 +83,7 @@ class PlanBuilder:
         default_start: t.Optional[TimeLike] = None,
         default_end: t.Optional[TimeLike] = None,
         enable_preview: bool = False,
+        end_bounded: bool = False,
     ):
         self._context_diff = context_diff
         self._no_gaps = no_gaps
@@ -88,6 +91,7 @@ class PlanBuilder:
         self._is_dev = is_dev
         self._forward_only = forward_only
         self._enable_preview = enable_preview
+        self._end_bounded = end_bounded
         self._environment_ttl = environment_ttl
         self._categorizer_config = categorizer_config or CategorizerConfig()
         self._auto_categorization_enabled = auto_categorization_enabled
@@ -221,6 +225,7 @@ class PlanBuilder:
             models_to_backfill=models_to_backfill,
             effective_from=self._effective_from,
             execution_time=self._execution_time,
+            end_bounded=self._end_bounded,
         )
         self._latest_plan = plan
         return plan

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -35,6 +35,7 @@ class Plan(PydanticModel, frozen=True):
     no_gaps: bool
     forward_only: bool
     include_unmodified: bool
+    end_bounded: bool
 
     environment_ttl: t.Optional[str] = None
     environment_naming_info: EnvironmentNamingInfo
@@ -153,6 +154,7 @@ class Plan(PydanticModel, frozen=True):
                 execution_time=self.execution_time,
                 restatements=self.restatements,
                 deployability_index=self.deployability_index,
+                end_bounded=self.end_bounded,
             ).items()
             if snapshot.is_model and missing
         ]

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -157,6 +157,7 @@ class BuiltInPlanEvaluator(PlanEvaluator):
             selected_snapshots=selected_snapshots,
             deployability_index=deployability_index,
             circuit_breaker=circuit_breaker,
+            end_bounded=plan.end_bounded,
         )
         if not is_run_successful:
             raise SQLMeshError("Plan application failed.")
@@ -357,6 +358,7 @@ class StateBasedAirflowPlanEvaluator(BaseAirflowPlanEvaluator):
             is_dev=plan.is_dev,
             forward_only=plan.forward_only,
             models_to_backfill=plan.models_to_backfill,
+            end_bounded=plan.end_bounded,
         )
         plan_dag_spec = create_plan_dag_spec(plan_application_request, self.state_sync)
         PlanDagState.from_state_sync(self.state_sync).add_dag_spec(plan_dag_spec)
@@ -425,6 +427,7 @@ class AirflowPlanEvaluator(StateBasedAirflowPlanEvaluator):
             is_dev=plan.is_dev,
             forward_only=plan.forward_only,
             models_to_backfill=plan.models_to_backfill,
+            end_bounded=plan.end_bounded,
         )
 
 

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -89,6 +89,7 @@ class Scheduler:
         deployability_index: t.Optional[DeployabilityIndex] = None,
         restatements: t.Optional[t.Dict[SnapshotId, SnapshotInterval]] = None,
         ignore_cron: bool = False,
+        end_bounded: bool = False,
         selected_snapshots: t.Optional[t.Set[str]] = None,
     ) -> SnapshotToBatches:
         """Find the optimal date interval paramaters based on what needs processing and maximal batch size.
@@ -108,6 +109,8 @@ class Scheduler:
             deployability_index: Determines snapshots that are deployable in the context of this evaluation.
             restatements: A set of snapshot names being restated.
             ignore_cron: Whether to ignore the node's cron schedule.
+            end_bounded: If set to true, the returned intervals will be bounded by the target end date, disregarding lookback,
+                allow_partials, and other attributes that could cause the intervals to exceed the target end date.
             selected_snapshots: A set of snapshot names to run. If not provided, all snapshots will be run.
         """
         restatements = restatements or {}
@@ -127,6 +130,7 @@ class Scheduler:
             execution_time=execution_time or now(),
             restatements=restatements,
             ignore_cron=ignore_cron,
+            end_bounded=end_bounded,
         )
 
     def evaluate(
@@ -201,6 +205,7 @@ class Scheduler:
         execution_time: t.Optional[TimeLike] = None,
         restatements: t.Optional[t.Dict[SnapshotId, SnapshotInterval]] = None,
         ignore_cron: bool = False,
+        end_bounded: bool = False,
         selected_snapshots: t.Optional[t.Set[str]] = None,
         circuit_breaker: t.Optional[t.Callable[[], bool]] = None,
         deployability_index: t.Optional[DeployabilityIndex] = None,
@@ -216,6 +221,8 @@ class Scheduler:
             execution_time: The date/time time reference to use for execution time. Defaults to now.
             restatements: A dict of snapshots to restate and their intervals.
             ignore_cron: Whether to ignore the node's cron schedule.
+            end_bounded: If set to true, the evaluated intervals will be bounded by the target end date, disregarding lookback,
+                allow_partials, and other attributes that could cause the intervals to exceed the target end date.
             selected_snapshots: A set of snapshot names to run. If not provided, all snapshots will be run.
             circuit_breaker: An optional handler which checks if the run should be aborted.
             deployability_index: Determines snapshots that are deployable in the context of this render.
@@ -245,6 +252,7 @@ class Scheduler:
             deployability_index=deployability_index,
             restatements=restatements,
             ignore_cron=ignore_cron,
+            end_bounded=end_bounded,
             selected_snapshots=selected_snapshots,
         )
         if not batches:
@@ -369,6 +377,7 @@ def compute_interval_params(
     execution_time: t.Optional[TimeLike] = None,
     restatements: t.Optional[t.Dict[SnapshotId, SnapshotInterval]] = None,
     ignore_cron: bool = False,
+    end_bounded: bool = False,
 ) -> SnapshotToBatches:
     """Find the optimal date interval paramaters based on what needs processing and maximal batch size.
 
@@ -389,6 +398,8 @@ def compute_interval_params(
         execution_time: The date/time time reference to use for execution time.
         restatements: A dict of snapshot names being restated and their intervals.
         ignore_cron: Whether to ignore the node's cron schedule.
+        end_bounded: If set to true, the returned intervals will be bounded by the target end date, disregarding lookback,
+            allow_partials, and other attributes that could cause the intervals to exceed the target end date.
 
     Returns:
         A dict containing all snapshots needing to be run with their associated interval params.
@@ -403,6 +414,7 @@ def compute_interval_params(
         restatements=restatements,
         deployability_index=deployability_index,
         ignore_cron=ignore_cron,
+        end_bounded=end_bounded,
     ).items():
         batches = []
         batch_size = snapshot.node.batch_size

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -196,6 +196,7 @@ class AirflowClient(BaseAirflowClient):
         is_dev: bool = False,
         forward_only: bool = False,
         models_to_backfill: t.Optional[t.Set[str]] = None,
+        end_bounded: bool = False,
     ) -> None:
         request = common.PlanApplicationRequest(
             new_snapshots=list(new_snapshots),
@@ -211,6 +212,7 @@ class AirflowClient(BaseAirflowClient):
             is_dev=is_dev,
             forward_only=forward_only,
             models_to_backfill=models_to_backfill,
+            end_bounded=end_bounded,
         )
 
         response = self._session.post(

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -50,6 +50,7 @@ class PlanApplicationRequest(PydanticModel):
     is_dev: bool
     forward_only: bool
     models_to_backfill: t.Optional[t.Set[str]]
+    end_bounded: bool
 
     def is_selected_for_backfill(self, model_fqn: str) -> bool:
         return self.models_to_backfill is None or model_fqn in self.models_to_backfill

--- a/sqlmesh/schedulers/airflow/plan.py
+++ b/sqlmesh/schedulers/airflow/plan.py
@@ -127,6 +127,7 @@ def create_plan_dag_spec(
             execution_time=now(),
             deployability_index=deployability_index_for_evaluation,
             restatements=request.restatements,
+            end_bounded=request.end_bounded,
         )
     else:
         backfill_batches = {}

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -242,6 +242,7 @@ def test_missing_intervals_lookback(make_snapshot, mocker: MockerFixture):
         ignored=set(),
         deployability_index=DeployabilityIndex.all_deployable(),
         restatements={},
+        end_bounded=False,
     )
 
     assert not plan.missing_intervals

--- a/tests/core/test_plan_evaluator.py
+++ b/tests/core/test_plan_evaluator.py
@@ -99,6 +99,7 @@ def test_airflow_evaluator(sushi_plan: Plan, mocker: MockerFixture):
         is_dev=True,
         forward_only=False,
         models_to_backfill=None,
+        end_bounded=False,
     )
 
     airflow_client_mock.wait_for_dag_run_completion.assert_called_once()

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -157,6 +157,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
         "is_dev": False,
         "forward_only": False,
         "models_to_backfill": ['"test_model"'],
+        "end_bounded": False,
     }
 
 

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -116,6 +116,7 @@ def test_create_plan_dag_spec(
         is_dev=False,
         forward_only=True,
         models_to_backfill=None,
+        end_bounded=False,
     )
 
     deleted_snapshot = SnapshotTableInfo(
@@ -238,6 +239,7 @@ def test_restatement(
         is_dev=False,
         forward_only=True,
         models_to_backfill=None,
+        end_bounded=False,
     )
     old_environment = Environment(
         name=environment_name,
@@ -341,6 +343,7 @@ def test_select_models_for_backfill(mocker: MockerFixture, random_name, make_sna
         is_dev=False,
         forward_only=True,
         models_to_backfill={snapshot_b.name},
+        end_bounded=False,
     )
 
     state_sync_mock = mocker.Mock()
@@ -408,6 +411,7 @@ def test_create_plan_dag_spec_duplicated_snapshot(
         is_dev=False,
         forward_only=False,
         models_to_backfill=None,
+        end_bounded=False,
     )
 
     dag_run_mock = mocker.Mock()
@@ -456,6 +460,7 @@ def test_create_plan_dag_spec_unbounded_end(
         is_dev=False,
         forward_only=False,
         models_to_backfill=None,
+        end_bounded=False,
     )
 
     state_sync_mock = mocker.Mock()


### PR DESCRIPTION
Missing intervals might exceed the given end date in cases when the `allow_partials` or the `lookback` attribute is configured for a model. Even though, this behavior makes sense when executing the `sqlmesh run` command, it's confusing and undesirable when applying a plan (especially to a dev environment).

This update prevents unexpected backfills by bounding missing intervals to the target end date when applying a plan.