### PR TITLE
chore: bump airflow version for testing

### DIFF
--- a/examples/airflow/Makefile
+++ b/examples/airflow/Makefile
@@ -1,4 +1,4 @@
-AIRFLOW_VERSION ?= 2.3.3
+AIRFLOW_VERSION ?= 2.4.3
 AIRFLOW_IMAGE_NAME ?= airflow-sqlmesh
 AIRFLOW_UID ?= $(shell id -u)
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
             "databricks-cli",
         ],
         "dev": [
-            f"apache-airflow=={os.environ.get('AIRFLOW_VERSION', '2.3.3')}",
+            f"apache-airflow=={os.environ.get('AIRFLOW_VERSION', '2.4.3')}",
             "autoflake==1.7.7",
             "agate==1.7.1",
             "beautifulsoup4",


### PR DESCRIPTION
I realized that the Airflow library fix in this PR only works for Airflow 2.4+: https://github.com/TobikoData/sqlmesh/pull/2265

Therefore I just bumped to the latest bugfix of 2.4. I tested locally and it worked. 