### PR TITLE
Chore:! bump sqlglot to v22.0.1 (got rid of Subqueryable, Unionable)

### DIFF
--- a/examples/sushi/models/customers.sql
+++ b/examples/sushi/models/customers.sql
@@ -21,12 +21,14 @@ WITH current_marketing AS (
   FROM sushi.marketing
   WHERE valid_to is null
 )
-SELECT DISTINCT
-  o.customer_id::INT AS customer_id, -- customer_id uniquely identifies customers
-  m.status,
-  d.zip
-FROM sushi.orders AS o
-LEFT JOIN current_marketing AS m
+(
+  SELECT DISTINCT
+    o.customer_id::INT AS customer_id, -- customer_id uniquely identifies customers
+    m.status,
+    d.zip
+  FROM sushi.orders AS o
+  LEFT JOIN current_marketing AS m
     ON o.customer_id = m.customer_id
-LEFT JOIN raw.demographics AS d
+  LEFT JOIN raw.demographics AS d
     ON o.customer_id = d.customer_id
+)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=21.2.0",
+        "sqlglot[rs]~=22.0.0",
     ],
     extras_require={
         "bigquery": [

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=22.0.0",
+        "sqlglot[rs]~=22.0.1",
     ],
     extras_require={
         "bigquery": [

--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -74,7 +74,7 @@ class AuditMixin(AuditCommonMetaMixin):
         jinja_macros: A registry of jinja macros to use when rendering the audit query.
     """
 
-    query: t.Union[exp.Subqueryable, d.JinjaQuery]
+    query: t.Union[exp.Query, d.JinjaQuery]
     defaults: t.Dict[str, exp.Expression]
     expressions_: t.Optional[t.List[exp.Expression]]
     jinja_macros: JinjaMacroRegistry
@@ -89,7 +89,7 @@ class AuditMixin(AuditCommonMetaMixin):
         snapshots: t.Optional[t.Dict[str, Snapshot]] = None,
         deployability_index: t.Optional[DeployabilityIndex] = None,
         **kwargs: t.Any,
-    ) -> exp.Subqueryable:
+    ) -> exp.Query:
         """Renders the audit's query.
 
         Args:
@@ -169,7 +169,7 @@ class ModelAudit(PydanticModel, AuditMixin, frozen=True):
     skip: bool = False
     blocking: bool = True
     standalone: Literal[False] = False
-    query: t.Union[exp.Subqueryable, d.JinjaQuery]
+    query: t.Union[exp.Query, d.JinjaQuery]
     defaults: t.Dict[str, exp.Expression] = {}
     expressions_: t.Optional[t.List[exp.Expression]] = Field(default=None, alias="expressions")
     jinja_macros: JinjaMacroRegistry = JinjaMacroRegistry()
@@ -192,7 +192,7 @@ class ModelAudit(PydanticModel, AuditMixin, frozen=True):
         snapshots: t.Optional[t.Dict[str, Snapshot]] = None,
         deployability_index: t.Optional[DeployabilityIndex] = None,
         **kwargs: t.Any,
-    ) -> exp.Subqueryable:
+    ) -> exp.Query:
         from sqlmesh.core.snapshot import DeployabilityIndex, Snapshot
 
         deployability_index = deployability_index or DeployabilityIndex.all_deployable()
@@ -274,7 +274,7 @@ class StandaloneAudit(_Node, AuditMixin):
     skip: bool = False
     blocking: bool = False
     standalone: Literal[True] = True
-    query: t.Union[exp.Subqueryable, d.JinjaQuery]
+    query: t.Union[exp.Query, d.JinjaQuery]
     defaults: t.Dict[str, exp.Expression] = {}
     expressions_: t.Optional[t.List[exp.Expression]] = Field(default=None, alias="expressions")
     jinja_macros: JinjaMacroRegistry = JinjaMacroRegistry()
@@ -510,7 +510,7 @@ def load_audit(
     if extra_fields:
         _raise_config_error(f"Invalid extra fields {extra_fields} in the audit definition", path)
 
-    if not isinstance(query, exp.Subqueryable) and not isinstance(query, d.JinjaQuery):
+    if not isinstance(query, exp.Query) and not isinstance(query, d.JinjaQuery):
         _raise_config_error("Missing SELECT query in the audit definition", path)
         raise
 

--- a/sqlmesh/core/engine_adapter/_typing.py
+++ b/sqlmesh/core/engine_adapter/_typing.py
@@ -7,7 +7,7 @@ if t.TYPE_CHECKING:
     import pyspark
     import pyspark.sql.connect.dataframe
 
-    Query = t.Union[exp.Subqueryable, exp.DerivedTable]
+    Query = t.Union[exp.Query, exp.DerivedTable]
     PySparkSession = t.Union[pyspark.sql.SparkSession, pyspark.sql.connect.dataframe.SparkSession]
     PySparkDataFrame = t.Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame]
     DF = t.Union[pd.DataFrame, pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame]

--- a/sqlmesh/core/lineage.py
+++ b/sqlmesh/core/lineage.py
@@ -14,7 +14,7 @@ if t.TYPE_CHECKING:
     from sqlmesh.core.model import Model
 
 
-def _render_query(model: Model) -> exp.Subqueryable:
+def _render_query(model: Model) -> exp.Query:
     """Render a model's query, adding in managed columns"""
     query = model.render_query_or_raise()
     if model.managed_columns:

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -842,7 +842,7 @@ def union(
     evaluator: MacroEvaluator,
     type_: exp.Literal = exp.Literal.string("ALL"),
     *tables: exp.Column,  # These represent tables but the ast node will be columns
-) -> exp.Unionable:
+) -> exp.Query:
     """Returns a UNION of the given tables. Only choosing columns that have the same name and type.
 
     Example:

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -364,7 +364,7 @@ class QueryRenderer(BaseExpressionRenderer):
 
         self._model_fqn = model_fqn
 
-        self._optimized_cache: t.Dict[CacheKey, exp.Subqueryable] = {}
+        self._optimized_cache: t.Dict[CacheKey, exp.Query] = {}
 
     def update_schema(self, schema: t.Dict[str, t.Any]) -> None:
         super().update_schema(schema)
@@ -382,7 +382,7 @@ class QueryRenderer(BaseExpressionRenderer):
         optimize: bool = True,
         runtime_stage: RuntimeStage = RuntimeStage.LOADING,
         **kwargs: t.Any,
-    ) -> t.Optional[exp.Subqueryable]:
+    ) -> t.Optional[exp.Query]:
         """Renders a query, expanding macros with provided kwargs, and optionally expanding referenced models.
 
         Args:
