### PR TITLE
Fix: Remove not allowed categories

### DIFF
--- a/web/client/src/library/components/plan/PlanApplyStageTracker.tsx
+++ b/web/client/src/library/components/plan/PlanApplyStageTracker.tsx
@@ -542,12 +542,20 @@ function StageVirtualUpdate(): JSX.Element {
 }
 
 function PlanChanges(): JSX.Element {
+  const planAction = useStorePlan(s => s.planAction)
   const planOverview = useStorePlan(s => s.planOverview)
   const planApply = useStorePlan(s => s.planApply)
   const planCancel = useStorePlan(s => s.planCancel)
 
   const { hasChanges, added, removed, direct, indirect, metadata } =
     getPlanOverviewDetails(planApply, planOverview, planCancel)
+
+  const shouldDisable =
+    planAction.isProcessing ||
+    planAction.isDone ||
+    planApply.isFinished ||
+    (planOverview.isLatest && isFalse(planAction.isRun)) ||
+    planOverview.isVirtualUpdate
 
   return (
     <div className="w-full my-2">
@@ -583,7 +591,10 @@ function PlanChanges(): JSX.Element {
               headline="Modified Directly"
               type={EnumPlanChangeType.Direct}
             >
-              <PlanChangePreview.Direct changes={direct} />
+              <PlanChangePreview.Direct
+                changes={direct}
+                disabled={shouldDisable}
+              />
             </PlanChangePreview>
           )}
           {isArrayNotEmpty(indirect) && (

--- a/web/client/src/library/components/plan/PlanChangePreview.tsx
+++ b/web/client/src/library/components/plan/PlanChangePreview.tsx
@@ -23,17 +23,17 @@ import { type ModelSQLMeshChangeDisplay } from '@models/sqlmesh-change-display'
 import { useEffect } from 'react'
 import { type SnapshotChangeCategory } from '@api/client'
 
-interface PropsPlanChangePreview extends React.HTMLAttributes<HTMLElement> {
-  headline?: string
-  type: PlanChangeType
-}
-
 function PlanChangePreview({
   children,
   headline,
   type,
   className,
-}: PropsPlanChangePreview): JSX.Element {
+}: {
+  headline?: string
+  type: PlanChangeType
+  className?: string
+  children: React.ReactNode
+}): JSX.Element {
   return (
     <div
       className={clsx(
@@ -117,8 +117,10 @@ function PlanChangePreviewDefault({
 
 function PlanChangePreviewDirect({
   changes = [],
+  disabled = false,
 }: {
   changes: ModelSQLMeshChangeDisplay[]
+  disabled?: boolean
 }): JSX.Element {
   const dispatch = usePlanDispatch()
   const { categories } = usePlan()
@@ -168,7 +170,10 @@ function PlanChangePreviewDirect({
                     />
                   )}
                   <Divider className="border-neutral-200 mt-2" />
-                  <ChangeCategories change={change} />
+                  <ChangeCategories
+                    change={change}
+                    disabled={disabled}
+                  />
                   <Divider className="border-neutral-200 mt-2" />
                   <div className="flex flex-col w-full h-full overflow-hidden overflow-y-auto hover:scrollbar scrollbar--vertical scrollbar--horizontal">
                     {isNotNil(change?.diff) && (
@@ -211,7 +216,9 @@ function PlanChangePreviewDirect({
 
 function ChangeCategories({
   change,
+  disabled = false,
 }: {
+  disabled?: boolean
   change: ModelSQLMeshChangeDisplay
 }): JSX.Element {
   const dispatch = usePlanDispatch()
@@ -220,7 +227,11 @@ function ChangeCategories({
 
   return (
     <RadioGroup
-      className="flex flex-col mt-2"
+      className={clsx(
+        'flex flex-col mt-2',
+        disabled && 'pointer-events-none opacity-50 cursor-not-allowed',
+      )}
+      disabled={disabled}
       value={
         change_categorization.get(change.name)?.category?.value ??
         change.change_category

--- a/web/client/src/library/components/plan/PlanOptions.tsx
+++ b/web/client/src/library/components/plan/PlanOptions.tsx
@@ -51,7 +51,8 @@ export default function PlanOptions(): JSX.Element {
     planAction.isProcessing ||
     planAction.isDone ||
     planApply.isFinished ||
-    (planOverview.isLatest && isFalse(planAction.isRun))
+    (planOverview.isLatest && isFalse(planAction.isRun)) ||
+    planOverview.isVirtualUpdate
 
   useEffect(() => {
     if (isNil(elTrigger.current)) return

--- a/web/client/src/library/components/plan/context.tsx
+++ b/web/client/src/library/components/plan/context.tsx
@@ -304,18 +304,6 @@ function useCategories(): [Category, Category[]] {
       description: 'The change requires no rebuilding',
       value: SnapshotChangeCategory.NUMBER_3,
     },
-    {
-      id: EnumCategoryType.IndirectBreaking,
-      name: 'Indirect Breaking Change',
-      description: 'The change was caused indirectly and is breaking',
-      value: SnapshotChangeCategory.NUMBER_4,
-    },
-    {
-      id: EnumCategoryType.IndirectNonBreaking,
-      name: 'Indirect Non-Breaking Change',
-      description: 'The change was caused indirectly by a non-breaking change',
-      value: SnapshotChangeCategory.NUMBER_5,
-    },
   ]
 
   return [categoryBreakingChange, categories]


### PR DESCRIPTION
- [x] Why do we allow users to manually set Indirect * categories? This should not be allowed
- [x] I noticed that we allow to change the category even when the snapshot has been categorized previously