### PR TITLE
Fix!: Normalize dbt model cluster_by field

### DIFF
--- a/examples/sushi/config.py
+++ b/examples/sushi/config.py
@@ -11,6 +11,7 @@ from sqlmesh.core.config import (
     GatewayConfig,
     ModelDefaultsConfig,
     PlanConfig,
+    PostgresConnectionConfig,
     SparkConnectionConfig,
 )
 from sqlmesh.core.notification_target import (
@@ -149,5 +150,22 @@ environment_catalog_mapping_config = Config(
     environment_catalog_mapping={
         "^prod$": "prod_catalog",
         ".*": "dev_catalog",
+    },
+)
+
+postgresql_config = Config(
+    # default_connection=DuckDBConnectionConfig(database=f"{DATA_DIR}/local.duckdb"),
+    default_connection=DuckDBConnectionConfig(database="gclouddata.duckdb"),
+    model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+    gateways={
+        "my_gateway": GatewayConfig(
+            state_connection=PostgresConnectionConfig(
+                host="35.222.243.76",
+                port=5432,
+                user="unique-glider",
+                password="1d1dWu[NRYV5XUY3",
+                database="sushi-demo",
+            ),
+        ),
     },
 )

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -118,12 +118,12 @@ class ModelMeta(_Node):
     @field_validator("tags", mode="before")
     @field_validator_v1_args
     def _value_or_tuple_validator(cls, v: t.Any, values: t.Dict[str, t.Any]) -> t.Any:
-        return cls._validate_value_or_tuple(v, values)
+        return ensure_list(cls._validate_value_or_tuple(v, values))
 
     @field_validator("clustered_by", mode="before")
     @field_validator_v1_args
     def _normalized_value_or_tuple_validator(cls, v: t.Any, values: t.Dict[str, t.Any]) -> t.Any:
-        return cls._validate_value_or_tuple(v, values, normalize=True)
+        return ensure_list(cls._validate_value_or_tuple(v, values, normalize=True))
 
     @classmethod
     def _validate_value_or_tuple(
@@ -135,10 +135,12 @@ class ModelMeta(_Node):
         if isinstance(v, (exp.Tuple, exp.Array)):
             return [_normalize(e).name for e in v.expressions]
         if isinstance(v, exp.Expression):
-            return [_normalize(v).name]
+            return _normalize(v).name
         if isinstance(v, str):
             value = _normalize(v)
             return value.name if isinstance(value, exp.Expression) else value
+        if isinstance(v, (list, tuple)):
+            return [cls._validate_value_or_tuple(elm, values, normalize=normalize) for elm in v]
 
         return v
 

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -883,3 +883,37 @@ def test_snowflake_session_properties(sushi_test_project: Project, mocker: Mocke
         expressions=[exp.Literal.string("warehouse").eq(exp.Literal.string("test_warehouse"))]
     )
     assert model_with_warehouse.session_properties == {"warehouse": "test_warehouse"}
+
+
+def test_model_cluster_by():
+    context = DbtContext()
+    context._target = SnowflakeConfig(
+        name="target",
+        schema="test",
+        database="test",
+        account="account",
+        user="user",
+        password="password",
+    )
+
+    model = ModelConfig(
+        name="model",
+        alias="model",
+        package_name="package",
+        target_schema="test",
+        cluster_by="Bar",
+        sql="SELECT * FROM baz",
+        materialized=Materialization.TABLE.value,
+    )
+    assert model.to_sqlmesh(context).clustered_by == ["BAR"]
+
+    model = ModelConfig(
+        name="model",
+        alias="model",
+        package_name="package",
+        target_schema="test",
+        cluster_by=["Bar", "qux"],
+        sql="SELECT * FROM baz",
+        materialized=Materialization.TABLE.value,
+    )
+    assert model.to_sqlmesh(context).clustered_by == ["BAR", "QUX"]


### PR DESCRIPTION
There was a gap in `clustered_by` normalization where we didn't normalize if passed in a list. This PR adds normalization for list types.

Fixes #2293