### PR TITLE
Chore!: bump sqlglot to v22.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=22.3.1",
+        "sqlglot[rs]~=22.4.0",
     ],
     extras_require={
         "bigquery": [

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=22.2.0",
+        "sqlglot[rs]~=22.3.0",
     ],
     extras_require={
         "bigquery": [

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=22.3.0",
+        "sqlglot[rs]~=22.3.1",
     ],
     extras_require={
         "bigquery": [

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -379,7 +379,7 @@ class EngineAdapter:
             this=exp.Index(
                 this=exp.to_identifier(index_name),
                 table=exp.to_table(table_name),
-                columns=[exp.to_column(c) for c in columns],
+                params=exp.IndexParameters(columns=[exp.to_column(c) for c in columns]),
             ),
             kind="INDEX",
             exists=exists,

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -643,7 +643,7 @@ def test_select_partitions_expr():
             granularity="day",
             database="{{ target.database }}",
         )
-        == "SELECT MAX(PARSE_DATE('%Y%m%d', partition_id)) FROM `{{ target.database }}`.`{{ adapter.resolve_schema(this) }}`.INFORMATION_SCHEMA.PARTITIONS WHERE table_name = '{{ adapter.resolve_identifier(this) }}' AND NOT partition_id IS NULL AND partition_id <> '__NULL__'"
+        == "SELECT MAX(PARSE_DATE('%Y%m%d', partition_id)) FROM `{{ target.database }}.{{ adapter.resolve_schema(this) }}.INFORMATION_SCHEMA.PARTITIONS` WHERE table_name = '{{ adapter.resolve_identifier(this) }}' AND NOT partition_id IS NULL AND partition_id <> '__NULL__'"
     )
 
     assert (

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2870,7 +2870,7 @@ def test_default_catalog_sql(assert_exp_eq):
     The system is not designed to actually support having an engine that doesn't support default catalog
     to start supporting it or the reverse of that. If that did happen then bugs would occur.
     """
-    HASH_WITH_CATALOG = "1479069456"
+    HASH_WITH_CATALOG = "1074956187"
 
     # Test setting default catalog doesn't change hash if it matches existing logic
     expressions = d.parse(

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2870,7 +2870,7 @@ def test_default_catalog_sql(assert_exp_eq):
     The system is not designed to actually support having an engine that doesn't support default catalog
     to start supporting it or the reverse of that. If that did happen then bugs would occur.
     """
-    HASH_WITH_CATALOG = "1074956187"
+    HASH_WITH_CATALOG = "1479069456"
 
     # Test setting default catalog doesn't change hash if it matches existing logic
     expressions = d.parse(

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -760,7 +760,7 @@ def test_dbt_max_partition(sushi_test_project: Project, assert_exp_eq, mocker: M
 JINJA_STATEMENT_BEGIN;
 {% if is_incremental() %}
   DECLARE _dbt_max_partition DATETIME DEFAULT (
-    SELECT MAX(PARSE_DATETIME('%Y%m', partition_id)) FROM `{{ target.database }}`.`{{ adapter.resolve_schema(this) }}`.INFORMATION_SCHEMA.PARTITIONS WHERE table_name = '{{ adapter.resolve_identifier(this) }}' AND NOT partition_id IS NULL AND partition_id <> '__NULL__'
+    SELECT MAX(PARSE_DATETIME('%Y%m', partition_id)) FROM `{{ target.database }}.{{ adapter.resolve_schema(this) }}.INFORMATION_SCHEMA.PARTITIONS` WHERE table_name = '{{ adapter.resolve_identifier(this) }}' AND NOT partition_id IS NULL AND partition_id <> '__NULL__'
   );
 {% endif %}
 JINJA_END;""".strip()


### PR DESCRIPTION
@eakmanrq can you take a look at this change in `test_model.py` to verify it's correct?

```diff
-   HASH_WITH_CATALOG = "1074956187"
+   HASH_WITH_CATALOG = "1479069456"
```