### PR TITLE
Feat: disable bigquery comment registration table update metadata comparison

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -448,6 +448,11 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
                     comment
                 )
 
+        # An "etag" is BQ versioning metadata that changes when an object is updated/modified. `update_table`
+        # compares the etags of the table object passed to it and the remote table, erroring if the etags
+        # don't match. We set the local etag to None to avoid this check.
+        table_def["etag"] = None
+
         # convert dict back to a Table object
         table = table.from_api_repr(table_def)
 


### PR DESCRIPTION
An "etag" is BQ versioning metadata that changes when an object is updated/modified. 

BQ's `update_table` method compares the etags of the table object passed to it and the remote table being updated, erroring if the etags don't match. That ensures the structure of the update aligns with the current structure of the table. 

A customer project encountered this error because the remote table's etag changed between when comment registration pulled the table object with `get_table` and updated it with `update_table`. 

It's unclear how this could occur - sqlmesh created the table in the same process just prior to comment registration, so no other process could even know the name of the newly created physical table. The most probable cause is latency between table creation and etag registration, such that the etag creation and registration process had not completed when we called `get_table` and had completed when we called `update_table`. 

Disabling this check by setting the local etag to None is "safe" because we assume that it is impossible for another actor to **intentionally** update the object between the comment registration `get_table` and `update_table` calls. Therefore, a different etag cannot reflect changes to the table structure.

One edge case is if two sqlmesh plans run on the same project and simultaneously act on the environment views. Those view names are consistent over time, so multiple actors know their names.