### PR TITLE
fix: correct slack block with multiple fields

### DIFF
--- a/sqlmesh/integrations/slack.py
+++ b/sqlmesh/integrations/slack.py
@@ -80,16 +80,16 @@ def divider_block() -> dict:
 
 
 def fields_section_block(*messages: str) -> dict:
-    """Create a section block with multiple fields"""
+    """Create a section block with multiple markdown fields"""
     return {
         "type": "section",
-        **{
-            "fields": {
+        "fields": [
+            {
                 "type": "mrkdwn",
                 "text": normalize_message(message),
             }
             for message in messages
-        },
+        ],
     }
 
 


### PR DESCRIPTION
Previously, calling this helper method with `fields_section_block("a", "b", "c")` would produce the following dict:

```python
{'type': 'section', 'fields': {'type': 'mrkdwn', 'text': 'c'}}
```

This fixes things to produce the following (correct) format:

```python
{'type': 'section', 'fields': [{'type': 'mrkdwn', 'text': 'a'}, {'type': 'mrkdwn', 'text': 'b'}, {'type': 'mrkdwn', 'text': 'c'}]}
```