### PR TITLE
fix: suppress Pandas DBAPI2 connection warnings.

### DIFF
--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -73,6 +73,8 @@ class PandasNativeFetchDFSupportMixin(EngineAdapter):
         self, query: t.Union[exp.Expression, str], quote_identifiers: bool = False
     ) -> DF:
         """Fetches a Pandas DataFrame from a SQL query."""
+        from warnings import catch_warnings, filterwarnings
+
         from pandas.io.sql import read_sql_query
 
         sql = (
@@ -81,7 +83,14 @@ class PandasNativeFetchDFSupportMixin(EngineAdapter):
             else query
         )
         logger.debug(f"Executing SQL:\n{sql}")
-        return read_sql_query(sql, self._connection_pool.get())
+        with catch_warnings():
+            filterwarnings(
+                "ignore",
+                category=UserWarning,
+                message=".*pandas only supports SQLAlchemy connectable.*",
+            )
+            df = read_sql_query(sql, self._connection_pool.get())
+        return df
 
 
 class InsertOverwriteWithMergeMixin(EngineAdapter):


### PR DESCRIPTION
pandas.io.sql generates a UserWarning for DBAPI2 connections that are not sqlite3:

```
sqlmesh/core/engine_adapter/mixins.py:84: UserWarning: pandas only supports SQLAlchemy connectable (engine/connection) or database string URI or sqlite3 DBAPI2 connection. Other DBAPI2 objects are not tested. Please consider using SQLAlchemy.
```

This will suppress the warning within PandasNativeFetchDFSupportMixin._fetch_native_df().