### PR TITLE
chore: set airflow as library for some tests

### DIFF
--- a/tests/schedulers/airflow/operators/fixtures.py
+++ b/tests/schedulers/airflow/operators/fixtures.py
@@ -1,0 +1,10 @@
+import os
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture
+def set_airflow_as_library():
+    with mock.patch.dict(os.environ, {"_AIRFLOW__AS_LIBRARY": "1"}):
+        yield

--- a/tests/schedulers/airflow/operators/test_hwm_sensor.py
+++ b/tests/schedulers/airflow/operators/test_hwm_sensor.py
@@ -1,5 +1,3 @@
-import os
-from unittest import mock
 from unittest.mock import call
 
 import pytest
@@ -17,12 +15,6 @@ from sqlmesh.utils.date import to_datetime
 
 pytest_plugins = ["tests.schedulers.airflow.operators.fixtures"]
 pytestmark = pytest.mark.airflow
-
-
-@pytest.fixture
-def set_airflow_as_library():
-    with mock.patch.dict(os.environ, {"_AIRFLOW__AS_LIBRARY": "1"}):
-        yield
 
 
 def test_no_current_hwm(mocker: MockerFixture, make_snapshot, random_name, set_airflow_as_library):

--- a/tests/schedulers/airflow/operators/test_hwm_sensor.py
+++ b/tests/schedulers/airflow/operators/test_hwm_sensor.py
@@ -1,3 +1,5 @@
+import os
+from unittest import mock
 from unittest.mock import call
 
 import pytest
@@ -13,10 +15,17 @@ from sqlmesh.schedulers.airflow.operators.hwm_sensor import (
 )
 from sqlmesh.utils.date import to_datetime
 
+pytest_plugins = ["tests.schedulers.airflow.operators.fixtures"]
 pytestmark = pytest.mark.airflow
 
 
-def test_no_current_hwm(mocker: MockerFixture, make_snapshot, random_name):
+@pytest.fixture
+def set_airflow_as_library():
+    with mock.patch.dict(os.environ, {"_AIRFLOW__AS_LIBRARY": "1"}):
+        yield
+
+
+def test_no_current_hwm(mocker: MockerFixture, make_snapshot, random_name, set_airflow_as_library):
     this_snapshot = make_snapshot(SqlModel(name="this", query=parse_one("select 1, ds")))
     this_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
 
@@ -43,7 +52,7 @@ def test_no_current_hwm(mocker: MockerFixture, make_snapshot, random_name):
     get_snapshots_mock.assert_called_once_with([target_snapshot.table_info])
 
 
-def test_current_hwm_below_target(mocker: MockerFixture, make_snapshot):
+def test_current_hwm_below_target(mocker: MockerFixture, make_snapshot, set_airflow_as_library):
     this_snapshot = make_snapshot(
         SqlModel(name="this", query=parse_one("select 1, ds")), version="a"
     )
@@ -82,7 +91,7 @@ def test_current_hwm_below_target(mocker: MockerFixture, make_snapshot):
     get_snapshots_mock.assert_called_once_with([target_snapshot_v1.table_info])
 
 
-def test_current_hwm_above_target(mocker: MockerFixture, make_snapshot):
+def test_current_hwm_above_target(mocker: MockerFixture, make_snapshot, set_airflow_as_library):
     this_snapshot = make_snapshot(
         SqlModel(name="this", query=parse_one("select 1, ds")), version="a"
     )
@@ -115,7 +124,7 @@ def test_current_hwm_above_target(mocker: MockerFixture, make_snapshot):
     get_snapshots_mock.assert_called_once_with([target_snapshot_v1.table_info])
 
 
-def test_hwm_external_sensor(mocker: MockerFixture, make_snapshot):
+def test_hwm_external_sensor(mocker: MockerFixture, make_snapshot, set_airflow_as_library):
     snapshot = make_snapshot(
         SqlModel(
             name="this",

--- a/tests/schedulers/airflow/operators/test_targets.py
+++ b/tests/schedulers/airflow/operators/test_targets.py
@@ -18,6 +18,7 @@ from sqlmesh.engines import commands
 from sqlmesh.schedulers.airflow.operators import targets
 from sqlmesh.utils.date import to_datetime
 
+pytest_plugins = ["tests.schedulers.airflow.operators.fixtures"]
 pytestmark = pytest.mark.airflow
 
 
@@ -29,7 +30,9 @@ def model() -> Model:
     )
 
 
-def test_evaluation_target_execute(mocker: MockerFixture, make_snapshot: t.Callable, model: Model):
+def test_evaluation_target_execute(
+    mocker: MockerFixture, make_snapshot: t.Callable, model: Model, set_airflow_as_library
+):
     interval_ds = to_datetime("2022-01-01")
     logical_ds = to_datetime("2022-01-02")
 
@@ -76,7 +79,9 @@ def test_evaluation_target_execute(mocker: MockerFixture, make_snapshot: t.Calla
     )
 
 
-def test_evaluation_target_execute_seed_model(mocker: MockerFixture, make_snapshot: t.Callable):
+def test_evaluation_target_execute_seed_model(
+    mocker: MockerFixture, make_snapshot: t.Callable, set_airflow_as_library
+):
     interval_ds = to_datetime("2022-01-01")
     logical_ds = to_datetime("2022-01-02")
 
@@ -135,7 +140,9 @@ def test_evaluation_target_execute_seed_model(mocker: MockerFixture, make_snapsh
     )
 
 
-def test_cleanup_target_execute(mocker: MockerFixture, make_snapshot: t.Callable, model: Model):
+def test_cleanup_target_execute(
+    mocker: MockerFixture, make_snapshot: t.Callable, model: Model, set_airflow_as_library
+):
     snapshot = make_snapshot(model)
     snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
 
@@ -181,7 +188,7 @@ def test_cleanup_target_execute(mocker: MockerFixture, make_snapshot: t.Callable
 
 
 def test_cleanup_target_skip_execution(
-    mocker: MockerFixture, make_snapshot: t.Callable, model: Model
+    mocker: MockerFixture, make_snapshot: t.Callable, model: Model, set_airflow_as_library
 ):
     snapshot = make_snapshot(model)
     snapshot.version = "test_version"


### PR DESCRIPTION
Airflow code: https://github.com/apache/airflow/blob/7bba05d782a64da0b5cce68ec92ac6f5c7b49221/airflow/__init__.py#L55-L61

We don't want to set this generally but for these tests it should be fine. We may need to later serialize other airflow tests, or have them also set this env var, but doing these for now since I know they are problematic. I don't have a repro for the issue currently. 