### PR TITLE
expose additional fields in PlanDagSpec

### DIFF
--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -370,6 +370,9 @@ class StateBasedAirflowPlanEvaluator(BaseAirflowPlanEvaluator):
             models_to_backfill=plan.models_to_backfill,
             end_bounded=plan.end_bounded,
             ensure_finalized_snapshots=plan.ensure_finalized_snapshots,
+            directly_modified_snapshots=list(plan.directly_modified),
+            indirectly_modified_snapshots=plan.indirectly_modified,
+            removed_snapshots=list(plan.context_diff.removed_snapshots),
         )
         plan_dag_spec = create_plan_dag_spec(plan_application_request, self.state_sync)
         PlanDagState.from_state_sync(self.state_sync).add_dag_spec(plan_dag_spec)
@@ -440,6 +443,9 @@ class AirflowPlanEvaluator(StateBasedAirflowPlanEvaluator):
             models_to_backfill=plan.models_to_backfill,
             end_bounded=plan.end_bounded,
             ensure_finalized_snapshots=plan.ensure_finalized_snapshots,
+            directly_modified_snapshots=list(plan.directly_modified),
+            indirectly_modified_snapshots=plan.indirectly_modified,
+            removed_snapshots=list(plan.context_diff.removed_snapshots),
         )
 
 

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -198,6 +198,9 @@ class AirflowClient(BaseAirflowClient):
         models_to_backfill: t.Optional[t.Set[str]] = None,
         end_bounded: bool = False,
         ensure_finalized_snapshots: bool = False,
