### PR TITLE
Fix: Use latest finalized environment snapshots in selector

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -966,7 +966,10 @@ class GenericContext(BaseContext, t.Generic[C]):
         models_override: t.Optional[UniqueKeyDict[str, Model]] = None
         if select_models:
             models_override = model_selector.select_models(
-                select_models, environment, fallback_env_name=create_from or c.PROD
+                select_models,
+                environment,
+                fallback_env_name=create_from or c.PROD,
+                ensure_finalized_snapshots=self.config.plan.use_finalized_state,
             )
             if not backfill_models:
                 # Only backfill selected models unless explicitly specified.


### PR DESCRIPTION
This fixes a scenario when the selector sources models from the unfinalized set of environment snapshots, while the `ContextDiff` uses the finalized set which leads to unexpected diffs and backfills when using selector.