### PR TITLE
chore: fix version detection for sqlmesh_tests

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -16,6 +16,7 @@ setup(
     package_dir={"sqlmesh_tests": ""},
     package_data={"": ["fixtures/**"]},
     use_scm_version={
+        "root": "..",
         "write_to": "_version.py",
         "fallback_version": "0.0.0",
         "local_scheme": "no-local-version",


### PR DESCRIPTION
The goal is to publish a version of sqlmesh-tests that matches the version of core that it corresponds to. 