### PR TITLE
fix: indent yaml in github workflow example

### DIFF
--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -205,12 +205,12 @@ The GitHub Actions workflow needs to be updated to trigger the action based on i
 on:
   pull_request:
     types:
-    - synchronize
-    - opened
+      - synchronize
+      - opened
   # Required if using comments to issue commands to the bot
   issue_comment:
     types:
-    - created
+      - created
 ```
 
 ### Desynchronized Production Code and Data Configuration


### PR DESCRIPTION
This missing indentation causes the deploy command not to work as expected and default to auto merge behaviour. It can be difficult to spot when you copy and paste the example from the doc.