### PR TITLE
Feat: add flag for preserving unit test fixtures to improve debuggability

### DIFF
--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -413,3 +413,9 @@ You can also run tests that match a pattern or substring using a glob pathname e
 ```
 $ sqlmesh test tests/test_*
 ```
+
+### Debugging tests
+
+By default, SQLMesh drops all input fixtures in the testing database after running a test.
+
+It's possible to persist these fixtures using the `--persist-fixtures` option of the `sqlmesh test` command, which can be helpful when debugging a test failure post-hoc.

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -418,4 +418,4 @@ $ sqlmesh test tests/test_*
 
 By default, SQLMesh drops all input fixtures in the testing database after running a test.
 
-It's possible to persist these fixtures using the `--persist-fixtures` option of the `sqlmesh test` command, which can be helpful when debugging a test failure post-hoc.
+It's possible to preserve these fixtures using the `--preserve-fixtures` option of the `sqlmesh test` command, which can be helpful when debugging a test failure post-hoc.

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -418,4 +418,4 @@ $ sqlmesh test tests/test_*
 
 By default, SQLMesh drops all input fixtures in the testing database after running a test.
 
-It's possible to preserve these fixtures using the `--preserve-fixtures` option of the `sqlmesh test` command, which can be helpful when debugging a test failure post-hoc.
+It's possible to preserve these fixtures using the `--preserve-fixtures` option of the `sqlmesh test` command, which can be helpful when debugging a test failure.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -419,9 +419,11 @@ Usage: sqlmesh test [OPTIONS] [TESTS]...
   Run model unit tests.
 
 Options:
