### PR TITLE
Fix: make partial setting in unit tests deterministic

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -573,11 +573,11 @@ def _create_df(
     rows: t.List[Row], columns: t.Optional[t.Collection] = None, partial: t.Optional[bool] = False
 ) -> pd.DataFrame:
     if columns:
-        referenced_columns = {col for row in rows for col in row}
+        referenced_columns = list(dict.fromkeys(col for row in rows for col in row))
         _raise_if_unexpected_columns(columns, referenced_columns)
 
         if partial:
-            columns = list(referenced_columns)
+            columns = referenced_columns
 
     return pd.DataFrame.from_records(rows, columns=columns)
 


### PR DESCRIPTION
Prior to this change, setting `partial: True` in a unit test could result in non-deterministic behavior because `referenced_columns` was created as a set, meaning that the column order would not necessarily be respected, thus causing issues when comparing the actual and expected dataframes.