### PR TITLE
Fix: improve csv seed file type inference

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1165,7 +1165,7 @@ class SeedModel(_SqlBasedModel):
             for column in date_columns:
                 df[column] = df[column].dt.date
             df[bool_columns] = df[bool_columns].apply(lambda i: str_to_bool(str(i)))
-            df[string_columns] = df[string_columns].mask(
+            df.loc[:, string_columns] = df[string_columns].mask(
                 cond=lambda x: x.notna(), other=df[string_columns].astype(str)  # type: ignore
             )
             yield df

--- a/sqlmesh/core/model/seed.py
+++ b/sqlmesh/core/model/seed.py
@@ -76,6 +76,7 @@ class CsvSeedReader:
                 StringIO(self.content),
                 index_col=False,
                 on_bad_lines="error",
+                low_memory=False,
                 **{k: v for k, v in self.settings.dict().items() if v is not None},
             )
             self._df = self._df.rename(

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -30,7 +30,7 @@ async def watch_project() -> None:
     ]
     ignore_entity_patterns = context.config.ignore_patterns if context else c.IGNORE_PATTERNS
     ignore_entity_patterns.append("^\\.DS_Store$")
-    ignore_entity_patterns.append("^.*\.db(\.wal)?$")
+    ignore_entity_patterns.append("^.*\\.db(\\.wal)?$")
     ignore_paths = [str((settings.project_path / c.CACHE).resolve())]
     watch_filter = DefaultFilter(
         ignore_paths=ignore_paths, ignore_entity_patterns=ignore_entity_patterns


### PR DESCRIPTION
Prior to this change, large seed files were chunked and so pandas' type inference would be incomplete, leading to users seeing [warnings](https://pandas.pydata.org/docs/reference/api/pandas.errors.DtypeWarning.html) related to data type mismatches.

This PR makes it so that seed files are not chunked, in order to avoid the mixed type inference issues. The tradeoff here is that this could potentially lead to memory consumption issues for larger seed files, but that should be ok since we don't really encourage users to have really large seed files where memory consumption would actually be a problem.

One workaround we discussed was to add both `low_memory` and `dtype` to `CsvSettings`, but the latter was involved because we'd need to allow the properties to be arbitrarily nested in order to support `SEED` definitions like the following, so I opted for this simpler approach.

```sql
  kind SEED (
    path '../seeds/seed_data.csv',
    csv_settings (
      low_memory = False,
      dtype (
        k1 = v2,
        ...
      )
    ),
  )
```

While testing this, I also noticed a couple of other warnings that I fixed. The `loc` one was related to this:

```
sqlmesh/core/model/definition.py:1166: SettingWithCopyWarning:
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead
```

See https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.errors.SettingWithCopyWarning.html for reference.

Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1712655545849239