### PR TITLE
Fix: convert pandas timestamp to py datetime for unit test generation

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1277,7 +1277,7 @@ class Context(BaseContext):
         """
         input_queries = {
             # The get_model here has two purposes: return normalized names & check for missing deps
-            self.get_model(dep, raise_if_missing=True).name: query
+            self.get_model(dep, raise_if_missing=True).fqn: query
             for dep, query in input_queries.items()
         }
 

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -14,6 +14,7 @@ from sqlmesh.core.dialect import normalize_model_name, schema_
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.model import Model, PythonModel, SqlModel
 from sqlmesh.utils import UniqueKeyDict, yaml
+from sqlmesh.utils.date import pandas_timestamp_to_pydatetime
 from sqlmesh.utils.errors import ConfigError, SQLMeshError
 
 Row = t.Dict[str, t.Any]
@@ -379,8 +380,14 @@ def generate_test(
             f"Fixture '{fixture_path}' already exists, make sure to set --overwrite if it can be safely overwritten."
         )
 
+    # ruamel.yaml does not support pandas Timestamps, so we must convert them to python
+    # datetime or datetime.date objects based on column type
     inputs = {
-        dep: engine_adapter.fetchdf(query).to_dict(orient="records")
+        models[dep]
+        .name: pandas_timestamp_to_pydatetime(
+            engine_adapter.fetchdf(query), models[dep].columns_to_types
+        )
+        .to_dict(orient="records")
         for dep, query in input_queries.items()
     }
     outputs: t.Dict[str, t.Any] = {"query": {}}

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -398,7 +398,7 @@ def generate_test(
         test_body["vars"] = variables
 
     test = ModelTest.create_test(
-        body=test_body,
+        body=test_body.copy(),
         test_name=test_name,
         models=models,
         engine_adapter=test_engine_adapter,
@@ -423,7 +423,9 @@ def generate_test(
     else:
         output = t.cast(PythonModelTest, test)._execute_model()
 
-    outputs["query"] = output.to_dict(orient="records")
+    outputs["query"] = pandas_timestamp_to_pydatetime(output, model.columns_to_types).to_dict(
+        orient="records"
+    )
 
     test.tearDown()
 

--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -5,6 +5,8 @@ import time
 import typing as t
 import warnings
 
+from pandas.api.types import is_datetime64_any_dtype  # type: ignore
+
 warnings.filterwarnings(
     "ignore",
     message="The localize method is no longer necessary, as this time zone supports the fold attribute",
@@ -12,6 +14,7 @@ warnings.filterwarnings(
 from datetime import date, datetime, timedelta, timezone
 
 import dateparser
+import pandas as pd
 from dateparser import freshness_date_parser as freshness_date_parser_module
 from dateparser.freshness_date_parser import freshness_date_parser
 from sqlglot import exp
@@ -337,3 +340,19 @@ def to_time_column(
     if time_column_type.this in exp.DataType.NUMERIC_TYPES:
         return exp.Literal.number(time_column)
     return exp.convert(time_column)
+
+
+def pandas_timestamp_to_pydatetime(
+    df: pd.DataFrame, columns_to_types: t.Dict[str, exp.DataType]
+) -> pd.DataFrame:
+    for column, column_type in columns_to_types.items():
+        # Query projections may not include all columns, so we check if the column exists in the dataframe
+        if column in df.columns:
+            if is_datetime64_any_dtype(df.dtypes[column]):
+                # We must use `pd.Series` and dtype or pandas will convert it back to pd.Timestamp during assignment
+                # https://stackoverflow.com/a/68961834/1707525
+                df[column] = pd.Series(df[column].dt.to_pydatetime(), dtype="object")
+            if column_type.this in (exp.DataType.Type.DATE, exp.DataType.Type.DATE32):
+                df[column] = df[column].map(lambda x: x.date() if not pd.isna(x) else x)
+
+    return df

--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -343,16 +343,26 @@ def to_time_column(
 
 
 def pandas_timestamp_to_pydatetime(
-    df: pd.DataFrame, columns_to_types: t.Dict[str, exp.DataType]
+    df: pd.DataFrame, columns_to_types: t.Optional[t.Dict[str, exp.DataType]]
 ) -> pd.DataFrame:
-    for column, column_type in columns_to_types.items():
-        # Query projections may not include all columns, so we check if the column exists in the dataframe
-        if column in df.columns:
-            if is_datetime64_any_dtype(df.dtypes[column]):
-                # We must use `pd.Series` and dtype or pandas will convert it back to pd.Timestamp during assignment
-                # https://stackoverflow.com/a/68961834/1707525
-                df[column] = pd.Series(df[column].dt.to_pydatetime(), dtype="object")
-            if column_type.this in (exp.DataType.Type.DATE, exp.DataType.Type.DATE32):
-                df[column] = df[column].map(lambda x: x.date() if not pd.isna(x) else x)
+    for column in df.columns:
+        if is_datetime64_any_dtype(df.dtypes[column]):
+            # We must use `pd.Series` and dtype or pandas will convert it back to pd.Timestamp during assignment
+            # https://stackoverflow.com/a/68961834/1707525
+            df[column] = pd.Series(df[column].dt.to_pydatetime(), dtype="object")
+
+            if columns_to_types and columns_to_types[column].this in (
+                exp.DataType.Type.DATE,
+                exp.DataType.Type.DATE32,
+            ):
+                # Sometimes `to_pydatetime()` has already converted to date, so we only extract from datetime objects.
+                # `datetime` is a subclass of `date`, so we must look at the type to differentiate the two.
+                df[column] = df[column].map(
+                    lambda x: (
+                        x.date()
+                        if isinstance(x, datetime) and type(x) is datetime and not pd.isna(x)
+                        else x
+                    )
+                )
 
     return df

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -438,9 +438,9 @@ def test_create_test(notebook, sushi_context):
     assert (
         test_file.read_text()
         == """test_top_waiters:
-  model: '"memory"."sushi"."top_waiters"'
+  model: sushi.top_waiters
   inputs:
-    '"memory"."sushi"."waiter_revenue_by_day"':
+    sushi.waiter_revenue_by_day:
     - waiter_id: 1
   outputs:
     query: []


### PR DESCRIPTION
**Problem/background**
- `generate_test()` creates a SQLMesh unit test YAML file based on a user-specified model name and input query
- When we fetchdf the query results to Pandas, all datetime columns are converted to `pd.Timestamp` type (at least when queries run on DuckDB)
- We use `ruamel.yaml` to serialize the data values returned by the query to YAML, and it does not support `pd.Timestamp` objects

**This PR**
- Converts pd.Timestamp to datetime objects before writing query result data values to YAML
- We want to maintain fidelity to the source column type. If it is `DATE`, we extract the date component from the `datetime` object before writing so a time component of `00:00:00` isn't included in the YAML.