### PR TITLE
feat: Trigger enterprise testing on commit

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -214,15 +214,6 @@ jobs:
       resource_class: small
       steps:
         - run:
-            name: Inspect environment variables
-            command: |
-              echo "PR_NUMBER: $CIRCLE_PR_NUMBER"
-              echo "PR_REPONAME: $CIRCLE_PR_REPONAME"
-              echo "PR_USERNAME: $CIRCLE_PR_USERNAME"
-              echo "USERNAME: $CIRCLE_USERNAME"
-              echo "PULL REQUEST: $CIRCLE_PULL_REQUEST"
-              echo "SHA: $CIRCLE_SHA1"
-        - run:
             name: Trigger enterprise unit tests
             command: |
               curl --request POST \

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -221,6 +221,9 @@ jobs:
                 --header "Circle-Token: $ENTERPRISE_CIRCLE_API_TOKEN" \
                 --header "content-type: application/json" \
                 --data '{"branch":"main","parameters":{"run_main_pr":false, "run_core_commit":true, "sqlmesh_version":$CIRCLE_BRANCH}}'
+        - run:
+            name: Echo params
+            command: echo "$CIRCLE_BRANCH\n$ENTERPRISE_CIRCLE_API_TOKEN "
 
 workflows:
   main_pr:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -220,10 +220,7 @@ jobs:
                 --url https://circleci.com/api/v2/project/gh/TobikoData/sqlmesh-enterprise/pipeline \
                 --header "Circle-Token: $ENTERPRISE_CIRCLE_API_TOKEN" \
                 --header "content-type: application/json" \
-                --data '{"branch":"trigger_workflow_on_post","parameters":{"run_main_pr":false, "run_core_commit":true, "sqlmesh_version":"$CIRCLE_BRANCH"}}'
-        - run:
-            name: Announce params
-            command: echo "$CIRCLE_BRANCH"
+                --data '{"branch":"trigger_workflow_on_post","parameters":{"run_main_pr":false, "run_core_commit":true, "sqlmesh_version":"'"$CIRCLE_BRANCH"'"}}'
 
 workflows:
   main_pr:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -214,6 +214,15 @@ jobs:
       resource_class: small
       steps:
         - run:
+            name: Inspect environment variables
+            command: |
+              echo "PR_NUMBER: $CIRCLE_PR_NUMBER"
+              echo "PR_REPONAME: $CIRCLE_PR_REPONAME"
+              echo "PR_USERNAME: $CIRCLE_PR_USERNAME"
+              echo "USERNAME: $CIRCLE_USERNAME"
+              echo "PULL REQUEST: $CIRCLE_PULL_REQUEST"
+              echo "SHA: $CIRCLE_SHA1"
+        - run:
             name: Trigger enterprise unit tests
             command: |
               curl --request POST \

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -221,6 +221,9 @@ jobs:
                 --header "Circle-Token: $ENTERPRISE_CIRCLE_API_TOKEN" \
                 --header "content-type: application/json" \
                 --data '{"branch":"trigger_workflow_on_post","parameters":{"run_main_pr":false, "run_core_commit":true, "sqlmesh_version":"$CIRCLE_BRANCH"}}'
+        - run:
+            name: Announce params
+            command: echo "$CIRCLE_BRANCH"
 
 workflows:
   main_pr:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -220,10 +220,7 @@ jobs:
                 --url https://circleci.com/api/v2/project/gh/TobikoData/sqlmesh-enterprise/pipeline \
                 --header "Circle-Token: $ENTERPRISE_CIRCLE_API_TOKEN" \
                 --header "content-type: application/json" \
-                --data '{"branch":"main","parameters":{"run_main_pr":false, "run_core_commit":true, "sqlmesh_version":$CIRCLE_BRANCH}}'
-        - run:
-            name: Echo params
-            command: echo "$CIRCLE_BRANCH\n$ENTERPRISE_CIRCLE_API_TOKEN "
+                --data '{"branch":"main","parameters":{"run_main_pr":false, "run_core_commit":true, "sqlmesh_version":"$CIRCLE_BRANCH"}}'
 
 workflows:
   main_pr:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -217,15 +217,24 @@ jobs:
             name: Trigger private tests
             command: |
               curl --request POST \
-                --url  $TOBIKO_PRIVATE_CIRCLECI_URL\
+                --url $TOBIKO_PRIVATE_CIRCLECI_URL \
                 --header "Circle-Token: $TOBIKO_PRIVATE_CIRCLECI_KEY" \
                 --header "content-type: application/json" \
-                --data '{"branch":"trigger_workflow_on_post","parameters":{"run_main_pr":false, "run_sqlmesh_commit":true, "sqlmesh_version":"'"$CIRCLE_BRANCH"'"}}'
+                --data '{
+                  "branch":"main",
+                  "parameters":{
+                    "run_main_pr":false, 
+                    "run_sqlmesh_commit":true, 
+                    "sqlmesh_version":"'"$CIRCLE_BRANCH"'",
+                    "sqlmesh_commit_author":"'"$CIRCLE_USERNAME"'",
+                    "sqlmesh_commit_hash":"'"$CIRCLE_SHA1"'",
+                    "sqlmesh_commit_pr":"'"$CIRCLE_PULL_REQUEST"'"
+                    }
+                }'
 
 workflows:
   main_pr:
     jobs:
