### PR TITLE
chore: publish sqlmesh tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,9 @@ jobs:
       - run:
           name: Publish Python package
           command: make publish
-
+      - run:
+          name: Publish Python Tests package
+          command: make publish-tests
   gh-release:
     docker:
       - image: cimg/node:16.14

--- a/.circleci/update-pypirc.sh
+++ b/.circleci/update-pypirc.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+echo "[distutils]" >> ~/.pypirc
+echo "index-servers = tobiko-private" >> ~/.pypirc
+echo "[tobiko-private]" >> ~/.pypirc
+echo "repository = $TOBIKO_PRIVATE_PYPI_URL" >> ~/.pypirc
+echo "username = _json_key_base64" >> ~/.pypirc
+echo "password = $TOBIKO_PRIVATE_PYPI_KEY" >> ~/.pypirc

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,12 @@ package:
 publish: package
 	pip3 install twine && python3 -m twine upload dist/*
 
+package-tests:
+	pip3 install wheel && python3 tests/setup.py sdist bdist_wheel
+
+publish-tests: package-tests
+	pip3 install twine && python3 -m twine upload -r tobiko-private tests/dist/*
+
 develop:
 	python3 setup.py develop
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,0 +1,25 @@
+import os
+from distutils.core import run_setup, setup
+
+os.chdir(os.path.join(os.path.dirname(__file__), ".."))
+sqlmesh_dist = run_setup("setup.py", stop_after="init")
+requirements = sqlmesh_dist.install_requires + sqlmesh_dist.extras_require["dev"]  # type: ignore
+os.chdir(os.path.dirname(__file__))
+
+setup(
+    name="sqlmesh-tests",
+    description="Tests for SQLMesh",
+    url="https://github.com/TobikoData/sqlmesh",
+    author="TobikoData Inc.",
+    author_email="engineering@tobikodata.com",
+    license="Apache License 2.0",
+    package_dir={"sqlmesh_tests": ""},
+    package_data={"": ["fixtures/**"]},
+    use_scm_version={
+        "write_to": "_version.py",
+        "fallback_version": "0.0.0",
+        "local_scheme": "no-local-version",
+    },
+    setup_requires=["setuptools_scm"],
+    install_requires=requirements,
+)


### PR DESCRIPTION
Publishes to an internal repo within Tobiko SQLMesh core tests so they can be easily tested from other repos. 

Also includes some adjustments to http state sync tests to make them more portable. 