### PR TITLE
Fix: randomize unit test fixture names to avoid concurrency issues

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -206,8 +206,8 @@ class ExecutionContext(BaseContext):
         self,
         engine_adapter: EngineAdapter,
         snapshots: t.Dict[str, Snapshot],
-        deployability_index: t.Optional[DeployabilityIndex],
-        default_dialect: t.Optional[str],
+        deployability_index: t.Optional[DeployabilityIndex] = None,
+        default_dialect: t.Optional[str] = None,
         default_catalog: t.Optional[str] = None,
     ):
         self.snapshots = snapshots

--- a/sqlmesh/core/test/context.py
+++ b/sqlmesh/core/test/context.py
@@ -5,7 +5,7 @@ import typing as t
 from sqlmesh import Model
 from sqlmesh.core.context import ExecutionContext
 from sqlmesh.core.engine_adapter import EngineAdapter
-from sqlmesh.core.test.definition import _fully_qualified_test_fixture_name
+from sqlmesh.core.test.definition import ModelTest
 from sqlmesh.utils import UniqueKeyDict
 
 
@@ -21,17 +21,17 @@ class TestExecutionContext(ExecutionContext):
         self,
         engine_adapter: EngineAdapter,
         models: UniqueKeyDict[str, Model],
-        default_dialect: t.Optional[str],
+        test: ModelTest,
+        default_dialect: t.Optional[str] = None,
         default_catalog: t.Optional[str] = None,
     ):
-        self.is_dev = True
         self._engine_adapter = engine_adapter
-        self.__model_tables = {
-            name: _fully_qualified_test_fixture_name(name, model.dialect)
-            for name, model in models.items()
-        }
         self._default_catalog = default_catalog
         self._default_dialect = default_dialect
+
+        self.__model_tables = {
+            name: test._test_fixture_table(name).sql() for name, model in models.items()
+        }
 
     @property
     def _model_tables(self) -> t.Dict[str, str]:

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -123,7 +123,7 @@ class ModelTest(unittest.TestCase):
         """Drop all fixture tables."""
         for table in self.body.get("inputs", {}):
             self.engine_adapter.drop_view(
-                self._test_fixture_table(table).sql() if table in self.models else table
+                self._test_fixture_table(table) if table in self.models else table
             )
 
     def assert_equal(

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -87,6 +87,7 @@ class ModelTest(unittest.TestCase):
                 exp.CurrentTimestamp: lambda self, _: self.sql(exp.cast(exec_time, "timestamp")),
             }
 
+        self._test_id = random_id(short=True)
         self._fixture_table_cache: t.Dict[str, exp.Table] = {}
 
         super().__init__()
@@ -294,7 +295,7 @@ class ModelTest(unittest.TestCase):
         table = self._fixture_table_cache.get(name)
         if not table:
             table = exp.to_table(name, dialect=self.dialect)
-            table.this.set("this", f"{table.this.this}__fixture__{random_id(short=True)}")
+            table.this.set("this", f"{table.this.this}__fixture__{self._test_id}")
             self._fixture_table_cache[name] = table
 
         return table

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -135,8 +135,15 @@ test_foo:
     end: 2022-01-01
         """
     )
-    result = _create_test(body, "test_foo", model, sushi_context).run()
-    _check_successful_or_raise(result)
+    test = _create_test(body, "test_foo", model, sushi_context)
+
+    random_id = "jzngz56a"
+    test._test_id = random_id
+    _check_successful_or_raise(test.run())
+
+    assert len(test._fixture_table_cache) == len(sushi_context.models) + 1
+    for table in test._fixture_table_cache.values():
+        assert table.name.endswith(f"__fixture__{random_id}")
 
 
 def test_ctes_only(sushi_context: Context, full_model_with_two_ctes: SqlModel) -> None:


### PR DESCRIPTION
Addresses the 9th item in https://github.com/TobikoData/sqlmesh/issues/1637