### PR TITLE
Fix: Reload context on config change

### DIFF
--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -156,7 +156,7 @@ class Loader(abc.ABC):
             True if a modification is found; False otherwise
         """
         return any(
-            path.stat().st_mtime > initial_mtime
+            not path.exists() or path.stat().st_mtime > initial_mtime
             for path, initial_mtime in self._path_mtimes.items()
         )
 

--- a/web/client/src/library/components/documentation/Documentation.tsx
+++ b/web/client/src/library/components/documentation/Documentation.tsx
@@ -47,7 +47,7 @@ const Documentation = function Documentation({
     return () => {
       cancelRequestModel()
     }
-  }, [model.hash])
+  }, [model.name, model.hash])
 
   return (
     <Container>

--- a/web/client/src/library/components/editor/EditorInspector.tsx
+++ b/web/client/src/library/components/editor/EditorInspector.tsx
@@ -584,7 +584,7 @@ function FormDiffModel({
     void getDiff().then(({ data }) => {
       setPreviewDiff(data)
     })
-  }, [model.hash])
+  }, [model.name, model.hash])
 
   useEffect(() => {
     return () => {

--- a/web/client/src/library/components/fileExplorer/Directory.tsx
+++ b/web/client/src/library/components/fileExplorer/Directory.tsx
@@ -32,7 +32,7 @@ const Directory = function Directory({
   const [isDraggable, setIsDraggable] = useState(false)
 
   const attrs = useLongPress(() => setIsDraggable(true), {
-    threshold: 500,
+    threshold: 50,
     onFinish() {
       setIsDraggable(false)
     },

--- a/web/client/src/library/components/fileExplorer/File.tsx
+++ b/web/client/src/library/components/fileExplorer/File.tsx
@@ -35,7 +35,7 @@ function File({
   const [isDraggable, setIsDraggable] = useState(false)
 
   const attrs = useLongPress(() => setIsDraggable(true), {
-    threshold: 500,
+    threshold: 50,
     onFinish() {
       setIsDraggable(false)
     },

--- a/web/client/src/library/components/graph/ModelLineage.tsx
+++ b/web/client/src/library/components/graph/ModelLineage.tsx
@@ -118,7 +118,7 @@ export default function ModelLineage({
       setMainNode(undefined)
       setHighlightedNodes({})
     }
-  }, [model.hash])
+  }, [model.name, model.hash])
 
   useEffect(() => {
     Object.keys(modelLineage ?? {}).forEach(modelName => {

--- a/web/client/src/library/components/loading/LoadingStatus.tsx
+++ b/web/client/src/library/components/loading/LoadingStatus.tsx
@@ -9,7 +9,7 @@ export default function LoadingStatus({
   return (
     <Loading className="inline-block">
       <Spinner className="w-3 h-3 border border-neutral-10 mr-2" />
-      <span className="inline-block text-xs">{children}</span>
+      <span className="inline-block text-xs whitespace-nowrap">{children}</span>
     </Loading>
   )
 }

--- a/web/client/src/library/pages/root/Navigation.tsx
+++ b/web/client/src/library/pages/root/Navigation.tsx
@@ -14,16 +14,17 @@ export default function PageNavigation(): JSX.Element {
   return (
     <div
       className={clsx(
-        'min-w-[10rem] px-2 min-h-8 max-h-8 w-full flex items-center',
+        'relative min-w-[10rem] px-2 min-h-8 max-h-8 w-full flex items-center',
         modules.showHistoryNavigation ? 'justify-between' : 'justify-end',
       )}
     >
       {modules.showHistoryNavigation && <HistoryNavigation />}
-      {isFetchingModels ? (
-        <LoadingStatus>Loading Models...</LoadingStatus>
-      ) : (
-        modules.hasPlans && <EnvironmentDetails />
+      {isFetchingModels && (
+        <div className="absolute w-full h-full flex justify-center items-center z-10 bg-transparent-20 backdrop-blur-lg">
+          <LoadingStatus>Loading Models...</LoadingStatus>
+        </div>
       )}
+      {modules.hasPlans && <EnvironmentDetails />}
       {modules.hasErrors && <ReportErrors />}
     </div>
   )

--- a/web/server/api/endpoints/directories.py
+++ b/web/server/api/endpoints/directories.py
@@ -5,10 +5,9 @@ import typing as t
 from fastapi import APIRouter, Body, Depends, HTTPException, Response, status
 from starlette.status import HTTP_404_NOT_FOUND
 
-from sqlmesh.core.context import Context
 from web.server import models
 from web.server.exceptions import ApiException
-from web.server.settings import Settings, get_context, get_settings
+from web.server.settings import Settings, get_settings
 from web.server.utils import replace_file, validate_path
 
 router = APIRouter()
@@ -16,15 +15,13 @@ router = APIRouter()
 
 @router.post("/{path:path}", response_model=models.Directory)
 async def write_directory(
-    response: Response,
     path: str = Depends(validate_path),
     new_path: t.Optional[str] = Body(None, embed=True),
     settings: Settings = Depends(get_settings),
-    context: Context = Depends(get_context),
 ) -> models.Directory:
     """Create or rename a directory."""
     if new_path:
-        validate_path(new_path, context)
+        new_path = await validate_path(new_path, settings)
         replace_file(settings.project_path / path, settings.project_path / new_path)
         return models.Directory(name=os.path.basename(new_path), path=new_path)
 

--- a/web/server/settings.py
+++ b/web/server/settings.py
@@ -125,3 +125,9 @@ async def get_context_or_raise(settings: Settings = Depends(get_settings)) -> Co
             origin="API -> settings -> get_context",
         )
     return context
+
+
+def invalidate_context_cache() -> None:
+    _get_context.cache_clear()
+    _get_loaded_context.cache_clear()
+    _get_path_to_model_mapping.cache_clear()

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -4,34 +4,48 @@ from pathlib import Path
 from watchfiles import Change, DefaultFilter, awatch
 
 from sqlmesh.core import constants as c
+from sqlmesh.core.context import Context
 from web.server import models
 from web.server.api.endpoints.files import _get_directory, _get_file_with_content
 from web.server.console import api_console
 from web.server.exceptions import ApiException
-from web.server.settings import get_context_or_raise, get_settings
+from web.server.settings import (
+    Settings,
+    get_context,
+    get_settings,
+    invalidate_context_cache,
+)
+from web.server.utils import is_relative_to
 
 
 async def watch_project() -> None:
     settings = get_settings()
-    context = await get_context_or_raise(settings)
+    context = await get_context(settings)
+    paths = [
+        (settings.project_path / c.AUDITS).resolve(),
+        (settings.project_path / c.MACROS).resolve(),
+        (settings.project_path / c.MODELS).resolve(),
+        (settings.project_path / c.METRICS).resolve(),
+        (settings.project_path / c.SEEDS).resolve(),
+    ]
     ignore_entity_patterns = context.config.ignore_patterns if context else c.IGNORE_PATTERNS
     ignore_entity_patterns.append("^\\.DS_Store$")
     ignore_entity_patterns.append("^.*\.db(\.wal)?$")
-    ignore_paths = [str((context.path / c.CACHE).resolve())]
+    ignore_paths = [str((settings.project_path / c.CACHE).resolve())]
     watch_filter = DefaultFilter(
         ignore_paths=ignore_paths, ignore_entity_patterns=ignore_entity_patterns
     )
-
-    async for entries in awatch(context.path, watch_filter=watch_filter, force_polling=True):
+    async for entries in awatch(
+        settings.project_path, watch_filter=watch_filter, force_polling=True
+    ):
         changes: t.List[models.ArtifactChange] = []
         directories: t.Dict[str, models.Directory] = {}
         for change, path_str in entries:
             path = Path(path_str)
             try:
                 relative_path = path.relative_to(settings.project_path)
-
                 if change == Change.modified and path.is_dir():
-                    directory = _get_directory(path, settings, context)
+                    directory = await _get_directory(path, settings)
                     directories[directory.path] = directory
                 elif change == Change.deleted or not path.exists():
                     changes.append(
@@ -51,6 +65,16 @@ async def watch_project() -> None:
                             ),
                         )
                     )
+                if context:
+                    in_paths = any(is_relative_to(path, p) for p in paths)
+                    is_modified_new_file = (
+                        change == Change.modified and path not in context._loader._path_mtimes
+                    )
+                    should_track_file = path.is_file() and in_paths
+                    should_reset_mtime = Change.added or is_modified_new_file
+                    if should_track_file and should_reset_mtime:
+                        context._loader._path_mtimes[path] = 0
+
             except Exception:
                 error = ApiException(
                     message="Error updating file",
@@ -64,3 +88,26 @@ async def watch_project() -> None:
                 event=models.EventName.FILE,
                 data={"changes": changes, "directories": directories},
             )
+
+        if is_config_changed(entries, settings, context):
+            invalidate_context_cache()
+            api_console.log_event(
+                event=models.EventName.WARNINGS,
+                data=ApiException(
+                    message="Config file changed",
+                    origin="API -> watcher -> watch_project",
+                    trigger="config",
+                ).to_dict(),
+            )
+
+
+def is_config_changed(
+    entries: t.Set[t.Any], settings: Settings, context: t.Optional[Context] = None
+) -> bool:
+    config_paths = set(context.configs) if context else {settings.project_path}
+
+    return any(
+        Path(path) in config_path.glob("config.*")
+        for config_path in config_paths
+        for _, path in entries
+    )


### PR DESCRIPTION
- Optionally rely on `context` when working with files
- Reload `context` if `config.*` has changed
- Track newly added files to trigger `context.load()` 