### PR TITLE
Refactor: only use the last comment attached to a projection as its description

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1010,7 +1010,7 @@ class SqlModel(_SqlBasedModel):
             return {}
 
         return {
-            select.alias_or_name: "\n".join(comment.strip() for comment in select.comments)
+            select.alias_or_name: select.comments[-1].strip()
             for select in query.selects
             if select.comments
         }

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -528,6 +528,7 @@ def test_column_descriptions(sushi_context, assert_exp_eq):
         );
 
         SELECT
+          -- this is the id column, used in ...
           id::int, -- primary key
           foo::int, -- bar
         FROM table
@@ -539,11 +540,13 @@ def test_column_descriptions(sushi_context, assert_exp_eq):
         model.query,
         """
         SELECT
+          -- this is the id column, used in ...
           id::int, -- primary key
           foo::int, -- bar
         FROM table
-    """,
+        """,
     )
+    assert model.column_descriptions == {"id": "primary key", "foo": "bar"}
 
 
 def test_model_jinja_macro_reference_extraction():


### PR DESCRIPTION
Prior to this change, if a projection had multiple comments attached to it, all of them would be joined and used as its description.

This PR makes it so that we'll only use the last comment in the projection's `comments` list for the description. That should make the behavior more consistent, because we can now say "to add a description, simply add a comment to the end of the line" and we'll not mix other comments in.

The motivation around this can be found in https://github.com/TobikoData/sqlmesh/pull/2383#discussion_r1551745475. TL;DR: we want to avoid having to deal with how SQLGlot attaches comments in expressions.

For example, `comment 1` in the following example could be a comment that we don't really intend to register in the db, but is there to only provide additional information:

```sql
SELECT
  -- comment 1
  some_column,  -- actual description goes here
  ...
FROM t
```