### PR TITLE
Feat: improve unit test failure reporting when rows are missing

### DIFF
--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -99,7 +99,6 @@ SELECT
 FROM
     sqlmesh_example.incremental_model
 GROUP BY item_id
-ORDER BY item_id
 ```
 
 Notice how the query of the model definition above references one upstream model: `sqlmesh_example.incremental_model`.
@@ -111,16 +110,16 @@ test_example_full_model:
   model: sqlmesh_example.full_model
   inputs:
     sqlmesh_example.incremental_model:
-        rows:
-        - id: 1
-          item_id: 1
-          ds: '2020-01-01'
-        - id: 2
-          item_id: 1
-          ds: '2020-01-02'
-        - id: 3
-          item_id: 2
-          ds: '2020-01-03'
+      rows:
+      - id: 1
+        item_id: 1
+        event_date: '2020-01-01'
+      - id: 2
+        item_id: 1
+        event_date: '2020-01-02'
+      - id: 3
+        item_id: 2
+        event_date: '2020-01-03'
   outputs:
     query:
       rows:
@@ -130,7 +129,7 @@ test_example_full_model:
         num_orders: 1
 ```
 
-The `ds` column is not needed in the above test, since it is not referenced in `full_model`, so it may be omitted.
+The `event_date` column is not needed in the above test, since it is not referenced in `full_model`, so it may be omitted.
 
 If we were only interested in testing the `num_orders` column, we could only specify input values for the `id` column of `sqlmesh_example.incremental_model`, thus rewriting the above test more compactly as follows:
 
@@ -167,11 +166,10 @@ WITH filtered_orders_cte AS (
 )
 SELECT
   item_id,
-  COUNT(distinct id) AS num_orders,
+  COUNT(DISTINCT id) AS num_orders,
 FROM
     filtered_orders_cte
 GROUP BY item_id
-ORDER BY item_id
 ```
 
 Below is the example of a test that verifies individual rows returned by the `filtered_orders_cte` CTE before aggregation takes place:
@@ -184,13 +182,13 @@ test_example_full_model:
         rows:
         - id: 1
           item_id: 1
-          ds: '2020-01-01'
+          event_date: '2020-01-01'
         - id: 2
           item_id: 1
-          ds: '2020-01-02'
+          event_date: '2020-01-02'
         - id: 3
           item_id: 2
-          ds: '2020-01-03'
+          event_date: '2020-01-03'
   outputs:
     ctes:
       filtered_orders_cte:
@@ -219,22 +217,21 @@ In this example, we'll show how to generate a test for `sqlmesh_example.incremen
 MODEL (
     name sqlmesh_example.incremental_model,
     kind INCREMENTAL_BY_TIME_RANGE (
-        time_column ds
+        time_column event_date
     ),
     start '2020-01-01',
     cron '@daily',
-    grain (id, ds)
+    grain (id, event_date)
 );
 
 SELECT
     id,
     item_id,
-    ds,
+    event_date,
 FROM
     sqlmesh_example.seed_model
 WHERE
-    ds between @start_ds and @end_ds
-
+    event_date BETWEEN @start_date AND @end_date
 ```
 
 Firstly, we need to specify the input data for the upstream model `sqlmesh_example.seed_model`. The `create_test` command starts by executing a user-supplied query against the project's data warehouse and uses the returned data to produce the test's input rows.
@@ -245,14 +242,14 @@ For instance, the following query will return three rows from the table correspo
 SELECT * FROM sqlmesh_example.seed_model LIMIT 3
 ```
 
-Next, notice that `sqlmesh_example.incremental_model` contains a filter which references the `@start_ds` and `@end_ds` [macro variables](macros/macro_variables.md).
+Next, notice that `sqlmesh_example.incremental_model` contains a filter which references the `@start_date` and `@end_date` [macro variables](macros/macro_variables.md).
 
-To make the generated test deterministic and thus ensure that it will always succeed, we need to define these variables and modify the above query to constrain `ds` accordingly.
+To make the generated test deterministic and thus ensure that it will always succeed, we need to define these variables and modify the above query to constrain `event_date` accordingly.
 
-If we set `@start_ds` to `'2020-01-01'` and `@end_ds` to `'2020-01-04'`, the above query needs to be changed to:
+If we set `@start_date` to `'2020-01-01'` and `@end_date` to `'2020-01-04'`, the above query needs to be changed to:
 
 ```sql linenums="1"
-SELECT * FROM sqlmesh_example.seed_model WHERE ds BETWEEN '2020-01-01' AND '2020-01-04' LIMIT 3
+SELECT * FROM sqlmesh_example.seed_model WHERE event_date BETWEEN '2020-01-01' AND '2020-01-04' LIMIT 3
 ```
 
 Finally, combining this query with the proper macro variable definitions, we can compute the expected output for the model's query in order to generate the complete test.