-  -k TEXT        Only run tests that match the pattern of substring.
-  -v, --verbose  Verbose output.
-  --help         Show this message and exit.
+  -k TEXT             Only run tests that match the pattern of substring.
+  -v, --verbose       Verbose output.
+  --persist-fixtures  Persist the fixture tables in the testing database,
+                      useful for debugging.
+  --help              Show this message and exit.
 ```
 
 ## ui

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -419,11 +419,11 @@ Usage: sqlmesh test [OPTIONS] [TESTS]...
   Run model unit tests.
 
 Options:
-  -k TEXT             Only run tests that match the pattern of substring.
-  -v, --verbose       Verbose output.
-  --persist-fixtures  Persist the fixture tables in the testing database,
-                      useful for debugging.
-  --help              Show this message and exit.
+  -k TEXT              Only run tests that match the pattern of substring.
+  -v, --verbose        Verbose output.
+  --preserve-fixtures  Preserve the fixture tables in the testing database,
+                       useful for debugging.
+  --help               Show this message and exit.
 ```
 
 ## ui

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -358,7 +358,7 @@ options:
 
 #### run_test
 ```
-%run_test [--pattern [PATTERN ...]] [--verbose] [tests ...]
+%run_test [--pattern [PATTERN ...]] [--verbose] [--persist-fixtures] [tests ...]
 
 Run unit test(s).
 
@@ -369,6 +369,8 @@ options:
   --pattern <[PATTERN ...]>, -k <[PATTERN ...]>
                         Only run tests that match the pattern of substring.
   --verbose, -v         Verbose output.
+  --persist-fixtures    Persist the fixture tables in the testing database,
+                        useful for debugging.
 ```
 
 #### audit

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -358,7 +358,7 @@ options:
 
 #### run_test
 ```
-%run_test [--pattern [PATTERN ...]] [--verbose] [--persist-fixtures] [tests ...]
+%run_test [--pattern [PATTERN ...]] [--verbose] [--preserve-fixtures] [tests ...]
 
 Run unit test(s).
 
@@ -369,7 +369,7 @@ options:
   --pattern <[PATTERN ...]>, -k <[PATTERN ...]>
                         Only run tests that match the pattern of substring.
   --verbose, -v         Verbose output.
-  --persist-fixtures    Persist the fixture tables in the testing database,
+  --preserve-fixtures   Preserve the fixture tables in the testing database,
                         useful for debugging.
 ```
 

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -512,13 +512,29 @@ def create_test(
 @cli.command("test")
 @opt.match_pattern
 @opt.verbose
+@click.option(
+    "--persist-fixtures",
+    is_flag=True,
+    default=False,
+    help="Persist the fixture tables in the testing database, useful for debugging.",
+)
 @click.argument("tests", nargs=-1)
 @click.pass_obj
 @error_handler
-def test(obj: Context, k: t.List[str], verbose: bool, tests: t.List[str]) -> None:
+def test(
+    obj: Context,
+    k: t.List[str],
+    verbose: bool,
+    persist_fixtures: bool,
+    tests: t.List[str],
+) -> None:
     """Run model unit tests."""
-    # Set Python unittest verbosity level
-    result = obj.test(match_patterns=k, tests=tests, verbose=verbose)
+    result = obj.test(
+        match_patterns=k,
+        tests=tests,
+        verbose=verbose,
+        persist_fixtures=persist_fixtures,
+    )
     if not result.wasSuccessful():
         exit(1)
 

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -513,10 +513,10 @@ def create_test(
 @opt.match_pattern
 @opt.verbose
 @click.option(
-    "--persist-fixtures",
+    "--preserve-fixtures",
     is_flag=True,
     default=False,
-    help="Persist the fixture tables in the testing database, useful for debugging.",
+    help="Preserve the fixture tables in the testing database, useful for debugging.",
 )
 @click.argument("tests", nargs=-1)
 @click.pass_obj
@@ -525,7 +525,7 @@ def test(
     obj: Context,
     k: t.List[str],
     verbose: bool,
-    persist_fixtures: bool,
+    preserve_fixtures: bool,
     tests: t.List[str],
 ) -> None:
     """Run model unit tests."""
@@ -533,7 +533,7 @@ def test(
         match_patterns=k,
         tests=tests,
         verbose=verbose,
-        persist_fixtures=persist_fixtures,
+        preserve_fixtures=preserve_fixtures,
     )
     if not result.wasSuccessful():
         exit(1)

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1326,6 +1326,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         match_patterns: t.Optional[t.List[str]] = None,
         tests: t.Optional[t.List[str]] = None,
         verbose: bool = False,
+        persist_fixtures: bool = False,
         stream: t.Optional[t.TextIO] = None,
     ) -> ModelTextTestResult:
         """Discover and run model tests"""
@@ -1344,6 +1345,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                     dialect=self.default_dialect,
                     verbosity=verbosity,
                     patterns=match_patterns,
+                    persist_fixtures=persist_fixtures,
                     default_catalog=self.default_catalog,
                 )
             else:
@@ -1364,6 +1366,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                     engine_adapter=self._test_engine_adapter,
                     dialect=self.default_dialect,
                     verbosity=verbosity,
+                    persist_fixtures=persist_fixtures,
                     stream=stream,
                     default_catalog=self.default_catalog,
                 )

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1326,7 +1326,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         match_patterns: t.Optional[t.List[str]] = None,
         tests: t.Optional[t.List[str]] = None,
         verbose: bool = False,
-        persist_fixtures: bool = False,
+        preserve_fixtures: bool = False,
         stream: t.Optional[t.TextIO] = None,
     ) -> ModelTextTestResult:
         """Discover and run model tests"""
@@ -1345,7 +1345,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                     dialect=self.default_dialect,
                     verbosity=verbosity,
                     patterns=match_patterns,
-                    persist_fixtures=persist_fixtures,
+                    preserve_fixtures=preserve_fixtures,
                     default_catalog=self.default_catalog,
                 )
             else:
@@ -1366,7 +1366,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                     engine_adapter=self._test_engine_adapter,
                     dialect=self.default_dialect,
                     verbosity=verbosity,
-                    persist_fixtures=persist_fixtures,
+                    preserve_fixtures=preserve_fixtures,
                     stream=stream,
                     default_catalog=self.default_catalog,
                 )

