### PR TITLE
Fix: Ignore models from the 'elementary' package when loading a dbt project

### DIFF
--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -41,6 +41,7 @@ SourceConfigs = t.Dict[str, SourceConfig]
 MacroConfigs = t.Dict[str, MacroConfig]
 
 
+IGNORED_PACKAGES = {"elementary"}
 BUILTIN_CALLS = {*BUILTIN_GLOBALS, *BUILTIN_FILTERS}
 
 
@@ -193,7 +194,10 @@ class ManifestHelper:
 
     def _load_models_and_seeds(self) -> None:
         for node in self._manifest.nodes.values():
-            if node.resource_type not in ("model", "seed", "snapshot"):
+            if (
+                node.resource_type not in ("model", "seed", "snapshot")
+                or node.package_name in IGNORED_PACKAGES
+            ):
                 continue
 
             macro_references = _macro_references(self._manifest, node)


### PR DESCRIPTION
Closes #2242.

There're numerous macros in the [Elementary](https://www.elementary-data.com/) package that reference other macros in the following fashion:

```
{% set type_bigint = dbt.type_bigint or dbt_utils.type_bigint %}
{{ type_bigint() }}
```

Manipulating references in this way leads to dbt core not properly detecting macro dependencies, resulting in the omission of such dependencies from the manifest.

Since SQLMesh relies on the manifest to load dbt projects, it ends up not including omitted macro dependencies which leads to failures at runtime (see #2242). 

This update excludes models provided by the `elementary` package, ensuring that users relying on it can still load their projects with SQLMesh.

A long-term solution would involve improving our own macro dependency detection mechanism and stop using dbt manifest as the only source of macro definitions. 