### PR TITLE
Fix: Improve handling of branches that are behind the target branch in the git selector

### DIFF
--- a/sqlmesh/core/selector.py
+++ b/sqlmesh/core/selector.py
@@ -168,7 +168,8 @@ class Selector:
     def _expand_git(self, target_branch: str) -> t.Set[str]:
         git_modified_files = {
             *self._git_client.list_untracked_files(),
-            *self._git_client.list_changed_files(target_branch=target_branch),
+            *self._git_client.list_uncommitted_changed_files(),
+            *self._git_client.list_committed_changed_files(target_branch=target_branch),
         }
         matched_models = {m.fqn for m in self._models.values() if m._path in git_modified_files}
 

--- a/sqlmesh/utils/git.py
+++ b/sqlmesh/utils/git.py
@@ -15,9 +15,12 @@ class GitClient:
             ["ls-files", "--others", "--exclude-standard"], self._work_dir
         )
 
-    def list_changed_files(self, target_branch: str = "main") -> t.List[Path]:
+    def list_uncommitted_changed_files(self) -> t.List[Path]:
+        return self._execute_list_output(["diff", "--name-only", "--diff-filter=d"], self._git_root)
+
+    def list_committed_changed_files(self, target_branch: str = "main") -> t.List[Path]:
         return self._execute_list_output(
-            ["diff", "--name-only", "--diff-filter=d", target_branch], self._git_root
+            ["diff", "--name-only", "--diff-filter=d", f"{target_branch}..."], self._git_root
         )
 
     def _execute_list_output(self, commands: t.List[str], base_path: Path) -> t.List[Path]:

--- a/tests/core/test_selector.py
+++ b/tests/core/test_selector.py
@@ -408,14 +408,16 @@ def test_expand_git_selection(
 
     git_client_mock = mocker.Mock()
     git_client_mock.list_untracked_files.return_value = []
-    git_client_mock.list_changed_files.return_value = [model_a._path, model_c._path]
+    git_client_mock.list_uncommitted_changed_files.return_value = []
+    git_client_mock.list_committed_changed_files.return_value = [model_a._path, model_c._path]
 
     selector = Selector(mocker.Mock(), models)
     selector._git_client = git_client_mock
 
     assert selector.expand_model_selections(expressions) == expected_fqns
 
-    git_client_mock.list_changed_files.assert_called_once_with(target_branch="main")
+    git_client_mock.list_committed_changed_files.assert_called_once_with(target_branch="main")
+    git_client_mock.list_uncommitted_changed_files.assert_called_once()
     git_client_mock.list_untracked_files.assert_called_once()
 
 


### PR DESCRIPTION
This improves the behavior in case when the dev branch hasn't been rebased against the main branch in awhile.