### PR TITLE
Fix: Don't check previous versions when checking whether the snapshot is unrevertable

### DIFF
--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -582,10 +582,7 @@ class PlanBuilder:
                 and not promoted.is_paused
                 and not candidate.is_forward_only
                 and not candidate.is_indirect_non_breaking
-                and (
-                    promoted.version == candidate.version
-                    or candidate.data_version in promoted.previous_versions
-                )
+                and promoted.version == candidate.version
             ):
                 raise PlanError(
                     f"Attempted to revert to an unrevertable version of model '{name}'. Run `sqlmesh plan` again to mitigate the issue."


### PR DESCRIPTION
It should only matter whether versions are the same. Whether the snapshot is in previous versions should be irrelevant to what we're trying to prevent here.