### PR TITLE
Feat: truncate comments to engine-specific maximum

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1917,10 +1917,7 @@ class EngineAdapter:
         return None
 
     def _truncate_comment(self, comment: str, length: t.Optional[int]) -> str:
-        if length is None:
-            return comment
-
-        return comment[:length]
+        return comment[:length] if length else comment
 
     def _truncate_table_comment(self, comment: str) -> str:
         return self._truncate_comment(comment, self.MAX_TABLE_COMMENT_LENGTH)

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -172,7 +172,7 @@ class HiveMetastoreTablePropertiesMixin(EngineAdapter):
         if table_description:
             properties.append(
                 exp.SchemaCommentProperty(
-                    this=exp.Literal.string(self._truncate_comment(table_description, "table"))
+                    this=exp.Literal.string(self._truncate_table_comment(table_description))
                 )
             )
 
@@ -193,7 +193,7 @@ class HiveMetastoreTablePropertiesMixin(EngineAdapter):
         if table_description:
             properties.append(
                 exp.SchemaCommentProperty(
-                    this=exp.Literal.string(self._truncate_comment(table_description, "table"))
+                    this=exp.Literal.string(self._truncate_table_comment(table_description))
                 )
             )
 
@@ -203,19 +203,19 @@ class HiveMetastoreTablePropertiesMixin(EngineAdapter):
             return exp.Properties(expressions=properties)
         return None
 
-    def _truncate_comment(self, comment: str, table_or_column: str) -> str:
-        length = None
-
-        # iceberg has no limit on comment length so we leave length as None
-        if table_or_column == "table" and self.current_catalog_type == "hive":
-            length = self.MAX_TABLE_COMMENT_LENGTH
-        elif table_or_column == "column" and self.current_catalog_type == "hive":
-            length = self.MAX_COLUMN_COMMENT_LENGTH
-
-        if length is None:
+    def _truncate_table_comment(self, comment: str) -> str:
+        # iceberg tables do not have a comment length limit
+        if self.current_catalog_type == "iceberg":
             return comment
 
-        return comment[:length]
+        return super()._truncate_table_comment(comment)
+
+    def _truncate_column_comment(self, comment: str) -> str:
+        # iceberg tables do not have a comment length limit
+        if self.current_catalog_type == "iceberg":
+            return comment
+
+        return super()._truncate_column_comment(comment)
 
 
 class GetCurrentCatalogFromFunctionMixin(EngineAdapter):

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -203,19 +203,11 @@ class HiveMetastoreTablePropertiesMixin(EngineAdapter):
             return exp.Properties(expressions=properties)
         return None
 
-    def _truncate_table_comment(self, comment: str) -> str:
-        # iceberg tables do not have a comment length limit
+    def _truncate_comment(self, comment: str, length: t.Optional[int]) -> str:
+        # iceberg does not have a comment length limit
         if self.current_catalog_type == "iceberg":
             return comment
-
-        return super()._truncate_table_comment(comment)
-
-    def _truncate_column_comment(self, comment: str) -> str:
-        # iceberg tables do not have a comment length limit
-        if self.current_catalog_type == "iceberg":
-            return comment
-
-        return super()._truncate_column_comment(comment)
+        return super()._truncate_comment(comment, length)
 
 
 class GetCurrentCatalogFromFunctionMixin(EngineAdapter):

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -104,9 +104,7 @@ class MySQLEngineAdapter(
     ) -> exp.Comment | str:
         table_sql = table.sql(dialect=self.dialect, identify=True)
 
