### PR TITLE
Fix: Detection of broken model references when building a plan

### DIFF
--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -615,7 +615,7 @@ class PlanBuilder:
     def _ensure_no_broken_references(self) -> None:
         for snapshot in self._context_diff.snapshots.values():
             broken_references = {x.name for x in self._context_diff.removed_snapshots} & {
-                x.name for x in snapshot.parents
+                x for x in snapshot.node.depends_on
             }
             if broken_references:
                 broken_references_msg = ", ".join(f"'{x}'" for x in broken_references)

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -668,9 +668,7 @@ def test_broken_references(make_snapshot, mocker: MockerFixture):
     snapshot_a = make_snapshot(SqlModel(name="a", query=parse_one("select 1, ds")))
     snapshot_a.categorize_as(SnapshotChangeCategory.BREAKING)
 
-    snapshot_b = make_snapshot(
-        SqlModel(name="b", query=parse_one("select 2, ds FROM a")), nodes={'"a"': snapshot_a.node}
-    )
+    snapshot_b = make_snapshot(SqlModel(name="b", query=parse_one("select 2, ds FROM a")))
     snapshot_b.categorize_as(SnapshotChangeCategory.BREAKING)
 
     context_diff = ContextDiff(


### PR DESCRIPTION
Using `snapshot.parents` was incorrect for this check since the removed model wouldn't be present in the list of Snapshot parents (since there's no more snapshot), but is still available in the model's `depends_on` set.