@@ -260,7 +257,7 @@ Finally, combining this query with the proper macro variable definitions, we can
 This can be achieved using the following command:
 
 ```
-$ sqlmesh create_test sqlmesh_example.incremental_model --query sqlmesh_example.seed_model "select * from sqlmesh_example.seed_model where ds between '2020-01-01' and '2020-01-04' limit 3" --var start '2020-01-01' --var end '2020-01-04'
+$ sqlmesh create_test sqlmesh_example.incremental_model --query sqlmesh_example.seed_model "SELECT * FROM sqlmesh_example.seed_model WHERE event_date BETWEEN '2020-01-01' AND '2020-01-04' LIMIT 3" --var start '2020-01-01' --var end '2020-01-04'
 ```
 
 Running this creates the following new test, located at `tests/test_incremental_model.yaml`:
@@ -272,24 +269,24 @@ test_incremental_model:
     sqlmesh_example.seed_model:
     - id: 1
       item_id: 2
-      ds: '2020-01-01'
+      event_date: 2020-01-01
     - id: 2
       item_id: 1
-      ds: '2020-01-01'
+      event_date: 2020-01-01
     - id: 3
       item_id: 3
-      ds: '2020-01-03'
+      event_date: 2020-01-03
   outputs:
     query:
     - id: 1
       item_id: 2
-      ds: '2020-01-01'
+      event_date: 2020-01-01
     - id: 2
       item_id: 1
-      ds: '2020-01-01'
+      event_date: 2020-01-01
     - id: 3
       item_id: 3
-      ds: '2020-01-03'
+      event_date: 2020-01-03
   vars:
     start: '2020-01-01'
     end: '2020-01-04'

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -14,6 +14,7 @@ Tests within a suite file contain the following attributes:
 
 * The unique name of a test
 * The name of the model targeted by this test
+* [Optional] The test's description
 * Test inputs, which are defined per upstream model or external table referenced by the target model. Each test input consists of the following:
     * The name of an upstream model or external table
     * The list of rows defined as a mapping from a column name to a value associated with it
@@ -28,6 +29,7 @@ The YAML format is defined as follows:
 ```yaml linenums="1"
 <unique_test_name>:
   model: <target_model_name>
+  description: <description>  # Optional
   inputs:
     <upstream_model_or_external_table_name>:
       rows:
@@ -49,7 +51,7 @@ The YAML format is defined as follows:
 
 The `rows` key is optional in the above format, so the following would also be valid:
 
-```
+```yaml linenums="1"
 <unique_test_name>:
   model: <target_model_name>
   inputs:
@@ -257,7 +259,7 @@ Finally, combining this query with the proper macro variable definitions, we can
 
 This can be achieved using the following command:
 
-```bash
+```
 $ sqlmesh create_test sqlmesh_example.incremental_model --query sqlmesh_example.seed_model "select * from sqlmesh_example.seed_model where ds between '2020-01-01' and '2020-01-04' limit 3" --var start '2020-01-01' --var end '2020-01-04'
 ```
 
@@ -295,7 +297,7 @@ test_incremental_model:
 
 As shown below, we now have two passing tests. Hooray!
 
-```bash
+```
 $ sqlmesh test
 .
 ----------------------------------------------------------------------
@@ -314,7 +316,7 @@ Tests run automatically every time a new [plan](plans.md) is created.
 
 You can execute tests on demand using the `sqlmesh test` command as follows:
 
-```bash
+```
 $ sqlmesh test
 .
 ----------------------------------------------------------------------
@@ -325,13 +327,13 @@ OK
 
 The command returns a non-zero exit code if there are any failures, and reports them in the standard error stream:
 
-```bash
+```
 $ sqlmesh test
 F
 ======================================================================
 FAIL: test_example_full_model (test/tests/test_full_model.yaml)
 ----------------------------------------------------------------------
-AssertionError: Data differs (exp: expected, act: actual)
+AssertionError: Data mismatch (exp: expected, act: actual)
 
   num_orders
          exp  act
@@ -349,12 +351,12 @@ Note: when there are many differing columns, the corresponding DataFrame will be
 
 To run a specific model test, pass in the suite file name followed by `::` and the name of the test:
 
-```bash
+```
 $ sqlmesh test tests/test_full_model.yaml::test_example_full_model
 ```
 
 You can also run tests that match a pattern or substring using a glob pathname expansion syntax:
 
-```bash
+```
 $ sqlmesh test tests/test_*
 ```

