### PR TITLE
chore: allow overriding pydantic defaults

### DIFF
--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -116,7 +116,7 @@ class PydanticModel(pydantic.BaseModel):
         self,
         **kwargs: t.Any,
     ) -> t.Dict[str, t.Any]:
-        kwargs.update(DEFAULT_ARGS)
+        kwargs = {**DEFAULT_ARGS, **kwargs}
         if PYDANTIC_MAJOR_VERSION >= 2:
             return super().model_dump(**kwargs)  # type: ignore
 
@@ -130,7 +130,7 @@ class PydanticModel(pydantic.BaseModel):
         self,
         **kwargs: t.Any,
     ) -> str:
-        kwargs.update(DEFAULT_ARGS)
+        kwargs = {**DEFAULT_ARGS, **kwargs}
         if PYDANTIC_MAJOR_VERSION >= 2:
             # Pydantic v2 doesn't support arbitrary arguments for json.dump().
             if kwargs.pop("sort_keys", False):


### PR DESCRIPTION
Currently if you pass in a kwarg and it overlaps with a default value then the default will overwrite what you passed in. This makes it so that the default are just applied if a value is not passed in by the caller. 