### PR TITLE
Fix: Improve performance of migration

### DIFF
--- a/sqlmesh/core/config/__init__.py
+++ b/sqlmesh/core/config/__init__.py
@@ -21,6 +21,7 @@ from sqlmesh.core.config.loader import (
     load_config_from_yaml,
     load_configs,
 )
+from sqlmesh.core.config.migration import MigrationConfig
 from sqlmesh.core.config.model import ModelDefaultsConfig
 from sqlmesh.core.config.plan import PlanConfig
 from sqlmesh.core.config.root import Config

--- a/sqlmesh/core/config/migration.py
+++ b/sqlmesh/core/config/migration.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from sqlmesh.core.config.base import BaseConfig
+
+
+class MigrationConfig(BaseConfig):
+    """Configuration for the SQLMesh state migration.
+
+    Args:
+        promoted_snapshots_only: If True, only snapshots that are part of at least one environment will be migrated.
+            Otherwise, all snapshots will be migrated.
+    """
+
+    promoted_snapshots_only: bool = True

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -23,6 +23,7 @@ from sqlmesh.core.config.connection import (
 from sqlmesh.core.config.feature_flag import FeatureFlag
 from sqlmesh.core.config.format import FormatConfig
 from sqlmesh.core.config.gateway import GatewayConfig
+from sqlmesh.core.config.migration import MigrationConfig
 from sqlmesh.core.config.model import ModelDefaultsConfig
 from sqlmesh.core.config.plan import PlanConfig
 from sqlmesh.core.config.run import RunConfig
@@ -69,6 +70,8 @@ class Config(BaseConfig):
         format: The formatting options for SQL code.
         ui: The UI configuration for SQLMesh.
         feature_flags: Feature flags to enable/disable certain features.
+        plan: The plan configuration.
+        migration: The migration configuration.
     """
 
     gateways: t.Dict[str, GatewayConfig] = {"": GatewayConfig()}
@@ -104,6 +107,7 @@ class Config(BaseConfig):
     ui: UIConfig = UIConfig()
     feature_flags: FeatureFlag = FeatureFlag()
     plan: PlanConfig = PlanConfig()
+    migration: MigrationConfig = MigrationConfig()
 
     _FIELD_UPDATE_STRATEGY: t.ClassVar[t.Dict[str, UpdateStrategy]] = {
         "gateways": UpdateStrategy.KEY_UPDATE,

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1444,7 +1444,10 @@ class GenericContext(BaseContext, t.Generic[C]):
         """
         self.notification_target_manager.notify(NotificationEvent.MIGRATION_START)
         try:
-            self._new_state_sync().migrate(default_catalog=self.default_catalog)
+            self._new_state_sync().migrate(
+                default_catalog=self.default_catalog,
+                promoted_snapshots_only=self.config.migration.promoted_snapshots_only,
+            )
         except Exception as e:
             self.notification_target_manager.notify(
                 NotificationEvent.MIGRATION_FAILURE, traceback.format_exc()

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -417,7 +417,12 @@ class StateSync(StateReader, abc.ABC):
         """
 
     @abc.abstractmethod
-    def migrate(self, default_catalog: t.Optional[str], skip_backup: bool = False) -> None:
+    def migrate(
+        self,
+        default_catalog: t.Optional[str],
+        skip_backup: bool = False,
+        promoted_snapshots_only: bool = True,
+    ) -> None:
         """Migrate the state sync to the latest SQLMesh / SQLGlot version."""
 
     @abc.abstractmethod

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -322,7 +322,12 @@ class HttpStateSync(StateSync):
             "Compacting intervals is not supported by the Airflow state sync."
         )
 
-    def migrate(self, default_catalog: t.Optional[str], skip_backup: bool = False) -> None:
+    def migrate(
+        self,
+        default_catalog: t.Optional[str],
+        skip_backup: bool = False,
+        promoted_snapshots_only: bool = True,
+    ) -> None:
         """Migrate the state sync to the latest SQLMesh / SQLGlot version."""
         raise NotImplementedError("Migration is not supported by the Airflow state sync.")
 


### PR DESCRIPTION
This update migrates snapshot records in the DFS order which lets us achieve the following benefits:

* The fingerprint cache is now reused per snapshot parent which leads to a higher number of cache hits.
* The DFS order allows us to efficiently evict parsed snapshots from the cache, since once the child is processed we can be sure we won't be needing its parsed record any longer.


Additionally, this update introduces a new migration config option: `promoted_snapshots_only`.  When set to `True` only snapshots that are part of at least one environment will be promoted, reducing the total number of migrated records substantially. This can be helpful for really big states. The tradeoff is that some snapshots will no longer be available for a quick rollback of changes immediately following the migration.