### PR TITLE
fix: correctly skip loading archived snapshots

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -771,6 +771,9 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         Returns:
             A list of all the missing intervals as epoch timestamps.
         """
+        # If the node says that it has an end, and we are wanting to load past it, then we can return no empty intervals
+        if self.node.end and to_datetime(start) > to_datetime(self.node.end):
+            return []
         # If the amount of time being checked is less than the size of a single interval then we
         # know that there can't being missing intervals within that range and return
         validate_date_range(start, end)

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -273,3 +273,12 @@ def test_intervals_with_end_date_on_model(mocker: MockerFixture, make_snapshot):
     assert len(batches) == 10
     assert batches[0] == (to_datetime("2023-01-01"), to_datetime("2023-01-02"))
     assert batches[-1] == (to_datetime("2023-01-10"), to_datetime("2023-01-11"))
+
+    # generate for the last day of range
+    batches = scheduler.batches(start="2023-01-31", end="2023-01-31")[snapshot]
+    assert len(batches) == 1
+    assert batches[0] == (to_datetime("2023-01-31"), to_datetime("2023-02-01"))
+
+    # generate for future days to ensure no future batches are loaded
+    snapshot_to_batches = scheduler.batches(start="2023-02-01", end="2023-02-28")
+    assert len(snapshot_to_batches) == 0


### PR DESCRIPTION
Prior to this PR if you had a plan that required loading beyond a model's end date, for example catching up a group of models when deploying to prod since they fell behind, you would get an error saying that start cannot exceed end. 

This PR makes it so that cases where start > end then we will just return that there are no missing intervals. This should preserve the intended behavior of allowing these models to be active in dags, and potentially have changes, but never exceeding their desired end date. 