### PR TITLE
chore: trigger renovate after github release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,26 @@ jobs:
           root: web/client
           paths:
             - dist
+  trigger_private_renovate:
+      docker: 
+        - image: cimg/base:2021.11
+      resource_class: small
+      steps:
+        - run:
+            name: Trigger private renovate
+            command: |
+              curl --request POST \
+                --url $TOBIKO_PRIVATE_CIRCLECI_URL \
+                --header "Circle-Token: $TOBIKO_PRIVATE_CIRCLECI_KEY" \
+                --header "content-type: application/json" \
+                --data '{
+                  "branch":"main",
+                  "parameters":{
+                    "run_main_pr":false, 
+                    "run_sqlmesh_commit":false, 
+                    "run_renovate":true
+                    }
+                }'
 
 workflows:
   setup-workflow:
@@ -75,6 +95,10 @@ workflows:
       - gh-release:
           <<: *on_tag_filter
       - ui-build:
+          <<: *on_tag_filter
+          requires:
+            - gh-release
+      - trigger_private_renovate:
           <<: *on_tag_filter
           requires:
             - gh-release


### PR DESCRIPTION
When a tag is pushed and published on github releases, this will emit a webhook to trigger an auto-bump of the core version in enterprise