### PR TITLE
Feat!: Support variables in native SQLMesh projects

### DIFF
--- a/docs/concepts/macros/jinja_macros.md
+++ b/docs/concepts/macros/jinja_macros.md
@@ -53,6 +53,46 @@ JINJA_END;
 
 ## User-defined variables
 
+SQLMesh supports two kinds of user-defined macro variables: global and local.
+
+Global macro variables are defined in the project configuration file and can be accessed in any project model.
+
+Local macro variables are defined in a model definition and can only be accessed in that model.
+
+### Global variables
+
+Learn more about defining global variables in the [SQLMesh macros documentation](./sqlmesh_macros.md#global-variables).
+
+Access global variable values in a model definition using the `{{ var() }}` jinja function. The function requires the name of the variable _in single quotes_ as the first argument and an optional default value as the second argument. The default value is a safety mechanism used if the variable name is not found in the project configuration file.
+
+For example, a model would access a global variable named `int_var` like this:
+
+```sql linenums="1"
+JINJA_QUERY_BEGIN;
+
+SELECT *
+FROM table
+WHERE int_variable = {{ var('int_var') }};
+
+JINJA_END;
+```
+
+A default value can be passed as a second argument to the `{{ var() }}` jinja function, which will be used as a fallback value if the variable is missing from the configuration file.
+
+In this example, the `WHERE` clause would render to `WHERE some_value = 0` if no variable named `missing_var` was defined in the project configuration file:
+
+```sql linenums="1"
+JINJA_QUERY_BEGIN;
+
+SELECT *
+FROM table
+WHERE some_value = {{ var('missing_var', 0) }};
+
+JINJA_END;
+```
+
+### Local variables
+
 Define your own variables with the Jinja statement `{% set ... %}`. For example, we could specify the name of the `num_orders` column in the `sqlmesh_example.full_model` like this:
 
 ```sql linenums="1"

--- a/docs/concepts/macros/macro_variables.md
+++ b/docs/concepts/macros/macro_variables.md
@@ -100,3 +100,22 @@ Other macro variables:
     * 'creating' - The model tables are being created.
     * 'evaluating' - The models' logic is being evaluated.
 * @gateway - A string value that represents the name of the selected [gateway](../../guides/connections.md).
+
+## User-defined Variables
+
+Users can also pass custom variables in [configuration](../../reference/configuration.md#variables). To access variable values the `@var` macro should be used in model definitions. For example:
+
+```sql linenums="1"
+SELECT *
+FROM table
+WHERE some_value = @var('<var_name>')
+```
+
+The default value can be passed as a second argument to the `@var` macro, which will be used as a fallback when the variable with the given name is missing:
+```sql linenums="1"
+SELECT *
+FROM table
+WHERE some_value = @var('<var_name>', <default_value>)
+```
+
+The similar API is available for [Python models](../models/python_models.md) via the `context.var` method, as well as in [macros](./sqlmesh_macros.md) via `evaluator.var`.

--- a/docs/concepts/macros/macro_variables.md
+++ b/docs/concepts/macros/macro_variables.md
@@ -100,22 +100,3 @@ Other macro variables:
     * 'creating' - The model tables are being created.
     * 'evaluating' - The models' logic is being evaluated.
 * @gateway - A string value that represents the name of the selected [gateway](../../guides/connections.md).
-
-## User-defined Variables
-
-Users can also pass custom variables in [configuration](../../reference/configuration.md#variables). To access variable values the `@var` macro should be used in model definitions. For example:
-
-```sql linenums="1"
-SELECT *
-FROM table
-WHERE some_value = @var('<var_name>')
-```
-
-The default value can be passed as a second argument to the `@var` macro, which will be used as a fallback when the variable with the given name is missing:
-```sql linenums="1"
-SELECT *
-FROM table
-WHERE some_value = @var('<var_name>', <default_value>)
-```
-
-The similar API is available for [Python models](../models/python_models.md) via the `context.var` method, as well as in [macros](./sqlmesh_macros.md) via `evaluator.var`.

--- a/docs/concepts/macros/sqlmesh_macros.md
+++ b/docs/concepts/macros/sqlmesh_macros.md
@@ -1061,6 +1061,22 @@ def some_macro(evaluator):
     ...
 ```
 
+### Accessing variables
+
+[User-defined variables](../../reference/configuration.md#variables) can be accessed within the macro's body using the `evaluator.var` method. For example:
+
+```python linenums="1"
+from sqlmesh.core.macros import macro
+
+@macro()
+def some_macro(evaluator):
+    var_value = evaluator.var("<var_name>")
+    another_var_value = evaluator.var("<another_var_name>", "default_value")
+    ...
+```
+
+
+
 ## Mixing macro systems
 
 SQLMesh supports both SQLMesh and [Jinja](./jinja_macros.md) macro systems. We strongly recommend using only one system in a model - if both are present, they may fail or behave in unintuitive ways.

--- a/docs/concepts/macros/sqlmesh_macros.md
+++ b/docs/concepts/macros/sqlmesh_macros.md
@@ -29,7 +29,7 @@ It uses the following five step approach to accomplish this:
 2. Examine the placeholder values to classify them as one of the following types:
 
     - Creation of user-defined macro variables with the `@DEF` operator (see more about [user-defined macro variables](#user-defined-variables))
-    - Macro variables, both [SQLMesh pre-defined](./macro_variables.md) and [user-defined](#User-defined-variables)
+    - Macro variables: [SQLMesh pre-defined](./macro_variables.md), [user-defined local](#local-variables), and [user-defined global](#global-variables)
     - Macro functions, both [SQLMesh's](#sqlmesh-macro-operators) and [user-defined](#user-defined-macro-functions)
 
 3. Substitute macro variable values where they are detected. In most cases, this is direct string substitution as with a templating system.
@@ -41,7 +41,74 @@ It uses the following five step approach to accomplish this:
 
 ## User-defined variables
 
-Define your own macro variables with the `@DEF` macro operator. For example, you could set the macro variable `macro_var` to the value `1` with:
+SQLMesh supports two kinds of user-defined macro variables: global and local.
+
+Global macro variables are defined in the project configuration file and can be accessed in any project model.
+
+Local macro variables are defined in a model definition and can only be accessed in that model.
+
+### Global variables
+
+Global variables are defined in the project configuration file [`variables` key](../../reference/configuration.md#variables).
+
+Global variable values may be any of the following data types or lists or dictionaries containing these types: `int`, `float`, `bool`, `str`.
+
+Access global variable values in a model definition using the `@<VAR_NAME>` macro or the `@VAR()` macro function. The latter function requires the name of the variable _in single quotes_ as the first argument and an optional default value as the second argument. The default value is a safety mechanism used if the variable name is not found in the project configuration file.
+
+For example, this SQLMesh configuration key defines six variables of different data types:
+
+```yaml linenums="1"
+variables:
+    int_var: 1
+    float_var: 2.0
+    bool_var: true
+    str_var: "cat"
+    list_var: [1, 2, 3]
+    dict_var:
+        key1: 1
+        key2: 2
+```
+
+Additionally, variables can be configured as part of the gateway, in which case individual variable values take precedence over values with the same key in the root configuration:
+```yaml linenums="1"
+gateways:
+    my_gateway:
+        variables:
+            my_var: 1
+        ...
+```
+
+A model definition could access the `int_var` value in a `WHERE` clause like this:
+
+```sql linenums="1"
+SELECT *
+FROM table
+WHERE int_variable = @INT_VAR
+```
+
+Alternatively, the same variable can be accessed by passing the variable name into the `@VAR()` macro function. Note that the variable name is in single quotes in the call `@VAR('int_var')`:
+
+```sql linenums="1"
+SELECT *
+FROM table
+WHERE int_variable = @VAR('int_var')
+```
+
+A default value can be passed as a second argument to the `@VAR()` macro function, which will be used as a fallback value if the variable is missing from the configuration file.
+
+In this example, the `WHERE` clause would render to `WHERE some_value = 0` because no variable named `missing_var` was defined in the project configuration file:
+
+```sql linenums="1"
+SELECT *
+FROM table
+WHERE some_value = @VAR('missing_var', 0)
+```
+
+A similar API is available for [Python macro functions](#accessing-global-variable-values) via the `evaluator.var` method and [Python models](../models/python_models.md#global-variables) via the `context.var` method.
+
+### Local variables
+
+Define your own local macro variables with the `@DEF` macro operator. For example, you could set the macro variable `macro_var` to the value `1` with:
 
 ```sql linenums="1"
 @DEF(macro_var, 1);
@@ -889,9 +956,9 @@ Note that in the call `@make_indicators(vehicle, [truck, bus])` none of the thre
 
 Because they are unquoted, SQLGlot will parse them all as `Column` expressions. In the places we used single quotes when building the string (`'{value}'`), they will be single-quoted in the output. In the places we did not quote them (`{string_column} = ` and `{string_column}_{value}`), they will not.
 
-#### Accessing macro variable values
+#### Accessing predefined and local variable values
 
-Both predefined and user-defined macro variables can be accessed within a Python macro function.
+[Pre-defined variables](./macro_variables.md#predefined-variables) and [user-defined local variables](#local-variables) can be accessed within the macro's body via the `evaluator.locals` attribute.
 
 The first argument to every macro function, the macro evaluation context `evaluator`, contains macro variable values in its `locals` attribute. `evaluator.locals` is a dictionary whose key:value pairs are macro variables names and the associated values.
 
@@ -913,9 +980,9 @@ SELECT
 FROM table
 ```
 
-The same approach works for user-defined macro variables, where the key `"execution_epoch"` would be replaced with the name of the user-defined variable to be accessed.
+The same approach works for user-defined local macro variables, where the key `"execution_epoch"` would be replaced with the name of the user-defined variable to be accessed.
 
-One downside of that approach to accessing user-defined variables is that the name of the variable is hard-coded into the function. A more flexible approach is to pass the name of the macro variable as a function argument:
+One downside of that approach to accessing user-defined local variables is that the name of the variable is hard-coded into the function. A more flexible approach is to pass the name of the local macro variable as a function argument:
 
 ```python linenums="1"
 from sqlmesh import macro
@@ -925,12 +992,12 @@ def get_macro_var(evaluator, macro_var):
     return evaluator.locals[macro_var]
 ```
 
-We could define a macro variable `my_macro_var` with a value of 1 and pass it to the `get_macro_var` function like this:
+We could define a local macro variable `my_macro_var` with a value of 1 and pass it to the `get_macro_var` function like this:
 
 ```sql linenums="1"
 MODEL (...);
 
-@DEF(my_macro_var, 1); -- Define macro variable 'my_macro_var'
+@DEF(my_macro_var, 1); -- Define local macro variable 'my_macro_var'
 
 SELECT
   @get_macro_var('my_macro_var') as macro_var_value -- Access my_macro_var value from Python macro function
@@ -945,51 +1012,21 @@ SELECT
 FROM table
 ```
 
-#### Using SQLGlot expressions
+#### Accessing global variable values
 
-SQLMesh automatically parses strings returned by Python macro functions into [SQLGlot](https://github.com/tobymao/sqlglot) expressions so they can be incorporated into the model query's semantic representation. Functions can also return SQLGlot expressions directly.
+[User-defined global variables](#global-variables) can be accessed within the macro's body using the `evaluator.var` method.
 
-For example, consider a macro function that uses the `BETWEEN` operator in the predicate of a `WHERE` clause. A function returning the predicate as a string might look like this, where the function arguments are substituted into a Python f-string:
-
-```python linenums="1"
-from sqlmesh import macro
-
-@macro()
-def between_where(evaluator, column_name, low_val, high_val):
-    return f"{column_name} BETWEEN {low_val} AND {high_val}"
-```
-
-The function could then be called in a query:
-
-```sql linenums="1"
-SELECT
-  a
-FROM table
-WHERE @between_where(a, 1, 3)
-```
-
-And it would render to:
-
-```sql linenums="1"
-SELECT
-  a
-FROM table
-WHERE a BETWEEN 1 and 3
-```
-
-Alternatively, the function could return a [SQLGLot expression](https://github.com/tobymao/sqlglot/blob/main/sqlglot/expressions.py) equivalent to that string by using SQLGlot's expression methods for building semantic representations:
+For example:
 
 ```python linenums="1"
-from sqlmesh import macro
+from sqlmesh.core.macros import macro
 
 @macro()
-def between_where(evaluator, column, low_val, high_val):
-    return column.between(low_val, high_val)
+def some_macro(evaluator):
+    var_value = evaluator.var("<var_name>")
+    another_var_value = evaluator.var("<another_var_name>", "default_value")
+    ...
 ```
-
-The methods are available because the `column` argument is parsed as a SQLGlot [Column expression](https://sqlglot.com/sqlglot/expressions.html#Column) when the macro function is executed.
-
-Column expressions are sub-classes of the [Condition class](https://sqlglot.com/sqlglot/expressions.html#Condition), so they have builder methods like [`between`](https://sqlglot.com/sqlglot/expressions.html#Condition.between) and [`like`](https://sqlglot.com/sqlglot/expressions.html#Condition.like).
 
 #### Accessing model schemas
 
@@ -1043,7 +1080,7 @@ Having access to the schema of an upstream model can be useful for various reaso
 
 Thus, leveraging `columns_to_types` can also enable one to write code according to the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle, as they can implement these transformations in a single function instead of duplicating them in each model of interest.
 
-### Accessing snapshots
+#### Accessing snapshots
 
 After a SQLMesh project has been successfully loaded, its snapshots can be accessed in Python macro functions and Python models that generate SQL through the `get_snapshot` method of `MacroEvaluator`.
 
@@ -1061,20 +1098,51 @@ def some_macro(evaluator):
     ...
 ```
 
-### Accessing variables
+#### Using SQLGlot expressions
 
-[User-defined variables](../../reference/configuration.md#variables) can be accessed within the macro's body using the `evaluator.var` method. For example:
+SQLMesh automatically parses strings returned by Python macro functions into [SQLGlot](https://github.com/tobymao/sqlglot) expressions so they can be incorporated into the model query's semantic representation. Functions can also return SQLGlot expressions directly.
+
+For example, consider a macro function that uses the `BETWEEN` operator in the predicate of a `WHERE` clause. A function returning the predicate as a string might look like this, where the function arguments are substituted into a Python f-string:
 
 ```python linenums="1"
-from sqlmesh.core.macros import macro
+from sqlmesh import macro
 
 @macro()
-def some_macro(evaluator):
-    var_value = evaluator.var("<var_name>")
-    another_var_value = evaluator.var("<another_var_name>", "default_value")
-    ...
+def between_where(evaluator, column_name, low_val, high_val):
+    return f"{column_name} BETWEEN {low_val} AND {high_val}"
 ```
 
+The function could then be called in a query:
+
+```sql linenums="1"
+SELECT
+  a
+FROM table
+WHERE @between_where(a, 1, 3)
+```
+
+And it would render to:
+
+```sql linenums="1"
+SELECT
+  a
+FROM table
+WHERE a BETWEEN 1 and 3
+```
+
+Alternatively, the function could return a [SQLGLot expression](https://github.com/tobymao/sqlglot/blob/main/sqlglot/expressions.py) equivalent to that string by using SQLGlot's expression methods for building semantic representations:
+
+```python linenums="1"
+from sqlmesh import macro
+
+@macro()
+def between_where(evaluator, column, low_val, high_val):
+    return column.between(low_val, high_val)
+```
+
+The methods are available because the `column` argument is parsed as a SQLGlot [Column expression](https://sqlglot.com/sqlglot/expressions.html#Column) when the macro function is executed.
+
+Column expressions are sub-classes of the [Condition class](https://sqlglot.com/sqlglot/expressions.html#Condition), so they have builder methods like [`between`](https://sqlglot.com/sqlglot/expressions.html#Condition.between) and [`like`](https://sqlglot.com/sqlglot/expressions.html#Condition.like).
 
 
 ## Mixing macro systems

--- a/docs/concepts/models/python_models.md
+++ b/docs/concepts/models/python_models.md
@@ -143,6 +143,28 @@ def execute(
     context.table("docs_example.another_dependency")
 ```
 
+
+## Variables
+
+[User-defined variables](../../reference/configuration.md#variables) variables can be accessed from within the Python model using the `context.var` method. For example:
+
+```python linenums="1"
+@model(
+    "my_model.name",
+)
+def execute(
+    context: ExecutionContext,
+    start: datetime,
+    end: datetime,
+    execution_time: datetime,
+    **kwargs: t.Any,
+) -> pd.DataFrame:
+    var_value = context.var("<var_name>")
+    another_var_value = context.var("<another_var_name>", "default_value")
+    ...
+```
+
+
 ## Examples
 ### Basic
 The following is an example of a Python model returning a static Pandas DataFrame.

--- a/docs/concepts/models/python_models.md
+++ b/docs/concepts/models/python_models.md
@@ -144,11 +144,29 @@ def execute(
 ```
 
 
-## Variables
+## Global variables
 
-[User-defined variables](../../reference/configuration.md#variables) variables can be accessed from within the Python model using the `context.var` method. For example:
+[User-defined global variables](../../reference/configuration.md#variables) can be accessed from within the Python model using function arguments, where the name of the argument represents a variable key. For example:
 
-```python linenums="1"
+```python linenums="1" hl_lines="9"
+@model(
+    "my_model.name",
+)
+def execute(
+    context: ExecutionContext,
+    start: datetime,
+    end: datetime,
+    execution_time: datetime,
+    my_var: Optional[str] = None,
+    **kwargs: t.Any,
+) -> pd.DataFrame:
+    ...
+```
+
+Make sure to assign a default value to such arguments if you anticipate a missing variable key. Please note that arguments must be specified explicitly; in other words, variables can be accessed using `kwargs`.
+
+Alternatively, variables can be accessed using the `context.var` method. For example:
+```python linenums="1" hl_lines="11 12"
 @model(
     "my_model.name",
 )
@@ -163,8 +181,6 @@ def execute(
     another_var_value = context.var("<another_var_name>", "default_value")
     ...
 ```
-
-
 ## Examples
 ### Basic
 The following is an example of a Python model returning a static Pandas DataFrame.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -45,7 +45,7 @@ See all the keys allowed in `model_defaults` at the [model configuration referen
 
 The `variables` key can be used to provide values for user-defined variables, accessed using the [`@VAR` macro function](../concepts/macros/sqlmesh_macros.md#global-variables) in SQL model definitions, [`context.var` method](../concepts/models/python_models.md#global-variables) in Python model definitions, and [`evaluator.var` method](../concepts/macros/sqlmesh_macros.md#accessing-global-variable-values) in Python macro functions.
 
-The `variables` key consists of a mapping of variable names to their values - see an example on the [SQLMesh macros concepts page](../concepts/macros/sqlmesh_macros.md#global-variables).
+The `variables` key consists of a mapping of variable names to their values - see an example on the [SQLMesh macros concepts page](../concepts/macros/sqlmesh_macros.md#global-variables). Note that keys are case insensitive.
 
 Global variable values may be any of the data types in the table below or lists or dictionaries containing those types.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -41,6 +41,12 @@ The `model_defaults` key is **required** and must contain a value for the `diale
 
 See all the keys allowed in `model_defaults` at the [model configuration reference page](./model_configuration.md#model-defaults).
 
+### Variables
+
+The `variables` key can be used to provide values for user-defined variables which can then be accessed using the `@VAR` macro in model definitions.
+
+This attribute represents a mapping from variable names to their values. Note that supported value types include `int`, `float`, `bool`, `str`, as well as lists and dictionaries.
+
 ## Plan
 
 Configuration for the `sqlmesh plan` command.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -24,16 +24,16 @@ Configuration options for SQLMesh project directories.
 
 Configuration options for SQLMesh environment creation and promotion.
 
-| Option                       | Description                                                                                                                                                                                                                                                                                        | Type                 | Required |
-|------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------:|:--------:|
-| `snapshot_ttl`               | The period of time that a model snapshot not a part of any environment should exist before being deleted. This is defined as a string with the default `in 1 week`. Other [relative dates](https://dateparser.readthedocs.io/en/latest/) can be used, such as `in 30 days`. (Default: `in 1 week`) | string               | N        |
-| `environment_ttl`            | The period of time that a development environment should exist before being deleted. This is defined as a string with the default `in 1 week`. Other [relative dates](https://dateparser.readthedocs.io/en/latest/) can be used, such as `in 30 days`. (Default: `in 1 week`)                      | string               | N        |
-| `pinned_environments`        | The list of development environments that are exempt from deletion due to expiration                                                                                                                                                                                                               | list[string]         | N        |
-| `time_column_format`         | The default format to use for all model time columns. This time format uses [python format codes](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes) (Default: `%Y-%m-%d`)                                                                                        | string               | N        |
-| `default_target_environment` | The name of the environment that will be the default target for the `sqlmesh plan` and `sqlmesh run` commands. (Default: `prod`)                                                                                                                                                                   | string               | N        |
-| `physical_schema_override`   | A mapping from model schema names to names of schemas in which physical tables for the corresponding models will be placed - [addition details](../guides/configuration.md#physical-schema-override). (Default physical schema name: `sqlmesh__[model schema]`)                                                                                                                                                                   | string               | N        |
-| `environment_suffix_target`  | Whether SQLMesh views should append their environment name to the `schema` or `table` - [additional details](../guides/configuration.md#view-schema-override). (Default: `schema`)                                                                                                                                                                   | string               | N        |
-| `log_limit`                  | The default number of logs to keep (Default: `20`) | int               | N        |
+| Option                       | Description                                                                                                                                                                                                                                                                                        | Type         | Required |
+|------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------:|:--------:|
+| `snapshot_ttl`               | The period of time that a model snapshot not a part of any environment should exist before being deleted. This is defined as a string with the default `in 1 week`. Other [relative dates](https://dateparser.readthedocs.io/en/latest/) can be used, such as `in 30 days`. (Default: `in 1 week`) | string       | N        |
+| `environment_ttl`            | The period of time that a development environment should exist before being deleted. This is defined as a string with the default `in 1 week`. Other [relative dates](https://dateparser.readthedocs.io/en/latest/) can be used, such as `in 30 days`. (Default: `in 1 week`)                      | string       | N        |
+| `pinned_environments`        | The list of development environments that are exempt from deletion due to expiration                                                                                                                                                                                                               | list[string] | N        |
+| `time_column_format`         | The default format to use for all model time columns. This time format uses [python format codes](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes) (Default: `%Y-%m-%d`)                                                                                        | string       | N        |
+| `default_target_environment` | The name of the environment that will be the default target for the `sqlmesh plan` and `sqlmesh run` commands. (Default: `prod`)                                                                                                                                                                   | string       | N        |
+| `physical_schema_override`   | A mapping from model schema names to names of schemas in which physical tables for the corresponding models will be placed - [addition details](../guides/configuration.md#physical-schema-override). (Default physical schema name: `sqlmesh__[model schema]`)                                    | string       | N        |
+| `environment_suffix_target`  | Whether SQLMesh views should append their environment name to the `schema` or `table` - [additional details](../guides/configuration.md#view-schema-override). (Default: `schema`)                                                                                                                 | string       | N        |
+| `log_limit`                  | The default number of logs to keep (Default: `20`)                                                                                                                                                                                                                                                 | int          | N        |
 
 ### Model defaults
 
@@ -43,54 +43,61 @@ See all the keys allowed in `model_defaults` at the [model configuration referen
 
 ### Variables
 
-The `variables` key can be used to provide values for user-defined variables which can then be accessed using the `@VAR` macro in model definitions.
+The `variables` key can be used to provide values for user-defined variables, accessed using the [`@VAR` macro function](../concepts/macros/sqlmesh_macros.md#global-variables) in SQL model definitions, [`context.var` method](../concepts/models/python_models.md#global-variables) in Python model definitions, and [`evaluator.var` method](../concepts/macros/sqlmesh_macros.md#accessing-global-variable-values) in Python macro functions.
 
-This attribute represents a mapping from variable names to their values. Note that supported value types include `int`, `float`, `bool`, `str`, as well as lists and dictionaries.
+The `variables` key consists of a mapping of variable names to their values - see an example on the [SQLMesh macros concepts page](../concepts/macros/sqlmesh_macros.md#global-variables).
+
+Global variable values may be any of the data types in the table below or lists or dictionaries containing those types.
+
+| Option      | Description                         | Type                                                         | Required |
+|-------------|-------------------------------------|:------------------------------------------------------------:|:--------:|
+| `variables` | Mapping of variable names to values | dict[string, int \| float \| bool \| string \| list \| dict] | N        |
+
 
 ## Plan
 
 Configuration for the `sqlmesh plan` command.
 
-| Option                    | Description                                                                                                                                                                                                                                             | Type                 | Required |
-|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------:|:--------:|
-| `auto_categorize_changes` | Indicates whether SQLMesh should attempt to automatically [categorize](../concepts/plans.md#change-categories) model changes during plan creation per each model source type ([additional details](../guides/configuration.md#auto-categorize-changes)) | dict[string, string] | N        |
-| `include_unmodified`      | Indicates whether to create views for all models in the target development environment or only for modified ones (Default: False)                                                                                                                       | boolean              | N        |
-| `auto_apply`              | Indicates whether to automatically apply a new plan after creation (Default: False)                                                                                                                                                                     | boolean              | N        |
-| `forward_only`            | Indicates whether the plan should be [forward-only](../concepts/plans.md#forward-only-plans) (Default: False)                                                                                                                                           | boolean              | N        |
-| `enable_preview`         | Indicates whether to enable [data preview](../concepts/plans.md#data-preview) for forward-only models when targeting a development environment (Default: False)                                                                                         | boolean              | N        |
-| `no_diff`                 | Don't show diffs for changed models (Default: False)                                                                                                                                                                                                    | boolean              | N        |
-| `no_prompts`              | Disables interactive prompts in CLI (Default: False)                                                                                                                                                                                                    | boolean              | N        |
+| Option                    | Description                                                                                                                                                                                                                                             |         Type         | Required |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------: | :------: |
+| `auto_categorize_changes` | Indicates whether SQLMesh should attempt to automatically [categorize](../concepts/plans.md#change-categories) model changes during plan creation per each model source type ([additional details](../guides/configuration.md#auto-categorize-changes)) | dict[string, string] |    N     |
+| `include_unmodified`      | Indicates whether to create views for all models in the target development environment or only for modified ones (Default: False)                                                                                                                       |       boolean        |    N     |
+| `auto_apply`              | Indicates whether to automatically apply a new plan after creation (Default: False)                                                                                                                                                                     |       boolean        |    N     |
+| `forward_only`            | Indicates whether the plan should be [forward-only](../concepts/plans.md#forward-only-plans) (Default: False)                                                                                                                                           |       boolean        |    N     |
+| `enable_preview`          | Indicates whether to enable [data preview](../concepts/plans.md#data-preview) for forward-only models when targeting a development environment (Default: False)                                                                                         |       boolean        |    N     |
+| `no_diff`                 | Don't show diffs for changed models (Default: False)                                                                                                                                                                                                    |       boolean        |    N     |
+| `no_prompts`              | Disables interactive prompts in CLI (Default: False)                                                                                                                                                                                                    |       boolean        |    N     |
 
 ## Run
 
 Configuration for the `sqlmesh run` command. Please note that this is only applicable when configured with the [builtin](#builtin) scheduler.
 
 | Option                       | Description                                                                                                        | Type | Required |
-|------------------------------|--------------------------------------------------------------------------------------------------------------------|:----:|:--------:|
-| `environment_check_interval` | The number of seconds to wait between attempts to check the target environment for readiness (Default: 30 seconds) | int  | N        |
-| `environment_check_max_wait` | The maximum number of seconds to wait for the target environment to be ready (Default: 6 hours)                    | int  | N        |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------ | :--: | :------: |
+| `environment_check_interval` | The number of seconds to wait between attempts to check the target environment for readiness (Default: 30 seconds) | int  |    N     |
+| `environment_check_max_wait` | The maximum number of seconds to wait for the target environment to be ready (Default: 6 hours)                    | int  |    N     |
 
 ## Format
 
 Formatting settings for the `sqlmesh format` command and UI.
 
-| Option                | Description                                                                                    | Type    | Required |
-|-----------------------|------------------------------------------------------------------------------------------------|:-------:|:--------:|
-| `normalize`          | Whether to normalize SQL (Default: False)                                                      | boolean | N        |
-| `pad`                 | The number of spaces to use for padding (Default: 2)                                           | int     | N        |
-| `indent`              | The number of spaces to use for indentation (Default: 2)                                       | int     | N        |
-| `normalize_functions` | Whether to normalize function names. Supported values are: 'upper' and 'lower' (Default: None) | string  | N        |
-| `leading_comma`       | Whether to use leading commas (Default: False)                                                 | boolean | N        |
-| `max_text_width`      | The maximum text width in a segment before creating new lines (Default: 80)                    | int     | N        |
-| `append_newline`      | Whether to append a newline to the end of the file (Default: False)                            | boolean | N        |
+| Option                | Description                                                                                    |  Type   | Required |
+| --------------------- | ---------------------------------------------------------------------------------------------- | :-----: | :------: |
+| `normalize`           | Whether to normalize SQL (Default: False)                                                      | boolean |    N     |
+| `pad`                 | The number of spaces to use for padding (Default: 2)                                           |   int   |    N     |
+| `indent`              | The number of spaces to use for indentation (Default: 2)                                       |   int   |    N     |
+| `normalize_functions` | Whether to normalize function names. Supported values are: 'upper' and 'lower' (Default: None) | string  |    N     |
+| `leading_comma`       | Whether to use leading commas (Default: False)                                                 | boolean |    N     |
+| `max_text_width`      | The maximum text width in a segment before creating new lines (Default: 80)                    |   int   |    N     |
+| `append_newline`      | Whether to append a newline to the end of the file (Default: False)                            | boolean |    N     |
 
 ## UI
 
 SQLMesh UI settings.
 
-| Option   | Description                                                                                   | Type    | Required |
-|----------|-----------------------------------------------------------------------------------------------|:-------:|:--------:|
-| `format` | Whether to automatically format model definitions upon saving them to a file (Default: False) | boolean | N        |
+| Option   | Description                                                                                   |  Type   | Required |
+| -------- | --------------------------------------------------------------------------------------------- | :-----: | :------: |
+| `format` | Whether to automatically format model definitions upon saving them to a file (Default: False) | boolean |    N     |
 
 ## Gateways
 
@@ -134,13 +141,14 @@ Some connections use default values if not specified:
 
 NOTE: Spark and Trino engines may not be used for the state connection.
 
-| Option             | Description                                                                                                            |                  Type                   |                                Required                                |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------- | :-------------------------------------: | :--------------------------------------------------------------------: |
-| `connection`       | The data warehouse connection for core SQLMesh functions.                                                              | [connection configuration](#connection) | N (if [`default_connection`](#default-connectionsscheduler) specified) |
-| `state_connection` | The data warehouse connection where SQLMesh will store internal information about the project. (Default: `connection` if using builtin scheduler, otherwise scheduler database) | [connection configuration](#connection) |                                   N                                    |
-| `state_schema`     | The name of the schema where state information should be stored. (Default: `sqlmesh`)                                  |                 string                  |                                   N                                    |
-| `test_connection`  | The data warehouse connection SQLMesh will use to execute tests. (Default: `connection`)                               | [connection configuration](#connection) |                                   N                                    |
-| `scheduler`        | The scheduler SQLMesh will use to execute tests. (Default: `builtin`)                                                  |  [scheduler configuration](#scheduler)  |                                   N                                    |
+| Option             | Description                                                                                                                                                                     | Type                                                         | Required                                                               |
+|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------:|:----------------------------------------------------------------------:|
+| `connection`       | The data warehouse connection for core SQLMesh functions.                                                                                                                       | [connection configuration](#connection)                      | N (if [`default_connection`](#default-connectionsscheduler) specified) |
+| `state_connection` | The data warehouse connection where SQLMesh will store internal information about the project. (Default: `connection` if using builtin scheduler, otherwise scheduler database) | [connection configuration](#connection)                      | N                                                                      |
+| `state_schema`     | The name of the schema where state information should be stored. (Default: `sqlmesh`)                                                                                           | string                                                       | N                                                                      |
+| `test_connection`  | The data warehouse connection SQLMesh will use to execute tests. (Default: `connection`)                                                                                        | [connection configuration](#connection)                      | N                                                                      |
+| `scheduler`        | The scheduler SQLMesh will use to execute tests. (Default: `builtin`)                                                                                                           | [scheduler configuration](#scheduler)                        | N                                                                      |
+| `variables`        | The gateway-specific variables which override the root-level [variables](#variables) by key.                                                                                    | dict[string, int \| float \| bool \| string \| list \| dict] | N                                                                      |
 
 ### Connection
 
@@ -154,7 +162,7 @@ Most parameters are specific to the connection engine `type` - see [below](#engi
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------- | :--: | :------: |
 | `type`              | The engine type name, listed in engine-specific configuration pages below.                                                  | str  |    Y     |
 | `concurrent_tasks`  | The maximum number of concurrent tasks that will be run by SQLMesh. (Default: 4 for engines that support concurrent tasks.) | int  |    N     |
-| `register_comments` | Whether SQLMesh should register model comments with the SQL engine (if the engine supports it). (Default: `true`.)                            | bool |    N     |
+| `register_comments` | Whether SQLMesh should register model comments with the SQL engine (if the engine supports it). (Default: `true`.)          | bool |    N     |
 
 #### Engine-specific
 
@@ -189,19 +197,19 @@ No configuration options are supported by this scheduler type.
 
 See [Airflow Integration Guide](../integrations/airflow.md) for information about how to integrate Airflow with SQLMesh.
 
-| Option                            | Description                                                                                                                                                                                                                                                                                                                                                                          | Type    | Required |
-|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------:|:--------:|
-| `airflow_url`                     | The URL of the Airflow Webserver                                                                                                                                                                                                                                                                                                                                                     | string  | Y        |
-| `username`                        | The Airflow username                                                                                                                                                                                                                                                                                                                                                                 | string  | Y        |
-| `password`                        | The Airflow password                                                                                                                                                                                                                                                                                                                                                                 | string  | Y        |
-| `dag_run_poll_interval_secs`      | Determines, in seconds, how often a running DAG can be polled (Default: `10`)                                                                                                                                                                                                                                                                                                        | int     | N        |
-| `dag_creation_poll_interval_secs` | Determines, in seconds, how often SQLMesh should check whether a DAG has been created (Default: `30`)                                                                                                                                                                                                                                                                                | int     | N        |
-| `dag_creation_max_retry_attempts` | Determines the maximum number of attempts that SQLMesh will make while checking for whether a DAG has been created (Default: `10`)                                                                                                                                                                                                                                                   | int     | N        |
-| `backfill_concurrent_tasks`       | The number of concurrent tasks used for model backfilling during plan application (Default: `4`)                                                                                                                                                                                                                                                                                     | int     | N        |
-| `ddl_concurrent_tasks`            | The number of concurrent tasks used for DDL operations like table/view creation, deletion, and so forth (Default: `4`)                                                                                                                                                                                                                                                               | int     | N        |
-| `max_snapshot_ids_per_request`    | The maximum number of snapshot IDs that can be sent in a single HTTP GET request to the Airflow Webserver (Default: `None`)                                                                                                                                                                                                                                                          | int     | N        |
-| `use_state_connection`            | Whether to use the `state_connection` configuration to bypass Airflow Webserver and access the SQLMesh state directly (Default: `false`)                                                                                                                                                                                                                                             | boolean | N        |
-| `default_catalog_override`        | Overrides the default catalog value for this project. If specified, this value takes precedence over the default catalog value set on the Airflow side. This only applies in the [multi-repo](../guides/multi_repo.md) setup when different projects require different default catalog values (Default: `None`) | string  | N        |
+| Option                            | Description                                                                                                                                                                                                                                                                                                     |  Type   | Required |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-----: | :------: |
+| `airflow_url`                     | The URL of the Airflow Webserver                                                                                                                                                                                                                                                                                | string  |    Y     |
+| `username`                        | The Airflow username                                                                                                                                                                                                                                                                                            | string  |    Y     |
+| `password`                        | The Airflow password                                                                                                                                                                                                                                                                                            | string  |    Y     |
+| `dag_run_poll_interval_secs`      | Determines, in seconds, how often a running DAG can be polled (Default: `10`)                                                                                                                                                                                                                                   |   int   |    N     |
+| `dag_creation_poll_interval_secs` | Determines, in seconds, how often SQLMesh should check whether a DAG has been created (Default: `30`)                                                                                                                                                                                                           |   int   |    N     |
+| `dag_creation_max_retry_attempts` | Determines the maximum number of attempts that SQLMesh will make while checking for whether a DAG has been created (Default: `10`)                                                                                                                                                                              |   int   |    N     |
+| `backfill_concurrent_tasks`       | The number of concurrent tasks used for model backfilling during plan application (Default: `4`)                                                                                                                                                                                                                |   int   |    N     |
+| `ddl_concurrent_tasks`            | The number of concurrent tasks used for DDL operations like table/view creation, deletion, and so forth (Default: `4`)                                                                                                                                                                                          |   int   |    N     |
+| `max_snapshot_ids_per_request`    | The maximum number of snapshot IDs that can be sent in a single HTTP GET request to the Airflow Webserver (Default: `None`)                                                                                                                                                                                     |   int   |    N     |
+| `use_state_connection`            | Whether to use the `state_connection` configuration to bypass Airflow Webserver and access the SQLMesh state directly (Default: `false`)                                                                                                                                                                        | boolean |    N     |
+| `default_catalog_override`        | Overrides the default catalog value for this project. If specified, this value takes precedence over the default catalog value set on the Airflow side. This only applies in the [multi-repo](../guides/multi_repo.md) setup when different projects require different default catalog values (Default: `None`) | string  |    N     |
 
 
 #### Cloud Composer

--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -25,7 +25,10 @@ from sqlmesh.core.renderer import QueryRenderer
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.errors import AuditConfigError, SQLMeshError, raise_config_error
 from sqlmesh.utils.hashing import hash_data
-from sqlmesh.utils.jinja import JinjaMacroRegistry, extract_macro_references
+from sqlmesh.utils.jinja import (
+    JinjaMacroRegistry,
+    extract_macro_references_and_variables,
+)
 from sqlmesh.utils.metaprogramming import Executable
 from sqlmesh.utils.pydantic import (
     PydanticModel,
@@ -36,7 +39,6 @@ from sqlmesh.utils.pydantic import (
 
 if t.TYPE_CHECKING:
     from sqlmesh.core.snapshot import DeployabilityIndex, Node, Snapshot
-    from sqlmesh.utils.jinja import MacroReference
 
 if sys.version_info >= (3, 9):
     from typing import Literal
@@ -352,7 +354,7 @@ class StandaloneAudit(_Node, AuditMixin):
         ]
 
         query = self.render_query(self) or self.query
-        data.append(query.sql(comments=False))
+        data.append(query.sql(dialect=self.dialect, comments=False))
 
         return hash_data(data)
 
@@ -462,6 +464,7 @@ def load_audit(
     jinja_macros: t.Optional[JinjaMacroRegistry] = None,
     dialect: t.Optional[str] = None,
     default_catalog: t.Optional[str] = None,
+    variables: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> Audit:
     """Load an audit from a parsed SQLMesh audit file.
 
@@ -516,19 +519,22 @@ def load_audit(
 
     extra_kwargs: t.Dict[str, t.Any] = {}
     if is_standalone:
-        jinja_macro_refrences: t.Set[MacroReference] = {
-            r
-            for references in [
-                *[extract_macro_references(s.sql()) for s in statements],
-                extract_macro_references(query.sql()),
-            ]
-            for r in references
-        }
-        extra_kwargs["python_env"] = _python_env(
-            [*statements, query], jinja_macro_refrences, module_path, macros or macro.get_registry()
+        jinja_macro_refrences, used_variables = extract_macro_references_and_variables(
+            *(s.sql(dialect=dialect) for s in statements),
+            query.sql(dialect=dialect),
         )
-        extra_kwargs["jinja_macros"] = (jinja_macros or JinjaMacroRegistry()).trim(
-            jinja_macro_refrences
+        jinja_macros = (jinja_macros or JinjaMacroRegistry()).trim(jinja_macro_refrences)
+        for jinja_macro in jinja_macros.root_macros.values():
+            used_variables.update(extract_macro_references_and_variables(jinja_macro.definition)[1])
+
+        extra_kwargs["jinja_macros"] = jinja_macros
+        extra_kwargs["python_env"] = _python_env(
+            [*statements, query],
+            jinja_macro_refrences,
+            module_path,
+            macros or macro.get_registry(),
+            variables=variables,
+            used_variables=used_variables,
         )
         extra_kwargs["default_catalog"] = default_catalog
 
@@ -557,6 +563,7 @@ def load_multiple_audits(
     jinja_macros: t.Optional[JinjaMacroRegistry] = None,
     dialect: t.Optional[str] = None,
     default_catalog: t.Optional[str] = None,
+    variables: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> t.Generator[Audit, None, None]:
     audit_block: t.List[exp.Expression] = []
     for expression in expressions:
@@ -570,6 +577,7 @@ def load_multiple_audits(
                     jinja_macros=jinja_macros,
                     dialect=dialect,
                     default_catalog=default_catalog,
+                    variables=variables,
                 )
                 audit_block.clear()
         audit_block.append(expression)
@@ -578,6 +586,7 @@ def load_multiple_audits(
         path=path,
         dialect=dialect,
         default_catalog=default_catalog,
+        variables=variables,
     )
 
 

--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from pydantic import Field
 from sqlglot import exp
 from sqlglot.optimizer.qualify_columns import quote_identifiers
+from sqlglot.optimizer.simplify import gen
 
 from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
@@ -354,7 +355,7 @@ class StandaloneAudit(_Node, AuditMixin):
         ]
 
         query = self.render_query(self) or self.query
-        data.append(query.sql(dialect=self.dialect, comments=False))
+        data.append(gen(query))
 
         return hash_data(data)
 
@@ -520,8 +521,8 @@ def load_audit(
     extra_kwargs: t.Dict[str, t.Any] = {}
     if is_standalone:
         jinja_macro_refrences, used_variables = extract_macro_references_and_variables(
-            *(s.sql(dialect=dialect) for s in statements),
-            query.sql(dialect=dialect),
+            *(gen(s) for s in statements),
+            gen(query),
         )
         jinja_macros = (jinja_macros or JinjaMacroRegistry()).trim(jinja_macro_refrences)
         for jinja_macro in jinja_macros.root_macros.values():

--- a/sqlmesh/core/config/common.py
+++ b/sqlmesh/core/config/common.py
@@ -61,3 +61,28 @@ http_headers_validator = field_validator(
     mode="before",
     check_fields=False,
 )(_http_headers_validator)
+
+
+def _variables_validator(value: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
+    if not isinstance(value, dict):
+        raise ConfigError(f"Variables must be a dictionary, not {type(value)}")
+
+    def _validate_type(v: t.Any) -> None:
+        if isinstance(v, list):
+            for item in v:
+                _validate_type(item)
+        elif isinstance(v, dict):
+            for item in v.values():
+                _validate_type(item)
+        elif v is not None and not isinstance(v, (str, int, float, bool)):
+            raise ConfigError(f"Unsupported variable value type: {type(v)}")
+
+    _validate_type(value)
+    return {k.lower(): v for k, v in value.items()}
+
+
+variables_validator = field_validator(
+    "variables",
+    mode="before",
+    check_fields=False,
+)(_variables_validator)

--- a/sqlmesh/core/config/gateway.py
+++ b/sqlmesh/core/config/gateway.py
@@ -4,6 +4,7 @@ import typing as t
 
 from sqlmesh.core import constants as c
 from sqlmesh.core.config.base import BaseConfig
+from sqlmesh.core.config.common import variables_validator
 from sqlmesh.core.config.connection import (
     SerializableConnectionConfig,
     connection_config_validator,
@@ -23,6 +24,8 @@ class GatewayConfig(BaseConfig):
         scheduler: The scheduler configuration.
         state_schema: Schema name to use for the state tables. If None or empty string are provided
             then no schema name is used and therefore the default schema defined for the connection will be used
+        variables: A dictionary of gateway-specific variables that can be used in models / macros. This overrides
+            config-level variables by key.
     """
 
     connection: t.Optional[SerializableConnectionConfig] = None
@@ -30,5 +33,7 @@ class GatewayConfig(BaseConfig):
     test_connection: t.Optional[SerializableConnectionConfig] = None
     scheduler: t.Optional[SchedulerConfig] = None
     state_schema: t.Optional[str] = c.SQLMESH
+    variables: t.Dict[str, t.Any] = {}
 
     _connection_config_validator = connection_config_validator
+    _variables_validator = variables_validator

--- a/sqlmesh/core/config/gateway.py
+++ b/sqlmesh/core/config/gateway.py
@@ -25,7 +25,7 @@ class GatewayConfig(BaseConfig):
         state_schema: Schema name to use for the state tables. If None or empty string are provided
             then no schema name is used and therefore the default schema defined for the connection will be used
         variables: A dictionary of gateway-specific variables that can be used in models / macros. This overrides
-            config-level variables by key.
+            root-level variables by key.
     """
 
     connection: t.Optional[SerializableConnectionConfig] = None

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -155,6 +155,8 @@ class Config(BaseConfig):
     @field_validator("variables", mode="before")
     @classmethod
     def _validate_variables(cls, value: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
+        if not isinstance(value, dict):
+            raise ConfigError(f"Variables must be a dictionary, not {type(value)}")
 
         def _validate_type(v: t.Any) -> None:
             if isinstance(v, list):
@@ -167,7 +169,7 @@ class Config(BaseConfig):
                 raise ConfigError(f"Unsupported variable value type: {type(v)}")
 
         _validate_type(value)
-        return value
+        return {k.lower(): v for k, v in value.items()}
 
     @model_validator(mode="before")
     @model_validator_v1_args

--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -50,3 +50,5 @@ SCHEMA_YAML = "schema.yaml"
 
 
 DEFAULT_SCHEMA = "default"
+
+VARIABLES = "vars"

--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -51,4 +51,6 @@ SCHEMA_YAML = "schema.yaml"
 
 DEFAULT_SCHEMA = "default"
 
-VARIABLES = "vars"
+SQLMESH_VARS = "__sqlmesh__vars__"
+VAR = "var"
+GATEWAY = "gateway"

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -237,6 +237,11 @@ class ExecutionContext(BaseContext):
     def default_catalog(self) -> t.Optional[str]:
         return self._default_catalog
 
+    @property
+    def gateway(self) -> t.Optional[str]:
+        """Returns the gateway name."""
+        return self.var(c.GATEWAY)
+
     def var(self, var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
         """Returns a variable value."""
         return self._variables.get(var_name, default)

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -244,7 +244,7 @@ class ExecutionContext(BaseContext):
 
     def var(self, var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
         """Returns a variable value."""
-        return self._variables.get(var_name, default)
+        return self._variables.get(var_name.lower(), default)
 
     def with_variables(self, variables: t.Dict[str, t.Any]) -> ExecutionContext:
         """Returns a new ExecutionContext with additional variables."""

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -42,6 +42,7 @@ import traceback
 import typing as t
 import unittest.result
 from datetime import timedelta
+from functools import cached_property
 from io import StringIO
 from pathlib import Path
 from shutil import rmtree
@@ -209,13 +210,14 @@ class ExecutionContext(BaseContext):
         deployability_index: t.Optional[DeployabilityIndex] = None,
         default_dialect: t.Optional[str] = None,
         default_catalog: t.Optional[str] = None,
+        variables: t.Optional[t.Dict[str, t.Any]] = None,
     ):
         self.snapshots = snapshots
         self.deployability_index = deployability_index
         self._engine_adapter = engine_adapter
-        self.__model_tables = to_table_mapping(snapshots.values(), deployability_index)
         self._default_catalog = default_catalog
         self._default_dialect = default_dialect
+        self._variables = variables or {}
 
     @property
     def default_dialect(self) -> t.Optional[str]:
@@ -226,14 +228,29 @@ class ExecutionContext(BaseContext):
         """Returns an engine adapter."""
         return self._engine_adapter
 
-    @property
+    @cached_property
     def _model_tables(self) -> t.Dict[str, str]:
         """Returns a mapping of model names to tables."""
-        return self.__model_tables
+        return to_table_mapping(self.snapshots.values(), self.deployability_index)
 
     @property
     def default_catalog(self) -> t.Optional[str]:
         return self._default_catalog
+
+    def var(self, var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
+        """Returns a variable value."""
+        return self._variables.get(var_name, default)
+
+    def with_variables(self, variables: t.Dict[str, t.Any]) -> ExecutionContext:
+        """Returns a new ExecutionContext with additional variables."""
+        return ExecutionContext(
+            self._engine_adapter,
+            self.snapshots,
+            self.deployability_index,
+            self._default_dialect,
+            self._default_catalog,
+            variables=variables,
+        )
 
 
 class GenericContext(BaseContext, t.Generic[C]):

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -303,6 +303,7 @@ class SqlMeshLoader(Loader):
                         physical_schema_override=config.physical_schema_override,
                         project=config.project,
                         default_catalog=self._context.default_catalog,
+                        variables=config.variables,
                     )
 
                 model = cache.get_or_load_model(path, _load)
@@ -340,6 +341,7 @@ class SqlMeshLoader(Loader):
                         physical_schema_override=config.physical_schema_override,
                         project=config.project,
                         default_catalog=self._context.default_catalog,
+                        variables=config.variables,
                     )
                     models[model.fqn] = model
 
@@ -363,6 +365,7 @@ class SqlMeshLoader(Loader):
                         jinja_macros=jinja_macros,
                         dialect=config.model_defaults.dialect,
                         default_catalog=self._context.default_catalog,
+                        variables=config.variables,
                     )
                     for audit in audits:
                         audits_by_name[audit.name] = audit

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -30,7 +30,7 @@ from sqlmesh.utils import UniqueKeyDict
 from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.jinja import JinjaMacroRegistry, MacroExtractor
-from sqlmesh.utils.metaprogramming import Executable, import_python_file
+from sqlmesh.utils.metaprogramming import import_python_file
 from sqlmesh.utils.yaml import YAML
 
 if t.TYPE_CHECKING:
@@ -247,10 +247,6 @@ class SqlMeshLoader(Loader):
         macros = macro.get_registry()
         macro.set_registry(standard_macros)
 
-        gateway_name = self._context.gateway or self._context.config.default_gateway_name
-        macros["gateway"] = Executable.value(gateway_name)
-        jinja_macros.add_globals({"gateway": gateway_name})
-
         return macros, jinja_macros
 
     def _load_models(
@@ -303,7 +299,7 @@ class SqlMeshLoader(Loader):
                         physical_schema_override=config.physical_schema_override,
                         project=config.project,
                         default_catalog=self._context.default_catalog,
-                        variables=config.variables,
+                        variables=self._variables(config),
                     )
 
                 model = cache.get_or_load_model(path, _load)
@@ -341,7 +337,7 @@ class SqlMeshLoader(Loader):
                         physical_schema_override=config.physical_schema_override,
                         project=config.project,
                         default_catalog=self._context.default_catalog,
-                        variables=config.variables,
+                        variables=self._variables(config),
                     )
                     models[model.fqn] = model
 
@@ -365,7 +361,7 @@ class SqlMeshLoader(Loader):
                         jinja_macros=jinja_macros,
                         dialect=config.model_defaults.dialect,
                         default_catalog=self._context.default_catalog,
-                        variables=config.variables,
+                        variables=self._variables(config),
                     )
                     for audit in audits:
                         audits_by_name[audit.name] = audit
@@ -412,6 +408,12 @@ class SqlMeshLoader(Loader):
                     break
             else:
                 yield filepath
+
+    def _variables(self, config: Config) -> t.Dict[str, t.Any]:
+        return {
+            c.GATEWAY: self._context.gateway or self._context.config.default_gateway_name,
+            **config.variables,
+        }
 
     class _Cache:
         def __init__(self, loader: SqlMeshLoader, context_path: Path):

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -906,7 +906,7 @@ def or_(evaluator: MacroEvaluator, *expressions: t.Optional[exp.Expression]) -> 
 
 @macro("VAR")
 def var(
-    evaluator: MacroEvaluator, var_name: exp.Expression, default: exp.Expression = exp.null()
+    evaluator: MacroEvaluator, var_name: exp.Expression, default: t.Optional[exp.Expression] = None
 ) -> exp.Expression:
     """Returns the value of a variable or the default value if the variable is not set."""
     if not var_name.is_string:

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -14,6 +14,7 @@ from sqlglot.executor.python import Python
 from sqlglot.helper import csv, ensure_collection
 from sqlglot.schema import MappingSchema
 
+from sqlmesh.core import constants as c
 from sqlmesh.core.dialect import (
     SQLMESH_MACRO_PREFIX,
     MacroDef,
@@ -374,6 +375,10 @@ class MacroEvaluator:
                 " You can gate these calls by checking in Python: evaluator.runtime_stage != 'loading' or SQL: @runtime_stage <> 'loading'."
             )
         return self.locals["engine_adapter"]
+
+    def var(self, var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
+        """Returns the value of the specified variable, or the default value if it doesn't exist."""
+        return (self.locals.get(c.VARIABLES) or {}).get(var_name, default)
 
 
 class macro(registry_decorator):
@@ -891,6 +896,17 @@ def or_(evaluator: MacroEvaluator, *expressions: t.Optional[exp.Expression]) -> 
         return exp.true()
 
     return exp.or_(*conditions, dialect=evaluator.dialect)
+
+
+@macro("VAR")
+def var(
+    evaluator: MacroEvaluator, var_name: exp.Expression, default: exp.Expression = exp.null()
+) -> exp.Expression:
+    """Returns the value of a variable or the default value if the variable is not set."""
+    if not var_name.is_string:
+        raise SQLMeshError(f"Invalid variable name '{var_name.sql()}'. Expected a string literal.")
+
+    return exp.convert(evaluator.var(var_name.this, default))
 
 
 def normalize_macro_name(name: str) -> str:

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -376,9 +376,14 @@ class MacroEvaluator:
             )
         return self.locals["engine_adapter"]
 
+    @property
+    def gateway(self) -> t.Optional[str]:
+        """Returns the gateway name."""
+        return self.var(c.GATEWAY)
+
     def var(self, var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
         """Returns the value of the specified variable, or the default value if it doesn't exist."""
-        return (self.locals.get(c.VARIABLES) or {}).get(var_name, default)
+        return (self.locals.get(c.SQLMESH_VARS) or {}).get(var_name, default)
 
 
 class macro(registry_decorator):

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -384,7 +384,7 @@ class MacroEvaluator:
 
     def var(self, var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
         """Returns the value of the specified variable, or the default value if it doesn't exist."""
-        return (self.locals.get(c.SQLMESH_VARS) or {}).get(var_name, default)
+        return (self.locals.get(c.SQLMESH_VARS) or {}).get(var_name.lower(), default)
 
 
 class macro(registry_decorator):

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -172,13 +172,14 @@ class MacroEvaluator:
 
             if isinstance(node, MacroVar):
                 changed = True
-                if node.name not in self.locals:
+                variables = self.locals.get(c.SQLMESH_VARS, {})
+                if node.name not in self.locals and node.name.lower() not in variables:
                     if not isinstance(node.parent, StagedFilePath):
                         raise SQLMeshError(f"Macro variable '{node.name}' is undefined.")
 
                     return node
 
-                value = self.locals[node.name]
+                value = self.locals.get(node.name, variables.get(node.name.lower()))
                 if isinstance(value, list):
                     return exp.convert(
                         tuple(

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -71,6 +71,7 @@ class model(registry_decorator):
         physical_schema_override: t.Optional[t.Dict[str, str]] = None,
         project: str = "",
         default_catalog: t.Optional[str] = None,
+        variables: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> Model:
         """Get the model registered by this function."""
         env: t.Dict[str, t.Any] = {}
@@ -86,6 +87,7 @@ class model(registry_decorator):
             physical_schema_override=physical_schema_override,
             project=project,
             default_catalog=default_catalog,
+            variables=variables,
             **self.kwargs,
         )
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1455,9 +1455,9 @@ def load_sql_based_model(
         )
 
     jinja_macro_references, used_variables = extract_macro_references_and_variables(
-        *(e.sql(dialect=dialect) for e in pre_statements),
-        *(e.sql(dialect=dialect) for e in post_statements),
-        *([query_or_seed_insert.sql(dialect=dialect)] if query_or_seed_insert is not None else []),
+        *(gen(e) for e in pre_statements),
+        *(gen(e) for e in post_statements),
+        *([gen(query_or_seed_insert)] if query_or_seed_insert is not None else []),
     )
 
     jinja_macros = (jinja_macros or JinjaMacroRegistry()).trim(jinja_macro_references)

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1877,7 +1877,7 @@ def _python_env(
                                     f"The variable name must be a string literal, '{args[0].sql()}' was given instead",
                                     path,
                                 )
-                            used_variables.add(args[0].this)
+                            used_variables.add(args[0].this.lower())
                 elif macro_func_or_var.__class__ is d.MacroVar:
                     name = macro_func_or_var.name.lower()
                     if name in macros:
@@ -1955,7 +1955,7 @@ def _parse_dependencies(
                 if func.value.id == "context" and func.attr == "table":
                     depends_on.add(get_first_arg("model_name"))
                 elif func.value.id in ("context", "evaluator") and func.attr == c.VAR:
-                    variables.add(get_first_arg("var_name"))
+                    variables.add(get_first_arg("var_name").lower())
             elif (
                 isinstance(node, ast.Attribute)
                 and isinstance(node.value, ast.Name)

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1320,7 +1320,7 @@ class PythonModel(_Model):
         execution_time = to_datetime(execution_time or c.EPOCH)
         try:
             df_or_iter = env[self.entrypoint](
-                context=context.with_variables(env.get(c.VARIABLES, {})),
+                context=context.with_variables(env.get(c.SQLMESH_VARS, {})),
                 start=start,
                 end=end,
                 execution_time=execution_time,
@@ -1706,7 +1706,7 @@ def create_python_model(
 
     variables = {k: v for k, v in (variables or {}).items() if k in referenced_variables}
     if variables:
-        python_env[c.VARIABLES] = Executable.value(variables)
+        python_env[c.SQLMESH_VARS] = Executable.value(variables)
 
     return _create_model(
         PythonModel,
@@ -1862,7 +1862,7 @@ def _python_env(
                     name = macro_func_or_var.this.name.lower()
                     if name in macros:
                         used_macros[name] = macros[name]
-                        if name == "var":
+                        if name == c.VAR:
                             args = macro_func_or_var.this.expressions
                             if len(args) < 1:
                                 raise_config_error("Macro VAR requires at least one argument", path)
@@ -1876,6 +1876,8 @@ def _python_env(
                     name = macro_func_or_var.name
                     if name in macros:
                         used_macros[name] = macros[name]
+                    elif name == c.GATEWAY:
+                        used_variables.add(c.GATEWAY)
 
     for macro_ref in jinja_macro_references or set():
         if macro_ref.package is None and macro_ref.name in macros:
@@ -1894,7 +1896,9 @@ def _python_env(
 
     variables = {k: v for k, v in (variables or {}).items() if k in used_variables}
     if variables:
-        serialized_env[c.VARIABLES] = Executable.value(variables)
+        serialized_env[c.SQLMESH_VARS] = Executable.value(variables)
+    if c.GATEWAY in variables:
+        serialized_env[c.GATEWAY] = Executable.value(variables[c.GATEWAY])
 
     return serialized_env
 
@@ -1916,38 +1920,44 @@ def _parse_dependencies(python_env: t.Dict[str, Executable]) -> t.Tuple[t.Set[st
         if not executable.is_definition:
             continue
         for node in ast.walk(ast.parse(executable.payload)):
-            if not isinstance(node, ast.Call):
-                continue
+            if isinstance(node, ast.Call):
+                func = node.func
+                if not isinstance(func, ast.Attribute) or not isinstance(func.value, ast.Name):
+                    continue
 
-            func = node.func
-            if not isinstance(func, ast.Attribute) or not isinstance(func.value, ast.Name):
-                continue
+                def get_first_arg(keyword_arg_name: str) -> t.Any:
+                    if node.args:
+                        table: t.Optional[ast.expr] = node.args[0]
+                    else:
+                        table = next(
+                            (
+                                keyword.value
+                                for keyword in node.keywords
+                                if keyword.arg == keyword_arg_name
+                            ),
+                            None,
+                        )
 
-            def get_first_arg(keyword_arg_name: str) -> t.Any:
-                if node.args:
-                    table: t.Optional[ast.expr] = node.args[0]
-                else:
-                    table = next(
-                        (
-                            keyword.value
-                            for keyword in node.keywords
-                            if keyword.arg == keyword_arg_name
-                        ),
-                        None,
-                    )
+                    try:
+                        expression = to_source(table)
+                        return eval(expression, env)
+                    except Exception:
+                        raise ConfigError(
+                            f"Error resolving dependencies for '{executable.path}'. References to context / evaluator must be resolvable at parse time.\n\n{expression}"
+                        )
 
-                try:
-                    expression = to_source(table)
-                    return eval(expression, env)
-                except Exception:
-                    raise ConfigError(
-                        f"Error resolving dependencies for '{executable.path}'. References to context / evaluator must be resolvable at parse time.\n\n{expression}"
-                    )
-
-            if func.value.id == "context" and func.attr == "table":
-                depends_on.add(get_first_arg("model_name"))
-            elif func.value.id in ("context", "evaluator") and func.attr == "var":
-                variables.add(get_first_arg("var_name"))
+                if func.value.id == "context" and func.attr == "table":
+                    depends_on.add(get_first_arg("model_name"))
+                elif func.value.id in ("context", "evaluator") and func.attr == c.VAR:
+                    variables.add(get_first_arg("var_name"))
+            elif (
+                isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id in ("context", "evaluator")
+                and node.attr == c.GATEWAY
+            ):
+                # Check whether the gateway attribute is referenced.
+                variables.add(c.GATEWAY)
 
     return depends_on, variables
 

--- a/sqlmesh/core/test/context.py
+++ b/sqlmesh/core/test/context.py
@@ -29,6 +29,7 @@ class TestExecutionContext(ExecutionContext):
     ):
         self._engine_adapter = engine_adapter
         self._models = models
+        self._test = test
         self._default_catalog = default_catalog
         self._default_dialect = default_dialect
         self._variables = variables or {}
@@ -37,8 +38,7 @@ class TestExecutionContext(ExecutionContext):
     def _model_tables(self) -> t.Dict[str, str]:
         """Returns a mapping of model names to tables."""
         return {
-            name: test._test_fixture_table(name).sql()
-            for name, model in self._models.items()
+            name: self._test._test_fixture_table(name).sql() for name, model in self._models.items()
         }
 
     def with_variables(self, variables: t.Dict[str, t.Any]) -> TestExecutionContext:
@@ -46,6 +46,7 @@ class TestExecutionContext(ExecutionContext):
         return TestExecutionContext(
             self._engine_adapter,
             self._models,
+            self._test,
             self._default_dialect,
             self._default_catalog,
             variables=variables,

--- a/sqlmesh/core/test/context.py
+++ b/sqlmesh/core/test/context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing as t
+from functools import cached_property
 
 from sqlmesh import Model
 from sqlmesh.core.context import ExecutionContext
@@ -24,16 +25,28 @@ class TestExecutionContext(ExecutionContext):
         test: ModelTest,
         default_dialect: t.Optional[str] = None,
         default_catalog: t.Optional[str] = None,
+        variables: t.Optional[t.Dict[str, t.Any]] = None,
     ):
         self._engine_adapter = engine_adapter
+        self._models = models
         self._default_catalog = default_catalog
         self._default_dialect = default_dialect
+        self._variables = variables or {}
 
-        self.__model_tables = {
-            name: test._test_fixture_table(name).sql() for name, model in models.items()
-        }
-
-    @property
+    @cached_property
     def _model_tables(self) -> t.Dict[str, str]:
         """Returns a mapping of model names to tables."""
-        return self.__model_tables
+        return {
+            name: test._test_fixture_table(name).sql()
+            for name, model in self._models.items()
+        }
+
+    def with_variables(self, variables: t.Dict[str, t.Any]) -> TestExecutionContext:
+        """Returns a new TestExecutionContext with additional variables."""
+        return TestExecutionContext(
+            self._engine_adapter,
+            self._models,
+            self._default_dialect,
+            self._default_catalog,
+            variables=variables,
+        )

--- a/sqlmesh/utils/jinja.py
+++ b/sqlmesh/utils/jinja.py
@@ -156,7 +156,7 @@ def extract_macro_references_and_variables(
             if call_name[0] == c.VAR:
                 args = [jinja_call_arg_name(arg) for arg in node.args]
                 if args and args[0]:
-                    variables.add(args[0])
+                    variables.add(args[0].lower())
             elif call_name[0] == c.GATEWAY:
                 variables.add(c.GATEWAY)
             elif len(call_name) == 1:
@@ -558,7 +558,7 @@ def jinja_call_arg_name(node: nodes.Node) -> str:
 
 def create_var(variables: t.Dict[str, t.Any]) -> t.Callable:
     def _var(var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
-        return variables.get(var_name, default)
+        return variables.get(var_name.lower(), default)
 
     return _var
 

--- a/sqlmesh/utils/jinja.py
+++ b/sqlmesh/utils/jinja.py
@@ -153,10 +153,12 @@ def extract_macro_references_and_variables(
     variables = set()
     for jinja_str in jinja_strs:
         for call_name, node in extract_call_names(jinja_str):
-            if call_name[0] == "var":
+            if call_name[0] == c.VAR:
                 args = [jinja_call_arg_name(arg) for arg in node.args]
                 if args and args[0]:
                     variables.add(args[0])
+            elif call_name[0] == c.GATEWAY:
+                variables.add(c.GATEWAY)
             elif len(call_name) == 1:
                 macro_references.add(MacroReference(name=call_name[0]))
             elif len(call_name) == 2:
@@ -564,8 +566,10 @@ def create_var(variables: t.Dict[str, t.Any]) -> t.Callable:
 def create_builtin_globals(
     jinja_macros: JinjaMacroRegistry, global_vars: t.Dict[str, t.Any], *args: t.Any, **kwargs: t.Any
 ) -> t.Dict[str, t.Any]:
-    variables = global_vars.pop(c.VARIABLES, None) or {}
+    global_vars.pop(c.GATEWAY, None)
+    variables = global_vars.pop(c.SQLMESH_VARS, None) or {}
     return {
-        "var": create_var(variables),
+        c.VAR: create_var(variables),
+        c.GATEWAY: lambda: variables.get(c.GATEWAY, None),
         **global_vars,
     }

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -280,7 +280,11 @@ def build_env(
         # is accessible through the `__wrapped__` attribute added by functools.wraps
         env[name] = obj.__wrapped__ if getattr(obj, "__sqlmesh_macro__", None) else obj
 
-        if obj_module and _is_relative_to(obj_module.__file__, path):
+        if (
+            obj_module
+            and hasattr(obj_module, "__file__")
+            and _is_relative_to(obj_module.__file__, path)
+        ):
             walk(env[name])
     elif env[name] != obj:
         raise SQLMeshError(
@@ -362,7 +366,7 @@ def serialize_env(env: t.Dict[str, t.Any], path: Path) -> t.Dict[str, Executable
                 )
         elif inspect.ismodule(v):
             name = v.__name__
-            if _is_relative_to(v.__file__, path):
+            if hasattr(v, "__file__") and _is_relative_to(v.__file__, path):
                 raise SQLMeshError(
                     f"Cannot serialize 'import {name}'. Use 'from {name} import ...' instead."
                 )

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -698,6 +698,7 @@ def test_condition_with_macro_var(model: Model):
     assert (
         rendered_query.sql(dialect="duckdb")
         == """SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" BETWEEN '1970-01-01' AND '1970-01-01') AS "_q_0" WHERE "x" IS NULL AND "dt" BETWEEN CAST('1970-01-01 00:00:00+00:00' AS TIMESTAMP) AND CAST('1970-01-01 23:59:59.999999+00:00' AS TIMESTAMP)"""
+    )
 
 
 def test_variables(assert_exp_eq):
@@ -724,7 +725,7 @@ def test_variables(assert_exp_eq):
         dialect="bigquery",
         variables={"test_var": "test_val", "test_var_unused": "unused_val"},
     )
-    assert audit.python_env[c.VARIABLES] == Executable.value({"test_var": "test_val"})
+    assert audit.python_env[c.SQLMESH_VARS] == Executable.value({"test_var": "test_val"})
     assert (
         audit.render_query(audit).sql(dialect="bigquery")
         == "SELECT * FROM `db`.`table` AS `table` WHERE `col` = 'test_val'"

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -473,8 +473,14 @@ def test_variables():
         "list_var": [1, 2, 3],
         "dict_var": {"a": "test_value", "b": 2},
     }
-    config = Config(variables=variables)
+    gateway_variables = {
+        "UPPERCASE_VAR": 2,
+    }
+    config = Config(
+        variables=variables, gateways={"local": GatewayConfig(variables=gateway_variables)}
+    )
     assert config.variables == variables
+    assert config.get_gateway("local").variables == {"uppercase_var": 2}
 
     with pytest.raises(
         ConfigError, match="Unsupported variable value type: <class 'sqlglot.expressions.Column'>"

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+from sqlglot import exp
 
 from sqlmesh.core.config import (
     Config,
@@ -461,3 +462,21 @@ def test_connection_config_serialization():
         "connector_config": {},
         "database": "my_test_db",
     }
+
+
+def test_variables():
+    variables = {
+        "int_var": 1,
+        "str_var": "test_value",
+        "bool_var": True,
+        "float_var": 1.0,
+        "list_var": [1, 2, 3],
+        "dict_var": {"a": "test_value", "b": 2},
+    }
+    config = Config(variables=variables)
+    assert config.variables == variables
+
+    with pytest.raises(
+        ConfigError, match="Unsupported variable value type: <class 'sqlglot.expressions.Column'>"
+    ):
+        Config(variables={"invalid_var": exp.column("sqlglot_expr")})

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -544,47 +544,6 @@ def test_schema_error_no_default(sushi_context_pre_scheduling) -> None:
 
 
 @pytest.mark.slow
-def test_gateway_macro(sushi_context: Context) -> None:
-    sushi_context.upsert_model(
-        load_sql_based_model(
-            parse(
-                """
-            MODEL(name sushi.test_gateway_macro);
-            SELECT @gateway AS gateway;
-            """
-            ),
-            macros=sushi_context._macros,
-            default_catalog=sushi_context.default_catalog,
-        )
-    )
-
-    assert (
-        sushi_context.render("sushi.test_gateway_macro").sql()
-        == "SELECT 'in_memory' AS \"gateway\""
-    )
-
-    sushi_context.upsert_model(
-        load_sql_based_model(
-            parse(
-                """
-            MODEL(name sushi.test_gateway_macro_jinja);
-            JINJA_QUERY_BEGIN;
-            SELECT '{{ gateway }}' AS gateway_jinja;
-            JINJA_END;
-            """
-            ),
-            jinja_macros=sushi_context._jinja_macros,
-            default_catalog=sushi_context.default_catalog,
-        )
-    )
-
-    assert (
-        sushi_context.render("sushi.test_gateway_macro_jinja").sql()
-        == "SELECT 'in_memory' AS \"gateway_jinja\""
-    )
-
-
-@pytest.mark.slow
 def test_unrestorable_snapshot(sushi_context: Context) -> None:
     model_v1 = load_sql_based_model(
         parse(

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -3581,7 +3581,7 @@ def test_variables_python_model(mocker: MockerFixture) -> None:
 
 def test_named_variables_python_model(mocker: MockerFixture) -> None:
     @model(
-        "test_variables_python_model",
+        "test_named_variables_python_model",
         kind="full",
         columns={"a": "string", "b": "string", "c": "string"},
     )
@@ -3590,7 +3590,7 @@ def test_named_variables_python_model(mocker: MockerFixture) -> None:
     ):
         return pd.DataFrame([{"a": test_var_a, "b": test_var_b, "start": start.strftime("%Y-%m-%d")}])  # type: ignore
 
-    python_model = model.get_registry()["test_variables_python_model"].model(
+    python_model = model.get_registry()["test_named_variables_python_model"].model(
         module_path=Path("."),
         path=Path("."),
         # Passing `start` in variables to make sure that built-in arguments can't be overridden.

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -3414,7 +3414,7 @@ def test_end_no_start():
 def test_variables():
     @macro()
     def test_macro_var(evaluator) -> exp.Expression:
-        return exp.convert(evaluator.var("test_var_d") + 10)
+        return exp.convert(evaluator.var("TEST_VAR_D") + 10)
 
     expressions = parse(
         """
@@ -3423,7 +3423,7 @@ def test_variables():
             kind FULL,
         );
 
-        SELECT @VAR('test_var_a') AS a, @VAR('test_var_b', 'default_value') AS b, @VAR('test_var_c') AS c, @TEST_MACRO_VAR() AS d;
+        SELECT @VAR('TEST_VAR_A') AS a, @VAR('test_var_b', 'default_value') AS b, @VAR('test_var_c') AS c, @TEST_MACRO_VAR() AS d;
     """,
         default_dialect="bigquery",
     )
@@ -3491,7 +3491,7 @@ def test_named_variable_macros() -> None:
             """
         MODEL(name sushi.test_gateway_macro);
         @DEF(overridden_var, 'overridden_value');
-        SELECT @gateway AS gateway, @test_var_a AS test_var_a, @overridden_var AS overridden_var
+        SELECT @gateway AS gateway, @TEST_VAR_A AS test_var_a, @overridden_var AS overridden_var
         """
         ),
         variables={
@@ -3520,7 +3520,7 @@ def test_variables_jinja():
         );
 
         JINJA_QUERY_BEGIN;
-        SELECT '{{ var('test_var_a') }}' AS a, '{{ var('test_var_b', 'default_value') }}' AS b, '{{ var('test_var_c') }}' AS c, {{ test_macro_var() }} AS d;
+        SELECT '{{ var('TEST_VAR_A') }}' AS a, '{{ var('test_var_b', 'default_value') }}' AS b, '{{ var('test_var_c') }}' AS c, {{ test_macro_var() }} AS d;
         JINJA_END;
     """,
         default_dialect="bigquery",
@@ -3559,7 +3559,7 @@ def test_variables_python_model(mocker: MockerFixture) -> None:
         return pd.DataFrame(
             [
                 {
-                    "a": context.var("test_var_a"),
+                    "a": context.var("TEST_VAR_A"),
                     "b": context.var("test_var_b", "default_value"),
                     "c": context.var("test_var_c"),
                 }

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -3430,7 +3430,7 @@ def test_variables():
     model = load_sql_based_model(
         expressions, variables={"test_var_a": "test_value", "test_var_d": 1, "test_var_unused": 2}
     )
-    assert model.python_env[c.VARIABLES] == Executable.value(
+    assert model.python_env[c.SQLMESH_VARS] == Executable.value(
         {"test_var_a": "test_value", "test_var_d": 1}
     )
     assert (
@@ -3513,7 +3513,7 @@ def test_variables_jinja():
         variables={"test_var_a": "test_value", "test_var_d": 1, "test_var_unused": 2},
         jinja_macros=jinja_macros,
     )
-    assert model.python_env[c.VARIABLES] == Executable.value(
+    assert model.python_env[c.SQLMESH_VARS] == Executable.value(
         {"test_var_a": "test_value", "test_var_d": 1}
     )
     assert (
@@ -3524,7 +3524,7 @@ def test_variables_jinja():
 
 def test_variables_python_model(mocker: MockerFixture) -> None:
     @model(
-        "my_model",
+        "test_variables_python_model",
         kind="full",
         columns={"a": "string", "b": "string", "c": "string"},
     )
@@ -3539,14 +3539,88 @@ def test_variables_python_model(mocker: MockerFixture) -> None:
             ]
         )
 
-    python_model = model.get_registry()["my_model"].model(
+    python_model = model.get_registry()["test_variables_python_model"].model(
         module_path=Path("."),
         path=Path("."),
         variables={"test_var_a": "test_value", "test_var_unused": 2},
     )
 
-    assert python_model.python_env[c.VARIABLES] == Executable.value({"test_var_a": "test_value"})
+    assert python_model.python_env[c.SQLMESH_VARS] == Executable.value({"test_var_a": "test_value"})
 
     context = ExecutionContext(mocker.Mock(), {}, None, None)
     df = list(python_model.render(context=context))[0]
     assert df.to_dict(orient="records") == [{"a": "test_value", "b": "default_value", "c": None}]
+
+
+def test_gateway_macro() -> None:
+    model = load_sql_based_model(
+        parse(
+            """
+        MODEL(name sushi.test_gateway_macro);
+        SELECT @gateway AS gateway
+        """
+        ),
+        variables={c.GATEWAY: "in_memory"},
+    )
+
+    assert model.python_env[c.SQLMESH_VARS] == Executable.value({c.GATEWAY: "in_memory"})
+    assert model.render_query_or_raise().sql() == "SELECT 'in_memory' AS \"gateway\""
+
+    @macro()
+    def macro_uses_gateway(evaluator) -> exp.Expression:
+        return exp.convert(evaluator.gateway + "_from_macro")
+
+    model = load_sql_based_model(
+        parse(
+            """
+        MODEL(name sushi.test_gateway_macro);
+        SELECT @macro_uses_gateway() AS gateway_from_macro
+        """
+        ),
+        variables={c.GATEWAY: "in_memory"},
+    )
+
+    assert model.python_env[c.SQLMESH_VARS] == Executable.value({c.GATEWAY: "in_memory"})
+    assert (
+        model.render_query_or_raise().sql()
+        == "SELECT 'in_memory_from_macro' AS \"gateway_from_macro\""
+    )
+
+
+def test_gateway_macro_jinja() -> None:
+    model = load_sql_based_model(
+        parse(
+            """
+        MODEL(name sushi.test_gateway_macro_jinja);
+        JINJA_QUERY_BEGIN;
+        SELECT '{{ gateway() }}' AS gateway_jinja;
+        JINJA_END;
+        """
+        ),
+        variables={c.GATEWAY: "in_memory"},
+    )
+
+    assert model.python_env[c.SQLMESH_VARS] == Executable.value({c.GATEWAY: "in_memory"})
+    assert model.render_query_or_raise().sql() == "SELECT 'in_memory' AS \"gateway_jinja\""
+
+
+def test_gateway_python_model(mocker: MockerFixture) -> None:
+    @model(
+        "test_gateway_python_model",
+        kind="full",
+        columns={"gateway_python": "string"},
+    )
+    def model_with_variables(context, **kwargs):
+        return pd.DataFrame([{"gateway_python": context.gateway + "_from_python"}])
+
+    python_model = model.get_registry()["test_gateway_python_model"].model(
+        module_path=Path("."),
+        path=Path("."),
+        variables={c.GATEWAY: "in_memory"},
+    )
+
+    assert python_model.python_env[c.SQLMESH_VARS] == Executable.value({c.GATEWAY: "in_memory"})
+
+    context = ExecutionContext(mocker.Mock(), {}, None, None)
+    df = list(python_model.render(context=context))[0]
+    assert df.to_dict(orient="records") == [{"gateway_python": "in_memory_from_python"}]

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -119,6 +119,7 @@ def test_json(snapshot: Snapshot):
             "owner": "owner",
             "query": "SELECT @EACH([1, 2], x -> x), ds FROM parent.tbl",
             "jinja_macros": {
+                "create_builtins_module": "sqlmesh.utils.jinja",
                 "global_objs": {},
                 "packages": {},
                 "root_macros": {},

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -541,7 +541,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
     assert len(output.outputs) == 4
     assert convert_all_html_output_to_text(output) == [
         "Models: 14",
-        "Macros: 4",
+        "Macros: 3",
         "Data warehouse connection succeeded",
         "Test connection succeeded",
     ]
@@ -570,7 +570,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
                     h(
                         "span",
                         {"style": f"{NEUTRAL_STYLE}; font-weight: bold"},
-                        "4",
+                        "3",
                     )
                 ),
             )

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -104,6 +104,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
                     "project": "",
                     "storage_format": "parquet",
                     "jinja_macros": {
+                        "create_builtins_module": "sqlmesh.utils.jinja",
                         "global_objs": {},
                         "packages": {},
                         "root_macros": {},


### PR DESCRIPTION
This PR introduces support for user-defined variables to SQLMesh native projects. The variables can now be accessed in the following contexts:

* SQL model definitions
* Python model definitions
* Standalone audits
* Native macros
* Jinja macros

Additionally, SQLMesh intelligently detects variable names referenced in all aforementioned contexts and only includes values for referenced variables into snapshots. This means that if a variable changes, only models that actually use it will be impacted.

However, this capability comes with a few constraints, as the usage detection is performed statically by introspecting relevant SQL/Python/Jinja code.

* When using the `@VAR` macro in SQL, the first argument must always be a string literal. The same limitation applies to the `{{ var(...) }}` macro in Jinja code.
* When variables are accessed from within Python models / native macros, either the `context.var` or `evaluator.var` methods must be used, with the `context` / `evaluator` reference names preserved. Using different reference names breaks the variable detection logic, thus preventing the relevant values from being captured into snapshots.

The `@gateway` macro has been refactored to use variables to benefit from the described static analysis.

@treysp please review the docs. Please also note that a dedicated guide will likely be needed for this in future.