### PR TITLE
Feat: add unit test descriptions

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -137,7 +137,9 @@ class ModelTest(unittest.TestCase):
                 return
 
             diff = expected.compare(actual).rename(columns={"self": "exp", "other": "act"})
-            e.args = (f"Data differs (exp: expected, act: actual)\n\n{diff}",)
+            description = self.body.get("description")
+            description = f"\n\n\nTest description: {description}" if description else ""
+            e.args = (f"Data differs (exp: expected, act: actual)\n\n{diff}{description}",)
             raise e
 
     def runTest(self) -> None:

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -410,6 +410,7 @@ def test_missing_column_failure(sushi_context: Context, full_model_without_ctes:
         """
 test_foo:
   model: sushi.foo
+  description: sushi.foo's output has a missing column (fails intentionally)
   inputs:
     raw:
       - id: 1
@@ -424,7 +425,15 @@ test_foo:
     result = _create_test(body, "test_foo", model, sushi_context).run()
     assert result and not result.wasSuccessful()
 
-    expected_msg = "AssertionError: Data differs (exp: expected, act: actual)\n\n  value      ds    \n    exp act exp act\n0   NaN   2 NaN   3\n"
+    expected_msg = """AssertionError: Data differs (exp: expected, act: actual)
+
+  value      ds    
+    exp act exp act
+0   NaN   2 NaN   3
+
+
+Test description: sushi.foo's output has a missing column (fails intentionally)
+"""
     assert expected_msg in result.failures[0][1]
 
 


### PR DESCRIPTION
Small QOL addition - unit tests can now optionally have a description, which will be shown as part of the exception message in case the test fails.