### PR TITLE
Chore: Return files even if there is no SQLMesh context

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -71,10 +71,10 @@ def cli(
 
     if len(paths) == 1:
         path = os.path.abspath(paths[0])
-        if ctx.invoked_subcommand == "init":
+        if ctx.invoked_subcommand in ("init", "ui"):
             ctx.obj = path
             return
-        elif ctx.invoked_subcommand in ("create_external_models", "migrate", "rollback", "ui"):
+        elif ctx.invoked_subcommand in ("create_external_models", "migrate", "rollback"):
             load = False
 
     configs = load_configs(config, Context.CONFIG_TYPE, paths)
@@ -579,7 +579,7 @@ def ui(ctx: click.Context, host: str, port: int, mode: str) -> None:
             "Missing UI dependencies. Run `pip install 'sqlmesh[web]'` to install them."
         ) from e
 
-    os.environ["PROJECT_PATH"] = str(ctx.obj.path)
+    os.environ["PROJECT_PATH"] = ctx.obj
     os.environ["UI_MODE"] = mode
     if ctx.parent:
         config = ctx.parent.params.get("config")

--- a/web/server/main.py
+++ b/web/server/main.py
@@ -11,7 +11,7 @@ from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
 from web.server.api.endpoints import api_router
 from web.server.console import api_console
 from web.server.exceptions import ApiException
-from web.server.settings import get_context, get_settings
+from web.server.settings import get_context_or_raise, get_settings
 from web.server.watcher import watch_project
 
 app = FastAPI()
@@ -45,7 +45,7 @@ async def startup_event() -> None:
 async def shutdown_event() -> None:
     app.state.dispatch_task.cancel()
     app.state.watch_task.cancel()
-    context = await get_context(settings=get_settings())
+    context = await get_context_or_raise(settings=get_settings())
     context.close()
 
 

--- a/web/server/settings.py
+++ b/web/server/settings.py
@@ -109,12 +109,19 @@ async def get_loaded_context(settings: Settings = Depends(get_settings)) -> Cont
         )
 
 
-async def get_context(settings: Settings = Depends(get_settings)) -> Context:
+async def get_context(settings: Settings = Depends(get_settings)) -> t.Optional[Context]:
     try:
         async with get_context_lock:
             return _get_context(settings.project_path, settings.config, settings.gateway)
     except Exception:
+        return None
+
+
+async def get_context_or_raise(settings: Settings = Depends(get_settings)) -> Context:
+    context = await get_context(settings)
+    if not context:
         raise ApiException(
             message="Unable to create a context",
             origin="API -> settings -> get_context",
         )
+    return context

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -10,13 +10,17 @@ from web.server.api.endpoints.files import _get_directory, _get_file_with_conten
 from web.server.api.endpoints.models import serialize_all_models
 from web.server.console import api_console
 from web.server.exceptions import ApiException
-from web.server.settings import _get_path_to_model_mapping, get_context, get_settings
+from web.server.settings import (
+    _get_path_to_model_mapping,
+    get_context_or_raise,
+    get_settings,
+)
 from web.server.utils import is_relative_to, run_in_executor
 
 
 async def watch_project() -> None:
     settings = get_settings()
-    context = await get_context(settings)
+    context = await get_context_or_raise(settings)
 
     paths = [
         (context.path / c.MODELS).resolve(),


### PR DESCRIPTION
Currently, the UI will not launch if a SQLMesh context cannot be created. If, for example, the SQLMesh project config file is wrong or has a typo, a user cannot use the UI to fix it. This PR enables the UI to somewhat function even without a SQLMesh context by allowing it to launch and load files.