### PR TITLE
Fix: Reduce the memory footprint during the migration

### DIFF
--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -18,8 +18,8 @@ from functools import cached_property
 from sqlmesh.core.snapshot import (
     Snapshot,
     SnapshotChangeCategory,
-    SnapshotDataVersion,
     SnapshotId,
+    SnapshotIndirectVersion,
     SnapshotTableInfo,
 )
 from sqlmesh.utils.errors import SQLMeshError
@@ -148,7 +148,9 @@ class ContextDiff(PydanticModel):
         merged_snapshots = {}
         modified_snapshots = {}
         new_snapshots = {}
-        snapshot_remote_versions: t.Dict[str, t.Tuple[t.Tuple[SnapshotDataVersion, ...], int]] = {}
+        snapshot_remote_versions: t.Dict[
+            str, t.Tuple[t.Tuple[SnapshotIndirectVersion, ...], int]
+        ] = {}
 
         for snapshot in snapshots.values():
             s_id = snapshot.snapshot_id

--- a/sqlmesh/core/snapshot/__init__.py
+++ b/sqlmesh/core/snapshot/__init__.py
@@ -10,6 +10,7 @@ from sqlmesh.core.snapshot.definition import (
     SnapshotFingerprint,
     SnapshotId,
     SnapshotIdLike,
+    SnapshotIndirectVersion,
     SnapshotInfoLike,
     SnapshotIntervals,
     SnapshotNameVersion,

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -148,6 +148,11 @@ class SnapshotIntervals(PydanticModel, frozen=True):
         return SnapshotId(name=self.name, identifier=self.identifier)
 
 
+class SnapshotIndirectVersion(PydanticModel, frozen=True):
+    version: str
+    change_category: t.Optional[SnapshotChangeCategory] = None
+
+
 class SnapshotDataVersion(PydanticModel, frozen=True):
     fingerprint: SnapshotFingerprint
     version: str
@@ -172,6 +177,13 @@ class SnapshotDataVersion(PydanticModel, frozen=True):
     def is_new_version(self) -> bool:
         """Returns whether or not this version is new and requires a backfill."""
         return self.fingerprint.to_version() == self.version
+
+    @property
+    def indirect_version(self) -> SnapshotIndirectVersion:
+        return SnapshotIndirectVersion(
+            version=self.version,
+            change_category=self.change_category,
+        )
 
 
 class QualifiedViewName(PydanticModel, frozen=True):
@@ -455,7 +467,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
     updated_ts: int
     ttl: str
     previous_versions: t.Tuple[SnapshotDataVersion, ...] = ()
-    indirect_versions: t.Dict[str, t.Tuple[SnapshotDataVersion, ...]] = {}
+    indirect_versions: t.Dict[str, t.Tuple[SnapshotIndirectVersion, ...]] = {}
     version: t.Optional[str] = None
     temp_version: t.Optional[str] = None
     change_category: t.Optional[SnapshotChangeCategory] = None

--- a/sqlmesh/migrations/v0042_trim_indirect_versions.py
+++ b/sqlmesh/migrations/v0042_trim_indirect_versions.py
@@ -1,0 +1,64 @@
+"""Trim irrelevant attributes from indirect versions."""
+
+import json
+
+import pandas as pd
+from sqlglot import exp
+
+from sqlmesh.utils.migration import index_text_type
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+
+    new_snapshots = []
+
+    for name, identifier, version, snapshot, kind_name, expiration_ts in engine_adapter.fetchall(
+        exp.select("name", "identifier", "version", "snapshot", "kind_name", "expiration_ts").from_(
+            snapshots_table
+        ),
+        quote_identifiers=True,
+    ):
+        parsed_snapshot = json.loads(snapshot)
+        for indirect_versions in parsed_snapshot["indirect_versions"].values():
+            for indirect_version in indirect_versions:
+                # Only keep version and change_category.
+                version = indirect_version.get("version")
+                change_category = indirect_version.get("change_category")
+                indirect_version.clear()
+                indirect_version["version"] = version
+                indirect_version["change_category"] = change_category
+
+        new_snapshots.append(
+            {
+                "name": name,
+                "identifier": identifier,
+                "version": version,
+                "snapshot": json.dumps(parsed_snapshot),
+                "kind_name": kind_name,
+                "expiration_ts": expiration_ts,
+            }
+        )
+
+    if new_snapshots:
+        engine_adapter.delete_from(snapshots_table, "TRUE")
+
+        index_type = index_text_type(engine_adapter.dialect)
+
+        engine_adapter.insert_append(
+            snapshots_table,
+            pd.DataFrame(new_snapshots),
+            columns_to_types={
+                "name": exp.DataType.build(index_type),
+                "identifier": exp.DataType.build(index_type),
+                "version": exp.DataType.build(index_type),
+                "snapshot": exp.DataType.build("text"),
+                "kind_name": exp.DataType.build(index_type),
+                "expiration_ts": exp.DataType.build("bigint"),
+            },
+            contains_json=True,
+        )


### PR DESCRIPTION
Currently the memory footprint of the sqlmesh process during migration is way too high for large projects.

For example, it takes about 10-11GB of RAM to migrate ~10k snapshot records. 

During the investigation I've noticed that the raw snapshot payload doesn't consume that much memory. It's when we deserialize all snapshots at once the footprint grows drastically. 

This update ensures that we only keep a limited number of snapshots in deserialized form in memory during the migration.