### PR TITLE
Fix: Optionally load context on models request

### DIFF
--- a/web/client/openapi.json
+++ b/web/client/openapi.json
@@ -1357,10 +1357,19 @@
           "default_catalog": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Default Catalog"
-          }
+          },
+          "hash": { "type": "string", "title": "Hash" }
         },
         "type": "object",
-        "required": ["name", "fqn", "path", "dialect", "type", "columns"],
+        "required": [
+          "name",
+          "fqn",
+          "path",
+          "dialect",
+          "type",
+          "columns",
+          "hash"
+        ],
         "title": "Model"
       },
       "ModelDetails": {

--- a/web/client/src/library/components/documentation/Documentation.tsx
+++ b/web/client/src/library/components/documentation/Documentation.tsx
@@ -47,7 +47,7 @@ const Documentation = function Documentation({
     return () => {
       cancelRequestModel()
     }
-  }, [model.name])
+  }, [model.hash])
 
   return (
     <Container>

--- a/web/client/src/library/components/editor/Editor.tsx
+++ b/web/client/src/library/components/editor/Editor.tsx
@@ -61,6 +61,8 @@ function EditorMain({ tab }: { tab: EditorTab }): JSX.Element {
   const previewTable = useStoreEditor(s => s.previewTable)
   const previewDiff = useStoreEditor(s => s.previewDiff)
   const refreshTab = useStoreEditor(s => s.refreshTab)
+  const updateStoredTabsIds = useStoreEditor(s => s.updateStoredTabsIds)
+
   const setPreviewQuery = useStoreEditor(s => s.setPreviewQuery)
   const setPreviewTable = useStoreEditor(s => s.setPreviewTable)
   const setPreviewDiff = useStoreEditor(s => s.setPreviewDiff)
@@ -183,6 +185,7 @@ function EditorMain({ tab }: { tab: EditorTab }): JSX.Element {
     setPreviewQuery(undefined)
     setPreviewTable(undefined)
     setPreviewDiff(undefined)
+    updateStoredTabsIds()
   }, [tab.id, tab.file.fingerprint])
 
   useEffect(() => {

--- a/web/client/src/library/components/editor/EditorInspector.tsx
+++ b/web/client/src/library/components/editor/EditorInspector.tsx
@@ -584,7 +584,7 @@ function FormDiffModel({
     void getDiff().then(({ data }) => {
       setPreviewDiff(data)
     })
-  }, [model.name])
+  }, [model.hash])
 
   useEffect(() => {
     return () => {

--- a/web/client/src/library/components/editor/EditorPreview.tsx
+++ b/web/client/src/library/components/editor/EditorPreview.tsx
@@ -220,10 +220,7 @@ export default function EditorPreview({
                   'w-full h-full ring-white ring-opacity-60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2',
                 )}
               >
-                <ModelLineage
-                  key={tab.file.fingerprint}
-                  model={model}
-                />
+                <ModelLineage model={model} />
               </Tab.Panel>
             )}
             {isNotNil(previewDiff?.row_diff) && (

--- a/web/client/src/library/components/environmentDetails/EnvironmentDetails.tsx
+++ b/web/client/src/library/components/environmentDetails/EnvironmentDetails.tsx
@@ -120,7 +120,7 @@ export default function EnvironmentDetails(): JSX.Element {
   }, [planOverview, planApply, planCancel])
 
   return (
-    <div className="h-8 flex w-full items-center justify-end text-neutral-500">
+    <div className="min-h-8 max-h-8 flex w-full items-center justify-end text-neutral-500">
       {isFetchingEnvironments ? (
         <LoadingStatus>Loading Environments...</LoadingStatus>
       ) : (

--- a/web/client/src/library/components/search/SearchList.tsx
+++ b/web/client/src/library/components/search/SearchList.tsx
@@ -17,6 +17,7 @@ interface PropsSearchListInput {
   autoFocus?: boolean
   onInput?: (e: React.ChangeEvent<HTMLInputElement>) => void
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
+  disabled?: boolean
 }
 
 const SearchListInput = React.forwardRef<
@@ -32,6 +33,7 @@ const SearchListInput = React.forwardRef<
     onInput,
     onKeyDown,
     className,
+    disabled,
   },
   ref: React.Ref<HTMLInputElement>,
 ): JSX.Element {
@@ -50,6 +52,7 @@ const SearchListInput = React.forwardRef<
           value={value}
           onInput={onInput}
           onKeyDown={onKeyDown}
+          disabled={disabled}
         />
       )}
     </Input>
@@ -71,6 +74,7 @@ export default function SearchList<
   showIndex = true,
   isFullWidth = false,
   isLoading = false,
+  disabled = false,
   direction = 'bottom',
   className,
   onInput,
@@ -89,6 +93,7 @@ export default function SearchList<
   className?: string
   isFullWidth?: boolean
   isLoading?: boolean
+  disabled?: boolean
   onInput?: (value: string) => void
 }): JSX.Element {
   const navigate = useNavigate()
@@ -133,7 +138,11 @@ export default function SearchList<
 
   return (
     <div
-      className={clsx('px-2 py-1 relative', className)}
+      className={clsx(
+        'px-2 py-1 relative',
+        disabled && 'opacity-50 cursor-not-allowed',
+        className,
+      )}
       ref={ref}
       onKeyDown={(e: React.KeyboardEvent) => {
         if (e.key === 'Escape') {
@@ -145,7 +154,7 @@ export default function SearchList<
         <Popover.Button
           ref={elTrigger}
           as={SearchListInput}
-          className="w-full !m-0"
+          className={clsx('w-full !m-0', disabled && 'pointer-events-none')}
           type="search"
           size={size}
           value={search}
@@ -162,6 +171,7 @@ export default function SearchList<
             }
           }}
           autoFocus={autoFocus}
+          disabled={disabled}
         />
         <Transition
           show={showSearchResults}

--- a/web/client/src/library/pages/models/Models.tsx
+++ b/web/client/src/library/pages/models/Models.tsx
@@ -1,6 +1,12 @@
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useEffect, useMemo } from 'react'
-import { isArrayNotEmpty, isNil, isNotNil } from '@utils/index'
+import {
+  isArrayEmpty,
+  isArrayNotEmpty,
+  isFalse,
+  isNil,
+  isNotNil,
+} from '@utils/index'
 import { useStoreContext } from '@context/context'
 import { type ModelSQLMeshModel } from '@models/sqlmesh-model'
 import Container from '@components/container/Container'
@@ -57,38 +63,40 @@ export default function PageModels({
     navigate(`${to}/${model.name}`, { replace: true })
   }, [files, model, to])
 
-  const isNotFound = isNil(model) && isNotNil(modelName)
+  const isNotFound =
+    isNil(model) && isNotNil(modelName) && isFalse(isFetchingModels)
 
-  return isFetchingModels ? (
-    <LoadingSegment>Loading Models...</LoadingSegment>
-  ) : (
+  return (
     <Page
       sidebar={
-        <SourceList<ModelSQLMeshModel>
-          keyId="displayName"
-          keyName="displayName"
-          to={to}
-          items={list}
-          isActive={id => `${to}/${id}` === pathname}
-          types={list.reduce(
-            (acc: Record<string, string>, it) =>
-              Object.assign(acc, {
-                [it.name]: getModelNodeTypeTitle(
-                  it.type as LineageNodeModelType,
-                ),
-              }),
-            {},
-          )}
-          listItem={({ to, name, description, text, disabled = false }) => (
-            <SourceListItem
-              to={to}
-              name={name}
-              text={text}
-              description={description}
-              disabled={disabled}
-            />
-          )}
-        />
+        isArrayEmpty(list) ? undefined : (
+          <SourceList<ModelSQLMeshModel>
+            keyId="displayName"
+            keyName="displayName"
+            to={to}
+            items={list}
+            isActive={id => `${to}/${id}` === pathname}
+            types={list.reduce(
+              (acc: Record<string, string>, it) =>
+                Object.assign(acc, {
+                  [it.name]: getModelNodeTypeTitle(
+                    it.type as LineageNodeModelType,
+                  ),
+                }),
+              {},
+            )}
+            listItem={({ to, name, description, text, disabled = false }) => (
+              <SourceListItem
+                to={to}
+                name={name}
+                text={text}
+                description={description}
+                disabled={disabled}
+              />
+            )}
+            disabled={isFetchingModels}
+          />
+        )
       }
       content={
         <Container.Page>
@@ -103,6 +111,7 @@ export default function PageModels({
                 direction="top"
                 className="my-2"
                 isFullWidth
+                disabled={isFetchingModels}
               />
             )}
             <Divider />
@@ -112,6 +121,8 @@ export default function PageModels({
                 message="Go Back"
                 description={`Model "${modelName}" not found.`}
               />
+            ) : isFetchingModels ? (
+              <LoadingSegment>Loading Model page...</LoadingSegment>
             ) : (
               <Outlet />
             )}

--- a/web/client/src/library/pages/root/Navigation.tsx
+++ b/web/client/src/library/pages/root/Navigation.tsx
@@ -14,7 +14,7 @@ export default function PageNavigation(): JSX.Element {
   return (
     <div
       className={clsx(
-        'min-w-[10rem] px-2 h-8 w-full flex items-center',
+        'min-w-[10rem] px-2 min-h-8 max-h-8 w-full flex items-center',
         modules.showHistoryNavigation ? 'justify-between' : 'justify-end',
       )}
     >

--- a/web/client/src/library/pages/root/Page.tsx
+++ b/web/client/src/library/pages/root/Page.tsx
@@ -1,6 +1,6 @@
 import SplitPane from '@components/splitPane/SplitPane'
 import { useStoreContext } from '@context/context'
-import { isNotNil } from '@utils/index'
+import { isNil } from '@utils/index'
 
 export default function Page({
   sidebar,
@@ -14,7 +14,11 @@ export default function Page({
 
   return (
     <>
-      {isNotNil(sidebar) ? (
+      {isNil(sidebar) ? (
+        <div className="flex w-full h-full overflow-hidden justify-center">
+          {content}
+        </div>
+      ) : (
         <SplitPane
           sizes={splitPaneSizes}
           minSize={[0, 0]}
@@ -25,10 +29,6 @@ export default function Page({
           <div className="w-full h-full overflow-hidden">{sidebar}</div>
           <div className="w-full h-full overflow-hidden">{content}</div>
         </SplitPane>
-      ) : (
-        <div className="flex w-full h-full overflow-hidden justify-center">
-          {content}
-        </div>
       )}
     </>
   )

--- a/web/client/src/library/pages/root/Root.tsx
+++ b/web/client/src/library/pages/root/Root.tsx
@@ -100,19 +100,17 @@ export default function Root(): JSX.Element {
   const inTabs = useStoreEditor(s => s.inTabs)
   const setVersion = useStoreContext(s => s.setVersion)
 
-  // We need to fetch from IDE level to make sure
-  // all pages have access to models and files
+  const { refetch: getMeta, cancel: cancelRequestMeta } = useApiMeta()
   const { refetch: getModels, cancel: cancelRequestModels } = useApiModels()
   const { refetch: getFiles, cancel: cancelRequestFile } = useApiFiles()
   const { refetch: getEnvironments, cancel: cancelRequestEnvironments } =
     useApiEnvironments()
-  const { refetch: planRun, cancel: cancelRequestPlan } = useApiPlanRun(
+  const { refetch: getPlan, cancel: cancelRequestPlan } = useApiPlanRun(
     environment.name,
     {
       planOptions: { skip_tests: true, include_unmodified: true },
     },
   )
-  const { refetch: getMeta, cancel: cancelRequestMeta } = useApiMeta()
 
   const synchronizeEnvironment = useCallback(
     function synchronizeEnvironment(env: EnvironmentName): void {
@@ -157,7 +155,7 @@ export default function Root(): JSX.Element {
         return
 
       void getEnvironments().then(({ data }) => {
-        void planRun()
+        void getPlan()
 
         updateEnviroments(data)
       })
@@ -179,7 +177,7 @@ export default function Root(): JSX.Element {
         return
 
       // Sync backfills after plan apply canceled
-      void planRun()
+      void getPlan()
     },
     [synchronizeEnvironment, environment],
   )
@@ -263,6 +261,8 @@ export default function Root(): JSX.Element {
 
       refreshFiles()
       setActiveRange()
+
+      void getModels().then(({ data }) => updateModels(data as Model[]))
     },
     [files],
   )

--- a/web/server/api/endpoints/models.py
+++ b/web/server/api/endpoints/models.py
@@ -22,10 +22,9 @@ router = APIRouter()
     response_model_exclude_unset=True,
     response_model_exclude_none=True,
 )
-def get_models(
-    context: Context = Depends(get_loaded_context),
-) -> t.List[models.Model]:
+def get_models(context: Context = Depends(get_loaded_context)) -> t.List[models.Model]:
     """Get a list of models"""
+    context.refresh()
     return serialize_all_models(context)
 
 
@@ -130,6 +129,7 @@ def serialize_model(context: Context, model: Model, render_query: bool = False) 
         sql=sql,
         type=type,
         default_catalog=default_catalog,
+        hash=model.data_hash,
     )
 
 

--- a/web/server/models.py
+++ b/web/server/models.py
@@ -184,6 +184,7 @@ class Model(BaseModel):
     details: t.Optional[ModelDetails] = None
     sql: t.Optional[str] = None
     default_catalog: t.Optional[str] = None
+    hash: str
 
 
 class ChangeDisplay(BaseModel):

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -4,29 +4,16 @@ from pathlib import Path
 from watchfiles import Change, DefaultFilter, awatch
 
 from sqlmesh.core import constants as c
-from sqlmesh.core.context import Context
 from web.server import models
 from web.server.api.endpoints.files import _get_directory, _get_file_with_content
-from web.server.api.endpoints.models import serialize_all_models
 from web.server.console import api_console
 from web.server.exceptions import ApiException
-from web.server.settings import (
-    _get_path_to_model_mapping,
-    get_context_or_raise,
-    get_settings,
-)
-from web.server.utils import is_relative_to, run_in_executor
+from web.server.settings import get_context_or_raise, get_settings
 
 
 async def watch_project() -> None:
     settings = get_settings()
     context = await get_context_or_raise(settings)
-
-    paths = [
-        (context.path / c.MODELS).resolve(),
-        (context.path / c.SEEDS).resolve(),
-        (context.path / c.TESTS).resolve(),
-    ]
     ignore_entity_patterns = context.config.ignore_patterns if context else c.IGNORE_PATTERNS
     ignore_entity_patterns.append("^\\.DS_Store$")
     ignore_entity_patterns.append("^.*\.db(\.wal)?$")
@@ -36,17 +23,12 @@ async def watch_project() -> None:
     )
 
     async for entries in awatch(context.path, watch_filter=watch_filter, force_polling=True):
-        should_load_context = False
         changes: t.List[models.ArtifactChange] = []
         directories: t.Dict[str, models.Directory] = {}
-
         for change, path_str in entries:
             path = Path(path_str)
             try:
                 relative_path = path.relative_to(settings.project_path)
-                should_load_context = should_load_context or any(
-                    is_relative_to(path, p) for p in paths
-                )
 
                 if change == Change.modified and path.is_dir():
                     directory = _get_directory(path, settings, context)
@@ -80,28 +62,5 @@ async def watch_project() -> None:
         if settings.modules.intersection({models.Modules.FILES, models.Modules.DOCS}):
             api_console.log_event(
                 event=models.EventName.FILE,
-                data={
-                    "changes": changes,
-                    "directories": directories,
-                },
+                data={"changes": changes, "directories": directories},
             )
-
-        if should_load_context:
-            await run_in_executor(reload_context_and_update_models, context, path)
-
-
-def reload_context_and_update_models(context: Context, change_path: Path) -> None:
-    try:
-        context.load()
-        path_to_model_mapping = _get_path_to_model_mapping(context)
-        maybe_model = path_to_model_mapping.get(change_path)
-        api_console.log_event(
-            event=models.EventName.MODELS,
-            data=serialize_all_models(context, {maybe_model.name} if maybe_model else set()),
-        )
-    except Exception:
-        error = ApiException(
-            message="Error refreshing the models while watching file changes",
-            origin="API -> watcher -> reload_context",
-        ).to_dict()
-        api_console.log_event(event=models.EventName.ERRORS, data=error)


### PR DESCRIPTION
Main purpose is to delegate figuring what has changed to `context.refresh`, so file watcher does not have to rely on context much. And change flow a bit to be:
-> file change
-> send SSE to UI 
-> send request to get models
-> refresh context
-> send new loaded models back
-> send request to plan to get changes and backfills

this also affects how we updating Lineage and Rendered Query on Docs page