### PR TITLE
chore: pin cryptography

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,9 @@ setup(
         "astor",
         "click",
         "croniter",
-        "cryptography",
+        # Issue with Snowflake connector and cryptography 42+
+        # Check here if they have added support: https://github.com/dbt-labs/dbt-snowflake/blob/main/dev-requirements.txt#L12
+        "cryptography~=41.0.7",
         "duckdb",
         "dateparser",
         "fsspec",


### PR DESCRIPTION
Issue we see prior to pinning: 
```
tests/core/test_connection_config.py::test_snowflake_private_key_pass[snowflake_key_no_passphrase_path-snowflake_key_no_passphrase_pem-snowflake_key_no_passphrase_b64-snowflake_key_no_passphrase_bytes-None] - TypeError: Password was not given but private key is encrypted
```

Likely related to cryptography switching to rust: https://github.com/pyca/cryptography/pull/10064