### PR TITLE
Fix: correctly extract catalog name for table properties expression builder

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -688,12 +688,13 @@ class EngineAdapter:
         **kwargs: t.Any,
     ) -> exp.Create:
         exists = False if replace else exists
+        catalog_name = None
         if not isinstance(table_name_or_schema, exp.Schema):
             table_name_or_schema = exp.to_table(table_name_or_schema)
             catalog_name = table_name_or_schema.catalog
         else:
-            table: exp.Table = table_name_or_schema.this
-            catalog_name = table.catalog
+            if isinstance(table_name_or_schema.this, exp.Table):
+                catalog_name = table_name_or_schema.this.catalog
 
         properties = (
             self._build_table_properties_exp(

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -690,9 +690,14 @@ class EngineAdapter:
         exists = False if replace else exists
         if not isinstance(table_name_or_schema, exp.Schema):
             table_name_or_schema = exp.to_table(table_name_or_schema)
+            catalog_name = table_name_or_schema.catalog
+        else:
+            table: exp.Table = table_name_or_schema.this
+            catalog_name = table.catalog
+
         properties = (
             self._build_table_properties_exp(
-                **kwargs, table=table_name_or_schema.this, columns_to_types=columns_to_types
+                **kwargs, catalog_name=catalog_name, columns_to_types=columns_to_types
             )
             if kwargs
             else None
@@ -1864,7 +1869,7 @@ class EngineAdapter:
 
     def _build_table_properties_exp(
         self,
-        table: exp.Table,
+        catalog_name: t.Optional[str] = None,
         storage_format: t.Optional[str] = None,
         partitioned_by: t.Optional[t.List[exp.Expression]] = None,
         partition_interval_unit: t.Optional[IntervalUnit] = None,

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -459,7 +459,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
 
     def _build_table_properties_exp(
         self,
-        table: exp.Table,
+        catalog_name: t.Optional[str] = None,
         storage_format: t.Optional[str] = None,
         partitioned_by: t.Optional[t.List[exp.Expression]] = None,
         partition_interval_unit: t.Optional[IntervalUnit] = None,

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -128,7 +128,7 @@ class InsertOverwriteWithMergeMixin(EngineAdapter):
 class HiveMetastoreTablePropertiesMixin(EngineAdapter):
     def _build_table_properties_exp(
         self,
-        table: exp.Table,
+        catalog_name: t.Optional[str] = None,
         storage_format: t.Optional[str] = None,
         partitioned_by: t.Optional[t.List[exp.Expression]] = None,
         partition_interval_unit: t.Optional[IntervalUnit] = None,
@@ -155,7 +155,7 @@ class HiveMetastoreTablePropertiesMixin(EngineAdapter):
 
             if (
                 self.dialect == "trino"
-                and self.get_catalog_type(table.catalog or self.get_current_catalog()) == "iceberg"
+                and self.get_catalog_type(catalog_name or self.get_current_catalog()) == "iceberg"
             ):
                 # On the Trino Iceberg catalog, the table property is called "partitioning" - not "partitioned_by"
                 # In addition, partition column transform expressions like `day(col)` or `bucket(col, 5)` are allowed


### PR DESCRIPTION
Context: catalog name used to differentiate trino on hive from trino on iceberg