-      - trigger_private_tests
       - doc_tests
       - style_and_slow_tests:
           matrix:
@@ -242,6 +251,13 @@ workflows:
                 - main
       - engine_adapter_docker_tests:
           context: engine_adapter_slow
+          requires:
+            - style_and_slow_tests
+          filters:
+            branches:
+              only:
+                - main
+      - trigger_private_tests
           requires:
             - style_and_slow_tests
           filters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -208,24 +208,24 @@ jobs:
           command: make engine-docker-test
           no_output_timeout: 15m
   
-  trigger_enterprise_unit_tests:
+  trigger_private_tests:
       docker: 
         - image: cimg/base:2021.11
       resource_class: small
       steps:
         - run:
-            name: Trigger enterprise unit tests
+            name: Trigger private tests
             command: |
               curl --request POST \
-                --url https://circleci.com/api/v2/project/gh/TobikoData/sqlmesh-enterprise/pipeline \
-                --header "Circle-Token: $ENTERPRISE_CIRCLE_API_TOKEN" \
+                --url  $TOBIKO_PRIVATE_CIRCLECI_URL\
+                --header "Circle-Token: $TOBIKO_PRIVATE_CIRCLECI_KEY" \
                 --header "content-type: application/json" \
-                --data '{"branch":"trigger_workflow_on_post","parameters":{"run_main_pr":false, "run_core_commit":true, "sqlmesh_version":"$CIRCLE_BRANCH"}}'
+                --data '{"branch":"trigger_workflow_on_post","parameters":{"run_main_pr":false, "run_sqlmesh_commit":true, "sqlmesh_version":"'"$CIRCLE_BRANCH"'"}}'
 
 workflows:
   main_pr:
     jobs:
-      - trigger_enterprise_unit_tests
+      - trigger_private_tests
       - doc_tests
       - style_and_slow_tests:
           matrix:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -220,7 +220,7 @@ jobs:
                 --url https://circleci.com/api/v2/project/gh/TobikoData/sqlmesh-enterprise/pipeline \
                 --header "Circle-Token: $ENTERPRISE_CIRCLE_API_TOKEN" \
                 --header "content-type: application/json" \
-                --data '{"branch":"main","parameters":{"run_main_pr":false, "run_core_commit":true, "sqlmesh_version":"$CIRCLE_BRANCH"}}'
+                --data '{"branch":"trigger_workflow_on_post","parameters":{"run_main_pr":false, "run_core_commit":true, "sqlmesh_version":"$CIRCLE_BRANCH"}}'
 
 workflows:
   main_pr:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -257,7 +257,7 @@ workflows:
             branches:
               only:
                 - main
-      - trigger_private_tests
+      - trigger_private_tests:
           requires:
             - style_and_slow_tests
           filters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -207,10 +207,25 @@ jobs:
           name: Run tests
           command: make engine-docker-test
           no_output_timeout: 15m
+  
+  trigger_enterprise_unit_tests:
+      docker: 
+        - image: cimg/base:2021.11
+      resource_class: small
+      steps:
+        - run:
+            name: Trigger enterprise unit tests
+            command: |
+              curl --request POST \
+                --url https://circleci.com/api/v2/project/gh/TobikoData/sqlmesh-enterprise/pipeline \
+                --header "Circle-Token: $ENTERPRISE_CIRCLE_API_TOKEN" \
+                --header "content-type: application/json" \
+                --data '{"branch":"main","parameters":{"run_main_pr":false, "run_core_commit":true, "sqlmesh_version":$CIRCLE_BRANCH}}'
 
 workflows:
   main_pr:
     jobs:
+      - trigger_enterprise_unit_tests
       - doc_tests
       - style_and_slow_tests:
           matrix:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -225,7 +225,7 @@ jobs:
                   "parameters":{
                     "run_main_pr":false, 
                     "run_sqlmesh_commit":true, 
-                    "sqlmesh_version":"'"$CIRCLE_BRANCH"'",
+                    "sqlmesh_branch":"'"$CIRCLE_BRANCH"'",
                     "sqlmesh_commit_author":"'"$CIRCLE_USERNAME"'",
                     "sqlmesh_commit_hash":"'"$CIRCLE_SHA1"'",
                     "sqlmesh_commit_pr":"'"$CIRCLE_PULL_REQUEST"'"

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -220,7 +220,7 @@ jobs:
                 --url https://circleci.com/api/v2/project/gh/TobikoData/sqlmesh-enterprise/pipeline \
                 --header "Circle-Token: $ENTERPRISE_CIRCLE_API_TOKEN" \
                 --header "content-type: application/json" \
-                --data '{"branch":"trigger_workflow_on_post","parameters":{"run_main_pr":false, "run_core_commit":true, "sqlmesh_version":"'"$CIRCLE_BRANCH"'"}}'
+                --data '{"branch":"trigger_workflow_on_post","parameters":{"run_main_pr":false, "run_core_commit":true, "sqlmesh_version":"$CIRCLE_BRANCH"}}'
 
 workflows:
   main_pr:


### PR DESCRIPTION
This adds a job in the `main_pr` CircleCI workflow which emits a webhook to enterprise's pipeline endpoint to trigger testing ([PR #195](https://github.com/TobikoData/sqlmesh-enterprise/pull/195) in sqlmesh-enterprise repository)