### PR TITLE
fix: always set column order scd type 2

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1295,6 +1295,7 @@ class EngineAdapter:
         select_source_columns: t.List[t.Union[str, exp.Alias]] = [
             col for col in unmanaged_columns if col != updated_at_name
         ]
+        table_columns = [exp.column(c, quoted=True) for c in columns_to_types]
         if updated_at_name:
             select_source_columns.append(
                 exp.cast(updated_at_name, time_data_type).as_(updated_at_name)
@@ -1410,14 +1411,14 @@ class EngineAdapter:
                 # Historical Records that Do Not Change
                 .with_(
                     "static",
-                    self._select_columns(columns_to_types)
+                    exp.select(*table_columns)
                     .from_(target_table)
                     .where(f"{valid_to_name} IS NOT NULL"),
                 )
                 # Latest Records that can be updated
                 .with_(
                     "latest",
-                    self._select_columns(columns_to_types)
+                    exp.select(*table_columns)
                     .from_(target_table)
                     .where(f"{valid_to_name} IS NULL"),
                 )
@@ -1537,14 +1538,14 @@ class EngineAdapter:
                     .from_("joined")
                     .where(updated_row_filter),
                 )
-                .select("*")
+                .select(*table_columns)
                 .from_("static")
                 .union(
-                    "SELECT * FROM updated_rows",
+                    exp.select(*table_columns).from_("updated_rows"),
                     distinct=False,
                 )
                 .union(
-                    "SELECT * FROM inserted_rows",
+                    exp.select(*table_columns).from_("inserted_rows"),
                     distinct=False,
                 )
             )

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -1128,15 +1128,30 @@ WITH "source" AS (
     "test_updated_at" > "t_test_updated_at"
 )
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_updated_at",
+  "test_valid_from",
+  "test_valid_to"
 FROM "static"
 UNION ALL
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_updated_at",
+  "test_valid_from",
+  "test_valid_to"
 FROM "updated_rows"
 UNION ALL
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_updated_at",
+  "test_valid_from",
+  "test_valid_to"
 FROM "inserted_rows"
     """
         ).sql()
@@ -1300,15 +1315,30 @@ WITH "source" AS (
     "test_updated_at" > "t_test_updated_at"
 )
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_updated_at",
+  "test_valid_from",
+  "test_valid_to"
 FROM "static"
 UNION ALL
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_updated_at",
+  "test_valid_from",
+  "test_valid_to"
 FROM "updated_rows"
 UNION ALL
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_updated_at",
+  "test_valid_from",
+  "test_valid_to"
 FROM "inserted_rows"
     """
         ).sql()
@@ -1500,15 +1530,33 @@ WITH "source" AS (
     "test_updated_at" > "t_test_updated_at"
 )
 SELECT
-  *
+  "id1",
+  "id2",
+  "name",
+  "price",
+  "test_updated_at",
+  "test_valid_from",
+  "test_valid_to"
 FROM "static"
 UNION ALL
 SELECT
-  *
+  "id1",
+  "id2",
+  "name",
+  "price",
+  "test_updated_at",
+  "test_valid_from",
+  "test_valid_to"
 FROM "updated_rows"
 UNION ALL
 SELECT
-  *
+  "id1",
+  "id2",
+  "name",
+  "price",
+  "test_updated_at",
+  "test_valid_from",
+  "test_valid_to"
 FROM "inserted_rows"
 """
         ).sql()
@@ -1686,15 +1734,27 @@ WITH "source" AS (
     )
 )
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_valid_from",
+  "test_valid_to"
 FROM "static"
 UNION ALL
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_valid_from",
+  "test_valid_to"
 FROM "updated_rows"
 UNION ALL
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_valid_from",
+  "test_valid_to"
 FROM "inserted_rows"
     """
         ).sql()
@@ -1886,15 +1946,27 @@ WITH "source" AS (
     )
 )
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_valid_from",
+  "test_valid_to"
 FROM "static"
 UNION ALL
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_valid_from",
+  "test_valid_to"
 FROM "updated_rows"
 UNION ALL
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_valid_from",
+  "test_valid_to"
 FROM "inserted_rows"
     """
         ).sql()
@@ -2071,15 +2143,27 @@ WITH "source" AS (
     )
 )
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_valid_from",
+  "test_valid_to"
 FROM "static"
 UNION ALL
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_valid_from",
+  "test_valid_to"
 FROM "updated_rows"
 UNION ALL
 SELECT
-  *
+  "id",
+  "name",
+  "price",
+  "test_valid_from",
+  "test_valid_to"
 FROM "inserted_rows"
     """
         ).sql()

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -759,19 +759,25 @@ SELECT
   `test_updated_at`,
   `test_valid_from`,
   `test_valid_to`
-FROM (
-  SELECT
-    *
-  FROM `static`
-  UNION ALL
-  SELECT
-    *
-  FROM `updated_rows`
-  UNION ALL
-  SELECT
-    *
-  FROM `inserted_rows`
-) AS `_subquery`
+FROM `static`
+UNION ALL
+SELECT
+  `id`,
+  `name`,
+  `price`,
+  `test_updated_at`,
+  `test_valid_from`,
+  `test_valid_to`
+FROM `updated_rows`
+UNION ALL
+SELECT
+  `id`,
+  `name`,
+  `price`,
+  `test_updated_at`,
+  `test_valid_from`,
+  `test_valid_to`
+FROM `inserted_rows`
         """,
             dialect="spark",
         ).sql(dialect="spark"),


### PR DESCRIPTION
Prior to this change we would `select *` on the final selects to union the different CTEs together. This meant there was a unexpected assumption about column order of selects in the CTEs which was unnecessary since we know the column names within each of the selects and therefore we can not require an order to be maintained. 