@@ -430,7 +430,7 @@ class QueryRenderer(BaseExpressionRenderer):
 
             if not query:
                 return None
-            if not isinstance(query, exp.Subqueryable):
+            if not isinstance(query, exp.Query):
                 raise_config_error(f"Query needs to be a SELECT or a UNION {query}.", self._path)
                 raise
 
@@ -470,15 +470,15 @@ class QueryRenderer(BaseExpressionRenderer):
         **kwargs: t.Any,
     ) -> None:
         if optimized:
-            if not isinstance(expression, exp.Subqueryable):
-                raise SQLMeshError(f"Expected a subqueryable but got: {expression}")
+            if not isinstance(expression, exp.Query):
+                raise SQLMeshError(f"Expected a Query but got: {expression}")
             self._optimized_cache[self._cache_key(start, end, execution_time)] = expression
         else:
             super().update_cache(
                 expression, start=start, end=end, execution_time=execution_time, **kwargs
             )
 
-    def _optimize_query(self, query: exp.Subqueryable, all_deps: t.Set[str]) -> exp.Subqueryable:
+    def _optimize_query(self, query: exp.Query, all_deps: t.Set[str]) -> exp.Query:
         # We don't want to normalize names in the schema because that's handled by the optimizer
         original = query
         missing_deps = set()

--- a/sqlmesh/utils/errors.py
+++ b/sqlmesh/utils/errors.py
@@ -66,7 +66,7 @@ class AuditError(SQLMeshError):
         self,
         audit_name: str,
         count: int,
-        query: exp.Subqueryable,
+        query: exp.Query,
         model: t.Optional[Model] = None,
         # the dialect of the engine adapter that evaluated the audit query
         adapter_dialect: t.Optional[str] = None,

--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -78,8 +78,8 @@ def _expression_encoder(e: exp.Expression) -> str:
     return e.meta.get("sql") or e.sql(dialect=e.meta.get("dialect"))
 
 
-AuditQueryTypes = t.Union[exp.Subqueryable, d.JinjaQuery]
-ModelQueryTypes = t.Union[exp.Subqueryable, d.JinjaQuery, d.MacroFunc]
+AuditQueryTypes = t.Union[exp.Query, d.JinjaQuery]
+ModelQueryTypes = t.Union[exp.Query, d.JinjaQuery, d.MacroFunc]
 
 
 class PydanticModel(pydantic.BaseModel):

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -111,7 +111,7 @@ def test_merge_pr_has_non_breaking_change(
     ]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.expressions.append(exp.alias_("1", "new_col"))
+    model.query.select(exp.alias_("1", "new_col"), copy=False)
     controller._context.upsert_model(model)
 
     github_output_file = tmp_path / "github_output.txt"
@@ -309,7 +309,7 @@ def test_merge_pr_has_non_breaking_change_diff_start(
     ]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.expressions.append(exp.alias_("1", "new_col"))
+    model.query.select(exp.alias_("1", "new_col"), copy=False)
     controller._context.upsert_model(model)
 
     github_output_file = tmp_path / "github_output.txt"
@@ -511,7 +511,7 @@ def test_merge_pr_has_non_breaking_change_no_categorization(
     ]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.expressions.append(exp.alias_("1", "new_col"))
+    model.query.select(exp.alias_("1", "new_col"), copy=False)
     controller._context.upsert_model(model)
 
     github_output_file = tmp_path / "github_output.txt"
@@ -824,7 +824,7 @@ def test_no_merge_since_no_deploy_signal(
     ]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.expressions.append(exp.alias_("1", "new_col"))
