### PR TITLE
feat: support github enterprise url

### DIFF
--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -67,7 +67,7 @@ class PullRequestInfo(PydanticModel):
 
     @classmethod
     def create_from_pull_request_url(cls, pull_request_url: str) -> PullRequestInfo:
-        _, _, _, _, owner, repo, _, pr_number = pull_request_url.split("/")
+        owner, repo, _, pr_number = pull_request_url.split("/")[-4:]
         return cls(
             owner=owner,
             repo=repo,

--- a/tests/fixtures/github/pull_request_synchronized_enterprise.json
+++ b/tests/fixtures/github/pull_request_synchronized_enterprise.json
@@ -1,0 +1,10 @@
+{
+  "action": "synchronized",
+  "pull_request": {
+    "_links": {
+      "self": {
+        "href": "https://github.my-company.com/api/v3/repos/org/repo/pulls/3"
+      }
+    }
+  }
+}

--- a/tests/integrations/github/cicd/test_github_event.py
+++ b/tests/integrations/github/cicd/test_github_event.py
@@ -32,3 +32,13 @@ def test_pull_request_synchronized_info(make_event_from_fixture, make_pull_reque
     assert pull_request_info.repo == "Hello-World"
     assert pull_request_info.pr_number == 2
     assert pull_request_info.full_repo_path == "Codertocat/Hello-World"
+
+
+def test_pull_request_synchronized_enterprise(make_event_from_fixture, make_pull_request_info):
+    pull_request_info = make_pull_request_info(
+        make_event_from_fixture("tests/fixtures/github/pull_request_synchronized_enterprise.json")
+    )
+    assert pull_request_info.owner == "org"
+    assert pull_request_info.repo == "repo"
+    assert pull_request_info.pr_number == 3
+    assert pull_request_info.full_repo_path == "org/repo"


### PR DESCRIPTION
Enterprise has a different URL start than non-enterprise but the tail of the URL is the same and that is all we care about so this updates the url parsing to be more flexible to accommodate enteprise. 