### PR TITLE
feat: make cicd bot output verbose

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1587,9 +1587,9 @@ class GenericContext(BaseContext, t.Generic[C]):
         for path in self.configs:
             rmtree(path / c.CACHE)
 
-    def _run_tests(self) -> t.Tuple[unittest.result.TestResult, str]:
+    def _run_tests(self, verbose: bool = False) -> t.Tuple[unittest.result.TestResult, str]:
         test_output_io = StringIO()
-        result = self.test(stream=test_output_io)
+        result = self.test(stream=test_output_io, verbose=verbose)
         return result, test_output_io.getvalue()
 
     def _run_plan_tests(

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -456,7 +456,7 @@ class GithubController:
         """
         Run tests for the PR
         """
-        return self._context._run_tests()
+        return self._context._run_tests(verbose=True)
 
     def _get_or_create_comment(self, header: str = BOT_HEADER_MSG) -> IssueComment:
         comment = seq_get(

--- a/tests/integrations/github/cicd/test_github_commands.py
+++ b/tests/integrations/github/cicd/test_github_commands.py
@@ -68,7 +68,9 @@ def test_run_all_success_with_approvers_approved(
         github_client,
         bot_config=GithubCICDBotConfig(invalidate_environment_after_deploy=False),
     )
-    controller._context._run_tests = mocker.MagicMock(side_effect=lambda: (TestResult(), ""))
+    controller._context._run_tests = mocker.MagicMock(
+        side_effect=lambda **kwargs: (TestResult(), "")
+    )
     controller._context.users = [
         User(username="test", github_username="test_github", roles=[UserRole.REQUIRED_APPROVER])
     ]
@@ -193,7 +195,9 @@ def test_run_all_success_with_approvers_approved_merge_delete(
         github_client,
         bot_config=GithubCICDBotConfig(merge_method=MergeMethod.REBASE),
     )
-    controller._context._run_tests = mocker.MagicMock(side_effect=lambda: (TestResult(), ""))
+    controller._context._run_tests = mocker.MagicMock(
+        side_effect=lambda **kwargs: (TestResult(), "")
+    )
     controller._context.users = [
         User(username="test", github_username="test_github", roles=[UserRole.REQUIRED_APPROVER])
     ]
@@ -320,7 +324,9 @@ def test_run_all_missing_approval(
         github_client,
         bot_config=GithubCICDBotConfig(invalidate_environment_after_deploy=False),
     )
-    controller._context._run_tests = mocker.MagicMock(side_effect=lambda: (TestResult(), ""))
+    controller._context._run_tests = mocker.MagicMock(
+        side_effect=lambda **kwargs: (TestResult(), "")
+    )
     controller._context.users = [
         User(username="test", github_username="test_github", roles=[UserRole.REQUIRED_APPROVER])
     ]
@@ -440,7 +446,7 @@ def test_run_all_test_failed(
     test_result = TestResult()
     test_result.addFailure(TestCase(), (None, None, None))
     controller._context._run_tests = mocker.MagicMock(
-        side_effect=lambda: (test_result, "some error")
+        side_effect=lambda **kwargs: (test_result, "some error")
     )
     controller._context.users = [
         User(username="test", github_username="test_github", roles=[UserRole.REQUIRED_APPROVER])
@@ -561,7 +567,9 @@ def test_pr_update_failure(
         github_client,
         bot_config=GithubCICDBotConfig(merge_method=MergeMethod.REBASE),
     )
-    controller._context._run_tests = mocker.MagicMock(side_effect=lambda: (TestResult(), ""))
+    controller._context._run_tests = mocker.MagicMock(
+        side_effect=lambda **kwargs: (TestResult(), "")
+    )
     controller._context.users = [
         User(username="test", github_username="test_github", roles=[UserRole.REQUIRED_APPROVER])
     ]
@@ -681,7 +689,9 @@ def test_prod_update_failure(
         github_client,
         bot_config=GithubCICDBotConfig(merge_method=MergeMethod.REBASE),
     )
-    controller._context._run_tests = mocker.MagicMock(side_effect=lambda: (TestResult(), ""))
+    controller._context._run_tests = mocker.MagicMock(
+        side_effect=lambda **kwargs: (TestResult(), "")
+    )
     controller._context.users = [
         User(username="test", github_username="test_github", roles=[UserRole.REQUIRED_APPROVER])
     ]
@@ -815,7 +825,9 @@ def test_comment_command_invalid(
         github_client,
         bot_config=GithubCICDBotConfig(merge_method=MergeMethod.REBASE),
     )
-    controller._context._run_tests = mocker.MagicMock(side_effect=lambda: (TestResult(), ""))
+    controller._context._run_tests = mocker.MagicMock(
+        side_effect=lambda **kwargs: (TestResult(), "")
+    )
     controller._context.users = [
         User(username="test", github_username="test_github", roles=[UserRole.REQUIRED_APPROVER])
     ]
@@ -882,7 +894,9 @@ def test_comment_command_deploy_prod(
         github_client,
         bot_config=GithubCICDBotConfig(merge_method=MergeMethod.REBASE, enable_deploy_command=True),
     )
-    controller._context._run_tests = mocker.MagicMock(side_effect=lambda: (TestResult(), ""))
+    controller._context._run_tests = mocker.MagicMock(
+        side_effect=lambda **kwargs: (TestResult(), "")
+    )
     controller._context.users = [
         User(username="test", github_username="test_github", roles=[UserRole.REQUIRED_APPROVER])
     ]
@@ -1002,7 +1016,9 @@ def test_comment_command_deploy_prod_not_enabled(
         github_client,
         bot_config=GithubCICDBotConfig(merge_method=MergeMethod.REBASE),
     )
-    controller._context._run_tests = mocker.MagicMock(side_effect=lambda: (TestResult(), ""))
+    controller._context._run_tests = mocker.MagicMock(
+        side_effect=lambda **kwargs: (TestResult(), "")
+    )
     controller._context.users = []
     controller._context.invalidate_environment = mocker.MagicMock()
 


### PR DESCRIPTION
Prior this to change test summaries in the CI/CD bot would have columns truncated. This matches plan behavior. In plan though I am in the CLI itself so it not a big deal to just run the test again from cli to get the full output. WIthin Github that interactivity is not available so it seems better to default to showing more than not enough. 

I decided to just make this the new default behavior and see if we can avoid a config flag to change it. Also I'm not calling this breaking, despite being a behavior change, since it is a non-functional behavior change. 