### PR TITLE
chore: add name_version prop to name version class

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -135,6 +135,11 @@ class SnapshotNameVersion(PydanticModel, frozen=True):
     name: str
     version: str
 
+    @property
+    def name_version(self) -> SnapshotNameVersion:
+        """Helper method to return self."""
+        return self
+
 
 class SnapshotIntervals(PydanticModel, frozen=True):
     name: str


### PR DESCRIPTION
Similar to SnapshotId: https://github.com/TobikoData/sqlmesh/blob/22544717d4e16aef1f65aba1ac3b0a8eb29f8bb0/sqlmesh/core/snapshot/definition.py#L122-L125

This will now ensure that if you use `SnapshotNameVersionLike` that all classes have a `name_version` property. 