### PR TITLE
Feat: allow partial to be for every output in a test

### DIFF
--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -76,9 +76,16 @@ Additionally, it's possible to test only a subset of the output columns by setti
           ...
 ```
 
-This is useful when we can't treat the missing columns as `NULL`, but still want to ignore them.
+This is useful when we can't treat the missing columns as `NULL`, but still want to ignore them. In order to apply this setting to _all_ outputs, simply set it directly under the `outputs` key:
 
-When `partial` is set, the rows need to be defined as a mapping under the `rows` key and the tested columns are only those that are referenced in them.
+```yaml linenums="1"
+  ...
+  outputs:
+    partial: true
+    ...
+```
+
+When `partial` is set for a _specific_ output, its rows need to be defined as a mapping under the `rows` key and only the columns referenced in them will be tested.
 
 ### Example
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -76,7 +76,7 @@ Additionally, it's possible to test only a subset of the output columns by setti
           ...
 ```
 
-This is useful when we can't treat the missing columns as `NULL`, but still want to ignore them. In order to apply this setting to _all_ outputs, simply set it directly under the `outputs` key:
+This is useful when we can't treat the missing columns as `NULL`, but still want to ignore them. In order to apply this setting to _all_ outputs, simply set it under the `outputs` key:
 
 ```yaml linenums="1"
   ...

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -357,14 +357,13 @@ test_foo:
         b: 6
         c: 7
   outputs:
+    partial: true  # Applies to all outputs
     ctes:
       t:
-        partial: true
         rows:
           - c: 3
           - c: 7
     query:
-      partial: true
       rows:
         - a: 1
           b: 2
@@ -378,6 +377,43 @@ test_foo:
     ).run()
 
     _check_successful_or_raise(result)
+
+    result = _create_test(
+        body=load_yaml(
+            """
+test_foo:
+  model: sushi.foo
+  inputs:
+    raw:
+      - a: 1
+        b: 2
+        c: 3
+        d: 4
+      - a: 5
+        b: 6
+        c: 7
+  outputs:
+    ctes:
+      t:
+        partial: true
+        rows:
+          - c: 3
+          - c: 7
+    query:
+      rows:
+        - a: 1
+          b: 2
+          c: 3
+          d: 4
+        - a: 5
+          b: 6
+          c: 7
+            """
+        ),
+        test_name="test_foo",
+        model=_create_model("WITH t AS (SELECT a, b, c, d FROM raw) SELECT a, b, c, d FROM t"),
+        context=Context(config=Config(model_defaults=ModelDefaultsConfig(dialect="duckdb"))),
+    ).run()
 
 
 def test_partial_data_column_order(sushi_context: Context) -> None:


### PR DESCRIPTION
This allows one to set `partial` in a single place and have it be applied to _every_ output fixture.