+    model.query.select(exp.alias_("1", "new_col"), copy=False)
     controller._context.upsert_model(model)
 
     github_output_file = tmp_path / "github_output.txt"
@@ -1007,7 +1007,7 @@ def test_no_merge_since_no_deploy_signal_no_approvers_defined(
     controller._context.users = [User(username="test", github_username="test_github", roles=[])]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.expressions.append(exp.alias_("1", "new_col"))
+    model.query.select(exp.alias_("1", "new_col"), copy=False)
     controller._context.upsert_model(model)
 
     github_output_file = tmp_path / "github_output.txt"
@@ -1174,7 +1174,7 @@ def test_deploy_comment_pre_categorized(
     controller._context.users = [User(username="test", github_username="test_github", roles=[])]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.expressions.append(exp.alias_("1", "new_col"))
+    model.query.select(exp.alias_("1", "new_col"), copy=False)
     controller._context.upsert_model(model)
 
     # Manually categorize the change as non-breaking and don't backfill anything
@@ -1367,7 +1367,7 @@ def test_error_msg_when_applying_plan_with_bug(
     ]
     # Make an error by adding a column that doesn't exist
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.expressions.append(exp.alias_("non_existing_col", "new_col"))
+    model.query.select(exp.alias_("non_existing_col", "new_col"), copy=False)
     controller._context.upsert_model(model)
 
     github_output_file = tmp_path / "github_output.txt"
@@ -1523,7 +1523,7 @@ def test_overlapping_changes_models(
     # These changes have shared children and this ensures we don't repeat the children in the output
     # Make a non-breaking change
     model = controller._context.get_model("sushi.customers").copy()
-    model.query.expressions.append(exp.alias_("1", "new_col"))
+    model.query.select(exp.alias_("1", "new_col"), copy=False)
     controller._context.upsert_model(model)
 
     # Make a breaking change
@@ -1576,17 +1576,17 @@ def test_overlapping_changes_models(
 
 +++ 
 
-@@ -25,7 +25,8 @@
+@@ -26,7 +26,8 @@
 
- SELECT DISTINCT
-   CAST(o.customer_id AS INT) AS customer_id,
-   m.status,
--  d.zip
-+  d.zip,
-+  1 AS new_col
- FROM sushi.orders AS o
- LEFT JOIN current_marketing AS m
-   ON o.customer_id = m.customer_id
+   SELECT DISTINCT
+     CAST(o.customer_id AS INT) AS customer_id,
+     m.status,
+-    d.zip
++    d.zip,
++    1 AS new_col
+   FROM sushi.orders AS o
+   LEFT JOIN current_marketing AS m
+     ON o.customer_id = m.customer_id
 ```
 
 ```
@@ -1744,7 +1744,7 @@ def test_capture_console_errors(
     ]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.expressions.append(exp.alias_("1", "new_col"))
+    model.query.select(exp.alias_("1", "new_col"), copy=False)
     controller._context.upsert_model(model)
 
     github_output_file = tmp_path / "github_output.txt"

--- a/web/server/api/endpoints/lineage.py
+++ b/web/server/api/endpoints/lineage.py
@@ -37,9 +37,9 @@ def _get_table(
             ancestor = ancestor.parent
         if isinstance(ancestor, exp.CTE):
             table = ancestor.alias
-    if not table and node.alias:
-        # Use node alias if available
-        table = node.alias
+    if not table and node.source_name:
+        # Use node source name if available
+        table = node.source_name
 
     try:
         return normalize_model_name(table, default_catalog=default_catalog, dialect=dialect)

--- a/web/server/api/endpoints/lineage.py
+++ b/web/server/api/endpoints/lineage.py
@@ -84,7 +84,7 @@ def _process_downstream(
     return graph
 
 
-def render_query(model: Model) -> exp.Subqueryable:
+def render_query(model: Model) -> exp.Query:
     """Render a model's query, adding in managed columns"""
     query = model.render_query_or_raise()
     if model.managed_columns:
@@ -110,7 +110,7 @@ async def column_lineage(
     try:
         model = context.get_model(model_name)
         dialect = model.dialect
-        sources: t.Dict[str, str | exp.Subqueryable] = {}
+        sources: t.Dict[str, str | exp.Query] = {}
         for m in context.dag.upstream(model.fqn):
             if m in context.models:
                 try:


### PR DESCRIPTION
This PR is early in anticipation of https://github.com/tobymao/sqlglot/commit/2507aa2dbad3304304558565f266a7f94acd9e98 (TL;DR merged `Subqueryable` and `Unionable` into `Query`).

Initial motivation was to fix #2137 but after discussion we decided it would be generally good to consolidate these two classes. I haven't fully investigated what this means for SQLMesh - these changes were made using search-and-replace, but I intend to audit them more closely soon. I verified that at least `make style && make fast-test` passed locally.

- [x] Add test for 2137 (not sure if it runs yet - I imagine we may not be expecting a wrapped query in some places, so there may be more syntax errors down the line)
- [x] Bump SQLGlot version