--- a/sqlmesh/cli/example_project.py
+++ b/sqlmesh/cli/example_project.py
@@ -70,7 +70,7 @@ EXAMPLE_FULL_MODEL_DEF = f"""MODEL (
 
 SELECT
   item_id,
-  count(distinct id) AS num_orders,
+  COUNT(DISTINCT id) AS num_orders,
 FROM
     {EXAMPLE_INCREMENTAL_MODEL_NAME}
 GROUP BY item_id
@@ -93,7 +93,7 @@ SELECT
 FROM
     {EXAMPLE_SEED_MODEL_NAME}
 WHERE
-    event_date between @start_date and @end_date
+    event_date BETWEEN @start_date AND @end_date
 """
 
 EXAMPLE_SEED_MODEL_DEF = f"""MODEL (

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing as t
 import unittest
+from collections import Counter
 from pathlib import Path
 
 import numpy as np
@@ -71,6 +72,9 @@ class ModelTest(unittest.TestCase):
 
         super().__init__()
 
+    def shortDescription(self) -> t.Optional[str]:
+        return self.body.get("description")
+
     def setUp(self) -> None:
         """Load all input tables"""
         for table_name, values in self.body.get("inputs", {}).items():
@@ -93,7 +97,7 @@ class ModelTest(unittest.TestCase):
                     schema_(test_fixture_table.args["db"], test_fixture_table.args.get("catalog"))
                 )
 
-            df = self._create_df(rows, columns=columns_to_types)
+            df = _create_df(rows, columns=columns_to_types)
             self.engine_adapter.create_view(test_fixture_table, df, columns_to_types)
 
     def tearDown(self) -> None:
@@ -145,13 +149,27 @@ class ModelTest(unittest.TestCase):
                 actual,
                 check_dtype=False,
                 check_datetimelike_compat=True,
-                check_like=True,  # ignore column order
+                check_like=True,  # Ignore column order
             )
         except AssertionError as e:
-            diff = expected.compare(actual).rename(columns={"self": "exp", "other": "act"})
-            description = self.body.get("description")
-            description = f"\n\n\nTest description: {description}" if description else ""
-            e.args = (f"Data differs (exp: expected, act: actual)\n\n{diff}{description}",)
+            if expected.shape != actual.shape:
+                _raise_if_unknown_columns(expected.columns, actual.columns)
+
+                error_msg = "Data mismatch (rows are different)"
+
+                missing_rows = _row_difference(expected, actual)
+                if not missing_rows.empty:
+                    error_msg += f"\n\nMissing rows:\n\n{missing_rows}"
+
+                unexpected_rows = _row_difference(actual, expected)
+                if not unexpected_rows.empty:
+                    error_msg += f"\n\nUnexpected rows:\n\n{unexpected_rows}"
+
+                e.args = (error_msg,)
+            else:
+                diff = expected.compare(actual).rename(columns={"self": "exp", "other": "act"})
+                e.args = (f"Data mismatch (exp: expected, act: actual)\n\n{diff}",)
+
             raise e
 
     def runTest(self) -> None:
@@ -251,25 +269,6 @@ class ModelTest(unittest.TestCase):
             self.body["model"], default_catalog=self.default_catalog, dialect=dialect
         )
 
-    def _create_df(
-        self,
-        rows: t.List[Row],
-        columns: t.Optional[t.Iterable] = None,
-        partial: t.Optional[bool] = False,
-    ) -> pd.DataFrame:
-        if columns:
-            referenced_columns = {col for row in rows for col in row}
-            unknown_columns = [col for col in referenced_columns if col not in columns]
-            if unknown_columns:
-                expected_cols = f"Expected column(s): {', '.join(columns)}\n"
-                unknown_cols = f"Unknown column(s): {', '.join(unknown_columns)}"
-                _raise_error(f"Detected unknown column(s)\n\n{expected_cols}{unknown_cols}")
-
-            if partial:
-                columns = list(referenced_columns)
-
-        return pd.DataFrame.from_records(rows, columns=columns)
-
 
 class SqlModelTest(ModelTest):
     def _execute(self, query: exp.Expression) -> pd.DataFrame:
@@ -294,7 +293,7 @@ class SqlModelTest(ModelTest):
                 sort = cte_query.args.get("order") is None
 
                 actual = self._execute(cte_query)
-                expected = self._create_df(rows, columns=cte_query.named_selects, partial=partial)
+                expected = _create_df(rows, columns=cte_query.named_selects, partial=partial)
 
                 self.assert_equal(expected, actual, sort=sort, partial=partial)
 
@@ -324,7 +323,7 @@ class SqlModelTest(ModelTest):
             sort = query.args.get("order") is None
 
             actual = self._execute(query)
-            expected = self._create_df(rows, columns=self.model.columns_to_types, partial=partial)
+            expected = _create_df(rows, columns=self.model.columns_to_types, partial=partial)
 
             self.assert_equal(expected, actual, sort=sort, partial=partial)
 
@@ -380,7 +379,7 @@ class PythonModelTest(ModelTest):
 
             actual_df = self._execute_model()
             actual_df.reset_index(drop=True, inplace=True)
-            expected = self._create_df(rows, columns=self.model.columns_to_types, partial=partial)
+            expected = _create_df(rows, columns=self.model.columns_to_types, partial=partial)
 
             self.assert_equal(expected, actual_df, sort=False, partial=partial)
 
@@ -483,6 +482,49 @@ def generate_test(
     fixture_path.parent.mkdir(exist_ok=True, parents=True)
     with open(fixture_path, "w", encoding="utf-8") as file:
         yaml.dump({test_name: test_body}, file)
+
+
+def _create_df(
+    rows: t.List[Row], columns: t.Optional[t.Collection] = None, partial: t.Optional[bool] = False
+) -> pd.DataFrame:
+    if columns:
+        referenced_columns = {col for row in rows for col in row}
+        _raise_if_unknown_columns(columns, referenced_columns)
+
+        if partial:
+            columns = list(referenced_columns)
+
+    return pd.DataFrame.from_records(rows, columns=columns)
+
+
+def _raise_if_unknown_columns(
+    expected_cols: t.Collection[str], actual_cols: t.Collection[str]
+) -> None:
+    unique_expected_cols = set(expected_cols)
+    unknown_cols = [col for col in actual_cols if col not in unique_expected_cols]
+
+    if unknown_cols:
+        expected = f"Expected column(s): {', '.join(list(expected_cols))}\n"
+        unknown = f"Unknown column(s): {', '.join(unknown_cols)}"
+        _raise_error(f"Detected unknown column(s)\n\n{expected}{unknown}")
+
+
+def _row_difference(left: pd.DataFrame, right: pd.DataFrame) -> pd.DataFrame:
+    """Returns all rows in `left` that don't appear in `right`."""
+    rows_missing_from_right = []
+
+    # `None` replaces `np.nan` because `np.nan != np.nan` and this would affect the mapping lookup
+    right_row_count: t.MutableMapping[t.Tuple, int] = Counter(
+        right.replace({np.nan: None}).itertuples(index=False, name=None)
+    )
+    for left_row in left.replace({np.nan: None}).itertuples(index=False):
+        left_row_tuple = tuple(left_row)
+        if right_row_count[left_row_tuple] <= 0:
+            rows_missing_from_right.append(left_row)
+        else:
+            right_row_count[left_row_tuple] -= 1
+
+    return pd.DataFrame(rows_missing_from_right)
 
 
 def _fully_qualified_test_fixture_table(name: str, dialect: str | None) -> exp.Table:

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -153,7 +153,7 @@ class ModelTest(unittest.TestCase):
             )
         except AssertionError as e:
             if expected.shape != actual.shape:
