### PR TITLE
Fixing typo in BigQuery default connection method documentation

### DIFF
--- a/docs/integrations/engines/bigquery.md
+++ b/docs/integrations/engines/bigquery.md
@@ -14,7 +14,7 @@ pip install "sqlmesh[bigquery]"
 | Option                          | Description                                                                                                    |  Type  | Required |
 |---------------------------------|----------------------------------------------------------------------------------------------------------------|:------:|:--------:|
 | `type`                          | Engine type name - must be `bigquery`                                                                          | string |    Y     |
-| `method`                        | Connection methods - see [allowed values below](#connection-methods). Default: `ouath`.                        | string |    N     |
+| `method`                        | Connection methods - see [allowed values below](#connection-methods). Default: `oauth`.                        | string |    N     |
 | `project`                       | The name of the GCP project                                                                                    | string |    N     |
 | `location`                      | The location of for the datasets (can be regional or multi-regional)                                           | string |    N     |
 | `keyfile`                       | Path to the keyfile to be used with service-account method                                                     | string |    N     |


### PR DESCRIPTION
Saw a typo in the BigQuery connection documentation, this corrects it!