### PR TITLE
Revert "Chore!: bump sqlglot to v23.6.3"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=23.6.3",
+        "sqlglot[rs]~=23.3.0",
     ],
     extras_require={
         "bigquery": [

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -87,6 +87,7 @@ class EngineAdapter:
     COMMENT_CREATION_VIEW = CommentCreationView.IN_SCHEMA_DEF_AND_COMMANDS
     MAX_TABLE_COMMENT_LENGTH: t.Optional[int] = None
     MAX_COLUMN_COMMENT_LENGTH: t.Optional[int] = None
+    ESCAPE_COMMENT_BACKSLASH = True
     INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.DELETE_INSERT
     SUPPORTS_MATERIALIZED_VIEWS = False
     SUPPORTS_MATERIALIZED_VIEW_SCHEMA = False
@@ -1919,14 +1920,22 @@ class EngineAdapter:
             return exp.Properties(expressions=properties)
         return None
 
-    def _truncate_comment(self, comment: str, length: t.Optional[int]) -> str:
+    def _truncate_comment(
+        self, comment: str, length: t.Optional[int], escape_backslash: bool = False
+    ) -> str:
+        if escape_backslash:
+            comment = comment.replace("\\", "\\\\")
         return comment[:length] if length else comment
 
     def _truncate_table_comment(self, comment: str) -> str:
-        return self._truncate_comment(comment, self.MAX_TABLE_COMMENT_LENGTH)
+        return self._truncate_comment(
+            comment, self.MAX_TABLE_COMMENT_LENGTH, self.ESCAPE_COMMENT_BACKSLASH
+        )
 
     def _truncate_column_comment(self, comment: str) -> str:
-        return self._truncate_comment(comment, self.MAX_COLUMN_COMMENT_LENGTH)
+        return self._truncate_comment(
+            comment, self.MAX_COLUMN_COMMENT_LENGTH, self.ESCAPE_COMMENT_BACKSLASH
+        )
 
     def _to_sql(self, expression: exp.Expression, quote: bool = True, **kwargs: t.Any) -> str:
         """

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -445,7 +445,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
             comment = column_comments.get(table_def["schema"]["fields"][i]["name"], None)
             if comment:
                 table_def["schema"]["fields"][i]["description"] = self._truncate_comment(
-                    comment, self.MAX_COLUMN_COMMENT_LENGTH
+                    comment, self.MAX_COLUMN_COMMENT_LENGTH, escape_backslash=False
                 )
 
         # An "etag" is BQ versioning metadata that changes when an object is updated/modified. `update_table`

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -221,11 +221,13 @@ class HiveMetastoreTablePropertiesMixin(EngineAdapter):
             return exp.Properties(expressions=properties)
         return None
 
-    def _truncate_comment(self, comment: str, length: t.Optional[int]) -> str:
+    def _truncate_comment(
+        self, comment: str, length: t.Optional[int], escape_backslash: bool = False
+    ) -> str:
         # iceberg and delta do not have a comment length limit
         if self.current_catalog_type in ("iceberg", "delta"):
             return comment
-        return super()._truncate_comment(comment, length)
+        return super()._truncate_comment(comment, length, escape_backslash)
 
 
 class GetCurrentCatalogFromFunctionMixin(EngineAdapter):

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -29,6 +29,7 @@ class PostgresEngineAdapter(
     HAS_VIEW_BINDING = True
     CURRENT_CATALOG_EXPRESSION = exp.column("current_catalog")
     SUPPORTS_REPLACE_TABLE = False
+    ESCAPE_COMMENT_BACKSLASH = False
 
     def _fetch_native_df(
         self, query: t.Union[exp.Expression, str], quote_identifiers: bool = False


### PR DESCRIPTION
Reverts TobikoData/sqlmesh#2382 to unblock releases. Will continue iterating locally to solved the CI issues.