### PR TITLE
fix: don't load models if start is ahead of end

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -772,7 +772,10 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
             A list of all the missing intervals as epoch timestamps.
         """
         # If the node says that it has an end, and we are wanting to load past it, then we can return no empty intervals
-        if self.node.end and to_datetime(start) > to_datetime(self.node.end):
+        # Also if a node's start is after the end of the range we are checking then we can return no empty intervals
+        if (self.node.end and to_datetime(start) > to_datetime(self.node.end)) or (
+            self.node.start and to_datetime(self.node.start) > to_datetime(end)
+        ):
             return []
         # If the amount of time being checked is less than the size of a single interval then we
         # know that there can't being missing intervals within that range and return

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -1249,7 +1249,7 @@ def test_inclusive_exclusive_hourly(make_snapshot):
             owner="owner",
             dialect="",
             cron="@hourly",
-            start="1 week ago",
+            start="2023-01-29",
             query=parse_one("SELECT id, @end_ds as ds FROM name"),
         )
     )


### PR DESCRIPTION
Prior to this PR if a start was set on a model that exceeded the max that had been loaded to prod then you would get an error that start > end. Although this would likely be uncommon in practice, while testing it could happen if you created a project without a start and had a daily model and then tested out adding an hourly model. 

This change checks if the node start exceeds the set end and if so we don't return any missing intervals. This does mean that you could end up with an empty table in production but I believe this is fine.

Example:
I have daily models in production that have been running for a bit and have loaded through until 2024-01-01. It is now 5 PM the next day and I add a new hourly model that starts at noon that day (2024-01-02 12:00:00). I deploy this to prod. Prod has only been loaded through 2024-01-01 so this model is now effectively "ahead" of production. Therefore, the fact the table is empty is not a gap but rather correct since it is "ahead" of prod. You could obviously run which would then fill in the intervals for the model. 