### PR TITLE
chore: unset twine when exporting sqlmesh tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: ./.circleci/update-pypirc.sh
       - run:
           name: Publish Python Tests package
-          command: make publish-tests
+          command: unset TWINE_USERNAME TWINE_PASSWORD && make publish-tests
   gh-release:
     docker:
       - image: cimg/node:16.14


### PR DESCRIPTION
The project level has these env vars set which makes us ignore the values in pypirc when we publish. We unset them so we use pypirc when publishing.

Thanks @vchan for the help. 