### PR TITLE
Fix: treat 'unknown' time_column fields as 'timestamp'

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1003,6 +1003,18 @@ class SqlModel(_SqlBasedModel):
                 for select in query.selects
             }
 
+            if self.time_column:
+                time_column_name = self.time_column.column.output_name
+                if self._columns_to_types[time_column_name] == exp.DataType.build(
+                    exp.DataType.Type.UNKNOWN
+                ):
+                    # if the user has specified a time column, but we cant detect its type - assume its a timestamp
+                    # if we assume its "unknown" then in practice gets treated like a string and the incremental model delete queries
+                    # will happily try to filter a timestamp column based on a string literal, which is invalid in some engines
+                    self._columns_to_types[time_column_name] = exp.DataType.build(
+                        exp.DataType.Type.TIMESTAMP
+                    )
+
         if "*" in self._columns_to_types:
             return None
 

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -20,7 +20,7 @@ from sqlmesh.utils.metaprogramming import Executable
 def model() -> Model:
     return create_sql_model(
         "db.test_model",
-        parse_one("SELECT a, b, ds"),
+        parse_one("SELECT a, b, ds::varchar"),
         kind=IncrementalByTimeRangeKind(time_column="ds"),
     )
 
@@ -29,7 +29,7 @@ def model() -> Model:
 def model_default_catalog() -> Model:
     return create_sql_model(
         "db.test_model",
-        parse_one("SELECT a, b, ds"),
+        parse_one("SELECT a, b, ds::varchar"),
         kind=IncrementalByTimeRangeKind(time_column="ds"),
         default_catalog="test_catalog",
     )

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1373,14 +1373,16 @@ def test_parse(assert_exp_eq):
 
         SELECT
           id::INT AS id,
-          ds
+          ds,
+          foo
         FROM x
         WHERE ds BETWEEN '{{ start_ds }}' AND @end_ds
     """
     )
     model = load_sql_based_model(expressions, dialect="hive")
     assert model.columns_to_types == {
-        "ds": exp.DataType.build("unknown"),
+        "foo": exp.DataType.build("unknown"),
+        "ds": exp.DataType.build("timestamp"),
         "id": exp.DataType.build("int"),
     }
     assert not model.annotated
@@ -1392,7 +1394,8 @@ def test_parse(assert_exp_eq):
         """
       SELECT
         CAST("id" AS INT) AS "id",
-        "ds" AS "ds"
+        "ds" AS "ds",
+        "foo" AS "foo"
       FROM "x" AS "x"
       WHERE
         "ds" BETWEEN '1970-01-01' AND '1970-01-01'


### PR DESCRIPTION
Given a model like:

```
        MODEL (
            name test_table,
            kind INCREMENTAL_BY_TIME_RANGE(
                time_column ds,
            )
        );

        SELECT ds from some_other_table
```

If the type of `ds` cant be determined, it defaults to `Type.UNKNOWN`. However, as a user I _know_ that `ds` is a timestamp column - its the whole reason why its specified as the `time_column` of my model.

The problem with defaulting to `Type.UNKNOWN` (at least on the Trino adapter) is that when applying intervals, sqlmesh starts generating invalid queries like:

`DELETE FROM test_table WHERE ds BETWEEN '2024-03-20' AND '2024-03-21'`

Which causes the query engine to throw errors like:

`Cannot check if timestamp(6) is BETWEEN varchar(10) and varchar(10)`

If the column is detected as a `timestamp` instead of `unknown`, the correct query is generated:

`DELETE FROM test_table WHERE ds BETWEEN CAST('2024-03-20 00:00:00' AS TIMESTAMP) AND CAST('2024-03-20 23:59:59.999999' AS TIMESTAMP)`

Can you guys see an issue with defaulting the `time_column` to `Type.TIMESTAMP` if its type couldn't be automatically detected? It would certainly help my use-case out a lot.

Note that I cant just change the query to `select cast(ds as timestamp) as ds` because in Trino's case it can prevent predicate pushdown to the underlying connector and trigger a table scan which I definitely dont want