-                _raise_if_unknown_columns(expected.columns, actual.columns)
+                _raise_if_unexpected_columns(expected.columns, actual.columns)
 
                 error_msg = "Data mismatch (rows are different)"
 
@@ -489,7 +489,7 @@ def _create_df(
 ) -> pd.DataFrame:
     if columns:
         referenced_columns = {col for row in rows for col in row}
-        _raise_if_unknown_columns(columns, referenced_columns)
+        _raise_if_unexpected_columns(columns, referenced_columns)
 
         if partial:
             columns = list(referenced_columns)
@@ -497,7 +497,7 @@ def _create_df(
     return pd.DataFrame.from_records(rows, columns=columns)
 
 
-def _raise_if_unknown_columns(
+def _raise_if_unexpected_columns(
     expected_cols: t.Collection[str], actual_cols: t.Collection[str]
 ) -> None:
     unique_expected_cols = set(expected_cols)

--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -356,13 +356,8 @@ def pandas_timestamp_to_pydatetime(
                 exp.DataType.Type.DATE32,
             ):
                 # Sometimes `to_pydatetime()` has already converted to date, so we only extract from datetime objects.
-                # `datetime` is a subclass of `date`, so we must look at the type to differentiate the two.
                 df[column] = df[column].map(
-                    lambda x: (
-                        x.date()
-                        if isinstance(x, datetime) and type(x) is datetime and not pd.isna(x)
-                        else x
-                    )
+                    lambda x: x.date() if type(x) is datetime and not pd.isna(x) else x
                 )
 
     return df

--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -554,6 +554,6 @@ def test_test_failure(project_context: Context) -> None:
         {
             "name": "test_foo",
             "path": "tests/test_foo.yaml",
-            "tb": "AssertionError: Data differs (exp: expected, act: actual)\n\n   ds    \n  exp act\n0   2   1\n",
+            "tb": "AssertionError: Data mismatch (exp: expected, act: actual)\n\n   ds    \n  exp act\n0   2   1\n",
         }
     ]


### PR DESCRIPTION
Fixes sixth item in https://github.com/TobikoData/sqlmesh/issues/1637