### PR TITLE
Fix: convert lists, ndarrays to tuples when sorting unit test dataframes

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -132,17 +132,10 @@ class ModelTest(unittest.TestCase):
             return str(x) if isinstance(x, (dict, list)) else x
 
         if sort:
-            actual = (
-                actual.apply(lambda col: col.map(_to_hashable))
-                .sort_values(by=actual.columns.to_list())
-                .reset_index(drop=True)
-            )
-            expected = (
-                expected.apply(lambda col: col.map(_to_hashable))
-                .sort_values(by=expected.columns.to_list())
-                .reset_index(drop=True)
-            )
-
+            actual = actual.apply(lambda col: col.map(_to_hashable))
+            actual = actual.sort_values(by=actual.columns.to_list()).reset_index(drop=True)
+            expected = expected.apply(lambda col: col.map(_to_hashable))
+            expected = expected.sort_values(by=expected.columns.to_list()).reset_index(drop=True)
         try:
             pd.testing.assert_frame_equal(
                 expected,

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -129,16 +129,16 @@ class ModelTest(unittest.TestCase):
         expected = expected.replace({None: np.nan})
 
         def _to_hashable(x: t.Any) -> t.Any:
-            return tuple(x) if isinstance(x, list) else x
+            return str(x) if isinstance(x, (dict, list)) else x
 
         if sort:
             actual = (
-                actual.apply(_to_hashable)
+                actual.apply(lambda col: col.map(_to_hashable))
                 .sort_values(by=actual.columns.to_list())
                 .reset_index(drop=True)
             )
             expected = (
-                expected.apply(_to_hashable)
+                expected.apply(lambda col: col.map(_to_hashable))
                 .sort_values(by=expected.columns.to_list())
                 .reset_index(drop=True)
             )

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -129,7 +129,9 @@ class ModelTest(unittest.TestCase):
         expected = expected.replace({None: np.nan})
 
         def _to_hashable(x: t.Any) -> t.Any:
-            return str(x) if isinstance(x, (dict, list)) else x
+            if isinstance(x, (list, np.ndarray)):
+                return tuple(x)
+            return str(x) if not isinstance(x, t.Hashable) else x
 
         if sort:
             actual = actual.apply(lambda col: col.map(_to_hashable))


### PR DESCRIPTION
~This was an oversight which probably surfaced with a delay, hopefully this fixes the CI in main.~ 

See comment below.