### PR TITLE
fix: include dialect when extracting macro references

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1479,7 +1479,9 @@ def load_sql_based_model(
     if query_or_seed_insert is not None and isinstance(
         query_or_seed_insert, (exp.Query, d.JinjaQuery)
     ):
-        jinja_macro_references.update(extract_macro_references(query_or_seed_insert.sql()))
+        jinja_macro_references.update(
+            extract_macro_references(query_or_seed_insert.sql(dialect=dialect))
+        )
         return create_sql_model(
             name,
             query_or_seed_insert,


### PR DESCRIPTION
Includes dialect when parsing SQL in case it contains dialect specific SQL inside. 

Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1711390457509869

Repro: `parse_one("select object_construct('key1', 'value1') as good_column").sql()` 
Error: `Error: Name needs to be a string or an Identifier, got: <class 'sqlglot.expressions.Literal'>`

Works: `parse_one("select object_construct('key1', 'value1') as good_column").sql(dialect="snowflake")` 