### PR TITLE
Fix: Use a correct deoployability index when running the scheduler against non-prod environments

### DIFF
--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -5,6 +5,7 @@ import traceback
 import typing as t
 from datetime import datetime
 
+from sqlmesh.core import constants as c
 from sqlmesh.core.console import Console, get_console
 from sqlmesh.core.environment import EnvironmentNamingInfo
 from sqlmesh.core.model import SeedModel
@@ -243,7 +244,11 @@ class Scheduler:
         else:
             environment_naming_info = environment
 
-        deployability_index = deployability_index or DeployabilityIndex.all_deployable()
+        deployability_index = deployability_index or (
+            DeployabilityIndex.create(self.snapshots.values())
+            if environment_naming_info.name != c.PROD
+            else DeployabilityIndex.all_deployable()
+        )
         execution_time = execution_time or now()
         batches = self.batches(
             start,


### PR DESCRIPTION
I've realized that deployability index would be wrong when running the `sqlmesh run` command against non-prod environments.