### PR TITLE
Fix: Serialization of the ConnectionConfig objects

### DIFF
--- a/sqlmesh/core/config/gateway.py
+++ b/sqlmesh/core/config/gateway.py
@@ -4,7 +4,10 @@ import typing as t
 
 from sqlmesh.core import constants as c
 from sqlmesh.core.config.base import BaseConfig
-from sqlmesh.core.config.connection import ConnectionConfig, connection_config_validator
+from sqlmesh.core.config.connection import (
+    SerializableConnectionConfig,
+    connection_config_validator,
+)
 from sqlmesh.core.config.scheduler import SchedulerConfig
 
 
@@ -22,9 +25,9 @@ class GatewayConfig(BaseConfig):
             then no schema name is used and therefore the default schema defined for the connection will be used
     """
 
-    connection: t.Optional[ConnectionConfig] = None
-    state_connection: t.Optional[ConnectionConfig] = None
-    test_connection: t.Optional[ConnectionConfig] = None
+    connection: t.Optional[SerializableConnectionConfig] = None
+    state_connection: t.Optional[SerializableConnectionConfig] = None
+    test_connection: t.Optional[SerializableConnectionConfig] = None
     scheduler: t.Optional[SchedulerConfig] = None
     state_schema: t.Optional[str] = c.SQLMESH
 

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -17,6 +17,7 @@ from sqlmesh.core.config.base import BaseConfig, UpdateStrategy
 from sqlmesh.core.config.connection import (
     ConnectionConfig,
     DuckDBConnectionConfig,
+    SerializableConnectionConfig,
     connection_config_validator,
 )
 from sqlmesh.core.config.feature_flag import FeatureFlag
@@ -71,8 +72,8 @@ class Config(BaseConfig):
     """
 
     gateways: t.Dict[str, GatewayConfig] = {"": GatewayConfig()}
-    default_connection: ConnectionConfig = DuckDBConnectionConfig()
-    default_test_connection_: t.Optional[ConnectionConfig] = Field(
+    default_connection: SerializableConnectionConfig = DuckDBConnectionConfig()
+    default_test_connection_: t.Optional[SerializableConnectionConfig] = Field(
         default=None, alias="default_test_connection"
     )
     default_scheduler: SchedulerConfig = BuiltInSchedulerConfig()

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -437,3 +437,27 @@ def test_load_alternative_config_type(yaml_config_path: Path, python_config_path
         },
         model_defaults=ModelDefaultsConfig(dialect=""),
     )
+
+
+def test_connection_config_serialization():
+    config = Config(
+        default_connection=DuckDBConnectionConfig(database="my_db"),
+        default_test_connection=DuckDBConnectionConfig(database="my_test_db"),
+    )
+    serialized = config.dict()
+    assert serialized["default_connection"] == {
+        "concurrent_tasks": 1,
+        "register_comments": True,
+        "type": "duckdb",
+        "extensions": [],
+        "connector_config": {},
+        "database": "my_db",
+    }
+    assert serialized["default_test_connection"] == {
+        "concurrent_tasks": 1,
+        "register_comments": True,
+        "type": "duckdb",
+        "extensions": [],
+        "connector_config": {},
+        "database": "my_test_db",
+    }


### PR DESCRIPTION
The serialization of abstract base classes has been intentionally broken in Pydantic V2. See https://docs.pydantic.dev/latest/concepts/serialization/#serializing-with-duck-typing for more details.