### PR TITLE
Fix: Make sure that builtin dbt macros can be referenced using the 'dbt.' prefix

### DIFF
--- a/docs/integrations/dbt.md
+++ b/docs/integrations/dbt.md
@@ -219,7 +219,6 @@ SQLMesh supports running dbt projects using the majority of dbt jinja methods, i
 The dbt jinja methods that are not currently supported are:
 
 * debug
-* run_started_at
 * selected_sources
 * adapter.expand_target_column_types
 * adapter.rename_relation

--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -19,6 +19,7 @@ from sqlmesh.dbt.adapter import BaseAdapter, ParsetimeAdapter, RuntimeAdapter
 from sqlmesh.dbt.target import TARGET_TYPE_TO_CONFIG_CLASS
 from sqlmesh.dbt.util import DBT_VERSION
 from sqlmesh.utils import AttributeDict, yaml
+from sqlmesh.utils.date import now
 from sqlmesh.utils.errors import ConfigError, MacroEvalError
 from sqlmesh.utils.jinja import JinjaMacroRegistry, MacroReference, MacroReturnVal
 
@@ -365,6 +366,9 @@ def create_builtin_globals(
             "statement": sql_execution.statement,
         }
     )
+
+    builtin_globals["run_started_at"] = jinja_globals.get("execution_dt") or now()
+    builtin_globals["dbt"] = AttributeDict(builtin_globals)
 
     return {**builtin_globals, **jinja_globals}
 

--- a/sqlmesh/utils/jinja.py
+++ b/sqlmesh/utils/jinja.py
@@ -267,14 +267,23 @@ class JinjaMacroRegistry(PydanticModel):
         if self.root_package_name is not None:
             package_macros[self.root_package_name].update(root_macros)
 
-        for top_level_package_name in self.top_level_packages:
-            root_macros.update(package_macros.get(top_level_package_name, {}))
-
         env = environment()
 
-        context.update(self._create_builtin_globals(kwargs))
+        builtin_globals = self._create_builtin_globals(kwargs)
+        merged_top_level_package_macros: t.Dict[str, AttributeDict] = {}
+        for top_level_package_name in self.top_level_packages:
+            root_macros.update(package_macros.get(top_level_package_name, {}))
+            merged_top_level_package_macros[top_level_package_name] = AttributeDict(
+                {
+                    **(builtin_globals.pop(top_level_package_name, None) or {}),
+                    **(package_macros.pop(top_level_package_name, None) or {}),
+                }
+            )
+
+        context.update(builtin_globals)
         context.update(root_macros)
         context.update(package_macros)
+        context.update(merged_top_level_package_macros)
 
         env.globals.update(context)
         env.filters.update(self._environment.filters)

--- a/sqlmesh/utils/jinja.py
+++ b/sqlmesh/utils/jinja.py
@@ -270,20 +270,19 @@ class JinjaMacroRegistry(PydanticModel):
         env = environment()
 
         builtin_globals = self._create_builtin_globals(kwargs)
-        merged_top_level_package_macros: t.Dict[str, AttributeDict] = {}
         for top_level_package_name in self.top_level_packages:
-            root_macros.update(package_macros.get(top_level_package_name, {}))
-            merged_top_level_package_macros[top_level_package_name] = AttributeDict(
+            # Make sure that the top-level package doesn't fully override the same builtin package.
+            package_macros[top_level_package_name] = AttributeDict(
                 {
                     **(builtin_globals.pop(top_level_package_name, None) or {}),
-                    **(package_macros.pop(top_level_package_name, None) or {}),
+                    **(package_macros.get(top_level_package_name) or {}),
                 }
             )
+            root_macros.update(package_macros[top_level_package_name])
 
         context.update(builtin_globals)
         context.update(root_macros)
         context.update(package_macros)
-        context.update(merged_top_level_package_macros)
 
         env.globals.update(context)
         env.filters.update(self._environment.filters)

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -8,6 +8,7 @@ import pytest
 from dbt.adapters.base import BaseRelation
 from dbt.contracts.relation import Policy
 from dbt.exceptions import CompilationError
+from freezegun import freeze_time
 from pytest_mock.plugin import MockerFixture
 from sqlglot import exp, parse_one
 
@@ -791,3 +792,13 @@ def test_snapshot_json_payload():
         "database": "memory",
         "target_name": "in_memory",
     }
+
+
+@freeze_time("2023-01-08 00:00:00")
+def test_dbt_package_macros(sushi_test_project: Project):
+    context = sushi_test_project.context
+
+    # Make sure external macros are available.
+    assert context.render("{{ dbt.current_timestamp() }}") == "now()"
+    # Make sure builtins are available too.
+    assert context.render("{{ dbt.run_started_at }}") == "2023-01-08 00:00:00+00:00"


### PR DESCRIPTION
This also introduces support for the `run_started_at` builtin.

Closes #2138