### PR TITLE
chore: improve recommended state sync documentation

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -147,14 +147,7 @@
 ## Databases/Engines
 
 ??? question "What databases/engines does SQLMesh work with?"
-    SQLMesh works with BigQuery, Databricks, DuckDB, MySQL, PostgreSQL, GCP PostgreSQL, Redshift, Snowflake, and Spark. See [this page](../integrations/overview.md) for more information.
-
-??? question "When would you use different databases for executing data transformations and storing state information?"
-    SQLMesh requires storing state information about projects and when their transformations were run. By default, it stores this information in the same database where the models run.
-
-    Unlike data transformations, storing state information requires database transactions. Some databases, like BigQuery, aren’t optimized for executing transactions, so storing state information in them can slow down your project. If this occurs, you can store state information in a different database, such as PostgreSQL, that executes transactions more efficiently.
-
-    Learn more about storing state information at the [configuration reference page](../reference/configuration.md#state-connection).
+    See [this page](../integrations/overview.md) for the list of currently supported engines.
 
 ## Scheduling
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -494,10 +494,26 @@ These pages describe the connection configuration options for each execution eng
 #### State connection
 
 Configuration for the state backend connection if different from the data warehouse connection.
+**Using the same connection for data warehouse and state is only recommended for non-production deployments of SQLMesh.**
+Unlike data transformations, storing state information requires database transactions. Data warehouses aren’t optimized for executing transactions, so storing state information in them can slow down your project. 
+Even worse data corruption can occur with simultaneous writes to the same table.
+Therefore, using your data warehouse is fine for testing but once you start running SQLMesh in production, you should use a dedicated state connection.
+
+Recommended state backend engines for production deployments:
+
+* [Postgres](../integrations/engines/postgres.md)
+* [GCP Postgres](../integrations/engines/gcp-postgres.md)
+
+Other supported state backend engines (less tested than recommended):
+
+* [MySQL](../integrations/engines/mysql.md)
+
+Ineligible state backends even for development:
+
+* [Spark](../integrations/engines/spark.md)
+* [Trino](../integrations/engines/trino.md)
 
 The data warehouse connection is used if the `state_connection` key is not specified, unless the configuration uses an Airflow or Google Cloud Composer scheduler. If using one of those schedulers and no state connection is specified, the state connection defaults to the scheduler's database.
-
-NOTE: Spark and Trino engines may not be used for the state connection.
 
 Example postgres state connection configuration:
 

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 class ConnectionConfig(abc.ABC, BaseConfig):
+    type_: str
     concurrent_tasks: int
     register_comments: bool
 
@@ -75,6 +76,11 @@ class ConnectionConfig(abc.ABC, BaseConfig):
     def _cursor_init(self) -> t.Optional[t.Callable[[t.Any], None]]:
         """A function that is called to initialize the cursor"""
         return None
+
+    @property
+    def is_recommended_for_state_sync(self) -> bool:
+        """Whether this connection is recommended for being used as a state sync for production state syncs"""
+        return False
 
     def create_engine_adapter(self, register_comments_override: bool = False) -> EngineAdapter:
         """Returns a new instance of the Engine Adapter."""
@@ -779,6 +785,11 @@ class GCPPostgresConnectionConfig(ConnectionConfig):
 
         return Connector().connect
 
+    @property
+    def is_recommended_for_state_sync(self) -> bool:
+        """Whether this connection is recommended for being used as a state sync for production state syncs"""
+        return True
+
 
 class RedshiftConnectionConfig(ConnectionConfig):
     """
@@ -915,6 +926,11 @@ class PostgresConnectionConfig(ConnectionConfig):
 
         return connect
 
+    @property
+    def is_recommended_for_state_sync(self) -> bool:
+        """Whether this connection is recommended for being used as a state sync for production state syncs"""
+        return True
+
 
 class MySQLConnectionConfig(ConnectionConfig):
     host: str
@@ -960,6 +976,11 @@ class MySQLConnectionConfig(ConnectionConfig):
         from mysql.connector import connect
 
         return connect
+
+    @property
+    def is_recommended_for_state_sync(self) -> bool:
+        """Whether this connection is recommended for being used as a state sync for production state syncs"""
+        return True
 
 
 class MSSQLConnectionConfig(ConnectionConfig):

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -36,6 +36,8 @@ else:
 
 logger = logging.getLogger(__name__)
 
+RECOMMENDED_STATE_SYNC_ENGINES = {"postgres", "gcp_postgres", "mysql"}
+
 
 class ConnectionConfig(abc.ABC, BaseConfig):
     type_: str
@@ -80,7 +82,7 @@ class ConnectionConfig(abc.ABC, BaseConfig):
     @property
     def is_recommended_for_state_sync(self) -> bool:
         """Whether this connection is recommended for being used as a state sync for production state syncs"""
-        return False
+        return self.type_ in RECOMMENDED_STATE_SYNC_ENGINES
 
     def create_engine_adapter(self, register_comments_override: bool = False) -> EngineAdapter:
         """Returns a new instance of the Engine Adapter."""
@@ -785,11 +787,6 @@ class GCPPostgresConnectionConfig(ConnectionConfig):
 
         return Connector().connect
 
-    @property
-    def is_recommended_for_state_sync(self) -> bool:
-        """Whether this connection is recommended for being used as a state sync for production state syncs"""
-        return True
-
 
 class RedshiftConnectionConfig(ConnectionConfig):
     """
@@ -926,11 +923,6 @@ class PostgresConnectionConfig(ConnectionConfig):
 
         return connect
 
-    @property
-    def is_recommended_for_state_sync(self) -> bool:
-        """Whether this connection is recommended for being used as a state sync for production state syncs"""
-        return True
-
 
 class MySQLConnectionConfig(ConnectionConfig):
     host: str
@@ -976,11 +968,6 @@ class MySQLConnectionConfig(ConnectionConfig):
         from mysql.connector import connect
 
         return connect
-
-    @property
-    def is_recommended_for_state_sync(self) -> bool:
-        """Whether this connection is recommended for being used as a state sync for production state syncs"""
-        return True
 
 
 class MSSQLConnectionConfig(ConnectionConfig):

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -81,7 +81,7 @@ class _EngineAdapterStateSyncSchedulerConfig(_SchedulerConfig):
             )
         if not state_connection.is_recommended_for_state_sync:
             logger.warning(
-                f"{state_connection.type_} is not recommended to be used as a state sync for production deployments. Please documentation ( https://sqlmesh.readthedocs.io/en/latest/guides/configuration/#state-connection) for list of recommended engines to be used for storing state and further details."
+                f"{state_connection.type_} is not recommended to be used as a state sync for production deployments. Please see documentation ( https://sqlmesh.readthedocs.io/en/latest/guides/configuration/#state-connection) for list of recommended engines to be used for storing state and further details."
             )
         schema = context.config.get_state_schema(context.gateway)
         return EngineAdapterStateSync(

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import logging
 import sys
 import typing as t
 
@@ -31,6 +32,9 @@ if sys.version_info >= (3, 9):
     from typing import Annotated, Literal
 else:
     from typing_extensions import Annotated, Literal
+
+
+logger = logging.getLogger(__name__)
 
 
 class _SchedulerConfig(abc.ABC):
@@ -66,12 +70,18 @@ class _SchedulerConfig(abc.ABC):
 
 class _EngineAdapterStateSyncSchedulerConfig(_SchedulerConfig):
     def create_state_sync(self, context: GenericContext) -> StateSync:
-        state_connection = context.config.get_state_connection(context.gateway)
-        engine_adapter = (state_connection or context._connection_config).create_engine_adapter()
+        state_connection = (
+            context.config.get_state_connection(context.gateway) or context._connection_config
+        )
+        engine_adapter = state_connection.create_engine_adapter()
         if not engine_adapter.SUPPORTS_ROW_LEVEL_OP:
             raise ConfigError(
                 f"The {engine_adapter.DIALECT.upper()} engine cannot be used to store SQLMesh state - please specify a different `state_connection` engine."
                 + " See https://sqlmesh.readthedocs.io/en/stable/reference/configuration/#gateways for more information."
+            )
+        if not state_connection.is_recommended_for_state_sync:
+            logger.warning(
+                f"{state_connection.type_} is not recommended to be used as a state sync for production deployments. Please documentation ( https://sqlmesh.readthedocs.io/en/latest/guides/configuration/#state-connection) for list of recommended engines to be used for storing state and further details."
             )
         schema = context.config.get_state_schema(context.gateway)
         return EngineAdapterStateSync(

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -8,6 +8,9 @@ from sqlmesh.core.config.connection import (
     BigQueryConnectionConfig,
     ConnectionConfig,
     DuckDBConnectionConfig,
+    GCPPostgresConnectionConfig,
+    MySQLConnectionConfig,
+    PostgresConnectionConfig,
     SnowflakeConnectionConfig,
     TrinoAuthenticationMethod,
     _connection_config_validator,
@@ -285,6 +288,7 @@ def test_trino(make_config):
     assert config.http_scheme == "https"
     assert config.port == 443
     assert config.get_catalog() == "catalog"
+    assert config.is_recommended_for_state_sync is False
 
     # Validate Basic Auth
     config = make_config(method="basic", password="password", **required_kwargs)
@@ -376,6 +380,7 @@ def test_duckdb(make_config):
         connector_config={"foo": "bar"},
     )
     assert isinstance(config, DuckDBConnectionConfig)
+    assert config.is_recommended_for_state_sync is False
 
 
 @pytest.mark.parametrize(
@@ -531,3 +536,40 @@ def test_bigquery(make_config):
     assert config.project == "project"
     assert config.execution_project == "execution_project"
     assert config.get_catalog() == "project"
+    assert config.is_recommended_for_state_sync is False
+
+
+def test_postgres(make_config):
+    config = make_config(
+        type="postgres",
+        host="host",
+        user="user",
+        password="password",
+        port=5432,
+        database="database",
+    )
+    assert isinstance(config, PostgresConnectionConfig)
+    assert config.is_recommended_for_state_sync is True
+
+
+def test_gcp_postgres(make_config):
+    config = make_config(
+        type="gcp_postgres",
+        instance_connection_string="something",
+        user="user",
+        password="password",
+        db="database",
+    )
+    assert isinstance(config, GCPPostgresConnectionConfig)
+    assert config.is_recommended_for_state_sync is True
+
+
+def test_mysql(make_config):
+    config = make_config(
+        type="mysql",
+        host="host",
+        user="user",
+        password="password",
+    )
+    assert isinstance(config, MySQLConnectionConfig)
+    assert config.is_recommended_for_state_sync is True


### PR DESCRIPTION
This PR improves the way we recommend that users use a separate state sync for production deployments in two ways:

* Moves information about this recommendation from FAQ to state connection configuration section
* More strongly emphasizes that this is recommended and explicitly lists what is recommended
* Warning log is output if not using the recommended state backend if in production