### PR TITLE
feat: allow more structured slack messages

### DIFF
--- a/sqlmesh/core/notification_target.py
+++ b/sqlmesh/core/notification_target.py
@@ -27,6 +27,16 @@ else:
 if t.TYPE_CHECKING:
     from slack_sdk import WebClient, WebhookClient
 
+
+def _sqlmesh_version() -> str:
+    try:
+        from sqlmesh import __version__
+
+        return __version__
+    except ImportError:
+        return "0.0.0"
+
+
 NOTIFICATION_FUNCTIONS: t.Dict[NotificationEvent, str] = {}
 
 
@@ -160,7 +170,7 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
         Args:
             exc: The exception stack trace.
         """
-        self.send(NotificationStatus.FAILURE, f"Failed to apply plan.\n{exc}")
+        self.send(NotificationStatus.FAILURE, "Plan apply failed.", exc=exc)
 
     @notify(NotificationEvent.RUN_FAILURE)
     def notify_run_failure(self, exc: str) -> None:
@@ -169,7 +179,7 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
         Args:
             exc: The exception stack trace.
         """
-        self.send(NotificationStatus.FAILURE, f"Failed to run SQLMesh.\n{exc}")
+        self.send(NotificationStatus.FAILURE, "SQLMesh run failed.", exc=exc)
 
     @notify(NotificationEvent.AUDIT_FAILURE)
     def notify_audit_failure(self, audit_error: AuditError) -> None:
@@ -178,7 +188,7 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
         Args:
             audit_error: The AuditError object.
         """
-        self.send(NotificationStatus.FAILURE, str(audit_error))
+        self.send(NotificationStatus.FAILURE, "Audit failure.", audit_error=audit_error)
 
     @notify(NotificationEvent.MIGRATION_FAILURE)
     def notify_migration_failure(self, exc: str) -> None:
@@ -187,14 +197,39 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
         Args:
             exc: The exception stack trace.
         """
-        self.send(NotificationStatus.FAILURE, f"Failed to migration SQLMesh.\n{exc}")
+        self.send(NotificationStatus.FAILURE, "SQLMesh migration failed.", exc=exc)
 
     @property
     def is_configured(self) -> bool:
         return True
 
 
-class ConsoleNotificationTarget(BaseNotificationTarget):
+class BaseTextBasedNotificationTarget(BaseNotificationTarget):
+    """
+    A base class for unstructured notification targets (e.g.: console, email, etc.)
+    """
+
+    def send_text_message(self, notification_status: NotificationStatus, msg: str) -> None:
+        """Send the notification message as text."""
+
+    def send(
+        self,
+        notification_status: NotificationStatus,
+        msg: str,
+        audit_error: t.Optional[AuditError] = None,
+        exc: t.Optional[str] = None,
+        **kwargs: t.Any,
+    ) -> None:
+        error = None
+        if audit_error:
+            error = str(audit_error)
+        elif exc:
+            error = exc
+
+        self.send_text_message(notification_status, msg if error is None else f"{msg}\n{error}")
+
+
+class ConsoleNotificationTarget(BaseTextBasedNotificationTarget):
     """
     Example console notification target. Keeping this around for testing purposes.
     """
@@ -208,7 +243,7 @@ class ConsoleNotificationTarget(BaseNotificationTarget):
             self._console = get_console()
         return self._console
 
-    def send(self, notification_status: NotificationStatus, msg: str, **kwargs: t.Any) -> None:
+    def send_text_message(self, notification_status: NotificationStatus, msg: str) -> None:
         if notification_status.is_success:
             self.console.log_success(msg)
         elif notification_status.is_failure:
@@ -218,7 +253,15 @@ class ConsoleNotificationTarget(BaseNotificationTarget):
 
 
 class BaseSlackNotificationTarget(BaseNotificationTarget):
-    def send(self, notification_status: NotificationStatus, msg: str, **kwargs: t.Any) -> None:
+    def send(
+        self,
+        notification_status: NotificationStatus,
+        msg: str,
+        audit_error: t.Optional[AuditError] = None,
+        exc: t.Optional[str] = None,
+        **kwargs: t.Any,
+    ) -> None:
+
         status_emoji = {
             NotificationStatus.PROGRESS: slack.SlackAlertIcon.START,
             NotificationStatus.SUCCESS: slack.SlackAlertIcon.SUCCESS,
@@ -226,13 +269,35 @@ class BaseSlackNotificationTarget(BaseNotificationTarget):
             NotificationStatus.WARNING: slack.SlackAlertIcon.WARNING,
             NotificationStatus.INFO: slack.SlackAlertIcon.INFO,
         }
+
         composed = slack.message().add_primary_blocks(
             slack.header_block(f"{status_emoji[notification_status]} SQLMesh Notification"),
-            slack.context_block(f"*Status:* {notification_status.value}"),
+            slack.context_block(f"*Status:* `{notification_status.value}`"),
             slack.divider_block(),
-            slack.text_section_block(msg),
-            slack.context_block(f"*Python Version:* {sys.version}"),
+            slack.text_section_block(f"*Message*: {msg}"),
         )