--- a/sqlmesh/core/test/__init__.py
+++ b/sqlmesh/core/test/__init__.py
@@ -23,6 +23,7 @@ def run_tests(
     engine_adapter: EngineAdapter,
     dialect: str | None = None,
     verbosity: int = 1,
+    persist_fixtures: bool = False,
     stream: t.TextIO | None = None,
     default_catalog: str | None = None,
 ) -> ModelTextTestResult:
@@ -33,6 +34,7 @@ def run_tests(
         models: All models to use for expansion and mapping of physical locations.
         engine_adapter: The engine adapter to use.
         verbosity: The verbosity level.
+        persist_fixtures: Persist the fixture tables in the testing database, useful for debugging.
     """
     suite = unittest.TestSuite(
         ModelTest.create_test(
@@ -43,6 +45,7 @@ def run_tests(
             dialect=dialect,
             path=metadata.path,
             default_catalog=default_catalog,
+            persist_fixtures=persist_fixtures,
         )
         for metadata in model_test_metadata
     )
@@ -62,17 +65,19 @@ def run_model_tests(
     dialect: str | None = None,
     verbosity: int = 1,
     patterns: list[str] | None = None,
+    persist_fixtures: bool = False,
     stream: t.TextIO | None = None,
     default_catalog: t.Optional[str] = None,
 ) -> ModelTextTestResult:
     """Load and run tests.
 
-    Args
+    Args:
         tests: A list of tests to run, e.g. [tests/test_orders.yaml::test_single_order]
         models: All models to use for expansion and mapping of physical locations.
         engine_adapter: The engine adapter to use.
         verbosity: The verbosity level.
         patterns: A list of patterns to match against.
+        persist_fixtures: Persist the fixture tables in the testing database, useful for debugging.
     """
     loaded_tests = []
     for test in tests:
@@ -91,8 +96,9 @@ def run_model_tests(
         loaded_tests,
         models,
         engine_adapter,
-        dialect,
-        verbosity,
-        stream,
+        dialect=dialect,
+        verbosity=verbosity,
+        persist_fixtures=persist_fixtures,
+        stream=stream,
         default_catalog=default_catalog,
     )

--- a/sqlmesh/core/test/__init__.py
+++ b/sqlmesh/core/test/__init__.py
@@ -23,7 +23,7 @@ def run_tests(
     engine_adapter: EngineAdapter,
     dialect: str | None = None,
     verbosity: int = 1,
-    persist_fixtures: bool = False,
+    preserve_fixtures: bool = False,
     stream: t.TextIO | None = None,
     default_catalog: str | None = None,
 ) -> ModelTextTestResult:
@@ -34,7 +34,7 @@ def run_tests(
         models: All models to use for expansion and mapping of physical locations.
         engine_adapter: The engine adapter to use.
         verbosity: The verbosity level.
-        persist_fixtures: Persist the fixture tables in the testing database, useful for debugging.
+        preserve_fixtures: Preserve the fixture tables in the testing database, useful for debugging.
     """
     suite = unittest.TestSuite(
         ModelTest.create_test(
@@ -45,7 +45,7 @@ def run_tests(
             dialect=dialect,
             path=metadata.path,
             default_catalog=default_catalog,
-            persist_fixtures=persist_fixtures,
+            preserve_fixtures=preserve_fixtures,
         )
         for metadata in model_test_metadata
     )
@@ -65,7 +65,7 @@ def run_model_tests(
     dialect: str | None = None,
     verbosity: int = 1,
     patterns: list[str] | None = None,
-    persist_fixtures: bool = False,
+    preserve_fixtures: bool = False,
     stream: t.TextIO | None = None,
     default_catalog: t.Optional[str] = None,
 ) -> ModelTextTestResult:
@@ -77,7 +77,7 @@ def run_model_tests(
         engine_adapter: The engine adapter to use.
         verbosity: The verbosity level.
         patterns: A list of patterns to match against.
-        persist_fixtures: Persist the fixture tables in the testing database, useful for debugging.
+        preserve_fixtures: Preserve the fixture tables in the testing database, useful for debugging.
     """
     loaded_tests = []
     for test in tests:
@@ -98,7 +98,7 @@ def run_model_tests(
         engine_adapter,
         dialect=dialect,
         verbosity=verbosity,
-        persist_fixtures=persist_fixtures,
+        preserve_fixtures=preserve_fixtures,
         stream=stream,
         default_catalog=default_catalog,
     )

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -41,7 +41,7 @@ class ModelTest(unittest.TestCase):
         engine_adapter: EngineAdapter,
         dialect: str | None = None,
         path: Path | None = None,
-        persist_fixtures: bool = False,
+        preserve_fixtures: bool = False,
         default_catalog: str | None = None,
     ) -> None:
         """ModelTest encapsulates a unit test for a model.
@@ -54,7 +54,7 @@ class ModelTest(unittest.TestCase):
             engine_adapter: The engine adapter to use.
             dialect: The models' dialect, used for normalization purposes.
             path: An optional path to the test definition yaml file.
-            persist_fixtures: Persist the fixture tables in the testing database, useful for debugging.
+            preserve_fixtures: Preserve the fixture tables in the testing database, useful for debugging.
         """
         self.body = body
         self.test_name = test_name
@@ -62,7 +62,7 @@ class ModelTest(unittest.TestCase):
         self.models = models
         self.engine_adapter = engine_adapter
         self.path = path
-        self.persist_fixtures = persist_fixtures
+        self.preserve_fixtures = preserve_fixtures
         self.default_catalog = default_catalog
         self.dialect = dialect
 
@@ -125,7 +125,7 @@ class ModelTest(unittest.TestCase):
 
     def tearDown(self) -> None:
         """Drop all fixture tables."""
-        if not self.persist_fixtures:
+        if not self.preserve_fixtures:
             for table_name in self.body.get("inputs", {}):
                 self.engine_adapter.drop_view(self._fixture_table_cache[table_name])
 
@@ -207,7 +207,7 @@ class ModelTest(unittest.TestCase):
         engine_adapter: EngineAdapter,
         dialect: str | None,
         path: Path | None,
-        persist_fixtures: bool = False,
+        preserve_fixtures: bool = False,
         default_catalog: str | None = None,
     ) -> ModelTest:
         """Create a SqlModelTest or a PythonModelTest.
@@ -219,7 +219,7 @@ class ModelTest(unittest.TestCase):
             engine_adapter: The engine adapter to use.
             dialect: The models' dialect, used for normalization purposes.
             path: An optional path to the test definition yaml file.
-            persist_fixtures: Persist the fixture tables in the testing database, useful for debugging.
+            preserve_fixtures: Preserve the fixture tables in the testing database, useful for debugging.
         """
         if "model" not in body:
             _raise_error("Incomplete test, missing model name", path)
@@ -243,7 +243,7 @@ class ModelTest(unittest.TestCase):
                 engine_adapter,
                 dialect,
                 path,
-                persist_fixtures,
+                preserve_fixtures,
                 default_catalog,
             )
         if isinstance(model, PythonModel):
@@ -255,7 +255,7 @@ class ModelTest(unittest.TestCase):
                 engine_adapter,
                 dialect,
                 path,
-                persist_fixtures,
+                preserve_fixtures,
                 default_catalog,
             )
 
@@ -390,7 +390,7 @@ class PythonModelTest(ModelTest):
         engine_adapter: EngineAdapter,
         dialect: str | None = None,
         path: Path | None = None,
-        persist_fixtures: bool = False,
+        preserve_fixtures: bool = False,
         default_catalog: str | None = None,
     ) -> None:
         """PythonModelTest encapsulates a unit test for a Python model.
@@ -403,7 +403,7 @@ class PythonModelTest(ModelTest):
             engine_adapter: The engine adapter to use.
             dialect: The models' dialect, used for normalization purposes.
             path: An optional path to the test definition yaml file.
-            persist_fixtures: Persist the fixture tables in the testing database, useful for debugging.
+            preserve_fixtures: Preserve the fixture tables in the testing database, useful for debugging.
         """
         from sqlmesh.core.test.context import TestExecutionContext
 
@@ -415,7 +415,7 @@ class PythonModelTest(ModelTest):
             engine_adapter,
             dialect,
             path,
-            persist_fixtures,
+            preserve_fixtures,
             default_catalog,
         )
 

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -39,8 +39,9 @@ class ModelTest(unittest.TestCase):
         model: Model,
         models: UniqueKeyDict[str, Model],
         engine_adapter: EngineAdapter,
-        dialect: str | None,
-        path: Path | None,
+        dialect: str | None = None,
+        path: Path | None = None,
+        persist_fixtures: bool = False,
         default_catalog: str | None = None,
     ) -> None:
         """ModelTest encapsulates a unit test for a model.
@@ -53,6 +54,7 @@ class ModelTest(unittest.TestCase):
             engine_adapter: The engine adapter to use.
             dialect: The models' dialect, used for normalization purposes.
             path: An optional path to the test definition yaml file.
+            persist_fixtures: Persist the fixture tables in the testing database, useful for debugging.
         """
         self.body = body
         self.test_name = test_name
@@ -60,6 +62,7 @@ class ModelTest(unittest.TestCase):
         self.models = models
         self.engine_adapter = engine_adapter
         self.path = path
+        self.persist_fixtures = persist_fixtures
         self.default_catalog = default_catalog
         self.dialect = dialect
 
@@ -122,8 +125,9 @@ class ModelTest(unittest.TestCase):
 
     def tearDown(self) -> None:
         """Drop all fixture tables."""
-        for table_name in self.body.get("inputs", {}):
-            self.engine_adapter.drop_view(self._fixture_table_cache[table_name])
+        if not self.persist_fixtures:
+            for table_name in self.body.get("inputs", {}):
+                self.engine_adapter.drop_view(self._fixture_table_cache[table_name])
 
     def assert_equal(
         self,
@@ -203,6 +207,7 @@ class ModelTest(unittest.TestCase):
         engine_adapter: EngineAdapter,
         dialect: str | None,
         path: Path | None,
+        persist_fixtures: bool = False,
         default_catalog: str | None = None,
     ) -> ModelTest:
         """Create a SqlModelTest or a PythonModelTest.
@@ -214,6 +219,7 @@ class ModelTest(unittest.TestCase):
             engine_adapter: The engine adapter to use.
             dialect: The models' dialect, used for normalization purposes.
             path: An optional path to the test definition yaml file.
+            persist_fixtures: Persist the fixture tables in the testing database, useful for debugging.
         """
         if "model" not in body:
             _raise_error("Incomplete test, missing model name", path)
@@ -230,11 +236,27 @@ class ModelTest(unittest.TestCase):
         model = models[model_name]
         if isinstance(model, SqlModel):
             return SqlModelTest(
-                body, test_name, model, models, engine_adapter, dialect, path, default_catalog
+                body,
+                test_name,
+                model,
+                models,
+                engine_adapter,
+                dialect,
+                path,
+                persist_fixtures,
+                default_catalog,
             )
         if isinstance(model, PythonModel):
             return PythonModelTest(
-                body, test_name, model, models, engine_adapter, dialect, path, default_catalog
+                body,
+                test_name,
+                model,
+                models,
+                engine_adapter,
+                dialect,
+                path,
+                persist_fixtures,
+                default_catalog,
             )
 
         raise TestError(f"Model '{model_name}' is an unsupported model type for testing at {path}")
@@ -366,8 +388,9 @@ class PythonModelTest(ModelTest):
         model: PythonModel,
         models: UniqueKeyDict[str, Model],
         engine_adapter: EngineAdapter,
-        dialect: str | None,
-        path: Path | None,
+        dialect: str | None = None,
+        path: Path | None = None,
+        persist_fixtures: bool = False,
         default_catalog: str | None = None,
     ) -> None:
         """PythonModelTest encapsulates a unit test for a Python model.
@@ -380,11 +403,20 @@ class PythonModelTest(ModelTest):
             engine_adapter: The engine adapter to use.
             dialect: The models' dialect, used for normalization purposes.
             path: An optional path to the test definition yaml file.
+            persist_fixtures: Persist the fixture tables in the testing database, useful for debugging.
         """
         from sqlmesh.core.test.context import TestExecutionContext
 
         super().__init__(
-            body, test_name, model, models, engine_adapter, dialect, path, default_catalog
+            body,
+            test_name,
+            model,
+            models,
+            engine_adapter,
+            dialect,
+            path,
+            persist_fixtures,
+            default_catalog,
         )
 
         self.context = TestExecutionContext(

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -783,9 +783,9 @@ class SQLMeshMagics(Magics):
     )
     @argument("--verbose", "-v", action="store_true", help="Verbose output.")
     @argument(
-        "--persist-fixtures",
+        "--preserve-fixtures",
         action="store_true",
-        help="Persist the fixture tables in the testing database, useful for debugging.",
+        help="Preserve the fixture tables in the testing database, useful for debugging.",
     )
     @line_magic
     @pass_sqlmesh_context
@@ -796,7 +796,7 @@ class SQLMeshMagics(Magics):
             match_patterns=args.pattern,
             tests=args.tests,
             verbose=args.verbose,
-            persist_fixtures=args.persist_fixtures,
+            preserve_fixtures=args.preserve_fixtures,
         )
 
     @magic_arguments()

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -782,12 +782,22 @@ class SQLMeshMagics(Magics):
         help="Only run tests that match the pattern of substring.",
     )
     @argument("--verbose", "-v", action="store_true", help="Verbose output.")
+    @argument(
+        "--persist-fixtures",
+        action="store_true",
+        help="Persist the fixture tables in the testing database, useful for debugging.",
+    )
     @line_magic
     @pass_sqlmesh_context
     def run_test(self, context: Context, line: str) -> None:
         """Run unit test(s)."""
         args = parse_argstring(self.run_test, line)
-        context.test(match_patterns=args.pattern, tests=args.tests, verbose=args.verbose)
+        context.test(
+            match_patterns=args.pattern,
+            tests=args.tests,
+            verbose=args.verbose,
+            persist_fixtures=args.persist_fixtures,
+        )
 
     @magic_arguments()
     @argument(


### PR DESCRIPTION
Addresses the tenth item in https://github.com/TobikoData/sqlmesh/issues/1637. I didn't address the CTE fixture item because creating views for CTEs may not be possible, e.g. if we don't have or can't correctly infer their `columns_to_types` mappings.

> Add support for "dumping" duckdb state on test failure to speed up debugging

As I mentioned in a reply in the above issue, I believe this PR should suffice because one can simply override the test connection database to "dump" the state for DuckDB, so the fixtures are not transient (due to creating them in-memory).

For example:

```yaml
gateways:
    local:
        connection:
            type: duckdb
            database: db.db
        test_connection:
            type: duckdb
            catalogs:
              db: test.db

default_gateway: local

model_defaults:
    dialect: duckdb
```

I'm using this config for the example project, and I can jump into `test.db` directly after running:

```
sqlmesh test --preserve-fixtures
```

Observe:

```
➜ duckdb test.db
v0.10.0 20b1486d11
Enter ".help" for usage hints.
D .schema
CREATE VIEW sqlmesh_example.incremental_model__fixture__mzn485dz (id, item_id, event_date) AS SELECT CAST(id AS INTEGER) AS id, CAST(item_id AS INTEGER) AS item_id, CAST(event_date AS DATE) AS event_date FROM (SELECT * FROM (VALUES (1, 1, '2020-01-01'), (2, 1, '2020-01-02'), (3, 2, '2020-01-03')) AS valueslist) AS t(id, item_id, event_date);

D select * from sqlmesh_example.incremental_model__fixture__mzn485dz;
┌───────┬─────────┬────────────┐
│  id   │ item_id │ event_date │
│ int32 │  int32  │    date    │
├───────┼─────────┼────────────┤
│     1 │       1 │ 2020-01-01 │
│     2 │       1 │ 2020-01-02 │
│     3 │       2 │ 2020-01-03 │
└───────┴─────────┴────────────┘
```