### PR TITLE
Fix: Set the default value for the _dbt_max_partition variable

### DIFF
--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -385,10 +385,15 @@ class ModelConfig(BaseModelConfig):
             database="{{ target.database }}",
         )
 
+        data_type = data_type.upper()
+        default_value = "NULL"
+        if data_type in ("DATE", "DATETIME", "TIMESTAMP"):
+            default_value = f"CAST('1970-01-01' AS {data_type})"
+
         return f"""
 {{% if is_incremental() %}}
-  DECLARE _dbt_max_partition {data_type.upper()} DEFAULT (
-    {select_max_partition_expr}
+  DECLARE _dbt_max_partition {data_type} DEFAULT (
+    COALESCE(({select_max_partition_expr}), {default_value})
   );
 {{% endif %}}
 """

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -796,7 +796,7 @@ def test_dbt_max_partition(sushi_test_project: Project, assert_exp_eq, mocker: M
 JINJA_STATEMENT_BEGIN;
 {% if is_incremental() %}
   DECLARE _dbt_max_partition DATETIME DEFAULT (
-    SELECT MAX(PARSE_DATETIME('%Y%m', partition_id)) FROM `{{ target.database }}.{{ adapter.resolve_schema(this) }}.INFORMATION_SCHEMA.PARTITIONS` WHERE table_name = '{{ adapter.resolve_identifier(this) }}' AND NOT partition_id IS NULL AND partition_id <> '__NULL__'
+    COALESCE((SELECT MAX(PARSE_DATETIME('%Y%m', partition_id)) FROM `{{ target.database }}.{{ adapter.resolve_schema(this) }}.INFORMATION_SCHEMA.PARTITIONS` WHERE table_name = '{{ adapter.resolve_identifier(this) }}' AND NOT partition_id IS NULL AND partition_id <> '__NULL__'), CAST('1970-01-01' AS DATETIME))
   );
 {% endif %}
 JINJA_END;""".strip()


### PR DESCRIPTION
Without the default value, the `_dbt_max_partition` will be NULL and conditions like:

```
WHERE created_at > _dbt_max_partition
```

always return `False` and so the table is never populated.

This update ensures that `_dbt_max_partition` always have a valid value by falling back to epoch time (1970-01-01) when the table is empty.