### PR TITLE
Feat: Support custom Virtual Warehouses for Snowflake

### DIFF
--- a/docs/integrations/engines/snowflake.md
+++ b/docs/integrations/engines/snowflake.md
@@ -275,3 +275,15 @@ sqlmesh_airflow = SQLMeshAirflow(
     },
 )
 ```
+
+## Configuring Virtual Warehouses
+
+The Snowflake Virtual Warehouse can be specified on a per-model basis using the `session_properties` attribute of the model definition:
+```sql
+MODEL (
+  name model_name,
+  session_properties (
+    'warehouse' = TEST_WAREHOUSE,
+  ),
+);
+```

--- a/sqlmesh/core/_typing.py
+++ b/sqlmesh/core/_typing.py
@@ -7,3 +7,4 @@ from sqlglot import exp
 if t.TYPE_CHECKING:
     TableName = t.Union[str, exp.Table]
     SchemaName = t.Union[str, exp.Table]
+    SessionProperties = t.Dict[str, t.Union[exp.Expression, str, int, float, bool]]

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -46,7 +46,7 @@ from sqlmesh.utils.errors import SQLMeshError, UnsupportedCatalogOperationError
 from sqlmesh.utils.pandas import columns_to_types_from_df
 
 if t.TYPE_CHECKING:
-    from sqlmesh.core._typing import SchemaName, TableName
+    from sqlmesh.core._typing import SchemaName, SessionProperties, TableName
     from sqlmesh.core.engine_adapter._typing import (
         DF,
         PySparkDataFrame,
@@ -1757,19 +1757,19 @@ class EngineAdapter:
             self._connection_pool.commit()
 
     @contextlib.contextmanager
-    def session(self) -> t.Iterator[None]:
+    def session(self, properties: SessionProperties) -> t.Iterator[None]:
         """A session context manager."""
         if self._is_session_active():
             yield
             return
 
-        self._begin_session()
+        self._begin_session(properties)
         try:
             yield
         finally:
             self._end_session()
 
-    def _begin_session(self) -> None:
+    def _begin_session(self, properties: SessionProperties) -> t.Any:
         """Begin a new session."""
 
     def _end_session(self) -> None:

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -30,7 +30,7 @@ if t.TYPE_CHECKING:
     from google.cloud.bigquery.job.base import _AsyncJob as BigQueryQueryResult
     from google.cloud.bigquery.table import Table as BigQueryTable
 
-    from sqlmesh.core._typing import SchemaName, TableName
+    from sqlmesh.core._typing import SchemaName, SessionProperties, TableName
     from sqlmesh.core.engine_adapter._typing import DF, Query
     from sqlmesh.core.engine_adapter.base import QueryOrDF
 
@@ -131,7 +131,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
             )
         ]
 
-    def _begin_session(self) -> None:
+    def _begin_session(self, properties: SessionProperties) -> None:
         from google.cloud.bigquery import QueryJobConfig
 
         job = self.client.query("SELECT 1;", job_config=QueryJobConfig(create_session=True))
@@ -366,7 +366,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
             raise SQLMeshError(
                 f"The partition expression '{partition_sql}' doesn't contain a column."
             )
-        with self.session(), self.temp_table(
+        with self.session({}), self.temp_table(
             query_or_df, name=table_name, partitioned_by=partitioned_by
         ) as temp_table_name:
             if columns_to_types is None or columns_to_types[

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -39,6 +39,9 @@ from sqlmesh.utils.pydantic import (
     model_validator_v1_args,
 )
 
+if t.TYPE_CHECKING:
+    from sqlmesh.core._typing import SessionProperties
+
 AuditReference = t.Tuple[str, t.Dict[str, exp.Expression]]
 
 
@@ -334,7 +337,7 @@ class ModelMeta(_Node):
         return {}
 
     @property
-    def session_properties(self) -> t.Dict[str, t.Union[exp.Expression | str | int | float | bool]]:
+    def session_properties(self) -> SessionProperties:
         """A dictionary of session properties."""
         if not self.session_properties_:
             return {}

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -504,7 +504,7 @@ class SnapshotEvaluator:
             **common_render_kwargs,
         )
 
-        with self.adapter.transaction(), self.adapter.session():
+        with self.adapter.transaction(), self.adapter.session(snapshot.model.session_properties):
             wap_id: t.Optional[str] = None
             if (
                 table_name
@@ -599,7 +599,7 @@ class SnapshotEvaluator:
 
         evaluation_strategy = _evaluation_strategy(snapshot, self.adapter)
 
-        with self.adapter.transaction(), self.adapter.session():
+        with self.adapter.transaction(), self.adapter.session(snapshot.model.session_properties):
             self.adapter.execute(snapshot.model.render_pre_statements(**render_kwargs))
 
             if (

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -529,7 +529,7 @@ def test_begin_end_session(mocker: MockerFixture):
 
     adapter = BigQueryEngineAdapter(lambda: connection_mock, job_retries=0)
 
-    with adapter.session():
+    with adapter.session({}):
         assert adapter._connection_pool.get_attribute("session_id") is not None
         adapter.execute("SELECT 2;")
 

--- a/tests/core/engine_adapter/test_snowflake.py
+++ b/tests/core/engine_adapter/test_snowflake.py
@@ -2,9 +2,11 @@ import typing as t
 
 import pytest
 from pytest_mock.plugin import MockerFixture
+from sqlglot import exp
 
 from sqlmesh.core.dialect import normalize_model_name
 from sqlmesh.core.engine_adapter import SnowflakeEngineAdapter
+from tests.core.engine_adapter import to_sql_calls
 
 pytestmark = [pytest.mark.engine, pytest.mark.snowflake]
 
@@ -19,3 +21,79 @@ def test_get_temp_table(mocker: MockerFixture, make_mocked_engine_adapter: t.Cal
     )
 
     assert value.sql(dialect=adapter.dialect) == '"CATALOG"."DB"."__temp_TEST_TABLE_abcdefgh"'
+
+
+@pytest.mark.parametrize(
+    "current_warehouse, current_warehouse_exp, configured_warehouse, configured_warehouse_exp, should_change",
+    [
+        (
+            "test_warehouse",
+            '"test_warehouse"',
+            exp.to_identifier("test_warehouse", quoted=True),
+            '"test_warehouse"',
+            False,
+        ),
+        ("test_warehouse", '"test_warehouse"', "test_warehouse", '"TEST_WAREHOUSE"', True),
+        ("TEST_WAREHOUSE", '"TEST_WAREHOUSE"', "test_warehouse", '"TEST_WAREHOUSE"', False),
+        ("test warehouse", '"test warehouse"', "test warehouse", '"test warehouse"', False),
+        ("test warehouse", '"test warehouse"', "another warehouse", '"another warehouse"', True),
+        (
+            "test warehouse",
+            '"test warehouse"',
+            exp.column("another warehouse"),
+            '"another warehouse"',
+            True,
+        ),
+        ("test warehouse", '"test warehouse"', "another_warehouse", '"ANOTHER_WAREHOUSE"', True),
+        ("TEST_WAREHOUSE", '"TEST_WAREHOUSE"', "another_warehouse", '"ANOTHER_WAREHOUSE"', True),
+        ("test_warehouse", '"test_warehouse"', "another_warehouse", '"ANOTHER_WAREHOUSE"', True),
+        (
+            "test_warehouse",
+            '"test_warehouse"',
+            exp.column("another_warehouse"),
+            '"ANOTHER_WAREHOUSE"',
+            True,
+        ),
+        (
+            "test_warehouse",
+            '"test_warehouse"',
+            exp.to_identifier("another_warehouse"),
+            '"ANOTHER_WAREHOUSE"',
+            True,
+        ),
+        (
+            "test_warehouse",
+            '"test_warehouse"',
+            exp.to_identifier("another_warehouse", quoted=True),
+            '"another_warehouse"',
+            True,
+        ),
+    ],
+)
+def test_session(
+    mocker: MockerFixture,
+    make_mocked_engine_adapter: t.Callable,
+    current_warehouse: t.Union[str, exp.Expression],
+    current_warehouse_exp: str,
+    configured_warehouse: t.Optional[str],
+    configured_warehouse_exp: t.Optional[str],
+    should_change: bool,
+):
+    adapter = make_mocked_engine_adapter(SnowflakeEngineAdapter)
+    adapter.cursor.fetchone.return_value = (current_warehouse,)
+
+    with adapter.session({"warehouse": configured_warehouse}):
+        pass
+
+    expected_calls = []
+    if configured_warehouse:
+        expected_calls.append("SELECT CURRENT_WAREHOUSE()")
+    if should_change:
+        expected_calls.extend(
+            [
+                f"USE WAREHOUSE {configured_warehouse_exp}",
+                f"USE WAREHOUSE {current_warehouse_exp}",
+            ]
+        )
+
+    assert to_sql_calls(adapter) == expected_calls

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -400,7 +400,6 @@ def test_parent_cron_before_child(init_and_plan_context: t.Callable):
     top_waiters_model = add_projection_to_model(t.cast(SqlModel, top_waiters_model), literal=True)
     context.upsert_model(top_waiters_model)
 
-    snapshot = context.get_snapshot(model, raise_if_missing=True)
     top_waiters_snapshot = context.get_snapshot("sushi.top_waiters", raise_if_missing=True)
 
     with freeze_time("2023-01-08 23:55:00"):  # Past parent's cron, but before child's

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2312,10 +2312,13 @@ def test_model_session_properties(sushi_context):
                 'spark.executor.memory' = '1G',
                 some_bool = True,
                 some_float = 0.1,
+                quoted_identifier = "quoted identifier",
+                unquoted_identifier = unquoted_identifier,
             )
         );
         SELECT a FROM tbl;
-        """
+        """,
+            default_dialect="snowflake",
         )
     )
 
@@ -2324,6 +2327,8 @@ def test_model_session_properties(sushi_context):
         "spark.executor.memory": "1G",
         "some_bool": True,
         "some_float": 0.1,
+        "quoted_identifier": exp.column("quoted identifier", quoted=True),
+        "unquoted_identifier": exp.column("unquoted_identifier", quoted=False),
     }
 
 


### PR DESCRIPTION
This update enables users to set a virtual warehouse on a per-model basis using the `session_properties` attribute of the model definition. 