+
+        details = []
+        if audit_error:
+            details = [
+                slack.fields_section_block(
+                    f"*Audit*: `{audit_error.audit_name}`",
+                    f"*Model*: `{audit_error.model_name}`",
+                    f"*Count*: `{audit_error.count}`",
+                ),
+                slack.preformatted_rich_text_block(str(audit_error.query)),
+            ]
+        elif exc:
+            details = [slack.preformatted_rich_text_block(exc)]
+
+        composed.add_primary_blocks(
+            *details,
+            slack.divider_block(),
+            slack.context_block(
+                f"*SQLMesh Version:* {_sqlmesh_version()}", f"*Python Version:* {sys.version}"
+            ),
+        )
+
         self._send_slack_message(
             composed=composed.slack_message,
         )
@@ -311,7 +376,7 @@ class SlackApiNotificationTarget(BaseSlackNotificationTarget):
         return all((self.token, self.channel))
 
 
-class BasicSMTPNotificationTarget(BaseNotificationTarget):
+class BasicSMTPNotificationTarget(BaseTextBasedNotificationTarget):
     host: t.Optional[str] = None
     port: int = 465
     user: t.Optional[str] = None
@@ -321,18 +386,16 @@ class BasicSMTPNotificationTarget(BaseNotificationTarget):
     subject: t.Optional[str] = "SQLMesh Notification"
     type_: Literal["smtp"] = Field(alias="type", default="smtp")
 
-    def send(
+    def send_text_message(
         self,
         notification_status: NotificationStatus,
         msg: str,
-        subject: t.Optional[str] = None,
-        **kwargs: t.Any,
     ) -> None:
         if not self.host:
             raise ConfigError("Missing SMTP host for notification")
 
         email = EmailMessage()
-        email["Subject"] = subject or self.subject
+        email["Subject"] = self.subject
         email["To"] = ",".join(self.recipients or [])
         email["From"] = self.sender
         email.set_content(msg)

--- a/sqlmesh/integrations/slack.py
+++ b/sqlmesh/integrations/slack.py
@@ -104,6 +104,30 @@ def text_section_block(message: str) -> dict:
     }
 
 
+def preformatted_rich_text_block(message: str) -> dict:
+    """Create a "rich text" block with pre-formatted text (i.e.: a code block).
+
+    Note that this can also be acheived with text_section_block and using markdown's
+    triple backticks.
+    This function avoids issues with the text containing such backticks and also does
+    not require editing the message in order to insert such backticks.
+    """
+    return {
+        "type": "rich_text",
+        "elements": [
+            {
+                "type": "rich_text_preformatted",
+                "elements": [
+                    {
+                        "type": "text",
+                        "text": normalize_message(message),
+                    },
+                ],
+            },
+        ],
+    }
+
+
 def empty_section_block() -> dict:
     """Create an empty section block"""
     return {


### PR DESCRIPTION
This change allows more structure in slack messages.

Specifically, audit failures and general failures are now formatted using a code block. Furthermore, audit failures will show the audit name, model and count failures more prominently.

[Here's](https://app.slack.com/block-kit-builder/#%7B%22blocks%22:%5B%7B%22type%22:%22header%22,%22text%22:%7B%22type%22:%22plain_text%22,%22text%22:%22:rotating_light:%20SQLMesh%20Notification%22%7D%7D,%7B%22type%22:%22context%22,%22elements%22:%5B%7B%22type%22:%22mrkdwn%22,%22text%22:%22*Status*:%20failure%22%7D%5D%7D,%7B%22type%22:%22divider%22%7D,%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22*Message*:%20Audit%20failure%22%7D%7D,%7B%22type%22:%22section%22,%22fields%22:%5B%7B%22type%22:%22mrkdwn%22,%22text%22:%22*Audit*:%20%60not_null%60%22%7D,%7B%22type%22:%22mrkdwn%22,%22text%22:%22*Model*:%20%60foo.bar%60%22%7D,%7B%22type%22:%22mrkdwn%22,%22text%22:%22*Count*:%20%607%60%22%7D%5D%7D,%7B%22type%22:%22rich_text%22,%22elements%22:%5B%7B%22type%22:%22rich_text_preformatted%22,%22elements%22:%5B%7B%22type%22:%22text%22,%22text%22:%22SELECT%20*%20FROM%20(SELECT%20*%20FROM%20%5C%22foo%5C%22.%5C%22bar%5C%22%20AS%20%5C%22foo__bar%5C%22%20WHERE%20%5C%22ts%5C%22%20BETWEEN%20CAST('2024-02-18'%20AS%20DATE)%20AND%20CAST('2024-02-18'%20AS%20DATE)%20AS%20%5C%22_q_0%5C%22%20WHERE%20%5C%22col_a%5C%22%20IS%20NULL%20OR%20%5C%22col_b%5C%22%20IS%20NULL)%22%7D%5D%7D%5D%7D,%7B%22type%22:%22divider%22%7D,%7B%22type%22:%22context%22,%22elements%22:%5B%7B%22type%22:%22mrkdwn%22,%22text%22:%22*SQLMesh%20version*:%200.71.0%22%7D,%7B%22type%22:%22mrkdwn%22,%22text%22:%22*Python%20Version*:%203.11.8%20(main,%20Feb%20%207%202024,%2004:02:05)%20%5BGCC%2011.4.0%5D%22%7D%5D%7D%5D%7D) an example of what an audit failure message should look like

The other thing I'd like to improve is to have the audit's SQL be in the correct dialect. Not sure what the recommended approach for that would be: any guidance would be appreciated.