### PR TITLE
fix: widen spark support

### DIFF
--- a/docs/integrations/engines/spark.md
+++ b/docs/integrations/engines/spark.md
@@ -7,12 +7,12 @@ NOTE: Spark may not be used for the SQLMesh [state connection](../../reference/c
 
 ### Connection options
 
-| Option          | Description                                               |  Type  | Required |
-|-----------------|-----------------------------------------------------------|:------:|:--------:|
-| `type`          | Engine type name - must be `spark`                        | string |    Y     |
-| `config_dir`    | Value to set for `SPARK_CONFIG_DIR`                       | string |    N     |
-| `catalog`       | Spark 3.4+ Only. The catalog to use when issuing commands | string |    N     |
-| `config`        | Key/value pairs to set for the Spark Configuration.       |  dict  |    N     |
+| Option       | Description                                                                                   |  Type  | Required |
+|--------------|-----------------------------------------------------------------------------------------------|:------:|:--------:|
+| `type`       | Engine type name - must be `spark`                                                            | string |    Y     |
+| `config_dir` | Value to set for `SPARK_CONFIG_DIR`                                                           | string |    N     |
+| `catalog`    | The catalog to use when issuing commands. See [Catalog Support](#catalog-support) for details | string |    N     |
+| `config`     | Key/value pairs to set for the Spark Configuration.                                           |  dict  |    N     |
 
 ## Airflow Scheduler
 **Engine Name:** `spark`
@@ -42,3 +42,14 @@ Similarly, the `engine_operator_args` parameter can be used to override other jo
 <br><br>
 
 Each Spark job submitted by SQLMesh is a PySpark application that depends on the SQLMesh library in its Driver process (but not in Executors). This means that if the Airflow connection is configured to submit jobs in `cluster` mode as opposed to `client` mode, the user must ensure that the SQLMesh Python library is installed on each node of a cluster where Spark jobs are submitted. This is because there is no way to know in advance which specific node to which a Driver process will be scheduled. No additional configuration is required if the deploy mode is set to `client`.
+
+
+## Catalog Support
+
+SQLMesh's Spark integration is only designed/tested with a single catalog usage in mind. 
+Therefore all SQLMesh models must be defined with a single catalog.
+
+If `catalog` is not set, then the behavior changes based on spark release:
+
+* If >=3.4, then the default catalog is determined at runtime
+* If <3.4, then the default catalog is `spark_catalog` 

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -8,6 +8,7 @@ from sqlglot import exp
 
 from sqlmesh.core.engine_adapter.shared import (
     CatalogSupport,
+    DataObject,
     InsertOverwriteStrategy,
     set_catalog,
 )
@@ -17,13 +18,17 @@ from sqlmesh.utils import classproperty
 from sqlmesh.utils.errors import SQLMeshError
 
 if t.TYPE_CHECKING:
-    from sqlmesh.core._typing import TableName
+    from sqlmesh.core._typing import SchemaName, TableName
     from sqlmesh.core.engine_adapter._typing import DF, PySparkSession
 
 logger = logging.getLogger(__name__)
 
 
-@set_catalog()
+@set_catalog(
+    {
+        "_get_data_objects": CatalogSupport.REQUIRES_SET_CATALOG,
+    }
+)
 class DatabricksEngineAdapter(SparkEngineAdapter):
     DIALECT = "databricks"
     INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
@@ -162,6 +167,11 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
                 super().set_current_catalog(catalog_name)
             except (Py4JError, SparkConnectGrpcException):
                 pass
+
+    def _get_data_objects(
+        self, schema_name: SchemaName, object_names: t.Optional[t.Set[str]] = None
+    ) -> t.List[DataObject]:
+        return super()._get_data_objects(schema_name, object_names=object_names)
 
     def clone_table(
         self,

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -330,23 +330,19 @@ class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTableP
         ]
 
     @property
-    def _spark_semver(self) -> t.Tuple[int, int, int]:
-        return tuple(int(x) for x in self.spark.version.split(".")[:3])  # type: ignore
+    def _spark_major_minor(self) -> t.Tuple[int, int]:
+        return tuple(int(x) for x in self.spark.version.split(".")[:2])  # type: ignore
 
     def get_current_catalog(self) -> t.Optional[str]:
-        # Spark 3.4+ API
         if self._use_spark_session:
-            major, minor, _ = self._spark_semver
-            if major > 3 or (major == 3 and minor >= 4):
+            if self._spark_major_minor >= (3, 4):
                 return self.spark.catalog.currentCatalog()
             else:
                 return self._default_catalog or "spark_catalog"
         return super().get_current_catalog()
 
     def set_current_catalog(self, catalog_name: str) -> None:
-        # Spark 3.4+ API
-        major, minor, _ = self._spark_semver
-        if major > 3 or (major == 3 and minor >= 4):
+        if self._spark_major_minor >= (3, 4):
             return self.spark.catalog.setCurrentCatalog(catalog_name)
         current_catalog = self.get_current_catalog()
         if current_catalog != catalog_name:

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -41,13 +41,7 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@set_catalog(
-    override_mapping={
-        "_get_data_objects": CatalogSupport.REQUIRES_SET_CATALOG,
-        "create_schema": CatalogSupport.REQUIRES_SET_CATALOG,
-        "drop_schema": CatalogSupport.REQUIRES_SET_CATALOG,
-    }
-)
+@set_catalog()
 class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTablePropertiesMixin):
     DIALECT = "spark"
     SUPPORTS_TRANSACTIONS = False
@@ -323,7 +317,8 @@ class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTableP
         return [
             DataObject(
                 catalog=self.get_current_catalog(),
-                schema=schema_name,
+                # This varies between Spark and Databricks
+                schema=row.asDict().get("namespace") or row["database"],
                 name=row["tableName"],
                 type=(
                     DataObjectType.VIEW
@@ -334,38 +329,40 @@ class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTableP
             for row in results  # type: ignore
         ]
 
+    @property
+    def _spark_semver(self) -> t.Tuple[int, int, int]:
+        major, minor, patch, *_ = map(int, self.spark.version.split("."))
+        return major, minor, patch
+
     def get_current_catalog(self) -> t.Optional[str]:
         # Spark 3.4+ API
         if self._use_spark_session:
-            return self.spark.catalog.currentCatalog()
+            major, minor, _ = self._spark_semver
+            if major >= 3:
+                if major > 3 or minor >= 4:
+                    return self.spark.catalog.currentCatalog()
+                else:
+                    return self.spark.conf.get("spark.sql.defaultCatalog", "spark_catalog")
+            else:
+                # We just assume it is the default catalog
+                return "spark_catalog"
         return super().get_current_catalog()
 
     def set_current_catalog(self, catalog_name: str) -> None:
         # Spark 3.4+ API
-        self.spark.catalog.setCurrentCatalog(catalog_name)
+        major, minor, _ = self._spark_semver
+        if major > 3 or (major == 3 and minor >= 4):
+            return self.spark.catalog.setCurrentCatalog(catalog_name)
+        current_catalog = self.get_current_catalog()
+        if current_catalog != catalog_name:
+            logger.warning(
+                "Spark <3.4 does not support certain cross catalog queries since the default catalog cannot be set <3.4"
+            )
 
     def get_current_database(self) -> str:
         if self._use_spark_session:
             return self.spark.catalog.currentDatabase()
         return self.fetchone(exp.select(exp.func("current_database")))[0]
-
-    def create_schema(
-        self,
-        schema_name: SchemaName,
-        ignore_if_exists: bool = True,
-        warn_on_error: bool = True,
-    ) -> None:
-        super().create_schema(
-            schema_name, ignore_if_exists=ignore_if_exists, warn_on_error=warn_on_error
-        )
-
-    def drop_schema(
-        self,
-        schema_name: SchemaName,
-        ignore_if_not_exists: bool = True,
-        cascade: bool = False,
-    ) -> None:
-        super().drop_schema(schema_name, ignore_if_not_exists=ignore_if_not_exists, cascade=cascade)
 
     def create_state_table(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -344,8 +344,8 @@ def make_mocked_engine_adapter(mocker: MockerFixture) -> t.Callable:
         )
         if isinstance(adapter, SparkEngineAdapter):
             mocker.patch(
-                "sqlmesh.core.engine_adapter.spark.SparkEngineAdapter._spark_semver",
-                new_callable=PropertyMock(return_value=(3, 5, 0)),
+                "sqlmesh.core.engine_adapter.spark.SparkEngineAdapter._spark_major_minor",
+                new_callable=PropertyMock(return_value=(3, 5)),
             )
         return adapter
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from sqlglot.helper import ensure_list
 
 from sqlmesh.core.config import DuckDBConnectionConfig
 from sqlmesh.core.context import Context
+from sqlmesh.core.engine_adapter import SparkEngineAdapter
 from sqlmesh.core.engine_adapter.base import EngineAdapter
 from sqlmesh.core.macros import macro
 from sqlmesh.core.model import model
@@ -336,11 +337,17 @@ def make_mocked_engine_adapter(mocker: MockerFixture) -> t.Callable:
         cursor_mock = mocker.Mock()
         connection_mock.cursor.return_value = cursor_mock
         cursor_mock.connection.return_value = connection_mock
-        return klass(
+        adapter = klass(
             lambda: connection_mock,
             dialect=dialect or klass.DIALECT,
             register_comments=register_comments,
         )
+        if isinstance(adapter, SparkEngineAdapter):
+            mocker.patch(
+                "sqlmesh.core.engine_adapter.spark.SparkEngineAdapter._spark_semver",
+                new_callable=PropertyMock(return_value=(3, 5, 0)),
+            )
+        return adapter
 
     return _make_function
 

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -1014,7 +1014,7 @@ def test_replace_query_with_wap_self_reference(
     sql_calls = to_sql_calls(adapter)
     assert sql_calls == [
         "CREATE TABLE IF NOT EXISTS `catalog`.`schema`.`table` (`a` INT)",
-        "CREATE SCHEMA IF NOT EXISTS `schema`",
+        "CREATE SCHEMA IF NOT EXISTS `catalog`.`schema`",
         "CREATE TABLE IF NOT EXISTS `catalog`.`schema`.`temp_branch_wap_12345_abcdefgh` USING ICEBERG AS SELECT `a` FROM `catalog`.`schema`.`table`.`branch_wap_12345`",
         "INSERT OVERWRITE TABLE `catalog`.`schema`.`table`.`branch_wap_12345` (`a`) SELECT 1 AS `a` FROM `catalog`.`schema`.`temp_branch_wap_12345_abcdefgh`",
         "DROP TABLE IF EXISTS `catalog`.`schema`.`temp_branch_wap_12345_abcdefgh`",


### PR DESCRIPTION
I've updated Spark's catalog operations to not rely solely on 3.4+. In general after testing it seems like Spark may only support a single catalog for managing SQLMesh models. 

For `set_catalog` override I tested and I couldn't find any reason why `create_schema` and `drop_schema` were to requiring set catalog to work and it seems like on both Spark and Databricks the full catalog.db reference is compatible. So I removed this entirely. 

Databricks does require the set catalog when getting objects outside of the default catalog. 
<img width="1041" alt="Screenshot 2024-04-08 at 12 46 11 PM" src="https://github.com/TobikoData/sqlmesh/assets/6326532/07ab2d15-8310-42e9-a636-ea4bdc9e21a6">

For Spark if I try to do this within my local environment I get an error about not being able to do this on v2 tables. So I think potentially our current implementation requires the use of `spark_catalog`? 