### PR TITLE
fix!: include end in metadata hash

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -755,6 +755,7 @@ class _Model(ModelMeta, frozen=True):
             json.dumps(self.column_descriptions, sort_keys=True),
             self.cron,
             str(self.start) if self.start else None,
+            str(self.end) if self.end else None,
             str(self.retention) if self.retention else None,
             str(self.batch_size) if self.batch_size is not None else None,
             json.dumps(self.mapping_schema, sort_keys=True),

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -606,7 +606,7 @@ def test_fingerprint(model: Model, parent_model: Model):
 
     original_fingerprint = SnapshotFingerprint(
         data_hash="372035512",
-        metadata_hash="3575901791",
+        metadata_hash="490962550",
     )
 
     assert fingerprint == original_fingerprint
@@ -666,7 +666,7 @@ def test_fingerprint_seed_model():
 
     expected_fingerprint = SnapshotFingerprint(
         data_hash="2156038176",
-        metadata_hash="3058233394",
+        metadata_hash="3304326900",
     )
 
     model = load_sql_based_model(expressions, path=Path("./examples/sushi/models/test_model.sql"))
@@ -705,7 +705,7 @@ def test_fingerprint_jinja_macros(model: Model):
     )
     original_fingerprint = SnapshotFingerprint(
         data_hash="900027747",
-        metadata_hash="3575901791",
+        metadata_hash="490962550",
     )
 
     fingerprint = fingerprint_from_node(model, nodes={})


### PR DESCRIPTION
Missed in the original PR: https://github.com/TobikoData/sqlmesh/pull/2287

Breaking because we need to calculate new fingerprints. 