### PR TITLE
Feat!: Infer column types in the same manner as dbt does when converting dbt seeds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
             "beautifulsoup4",
             "black==24.1.1",
             "cryptography~=41.0.7",
+            "dbt_common",
             "dbt-core",
             "dbt-duckdb>=1.7.1",
             "Faker",
@@ -113,6 +114,7 @@ setup(
         ],
         "dbt": [
             "dbt-core<2",
+            "dbt_common",
         ],
         "gcppostgres": [
             "cloud-sql-python-connector[pg8000]",

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
             "beautifulsoup4",
             "black==24.1.1",
             "cryptography~=41.0.7",
-            "dbt_common",
+            "dbt-common",
             "dbt-core",
             "dbt-duckdb>=1.7.1",
             "Faker",
@@ -114,7 +114,7 @@ setup(
         ],
         "dbt": [
             "dbt-core<2",
-            "dbt_common",
+            "dbt-common",
         ],
         "gcppostgres": [
             "cloud-sql-python-connector[pg8000]",

--- a/sqlmesh/dbt/seed.py
+++ b/sqlmesh/dbt/seed.py
@@ -44,7 +44,7 @@ class SeedConfig(BaseModelConfig):
 
 
 class Integer(agate.data_types.DataType):
-    def cast(self, d: str) -> int:
+    def cast(self, d: str) -> t.Optional[int]:
         if d is None:
             return d
         try:

--- a/sqlmesh/dbt/seed.py
+++ b/sqlmesh/dbt/seed.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import typing as t
 
+import agate
+from dbt_common.clients import agate_helper
+from sqlglot import exp
+
 from sqlmesh.core.model import Model, SeedKind, create_seed_model
 from sqlmesh.dbt.basemodel import BaseModelConfig
 
@@ -18,11 +22,51 @@ class SeedConfig(BaseModelConfig):
     General propreties, General configs, and For seeds sections.
     """
 
+    delimiter: str = ","
+
     def to_sqlmesh(self, context: DbtContext) -> Model:
         """Converts the dbt seed into a SQLMesh model."""
+        seed_path = self.path.absolute().as_posix()
+        kwargs = self.sqlmesh_model_kwargs(context)
+        if kwargs.get("columns") is None:
+            agate_table = agate_helper.from_csv(seed_path, [], delimiter=self.delimiter)
+            kwargs["columns"] = {
+                name: AGATE_TYPE_MAPPING[tpe.__class__]
+                for name, tpe in zip(agate_table.column_names, agate_table.column_types)
+            }
+
         return create_seed_model(
             self.canonical_name(context),
-            SeedKind(path=self.path.absolute().as_posix()),
+            SeedKind(path=seed_path),
             dialect=context.dialect,
-            **self.sqlmesh_model_kwargs(context),
+            **kwargs,
         )
+
+
+class Integer(agate.data_types.DataType):
+    def cast(self, d: str) -> int:
+        if d is None:
+            return d
+        try:
+            return int(d)
+        except ValueError:
+            raise agate.exceptions.CastError('Can not parse value "%s" as Integer.' % d)
+
+    def jsonify(self, d: str) -> str:
+        return d
+
+
+# The dbt version has a bug in which they check whether the type of the input value
+# is int, while the input value is actually always a string.
+agate_helper.Integer = Integer  # type: ignore
+
+
+AGATE_TYPE_MAPPING = {
+    agate_helper.Integer: exp.DataType.build("int"),
+    agate_helper.Number: exp.DataType.build("double"),
+    agate_helper.ISODateTime: exp.DataType.build("datetime"),
+    agate.Date: exp.DataType.build("date"),
+    agate.DateTime: exp.DataType.build("datetime"),
+    agate.Boolean: exp.DataType.build("boolean"),
+    agate.Text: exp.DataType.build("text"),
+}


### PR DESCRIPTION
This ensures that the original dbt behavior is preserved for seeds. Otherwise, projects that heavily rely on seeds and dbt's method of inferring column types can't be easily run with SQLMesh.