-        return (
-            f"ALTER TABLE {table_sql} COMMENT = '{self._truncate_comment(table_comment, 'table')}'"
-        )
+        return f"ALTER TABLE {table_sql} COMMENT = '{self._truncate_table_comment(table_comment)}'"
 
     def _create_column_comments(
         self,

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -37,6 +37,8 @@ class MySQLEngineAdapter(
     SUPPORTS_INDEXES = True
     COMMENT_CREATION_TABLE = CommentCreationTable.IN_SCHEMA_DEF_NO_CTAS
     COMMENT_CREATION_VIEW = CommentCreationView.UNSUPPORTED
+    MAX_TABLE_COMMENT_LENGTH = 2048
+    MAX_COLUMN_COMMENT_LENGTH = 1024
     SUPPORTS_REPLACE_TABLE = False
 
     def get_current_catalog(self) -> t.Optional[str]:
@@ -102,7 +104,9 @@ class MySQLEngineAdapter(
     ) -> exp.Comment | str:
         table_sql = table.sql(dialect=self.dialect, identify=True)
 
-        return f"ALTER TABLE {table_sql} COMMENT = '{table_comment}'"
+        return (
+            f"ALTER TABLE {table_sql} COMMENT = '{self._truncate_comment(table_comment, 'table')}'"
+        )
 
     def _create_column_comments(
         self,

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -529,7 +529,7 @@ class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTableP
         table_sql = table.sql(dialect=self.dialect, identify=True)
         column_sql = exp.column(column_name).sql(dialect=self.dialect, identify=True)
 
-        return f"ALTER TABLE {table_sql} ALTER COLUMN {column_sql} COMMENT '{column_comment}'"
+        return f"ALTER TABLE {table_sql} ALTER COLUMN {column_sql} COMMENT '{self._truncate_comment(column_comment, 'column')}'"
 
     @classmethod
     def _wap_branch_name(cls, wap_id: str) -> str:

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -529,7 +529,7 @@ class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTableP
         table_sql = table.sql(dialect=self.dialect, identify=True)
         column_sql = exp.column(column_name).sql(dialect=self.dialect, identify=True)
 
-        return f"ALTER TABLE {table_sql} ALTER COLUMN {column_sql} COMMENT '{self._truncate_comment(column_comment, 'column')}'"
+        return f"ALTER TABLE {table_sql} ALTER COLUMN {column_sql} COMMENT '{self._truncate_column_comment(column_comment)}'"
 
     @classmethod
     def _wap_branch_name(cls, wap_id: str) -> str:

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -587,9 +587,13 @@ def test_create_table_table_options(make_mocked_engine_adapter: t.Callable, mock
 def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(BigQueryEngineAdapter)
 
-    allowed_comment_length = BigQueryEngineAdapter.MAX_COMMENT_LENGTH
-    long_comment = "a" * (allowed_comment_length + 1)
-    truncated_comment = "a" * allowed_comment_length
+    allowed_table_comment_length = BigQueryEngineAdapter.MAX_TABLE_COMMENT_LENGTH
+    truncated_table_comment = "a" * allowed_table_comment_length
+    long_table_comment = truncated_table_comment + "b"
+
+    allowed_column_comment_length = BigQueryEngineAdapter.MAX_COLUMN_COMMENT_LENGTH
+    truncated_column_comment = "c" * allowed_column_comment_length
+    long_column_comment = truncated_column_comment + "d"
 
     execute_mock = mocker.patch(
         "sqlmesh.core.engine_adapter.bigquery.BigQueryEngineAdapter.execute"
@@ -598,35 +602,35 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
     adapter.create_table(
         "test_table",
         {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
-        table_description=long_comment,
-        column_descriptions={"a": long_comment},
+        table_description=long_table_comment,
+        column_descriptions={"a": long_column_comment},
     )
 
     adapter.ctas(
         "test_table",
         parse_one("SELECT a, b FROM source_table"),
         {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
-        table_description=long_comment,
-        column_descriptions={"a": long_comment},
+        table_description=long_table_comment,
+        column_descriptions={"a": long_column_comment},
     )
 
     adapter.create_view(
         "test_table",
         parse_one("SELECT a, b FROM source_table"),
-        table_description=long_comment,
+        table_description=long_table_comment,
     )
 
     adapter._create_table_comment(
         "test_table",
-        long_comment,
+        long_table_comment,
     )
 
     sql_calls = _to_sql_calls(execute_mock)
     assert sql_calls == [
-        f"CREATE TABLE IF NOT EXISTS `test_table` (`a` INT64 OPTIONS (description='{truncated_comment}'), `b` INT64) OPTIONS (description='{truncated_comment}')",
-        f"CREATE TABLE IF NOT EXISTS `test_table` (`a` INT64 OPTIONS (description='{truncated_comment}'), `b` INT64) OPTIONS (description='{truncated_comment}') AS SELECT `a`, `b` FROM `source_table`",
-        f"CREATE OR REPLACE VIEW `test_table` OPTIONS (description='{truncated_comment}') AS SELECT `a`, `b` FROM `source_table`",
-        f"ALTER TABLE `test_table` SET OPTIONS(description = '{truncated_comment}')",
+        f"CREATE TABLE IF NOT EXISTS `test_table` (`a` INT64 OPTIONS (description='{truncated_column_comment}'), `b` INT64) OPTIONS (description='{truncated_table_comment}')",
+        f"CREATE TABLE IF NOT EXISTS `test_table` (`a` INT64 OPTIONS (description='{truncated_column_comment}'), `b` INT64) OPTIONS (description='{truncated_table_comment}') AS SELECT `a`, `b` FROM `source_table`",
+        f"CREATE OR REPLACE VIEW `test_table` OPTIONS (description='{truncated_table_comment}') AS SELECT `a`, `b` FROM `source_table`",
+        f"ALTER TABLE `test_table` SET OPTIONS(description = '{truncated_table_comment}')",
     ]
 
 

--- a/tests/core/engine_adapter/test_mysql.py
+++ b/tests/core/engine_adapter/test_mysql.py
@@ -2,6 +2,7 @@
 import typing as t
 
 from pytest_mock.plugin import MockerFixture
+from sqlglot import exp, parse_one
 
 from sqlmesh.core.engine_adapter import MySQLEngineAdapter
 from tests.core.engine_adapter import to_sql_calls
@@ -10,21 +11,54 @@ from tests.core.engine_adapter import to_sql_calls
 def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(MySQLEngineAdapter)
 
+    allowed_table_comment_length = MySQLEngineAdapter.MAX_TABLE_COMMENT_LENGTH
+    truncated_table_comment = "a" * allowed_table_comment_length
+    long_table_comment = truncated_table_comment + "b"
+
+    allowed_column_comment_length = MySQLEngineAdapter.MAX_COLUMN_COMMENT_LENGTH
+    truncated_column_comment = "c" * allowed_column_comment_length
+    long_column_comment = truncated_column_comment + "d"
+
     fetchone_mock = mocker.patch("sqlmesh.core.engine_adapter.mysql.MySQLEngineAdapter.fetchone")
     fetchone_mock.return_value = ["test_table", "CREATE TABLE test_table (a INT)"]
 
+    adapter.create_table(
+        "test_table",
+        {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
+        table_description=long_table_comment,
+        column_descriptions={"a": long_column_comment},
+    )
+
+    adapter.ctas(
+        "test_table",
+        parse_one("SELECT a, b FROM source_table"),
+        {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
+        table_description=long_table_comment,
+        column_descriptions={"a": long_column_comment},
+    )
+
+    adapter.create_view(
+        "test_view",
+        parse_one("SELECT a, b FROM source_table"),
+        table_description=long_table_comment,
+    )
+
     adapter._create_table_comment(
         "test_table",
-        "test description",
+        long_table_comment,
     )
 
     adapter._create_column_comments(
         "test_table",
-        {"a": "a description"},
+        {"a": long_column_comment},
     )
 
     sql_calls = to_sql_calls(adapter)
     assert sql_calls == [
-        "ALTER TABLE `test_table` COMMENT = 'test description'",
-        "ALTER TABLE `test_table` MODIFY `a` INT COMMENT 'a description'",
+        f"CREATE TABLE IF NOT EXISTS `test_table` (`a` INT COMMENT '{truncated_column_comment}', `b` INT) COMMENT='{truncated_table_comment}'",
+        f"CREATE TABLE IF NOT EXISTS `test_table` COMMENT='{truncated_table_comment}' AS SELECT `a`, `b` FROM `source_table`",
+        f"ALTER TABLE `test_table` MODIFY `a` INT COMMENT '{truncated_column_comment}'",
+        f"CREATE OR REPLACE VIEW `test_view` AS SELECT `a`, `b` FROM `source_table`",
+        f"ALTER TABLE `test_table` COMMENT = '{truncated_table_comment}'",
+        f"ALTER TABLE `test_table` MODIFY `a` INT COMMENT '{truncated_column_comment}'",
     ]

--- a/tests/core/engine_adapter/test_trino.py
+++ b/tests/core/engine_adapter/test_trino.py
@@ -178,3 +178,129 @@ def test_partitioned_by_with_multiple_catalogs_same_server(
         """CREATE TABLE IF NOT EXISTS "datalake_iceberg"."test_schema"."test_table" ("cola" INTEGER, "colb" VARCHAR) WITH (PARTITIONING=ARRAY['colb'])""",
         """CREATE TABLE IF NOT EXISTS "datalake_iceberg"."test_schema"."test_table" WITH (PARTITIONING=ARRAY['colb']) AS SELECT 1""",
     ]
+
+
+def test_comments_hive(mocker: MockerFixture, make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(TrinoEngineAdapter)
+
+    current_catalog_mock = mocker.patch(
+        "sqlmesh.core.engine_adapter.trino.TrinoEngineAdapter.get_current_catalog"
+    )
+    current_catalog_mock.return_value = "hive"
+    catalog_type_mock = mocker.patch(
+        "sqlmesh.core.engine_adapter.trino.TrinoEngineAdapter.get_catalog_type"
+    )
+    catalog_type_mock.return_value = "hive"
+
+    allowed_table_comment_length = TrinoEngineAdapter.MAX_TABLE_COMMENT_LENGTH
+    truncated_table_comment = "a" * allowed_table_comment_length
+    long_table_comment = truncated_table_comment + "b"
+
+    allowed_column_comment_length = TrinoEngineAdapter.MAX_COLUMN_COMMENT_LENGTH
+    truncated_column_comment = "c" * allowed_column_comment_length
+    long_column_comment = truncated_column_comment + "d"
+
+    adapter.create_table(
+        "test_table",
+        {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
+        table_description=long_table_comment,
+        column_descriptions={"a": long_column_comment},
+    )
+
+    adapter.ctas(
+        "test_table",
+        parse_one("SELECT a, b FROM source_table"),
+        {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
+        table_description=long_table_comment,
+        column_descriptions={"a": long_column_comment},
+    )
+
+    adapter.create_view(
+        "test_view",
+        parse_one("SELECT a, b FROM source_table"),
+        table_description=long_table_comment,
+    )
+
+    adapter._create_table_comment(
+        "test_table",
+        long_table_comment,
+    )
+
+    adapter._create_column_comments(
+        "test_table",
+        {"a": long_column_comment},
+    )
+
+    sql_calls = to_sql_calls(adapter)
+    assert sql_calls == [
+        f"""CREATE TABLE IF NOT EXISTS "test_table" ("a" INTEGER COMMENT '{truncated_column_comment}', "b" INTEGER) COMMENT '{truncated_table_comment}'""",
+        f"""CREATE TABLE IF NOT EXISTS "test_table" COMMENT '{truncated_table_comment}' AS SELECT "a", "b" FROM "source_table\"""",
+        f"""COMMENT ON COLUMN "test_table"."a" IS '{truncated_column_comment}'""",
+        f"""CREATE OR REPLACE VIEW "test_view" AS SELECT "a", "b" FROM "source_table\"""",
+        f"""COMMENT ON VIEW "test_view" IS '{truncated_table_comment}'""",
+        f"""COMMENT ON TABLE "test_table" IS '{truncated_table_comment}'""",
+        f"""COMMENT ON COLUMN "test_table"."a" IS '{truncated_column_comment}'""",
+    ]
+
+
+def test_comments_iceberg(mocker: MockerFixture, make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(TrinoEngineAdapter)
+
+    current_catalog_mock = mocker.patch(
+        "sqlmesh.core.engine_adapter.trino.TrinoEngineAdapter.get_current_catalog"
+    )
+    current_catalog_mock.return_value = "iceberg"
+    catalog_type_mock = mocker.patch(
+        "sqlmesh.core.engine_adapter.trino.TrinoEngineAdapter.get_catalog_type"
+    )
+    catalog_type_mock.return_value = "iceberg"
+
+    allowed_table_comment_length = TrinoEngineAdapter.MAX_TABLE_COMMENT_LENGTH
+    truncated_table_comment = "a" * allowed_table_comment_length
+    long_table_comment = truncated_table_comment + "b"
+
+    allowed_column_comment_length = TrinoEngineAdapter.MAX_COLUMN_COMMENT_LENGTH
+    truncated_column_comment = "c" * allowed_column_comment_length
+    long_column_comment = truncated_column_comment + "d"
+
+    adapter.create_table(
+        "test_table",
+        {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
+        table_description=long_table_comment,
+        column_descriptions={"a": long_column_comment},
+    )
+
+    adapter.ctas(
+        "test_table",
+        parse_one("SELECT a, b FROM source_table"),
+        {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
+        table_description=long_table_comment,
+        column_descriptions={"a": long_column_comment},
+    )
+
+    adapter.create_view(
+        "test_view",
+        parse_one("SELECT a, b FROM source_table"),
+        table_description=long_table_comment,
+    )
+
+    adapter._create_table_comment(
+        "test_table",
+        long_table_comment,
+    )
+
+    adapter._create_column_comments(
+        "test_table",
+        {"a": long_column_comment},
+    )
+
+    sql_calls = to_sql_calls(adapter)
+    assert sql_calls == [
+        f"""CREATE TABLE IF NOT EXISTS "test_table" ("a" INTEGER COMMENT '{long_column_comment}', "b" INTEGER) COMMENT '{long_table_comment}'""",
+        f"""CREATE TABLE IF NOT EXISTS "test_table" COMMENT '{long_table_comment}' AS SELECT "a", "b" FROM "source_table\"""",
+        f"""COMMENT ON COLUMN "test_table"."a" IS '{long_column_comment}'""",
+        f"""CREATE OR REPLACE VIEW "test_view" AS SELECT "a", "b" FROM "source_table\"""",
+        f"""COMMENT ON VIEW "test_view" IS '{long_table_comment}'""",
+        f"""COMMENT ON TABLE "test_table" IS '{long_table_comment}'""",
+        f"""COMMENT ON COLUMN "test_table"."a" IS '{long_column_comment}'""",
+    ]


### PR DESCRIPTION
Some engines error if comments are longer than a maximum length. With this PR they will be automatically truncated to the engine's max.

Some engines, like Spark and Trino, have modular compute, metadata, and storage layers. The max comment length may differ across choices of metadata layer, such as Hive (max 4000 chars) or Iceberg (no max). For modular engines, we handle truncation in the Hive mixin rather than the engine adapter itself. 