### PR TITLE
fix!: fix time_data_type serialization/deserialization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=23.0.3",
+        "sqlglot[rs]~=23.2.0",
     ],
     extras_require={
         "bigquery": [

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -444,6 +444,40 @@ def test_json_serde():
     assert deserialized_model == model
 
 
+def test_scd_type_2_by_col_serde():
+    expressions = parse(
+        """
+        MODEL(
+            name test_model,
+            KIND SCD_TYPE_2_BY_COLUMN (
+                unique_key a,
+                columns *,
+            ),
+            cron '@daily',
+            owner 'reakman',
+            grain a,
+            dialect bigquery
+        );
+
+        SELECT a, ds FROM `tbl`
+    """,
+        default_dialect="bigquery",
+    )
+
+    model = load_sql_based_model(expressions)
+
+    model_json = model.json()
+    model_json_parsed = json.loads(model.json())
+    assert model_json_parsed["kind"]["dialect"] == "bigquery"
+    assert model_json_parsed["kind"]["unique_key"] == ["`a`"]
+    assert model_json_parsed["kind"]["columns"] == "*"
+    # Bigquery converts TIMESTAMP -> DATETIME
+    assert model_json_parsed["kind"]["time_data_type"] == "DATETIME"
+
+    deserialized_model = SqlModel.parse_raw(model_json)
+    assert deserialized_model.dict() == model.dict()
+
+
 def test_column_descriptions(sushi_context, assert_exp_eq):
     assert sushi_context.models[
         '"memory"."sushi"."customer_revenue_by_day"'


### PR DESCRIPTION
The bug described here is what would happen prior to this PR: https://github.com/TobikoData/sqlmesh/pull/2318

This PR is expected to fix this behavior. I was able to repro the bugged behavior locally and it did fix that. I also verified scd type 2 column BQ integration still passes. The added test would fail with past behavior but now works.

Breaking because it depends on a minor bump of SQLGlot. 

Depends on: https://github.com/tobymao/sqlglot/pull/3220