### PR TITLE
fix: ensure start if using end

### DIFF
--- a/sqlmesh/core/node.py
+++ b/sqlmesh/core/node.py
@@ -258,7 +258,11 @@ class _Node(PydanticModel):
                 raise ConfigError(
                     f"Interval unit of '{interval_unit}' is larger than cron period of '{cron}'"
                 )
-        validate_date_range(values.get("start"), values.get("end"))
+        start = values.get("start")
+        end = values.get("end")
+        if end is not None and start is None:
+            raise ConfigError("Must define a start date if an end date is defined.")
+        validate_date_range(start, end)
         return values
 
     @property

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -3323,3 +3323,22 @@ def test_end_date():
             """
             )
         )
+
+
+def test_end_no_start():
+    expressions = d.parse(
+        f"""
+        MODEL (
+            name db.table,
+            kind INCREMENTAL_BY_TIME_RANGE (
+                time_column ts,
+            ),
+            end '2023-06-01'
+        );
+
+        SELECT 1::int AS a, 2::int AS b, now::timestamp as ts
+        """
+    )
+    with pytest.raises(ConfigError, match="Must define a start date if an end date is defined"):
+        load_sql_based_model(expressions)
+    load_sql_based_model(expressions, defaults={"start": "2023-01-01"})


### PR DESCRIPTION
Prior to this PR a user would get validation error if defining an end without start that wasn't clear on the issue. This validates prior to the actual value validation if an end is defined without a start and gives a more clear error.

I think requiring start with end seems reasonable. Open to other thoughts though. 