### PR TITLE
Fix: Reset the 'effective_from' attribute for migrated snapshots

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -736,7 +736,8 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         previous_ids = {s.snapshot_id(self.name) for s in self.previous_versions}
         if self.identifier == other.identifier or (
             # Indirect Non-Breaking snapshots share the dev table with its previous version.
-            self.is_indirect_non_breaking
+            # The same applies to migrated snapshots.
+            (self.is_indirect_non_breaking or self.migrated)
             and other.snapshot_id in previous_ids
         ):
             for start, end in other.dev_intervals:

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -1097,6 +1097,8 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
                 logger.exception("Could not compute fingerprint for %s", snapshot.snapshot_id)
                 return
 
+            # Reset the effective_from date for the new snapshot to avoid unexpected backfills.
+            new_snapshot.effective_from = None
             new_snapshot.previous_versions = snapshot.all_versions
             new_snapshot.migrated = True
             if not new_snapshot.temp_version:

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -198,7 +198,7 @@ def test_add_interval(snapshot: Snapshot, make_snapshot):
     ]
 
 
-def test_add_interval_dev(snapshot: Snapshot):
+def test_add_interval_dev(snapshot: Snapshot, make_snapshot):
     snapshot.version = "existing_version"
     snapshot.change_category = SnapshotChangeCategory.FORWARD_ONLY
 
@@ -208,6 +208,18 @@ def test_add_interval_dev(snapshot: Snapshot):
     snapshot.add_interval("2020-01-02", "2020-01-02", is_dev=True)
     assert snapshot.intervals == [(to_timestamp("2020-01-01"), to_timestamp("2020-01-02"))]
     assert snapshot.dev_intervals == [(to_timestamp("2020-01-02"), to_timestamp("2020-01-03"))]
+
+    new_snapshot = make_snapshot(snapshot.model)
+    new_snapshot.merge_intervals(snapshot)
+    assert new_snapshot.intervals == [(to_timestamp("2020-01-01"), to_timestamp("2020-01-02"))]
+    assert new_snapshot.dev_intervals == []
+
+    new_snapshot = make_snapshot(snapshot.model)
+    new_snapshot.previous_versions = snapshot.all_versions
+    new_snapshot.migrated = True
+    new_snapshot.merge_intervals(snapshot)
+    assert new_snapshot.intervals == [(to_timestamp("2020-01-01"), to_timestamp("2020-01-02"))]
+    assert new_snapshot.dev_intervals == [(to_timestamp("2020-01-02"), to_timestamp("2020-01-03"))]
 
 
 def test_add_interval_partial(snapshot: Snapshot, make_snapshot):


### PR DESCRIPTION
If not reset, the next time the migrated snapshot is executed it'd detect that there are no intervals associated with its `identifier` after the `effective_from` timestamp and conclude that additional backfill is necessary in order to meet the configured `effective_from` setting.