+        directly_modified_snapshots: t.List[SnapshotId] = [],
+        indirectly_modified_snapshots: t.Dict[SnapshotId, t.Set[SnapshotId]] = {},
+        removed_snapshots: t.List[SnapshotId] = [],
     ) -> None:
         request = common.PlanApplicationRequest(
             new_snapshots=list(new_snapshots),
@@ -215,6 +218,9 @@ class AirflowClient(BaseAirflowClient):
             models_to_backfill=models_to_backfill,
             end_bounded=end_bounded,
             ensure_finalized_snapshots=ensure_finalized_snapshots,
+            directly_modified_snapshots=directly_modified_snapshots,
+            indirectly_modified_snapshots=indirectly_modified_snapshots,
+            removed_snapshots=removed_snapshots,
         )
 
         response = self._session.post(

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -52,6 +52,9 @@ class PlanApplicationRequest(PydanticModel):
     models_to_backfill: t.Optional[t.Set[str]]
     end_bounded: bool
     ensure_finalized_snapshots: bool
+    directly_modified_snapshots: t.List[SnapshotId]
+    indirectly_modified_snapshots: t.Dict[SnapshotId, t.Set[SnapshotId]]
+    removed_snapshots: t.List[SnapshotId]
 
     def is_selected_for_backfill(self, model_fqn: str) -> bool:
         return self.models_to_backfill is None or model_fqn in self.models_to_backfill
@@ -83,6 +86,9 @@ class PlanDagSpec(PydanticModel):
     no_gaps_snapshot_names: t.Optional[t.Set[str]] = None
     models_to_backfill: t.Optional[t.Set[str]] = None
     ensure_finalized_snapshots: bool = False
+    directly_modified_snapshots: t.Optional[t.List[SnapshotId]] = None
+    indirectly_modified_snapshots: t.Optional[t.Dict[SnapshotId, t.Set[SnapshotId]]] = None
+    removed_snapshots: t.Optional[t.List[SnapshotId]] = None
 
 
 class EnvironmentsResponse(PydanticModel):

--- a/sqlmesh/schedulers/airflow/plan.py
+++ b/sqlmesh/schedulers/airflow/plan.py
@@ -171,6 +171,9 @@ def create_plan_dag_spec(
         no_gaps_snapshot_names=no_gaps_snapshot_names,
         models_to_backfill=request.models_to_backfill,
         ensure_finalized_snapshots=request.ensure_finalized_snapshots,
+        directly_modified_snapshots=request.directly_modified_snapshots,
+        indirectly_modified_snapshots=request.indirectly_modified_snapshots,
+        removed_snapshots=request.removed_snapshots,
     )
 
 

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -61,12 +61,19 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
     request_id = "test_request_id"
 
     client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
-    client.apply_plan([snapshot], environment, request_id, models_to_backfill={'"test_model"'})
+    client.apply_plan(
+        [snapshot],
+        environment,
+        request_id,
+        models_to_backfill={'"test_model"'},
+        directly_modified_snapshots=[snapshot.snapshot_id],
+    )
 
     apply_plan_mock.assert_called_once()
     args, data = apply_plan_mock.call_args_list[0]
 
     assert args[0] == "http://localhost:8080/sqlmesh/api/v1/plans"
+    pytest.set_trace()
     assert json.loads(data["data"]) == {
         "new_snapshots": [
             {
@@ -158,6 +165,9 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
         "models_to_backfill": ['"test_model"'],
         "end_bounded": False,
         "ensure_finalized_snapshots": False,
+        "directly_modified_snapshots": [snapshot.snapshot_id],
+        "indirectly_modified_snapshots": {},
+        "removed_snapshots": [],
     }
 
 

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -118,6 +118,9 @@ def test_create_plan_dag_spec(
         models_to_backfill=None,
         end_bounded=False,
         ensure_finalized_snapshots=False,
+        directly_modified_snapshots=[the_snapshot.snapshot_id],
+        indirectly_modified_snapshots={},
+        removed_snapshots=[],
     )
 
     deleted_snapshot = SnapshotTableInfo(
@@ -152,6 +155,7 @@ def test_create_plan_dag_spec(
         side_effect=lambda: to_datetime("2023-01-01"),
     ):
         plan_spec = create_plan_dag_spec(plan_request, state_sync_mock)
+
     assert plan_spec == common.PlanDagSpec(
         request_id="test_request_id",
         environment=new_environment,
@@ -179,6 +183,9 @@ def test_create_plan_dag_spec(
             if not paused_forward_only
             else DeployabilityIndex.none_deployable()
         ),
+        directly_modified_snapshots=[the_snapshot.snapshot_id],
+        indirectly_modified_snapshots={},
+        removed_snapshots=[],
     )
 
     state_sync_mock.get_snapshots.assert_called_once()
@@ -242,6 +249,9 @@ def test_restatement(
         models_to_backfill=None,
         end_bounded=False,
         ensure_finalized_snapshots=False,
+        directly_modified_snapshots=[],
+        indirectly_modified_snapshots={},
+        removed_snapshots=[],
     )
     old_environment = Environment(
         name=environment_name,
@@ -283,6 +293,9 @@ def test_restatement(
         forward_only=True,
         dag_start_ts=to_timestamp(now_value),
         no_gaps_snapshot_names={the_snapshot.name},
+        directly_modified_snapshots=[],
+        indirectly_modified_snapshots={},
+        removed_snapshots=[],
     )
 
     state_sync_mock.get_snapshots.assert_called_once()
@@ -347,6 +360,9 @@ def test_select_models_for_backfill(mocker: MockerFixture, random_name, make_sna
         models_to_backfill={snapshot_b.name},
         end_bounded=False,
         ensure_finalized_snapshots=False,
+        directly_modified_snapshots=[snapshot_a.snapshot_id, snapshot_b.snapshot_id],
+        indirectly_modified_snapshots={},
+        removed_snapshots=[],
     )
 
     state_sync_mock = mocker.Mock()
@@ -385,6 +401,9 @@ def test_select_models_for_backfill(mocker: MockerFixture, random_name, make_sna
         deployability_index=DeployabilityIndex.all_deployable(),
         no_gaps_snapshot_names={'"a"', '"b"'},
         models_to_backfill={snapshot_b.name},
+        directly_modified_snapshots=[snapshot_a.snapshot_id, snapshot_b.snapshot_id],
+        indirectly_modified_snapshots={},
+        removed_snapshots=[],
     )
 
 
@@ -416,6 +435,9 @@ def test_create_plan_dag_spec_duplicated_snapshot(
         models_to_backfill=None,
         end_bounded=False,
         ensure_finalized_snapshots=False,
+        directly_modified_snapshots=[],
+        indirectly_modified_snapshots={},
+        removed_snapshots=[],
     )
 
     dag_run_mock = mocker.Mock()
@@ -466,6 +488,9 @@ def test_create_plan_dag_spec_unbounded_end(
         models_to_backfill=None,
         end_bounded=False,
         ensure_finalized_snapshots=False,
+        directly_modified_snapshots=[],
+        indirectly_modified_snapshots={},
+        removed_snapshots=[],
     )
 
     state_sync_mock = mocker.Mock()


### PR DESCRIPTION
this is meant to help `EnterpriseSnapshotDagGenerator` get some additional plan-related information for observer