### PR TITLE
Fix: The default start value in the CICD bot config

### DIFF
--- a/sqlmesh/integrations/github/cicd/config.py
+++ b/sqlmesh/integrations/github/cicd/config.py
@@ -29,7 +29,7 @@ class GithubCICDBotConfig(BaseConfig):
     merge_method: t.Optional[MergeMethod] = None
     command_namespace: t.Optional[str] = None
     auto_categorize_changes: CategorizerConfig = CategorizerConfig.all_off()
-    default_pr_start: t.Optional[TimeLike] = "1 day ago"
+    default_pr_start: t.Optional[TimeLike] = None
     skip_pr_backfill: bool = True
     pr_include_unmodified: t.Optional[bool] = None
     run_on_deploy_to_prod: bool = True

--- a/tests/integrations/github/cicd/test_config.py
+++ b/tests/integrations/github/cicd/test_config.py
@@ -34,7 +34,7 @@ model_defaults:
     assert config.cicd_bot.merge_method is None
     assert config.cicd_bot.command_namespace is None
     assert config.cicd_bot.auto_categorize_changes == CategorizerConfig.all_off()
-    assert config.cicd_bot.default_pr_start == "1 day ago"
+    assert config.cicd_bot.default_pr_start is None
     assert not config.cicd_bot.enable_deploy_command
     assert config.cicd_bot.skip_pr_backfill
     assert config.cicd_bot.pr_include_unmodified is None
@@ -106,7 +106,7 @@ config = Config(
     assert config.cicd_bot.merge_method is None
     assert config.cicd_bot.command_namespace is None
     assert config.cicd_bot.auto_categorize_changes == CategorizerConfig.all_off()
-    assert config.cicd_bot.default_pr_start == "1 day ago"
+    assert config.cicd_bot.default_pr_start is None
     assert not config.cicd_bot.enable_deploy_command
     assert config.cicd_bot.skip_pr_backfill
     assert config.cicd_bot.pr_include_unmodified is None

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -1214,7 +1214,7 @@ def test_deploy_comment_pre_categorized(
     assert pr_checks_runs[2]["output"]["title"] == "PR Virtual Data Environment: hello_world_2"
     assert (
         pr_checks_runs[2]["output"]["summary"]
-        == """<table><thead><tr><th colspan="3">PR Environment Summary</th></tr><tr><th>Model</th><th>Change Type</th><th>Dates Loaded</th></tr></thead><tbody><tr><td>sushi.waiter_revenue_by_day</td><td>Non-breaking</td><td>2022-12-31 - 2022-12-31</td></tr></tbody></table>"""
+        == """<table><thead><tr><th colspan="3">PR Environment Summary</th></tr><tr><th>Model</th><th>Change Type</th><th>Dates Loaded</th></tr></thead><tbody><tr><td>sushi.waiter_revenue_by_day</td><td>Non-breaking</td><td>2022-12-25 - 2022-12-31</td></tr></tbody></table>"""
     )
 
     assert "SQLMesh - Prod Plan Preview" in controller._check_run_mapping
@@ -1251,13 +1251,6 @@ Directly Modified: sushi.waiter_revenue_by_day (Non-breaking)
     └── sushi.top_waiters (Indirect Non-breaking)
 
 ```
-
-**Models needing backfill (missing dates):**
-
-
-* `sushi.waiter_revenue_by_day`: 2022-12-25 - 2022-12-30
-
-
 
 """
     assert prod_plan_preview_checks_runs[2]["output"]["title"] == "Prod Plan Preview"


### PR DESCRIPTION
The Plan Builder correctly figures out the default start for the plan even when there forward-only changes. There's no reason to set the default to `1 day ago` since it sometimes leads to incorrect behavior when the prod is behind by a couple of days.