### PR TITLE
add bigquery execution project config support

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -614,6 +614,7 @@ class BigQueryConnectionConfig(ConnectionConfig):
     method: BigQueryConnectionMethod = BigQueryConnectionMethod.OAUTH
 
     project: t.Optional[str] = None
+    execution_project: t.Optional[str] = None
     location: t.Optional[str] = None
     # Keyfile Auth
     keyfile: t.Optional[str] = None
@@ -675,7 +676,7 @@ class BigQueryConnectionConfig(ConnectionConfig):
         else:
             raise ConfigError("Invalid BigQuery Connection Method")
         client = google.cloud.bigquery.Client(
-            project=self.project,
+            project=self.execution_project or self.project,
             credentials=creds,
             location=self.location,
             client_info=client_info.ClientInfo(user_agent="sqlmesh"),

--- a/sqlmesh/dbt/target.py
+++ b/sqlmesh/dbt/target.py
@@ -489,6 +489,7 @@ class BigQueryConfig(TargetConfig):
     method: t.Optional[str] = BigQueryConnectionMethod.OAUTH
     dataset: t.Optional[str] = None
     project: t.Optional[str] = None
+    execution_project: t.Optional[str] = None
     location: t.Optional[str] = None
     keyfile: t.Optional[str] = None
     keyfile_json: t.Optional[t.Dict[str, t.Any]] = None
@@ -548,6 +549,7 @@ class BigQueryConfig(TargetConfig):
         return BigQueryConnectionConfig(
             method=self.method,
             project=self.database,
+            execution_project=self.execution_project,
             location=self.location,
             concurrent_tasks=self.threads,
             keyfile=self.keyfile,

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -5,6 +5,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 
 from sqlmesh.core.config.connection import (
+    BigQueryConnectionConfig,
     ConnectionConfig,
     DuckDBConnectionConfig,
     SnowflakeConnectionConfig,
@@ -508,3 +509,16 @@ def test_duckdb_shared(make_config, caplog, kwargs1, kwargs2, shared_adapter):
         assert id(adapter1) != id(adapter2)
         assert "Creating new DuckDB adapter" in caplog.messages[0]
         assert "Creating new DuckDB adapter" in caplog.messages[1]
+
+
+def test_bigquery(make_config):
+    config = make_config(
+        type="bigquery",
+        project="project",
+        execution_project="execution_project",
+    )
+
+    assert isinstance(config, BigQueryConnectionConfig)
+    assert config.project == "project"
+    assert config.execution_project == "execution_project"
+    assert config.get_catalog() == "project"


### PR DESCRIPTION
Support for execution_project (which is going to be the GCP project used for execution as in the resources used ... opposed to the storage). It's mandatory for organizations that split "storage project" vs "execution project" to enable fine grained resources management.

For reference, the similar change I made for dbt 3 years ago: https://github.com/dbt-labs/dbt-bigquery/commit/42cd89d08e38a871743ffd49716708475bb48d1f

I added the fallback to `project` for backward compatibility.

I couldn't find tests for bigquery related config... so I made one but it's not as useful as I'd like 🙄 