### PR TITLE
Fix: Remove trailing newline from dbt  multiline test kwargs.

### DIFF
--- a/sqlmesh/dbt/test.py
+++ b/sqlmesh/dbt/test.py
@@ -172,6 +172,8 @@ class TestConfig(GeneralConfig):
         kwargs = {}
         for key, value in self.test_kwargs.items():
             if isinstance(value, str):
+                # Multiline values will end with a newline. Remove it here.
+                value = value.rstrip()
                 # Mimic dbt kwargs logic
                 no_braces = _remove_jinja_braces(value)
                 jinja_function_regex = r"^\s*(env_var|ref|var|source|doc)\s*\(.+\)\s*$"

--- a/tests/dbt/test_test.py
+++ b/tests/dbt/test_test.py
@@ -1,0 +1,10 @@
+from sqlmesh.dbt.test import TestConfig
+
+
+def test_multiline_test_kwarg() -> None:
+    test = TestConfig(
+        name="test",
+        sql="{{ test(**_dbt_generic_test_kwargs) }}",
+        test_kwargs={"test_field": "foo\nbar\n"},
+    )
+    assert test._kwargs() == 'test_field="foo\nbar"'


### PR DESCRIPTION
dbt test kwargs can be multiline. According to the yaml standard, multiline values will end in a newline. This causes a problem with Jinja rendering, where it fails to parse when the trailing newline is present. This PR removes the trailing newline when building the test kwargs.