### PR TITLE
Fix: temporarily unwrap sushi.customers's query again

### DIFF
--- a/examples/sushi/models/customers.sql
+++ b/examples/sushi/models/customers.sql
@@ -21,14 +21,12 @@ WITH current_marketing AS (
   FROM sushi.marketing
   WHERE valid_to is null
 )
-(
-  SELECT DISTINCT
-    o.customer_id::INT AS customer_id, -- customer_id uniquely identifies customers
-    m.status,
-    d.zip
+SELECT DISTINCT
+  o.customer_id::INT AS customer_id, -- customer_id uniquely identifies customers
+  m.status,
+  d.zip
   FROM sushi.orders AS o
-  LEFT JOIN current_marketing AS m
-    ON o.customer_id = m.customer_id
+LEFT JOIN current_marketing AS m
+  ON o.customer_id = m.customer_id
   LEFT JOIN raw.demographics AS d
-    ON o.customer_id = d.customer_id
-)
+  ON o.customer_id = d.customer_id

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -1576,17 +1576,17 @@ def test_overlapping_changes_models(
 
 +++ 
 
-@@ -26,7 +26,8 @@
+@@ -25,7 +25,8 @@
 
-   SELECT DISTINCT
-     CAST(o.customer_id AS INT) AS customer_id,
-     m.status,
--    d.zip
-+    d.zip,
-+    1 AS new_col
-   FROM sushi.orders AS o
-   LEFT JOIN current_marketing AS m
-     ON o.customer_id = m.customer_id
+ SELECT DISTINCT
+   CAST(o.customer_id AS INT) AS customer_id,
+   m.status,
+-  d.zip
++  d.zip,
++  1 AS new_col
+ FROM sushi.orders AS o
+ LEFT JOIN current_marketing AS m
+   ON o.customer_id = m.customer_id
 ```
 
 ```


### PR DESCRIPTION
Even though https://github.com/TobikoData/sqlmesh/commit/3b970bdcecd41dd340d50ce14102b909285a5581 passed all tests in CI, @vchan came across a couple of issues when computing the lineage of `sushi.customers`. After chatting we realized it's a bit more involved to fix them, because we'll need to update either SQLGlot's lineage or scope module (or both), so I'm temporarily reverting this change to unblock new releases.