### PR TITLE
docs: fix docs for dag CLI

### DIFF
--- a/docs/guides/incremental_time.md
+++ b/docs/guides/incremental_time.md
@@ -71,7 +71,7 @@ It compares this set of 84 to the stored set of 60 that we already backfilled to
 
 SQLMesh has two different commands for processing data. If any model has been changed, [`sqlmesh plan`](../reference/cli.md#plan) is used to apply the change to data in a specific environment. If no models have changed, [`sqlmesh run`](../reference/cli.md#run) is used to execute the project's models.
 
-Data accumulation rates and freshness requirements may differ across models. If `sqlmesh run` ran every model whenever it was executed, all models would be held to the same freshness requirements as the most stringent model. This is inefficient and wastes computational resources (and money).
+Data accumulation rates and freshness requirements may differ across models. If `sqlmesh run` ran every model whenever the command was executed, all models would be held to the same freshness requirements as the most stringent model. This is inefficient and wastes computational resources (and money).
 
 Instead, you specify the [`cron` parameter](../concepts/models/overview.md#cron) for each model. `sqlmesh run` uses each model's `cron` to determine whether that model should be executed in a given run.
 

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -244,6 +244,6 @@ sudo apt-get install graphviz
 
 To view the DAG, enter the following command:
 
-`sqlmesh dag`
+`sqlmesh dag FILE`
 
-The generated files (.gv and .jpeg formats) will be placed at the root of your project folder.
+A file containing your project's DAG will be placed at the root of your project folder. Save this file using the `.html` extension and open it in your browser to view.

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -246,4 +246,4 @@ To view the DAG, enter the following command:
 
 `sqlmesh dag FILE`
 
-A file containing your project's DAG will be placed at the root of your project folder. Save this file using the `.html` extension and open it in your browser to view.
+An html file containing your project's DAG will be placed at the root of your project folder. The DAG can then be viewed by opening this file in your browser.

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1261,6 +1261,8 @@ class GenericContext(BaseContext, t.Generic[C]):
             path: filename to save the dag html to
             select_models: A list of model selection strings that should be included in the dag.
         """
+        if not path.endswith(".html"):
+            path += ".html"
 
         with open(path, "w", encoding="utf-8") as file:
             file.write(str(self.get_dag(select_models)))

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1261,8 +1261,14 @@ class GenericContext(BaseContext, t.Generic[C]):
             path: filename to save the dag html to
             select_models: A list of model selection strings that should be included in the dag.
         """
-        if not path.endswith(".html"):
-            path += ".html"
+        file_path = Path(path)
+        suffix = file_path.suffix
+        if suffix != ".html":
+            if suffix:
+                logger.warning(
+                    f"The extension {suffix} does not designate an html file. A file with a `.html` extension will be created instead."
+                )
+            path = str(file_path.with_suffix(".html"))
 
         with open(path, "w", encoding="utf-8") as file:
             file.write(str(self.get_dag(select_models)))


### PR DESCRIPTION
Documentation for the `sqlmesh dag` CLI on the models guide was incorrect and contradicted documentation for the command in other places. Also, a minor change to incremental time guide: in that sentence 'it' could refer to the model or the command so I made it explicit