### PR TITLE
Fix: Cache Trino catalog type lookup to reduce load

### DIFF
--- a/sqlmesh/core/engine_adapter/trino.py
+++ b/sqlmesh/core/engine_adapter/trino.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing as t
+from functools import lru_cache
 
 import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype  # type: ignore
@@ -60,6 +61,7 @@ class TrinoEngineAdapter(
         """Sets the catalog name of the current connection."""
         self.execute(exp.Use(this=schema_(db="information_schema", catalog=catalog)))
 
+    @lru_cache()
     def get_catalog_type(self, catalog: t.Optional[str]) -> str:
         row: t.Tuple = tuple()
         if catalog:


### PR DESCRIPTION
When running a bunch of incremental models with thousands of intervals across them, I noticed thousands of catalog type lookup queries being submitted (one for each interval).

It doesn't add a heap of load but I thought it was a bit unnecessary, so here's a patch to address it.

I notice other components within sqlmesh making use of `functools.lru_cache` so I wrapped `TrinoEngineAdapter.get_catalog_type` with it.

The core assumption is that the catalog type wont change within the same sqlmesh run. I think this is fine; to change a catalog type in Trino you have to restart the server, which would abort the current sqlmesh run anyway.