### PR TITLE
Fix: Fix partitioning property for Trino iceberg tables

### DIFF
--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -157,11 +157,11 @@ class HiveMetastoreTablePropertiesMixin(EngineAdapter):
                 properties.append(
                     exp.Property(
                         this=exp.var("PARTITIONING"),
-                        value=exp.Array(
-                            expressions=[
+                        value=exp.array(
+                            *(
                                 exp.Literal.string(e.sql(dialect=self.dialect))
                                 for e in partitioned_by
-                            ]
+                            )
                         ),
                     )
                 )
@@ -169,7 +169,7 @@ class HiveMetastoreTablePropertiesMixin(EngineAdapter):
                 for expr in partitioned_by:
                     if not isinstance(expr, exp.Column):
                         raise SQLMeshError(
-                            f"PARTITIONED BY contains non-column value '{expr.sql(dialect='spark')}'."
+                            f"PARTITIONED BY contains non-column value '{expr.sql(dialect=self.dialect)}'."
                         )
 
                 properties.append(

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -146,28 +146,37 @@ class HiveMetastoreTablePropertiesMixin(EngineAdapter):
             properties.append(exp.FileFormatProperty(this=exp.Var(this=storage_format)))
 
         if partitioned_by:
-            for expr in partitioned_by:
-                if not isinstance(expr, exp.Column):
-                    raise SQLMeshError(
-                        f"PARTITIONED BY contains non-column value '{expr.sql(dialect='spark')}'."
-                    )
-
-            property: exp.Property = exp.PartitionedByProperty(
-                this=exp.Schema(expressions=partitioned_by),
-            )
-
             if (
                 self.dialect == "trino"
                 and self.get_catalog_type(catalog_name or self.get_current_catalog()) == "iceberg"
             ):
                 # On the Trino Iceberg catalog, the table property is called "partitioning" - not "partitioned_by"
                 # In addition, partition column transform expressions like `day(col)` or `bucket(col, 5)` are allowed
+                # Also, column names and transforms need to be strings and supplied as an ARRAY[varchar]
                 # ref: https://trino.io/docs/current/connector/iceberg.html#table-properties
-                property = exp.Property(
-                    this=exp.var("PARTITIONING"), value=exp.Schema(expressions=partitioned_by)
+                properties.append(
+                    exp.Property(
+                        this=exp.var("PARTITIONING"),
+                        value=exp.Array(
+                            expressions=[
+                                exp.Literal.string(e.sql(dialect=self.dialect))
+                                for e in partitioned_by
+                            ]
+                        ),
+                    )
                 )
+            else:
+                for expr in partitioned_by:
+                    if not isinstance(expr, exp.Column):
+                        raise SQLMeshError(
+                            f"PARTITIONED BY contains non-column value '{expr.sql(dialect='spark')}'."
+                        )
 
-            properties.append(property)
+                properties.append(
+                    exp.PartitionedByProperty(
+                        this=exp.Schema(expressions=partitioned_by),
+                    )
+                )
 
         if table_description:
             properties.append(

--- a/tests/core/engine_adapter/test_trino.py
+++ b/tests/core/engine_adapter/test_trino.py
@@ -5,7 +5,10 @@ import pytest
 from pytest_mock.plugin import MockerFixture
 from sqlglot import exp, parse_one
 
+import sqlmesh.core.dialect as d
 from sqlmesh.core.engine_adapter import TrinoEngineAdapter
+from sqlmesh.core.model import load_sql_based_model
+from sqlmesh.core.model.definition import SqlModel
 from tests.core.engine_adapter import to_sql_calls
 
 pytestmark = [pytest.mark.engine, pytest.mark.trino]
@@ -148,26 +151,36 @@ def test_partitioned_by_iceberg_transforms(
         return_value="datalake_iceberg",
     )
 
-    columns_to_types = {
-        "cola": exp.DataType.build("INT"),
-        "colb": exp.DataType.build("TEXT"),
-    }
+    expressions = d.parse(
+        f"""
+        MODEL (
+            name test_table,
+            partitioned_by (day(cola), truncate(colb, 8), colc),
+            kind INCREMENTAL_BY_TIME_RANGE(
+                time_column cola,
+            ),
+        );
+
+        SELECT 1::timestamp AS cola, 2::varchar as colb, 'foo' as colc;
+    """
+    )
+    model: SqlModel = t.cast(SqlModel, load_sql_based_model(expressions))
 
     adapter.create_table(
-        "test_table",
-        columns_to_types,
-        partitioned_by=[exp.to_column("day(cola)"), exp.to_column("truncate(colb, 8)")],
+        table_name=model.view_name,
+        columns_to_types=model.columns_to_types_or_raise,
+        partitioned_by=model.partitioned_by,
     )
 
     adapter.ctas(
-        "test_table",
-        parse_one("select 1"),  # type: ignore
-        partitioned_by=[exp.to_column("day(cola)"), exp.to_column("truncate(colb, 8)")],
+        table_name=model.view_name,
+        query_or_df=t.cast(exp.Query, model.query),
+        partitioned_by=model.partitioned_by,
     )
 
     assert to_sql_calls(adapter) == [
-        """CREATE TABLE IF NOT EXISTS "test_table" ("cola" INTEGER, "colb" VARCHAR) WITH (PARTITIONING=ARRAY['day(cola)', 'truncate(colb, 8)'])""",
-        """CREATE TABLE IF NOT EXISTS "test_table" WITH (PARTITIONING=ARRAY['day(cola)', 'truncate(colb, 8)']) AS SELECT 1""",
+        """CREATE TABLE IF NOT EXISTS "test_table" ("cola" TIMESTAMP, "colb" VARCHAR, "colc" VARCHAR) WITH (PARTITIONING=ARRAY['DAY("cola")', 'TRUNCATE("colb", 8)', '"colc"'])""",
+        """CREATE TABLE IF NOT EXISTS "test_table" WITH (PARTITIONING=ARRAY['DAY("cola")', 'TRUNCATE("colb", 8)', '"colc"']) AS SELECT CAST(1 AS TIMESTAMP) AS "cola", CAST(2 AS VARCHAR) AS "colb", \'foo\' AS "colc\"""",
     ]
 
 


### PR DESCRIPTION
Currently, using iceberg column transforms as the `partitioned_by` model property, eg:

```
MODEL (
     name foo,
     kind INCREMENTAL_BY_TIME_RANGE (
        time_column transacttime,
    ),
    partitioned_by day(transacttime),
  ....
)
```

throw a SQLMesh error:

`Error: partitioned_by field ''day(transacttime)'' does not contain a column`

A closer look at [the docs](https://trino.io/docs/current/connector/iceberg.html#partitioned-tables) reveal that, for an Iceberg table, the partition columns need to be defined as `ARRAY[varchar]`.

So this PR addresses that by wrapping the partition columns in `exp.Array` instead of `exp.Schema` and rendering them as varchar literals.

Note that Trino works with both the following syntax:

`partitioning = ARRAY['day("cola")', '"colb"']`
or
`partitioning = ARRAY['day(cola)','colb']`

(that is, if the column names are quoted within the string literals, it still works as expected)