### PR TITLE
Fix: Handle arrays in test generation

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -434,7 +434,7 @@ def generate_test(
         .name: pandas_timestamp_to_pydatetime(
             engine_adapter.fetchdf(query), models[dep].columns_to_types
         )
-        .map(_convert_dataframe)
+        .apply(lambda col: col.map(_normalize_dataframe))
         .to_dict(orient="records")
         for dep, query in input_queries.items()
     }
@@ -473,7 +473,7 @@ def generate_test(
 
     outputs["query"] = (
         pandas_timestamp_to_pydatetime(output, model.columns_to_types)
-        .map(_convert_dataframe)
+        .apply(lambda col: col.map(_normalize_dataframe))
         .to_dict(orient="records")
     )
 
@@ -500,8 +500,8 @@ def _raise_error(msg: str, path: Path | None = None) -> None:
     raise TestError(msg)
 
 
-def _convert_dataframe(value: t.Any) -> t.Any:
-    """Convert data in a pandas dataframe so ruamel and sqlglot can deal with it."""
+def _normalize_dataframe(value: t.Any) -> t.Any:
+    """Normalize data in a pandas dataframe so ruamel and sqlglot can deal with it."""
     if isinstance(value, np.ndarray):
         return list(value)
     return value

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -700,3 +700,41 @@ def test_successes(sushi_context: Context) -> None:
     assert len(successful_tests) == 2
     assert "test_order_items" in successful_tests
     assert "test_customer_revenue_by_day" in successful_tests
+
+
+def test_test_generation_with_array(tmp_path: Path) -> None:
+    init_example_project(tmp_path, dialect="duckdb")
+
+    config = Config(
+        default_connection=DuckDBConnectionConfig(),
+        model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+    )
+    foo_sql_file = tmp_path / "models" / "foo.sql"
+    foo_sql_file.write_text(
+        "MODEL (name sqlmesh_example.foo); SELECT array_col FROM sqlmesh_example.bar;"
+    )
+    bar_sql_file = tmp_path / "models" / "bar.sql"
+    bar_sql_file.write_text(
+        "MODEL (name sqlmesh_example.bar); SELECT array_col FROM external_table;"
+    )
+
+    context = Context(paths=tmp_path, config=config)
+
+    input_queries = {"sqlmesh_example.bar": "SELECT ['value1', 'value2'] AS array_col"}
+
+    context.create_test(
+        "sqlmesh_example.foo",
+        input_queries=input_queries,
+        overwrite=True,
+        variables={"start": "2020-01-01", "end": "2024-01-01"},
+    )
+
+    test = load_yaml(context.path / c.TESTS / "test_foo.yaml")
+
+    assert len(test) == 1
+    assert "test_foo" in test
+    assert "vars" in test["test_foo"]
+    assert test["test_foo"]["inputs"] == {
+        "sqlmesh_example.bar": [{"array_col": ["value1", "value2"]}]
+    }
+    assert test["test_foo"]["outputs"] == {"query": [{"array_col": ["value1", "value2"]}]}


### PR DESCRIPTION
Array columns in input queries are returned with the `np.ndarray` type from an engine adapter's fetchdf() function. This PR converts them into Python lists so ruamel and sqlglot can handle them.