### PR TITLE
feat: add ability to configure logging dir

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -52,6 +52,11 @@ def _sqlmesh_version() -> str:
     is_flag=True,
     help="Display logs in stdout.",
 )
+@click.option(
+    "--log-file-dir",
+    type=str,
+    help="The directory to write log files to.",
+)
 @click.pass_context
 @error_handler
 def cli(
@@ -62,6 +67,7 @@ def cli(
     ignore_warnings: bool = False,
     debug: bool = False,
     log_to_stdout: bool = False,
+    log_file_dir: t.Optional[str] = None,
 ) -> None:
     """SQLMesh command line tool."""
     if "--help" in sys.argv:
@@ -79,7 +85,9 @@ def cli(
 
     configs = load_configs(config, Context.CONFIG_TYPE, paths)
     log_limit = list(configs.values())[0].log_limit
-    configure_logging(debug, ignore_warnings, log_to_stdout, log_limit=log_limit)
+    configure_logging(
+        debug, ignore_warnings, log_to_stdout, log_limit=log_limit, log_file_dir=log_file_dir
+    )
 
     try:
         context = Context(

--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -36,6 +36,9 @@ DEFAULT_MAX_LIMIT = 1000
 DEFAULT_LOG_LIMIT = 20
 """The default number of logs to keep."""
 
+DEFAULT_LOG_FILE_DIR = "logs"
+"""The default directory for log files."""
+
 AUDITS = "audits"
 MACROS = "macros"
 METRICS = "metrics"

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -91,6 +91,7 @@ class SQLMeshMagics(Magics):
     @argument("--gateway", type=str, help="The name of the gateway.")
     @argument("--ignore-warnings", action="store_true", help="Ignore warnings.")
     @argument("--debug", action="store_true", help="Enable debug mode.")
+    @argument("--log-file-dir", type=str, help="The directory to write the log file to.")
     @line_magic
     def context(self, line: str) -> None:
         """Sets the context in the user namespace."""
@@ -99,7 +100,9 @@ class SQLMeshMagics(Magics):
         args = parse_argstring(self.context, line)
         configs = load_configs(args.config, Context.CONFIG_TYPE, args.paths)
         log_limit = list(configs.values())[0].log_limit
-        configure_logging(args.debug, args.ignore_warnings, log_limit=log_limit)
+        configure_logging(
+            args.debug, args.ignore_warnings, log_limit=log_limit, log_file_dir=args.log_file_dir
+        )
         try:
             context = Context(paths=args.paths, config=configs, gateway=args.gateway)
             self._shell.user_ns["context"] = context

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -46,9 +46,11 @@ def notebook(mocker: MockerFixture, ip):
 
 
 @pytest.fixture
-def sushi_context(copy_to_temp_path, notebook) -> Context:
+def sushi_context(copy_to_temp_path, notebook, tmp_path) -> Context:
     sushi_dir = copy_to_temp_path(SUSHI_EXAMPLE_PATH)[0]
-    notebook.run_line_magic(magic_name="context", line=str(sushi_dir))
+    notebook.run_line_magic(
+        magic_name="context", line=f"{str(sushi_dir)} --log-file-dir {tmp_path}"
+    )
     return notebook.user_ns["context"]
 
 
@@ -95,9 +97,11 @@ def get_all_html_output():
     return _convert
 
 
-def test_context(notebook, convert_all_html_output_to_text, get_all_html_output):
+def test_context(notebook, convert_all_html_output_to_text, get_all_html_output, tmp_path):
     with capture_output() as output:
-        notebook.run_line_magic(magic_name="context", line=str(SUSHI_EXAMPLE_PATH))
+        notebook.run_line_magic(
+            magic_name="context", line=f"{str(SUSHI_EXAMPLE_PATH)}  --log-file-dir {tmp_path}"
+        )
 
     assert output.stdout == ""
     assert output.stderr == ""


### PR DESCRIPTION
Currently we assume all logging should go to a relative directly of "logs". This change makes it so that users of CLI or Magics can change the logging directory to where they want but default still to "logs". 

Also included is a fix for tests so they use a function scoped path for the log files instead of sharing log directory with other tests. 