### PR TITLE
Fix: cast to timestamp to guarantee safe coalesce in SCD_TYPE_2_BY_COLUMN logic

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1376,8 +1376,8 @@ class EngineAdapter:
             )
             valid_from_case_stmt = exp.func(
                 "COALESCE",
-                exp.column(f"t_{valid_from_name}"),
-                update_valid_from_start,
+                exp.cast(exp.column(f"t_{valid_from_name}"), "TIMESTAMPTZ"),
+                exp.cast(update_valid_from_start, "TIMESTAMPTZ"),
             ).as_(valid_from_name)
         else:
             assert updated_at_name is not None

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1331,6 +1331,7 @@ class EngineAdapter:
             update_valid_from_start = execution_ts
         else:
             update_valid_from_start = to_time_column("1970-01-01 00:00:00+00:00", time_data_type)
+        update_valid_from_start = exp.cast(update_valid_from_start, time_data_type)
         insert_valid_from_start = execution_ts if check_columns else exp.column(updated_at_name)  # type: ignore
         # joined._exists IS NULL is saying "if the row is deleted"
         delete_check = (
@@ -1376,8 +1377,8 @@ class EngineAdapter:
             )
             valid_from_case_stmt = exp.func(
                 "COALESCE",
-                exp.cast(exp.column(f"t_{valid_from_name}"), "TIMESTAMPTZ"),
-                exp.cast(update_valid_from_start, "TIMESTAMPTZ"),
+                exp.column(f"t_{valid_from_name}"),
+                update_valid_from_start,
             ).as_(valid_from_name)
         else:
             assert updated_at_name is not None


### PR DESCRIPTION
SCD_TYPE_2_BY_COLUMN do not work due to a coalesce with a datetime column with a value that may be a timestamp. 

Not sure if this fix is better than making sure we get timestamps in the generated table, but for BQ this is totally broken without this.


EDIT: I manage to get out of the state on the latest release meaning this fix isnt the root cause. There is some bad state thats possible, obviously, and it seems to have to do with columns_to_types in the _scd_type_2 function where the `time_column_type` is pulled out. Its totally possible I get back into the same state tomorrow. I just have no idea how/why.