### PR TITLE
Fix: get physical table name in ibis example

### DIFF
--- a/examples/ibis/models/ibis_full_model_python.py
+++ b/examples/ibis/models/ibis_full_model_python.py
@@ -17,7 +17,7 @@ from sqlmesh.core.model import FullKind
         "num_orders": "int",
     },
     audits=["assert_positive_order_ids"],
-    description="This model uses ibis to generate and run a query",
+    description="This model uses ibis to transform a `table` object and return a dataframe",
 )
 def execute(
     context: ExecutionContext,
@@ -26,11 +26,14 @@ def execute(
     execution_time: datetime,
     **kwargs: t.Any,
 ) -> pd.DataFrame:
+    # get physical table name
+    table_name = context.table("ibis.incremental_model").split(".")
+
     # connect ibis to database
     con = ibis.duckdb.connect(DB_PATH)
 
     # retrieve table
-    incremental_model = con.table("incremental_model", schema="ibis")
+    incremental_model = con.table(name=table_name[-1], schema=table_name[-2])
 
     # build query
     count = incremental_model.id.nunique()

--- a/examples/ibis/models/ibis_full_model_python.py
+++ b/examples/ibis/models/ibis_full_model_python.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import ibis  # type: ignore
 import pandas as pd
 from constants import DB_PATH  # type: ignore
+from sqlglot import exp
 
 from sqlmesh import ExecutionContext, model
 from sqlmesh.core.model import FullKind
@@ -27,13 +28,12 @@ def execute(
     **kwargs: t.Any,
 ) -> pd.DataFrame:
     # get physical table name
-    table_name = context.table("ibis.incremental_model").split(".")
-
+    upstream_model = exp.to_table(context.table("ibis.incremental_model"))
     # connect ibis to database
     con = ibis.duckdb.connect(DB_PATH)
 
     # retrieve table
-    incremental_model = con.table(name=table_name[-1], schema=table_name[-2])
+    incremental_model = con.table(name=upstream_model.name, schema=upstream_model.db)
 
     # build query
     count = incremental_model.id.nunique()

--- a/examples/ibis/models/ibis_full_model_sql.py
+++ b/examples/ibis/models/ibis_full_model_sql.py
@@ -10,7 +10,7 @@ from sqlmesh.core.model import model
     is_sql=True,
     kind="FULL",
     audits=["assert_positive_order_ids"],
-    description="This model uses ibis to generate a SQL string",
+    description="This model uses ibis to generate and return a SQL string",
 )
 def entrypoint(evaluator: MacroEvaluator) -> str:
     # create table reference


### PR DESCRIPTION
Previously, applying a plan in this project from an empty state would fail since the table `ibis.incremental_model` would not yet exist. This gets the physical table name from context and passes that into the ibis connection instead