### PR TITLE
fix: dbt alias databricks catalog to database

### DIFF
--- a/sqlmesh/dbt/target.py
+++ b/sqlmesh/dbt/target.py
@@ -433,11 +433,10 @@ class DatabricksConfig(TargetConfig):
     """
 
     type: Literal["databricks"] = "databricks"
-    catalog: t.Optional[str] = None
     host: str
     http_path: str
     token: str
-    database: t.Optional[str] = None  # type: ignore
+    database: t.Optional[str] = Field(alias="catalog")  # type: ignore
 
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "merge"
@@ -460,7 +459,7 @@ class DatabricksConfig(TargetConfig):
             http_path=self.http_path,
             access_token=self.token,
             concurrent_tasks=self.threads,
-            catalog=self.catalog,
+            catalog=self.database,
         )
 
 


### PR DESCRIPTION
We assume in the code that `database` is set by all connection configs to mean the catalog: https://github.com/TobikoData/sqlmesh/blob/b5926ab464a55f3c0a87fc159df0d2ada11b4d96/sqlmesh/dbt/loader.py#L153

So we just alias `catalog` to be `database` for Databricks since it doesn't support the `database` argument. 