### PR TITLE
Feat: Support restatements for the incremental unmanaged model kind

### DIFF
--- a/docs/concepts/models/model_kinds.md
+++ b/docs/concepts/models/model_kinds.md
@@ -166,7 +166,7 @@ WHERE
   event_date BETWEEN @start_date AND @end_date;
 ```
 
-**Note:** Models of the `INCREMENTAL_BY_UNIQUE_KEY` kind are inherently [non-idempotent](../glossary.md#idempotency), which should be taken into consideration during data [restatement](../plans.md#restatement-plans).
+**Note:** Models of the `INCREMENTAL_BY_UNIQUE_KEY` kind are inherently [non-idempotent](../glossary.md#idempotency), which should be taken into consideration during data [restatement](../plans.md#restatement-plans). As a result, partial data restatement is not supported for this model kind, which means that the entire table will be recreated from scratch if restated.
 
 ### Unique Key Expressions
 
@@ -320,7 +320,9 @@ SQLMesh achieves this by adding a `valid_from` and `valid_to` column to your mod
 
 Therefore you can use these models to not only tell you what the latest value is for a given record but also what the values were anytime in the past. Note that maintaining this history does come at a cost of increased storage and compute and this may not be a good fit for sources that change frequently since the history could get very large.
 
-There are two ways to tracking changes: By Time (Recommended) or By Column. 
+**Note**: Partial data [restatement](../plans.md#restatement-plans) is not supported for this model kind, which means that the entire table will be recreated from scratch if restated. This may lead to data loss, which is why data restatement is disabled for models of this kind by default.
+
+There are two ways to tracking changes: By Time (Recommended) or By Column.
 
 ### SCD Type 2 By Time (Recommended)
 

--- a/docs/concepts/plans.md
+++ b/docs/concepts/plans.md
@@ -133,7 +133,7 @@ For this reason, the `plan` command supports the `--restate-model`, which allows
 
 Application of a plan will trigger a cascading backfill for all specified models (other than external tables), as well as all models downstream from them. The plan's date range determines the data intervals that will be affected.
 
-Please note that models of kinds [INCREMENTAL_BY_UNIQUE_KEY](models/model_kinds.md#INCREMENTAL_BY_UNIQUE_KEY), [SCD_TYPE_2_BY_TIME](models/model_kinds.md#scd-type-2), and [SCD_TYPE_2_BY_COLUMN](models/model_kinds.md#scd-type-2) cannot be partially restated. Therefore, such models will be fully refreshed regardless of the start/end dates provided by a user in the plan.
+Please note that models of kinds [INCREMENTAL_BY_UNIQUE_KEY](models/model_kinds.md#INCREMENTAL_BY_UNIQUE_KEY), [SCD_TYPE_2_BY_TIME](models/model_kinds.md#scd-type-2), and [SCD_TYPE_2_BY_COLUMN](models/model_kinds.md#scd-type-2) cannot be partially restated. Therefore, such models will be fully refreshed regardless of the start/end dates provided by a user in the plan. To prevent such models from ever being restated, set the [disable_restatement](models/overview.md#disable_restatement) attribute to `true`.
 
 See examples below for how to restate both based on model names and model tags.
 

--- a/docs/concepts/plans.md
+++ b/docs/concepts/plans.md
@@ -133,6 +133,8 @@ For this reason, the `plan` command supports the `--restate-model`, which allows
 
 Application of a plan will trigger a cascading backfill for all specified models (other than external tables), as well as all models downstream from them. The plan's date range determines the data intervals that will be affected.
 
+Please note that models of kinds [INCREMENTAL_BY_UNIQUE_KEY](models/model_kinds.md#INCREMENTAL_BY_UNIQUE_KEY), [SCD_TYPE_2_BY_TIME](models/model_kinds.md#scd-type-2), and [SCD_TYPE_2_BY_COLUMN](models/model_kinds.md#scd-type-2) cannot be partially restated. Therefore, such models will be fully refreshed regardless of the start/end dates provided by a user in the plan.
+
 See examples below for how to restate both based on model names and model tags.
 
 

--- a/docs/concepts/plans.md
+++ b/docs/concepts/plans.md
@@ -133,7 +133,9 @@ For this reason, the `plan` command supports the `--restate-model`, which allows
 
 Application of a plan will trigger a cascading backfill for all specified models (other than external tables), as well as all models downstream from them. The plan's date range determines the data intervals that will be affected.
 
-Please note that models of kinds [INCREMENTAL_BY_UNIQUE_KEY](models/model_kinds.md#INCREMENTAL_BY_UNIQUE_KEY), [SCD_TYPE_2_BY_TIME](models/model_kinds.md#scd-type-2), and [SCD_TYPE_2_BY_COLUMN](models/model_kinds.md#scd-type-2) cannot be partially restated. Therefore, such models will be fully refreshed regardless of the start/end dates provided by a user in the plan. To prevent such models from ever being restated, set the [disable_restatement](models/overview.md#disable_restatement) attribute to `true`.
+Please note that models of kinds [INCREMENTAL_BY_UNIQUE_KEY](models/model_kinds.md#INCREMENTAL_BY_UNIQUE_KEY), [SCD_TYPE_2_BY_TIME](models/model_kinds.md#scd-type-2), and [SCD_TYPE_2_BY_COLUMN](models/model_kinds.md#scd-type-2) cannot be partially restated. Therefore, such models will be fully refreshed regardless of the start/end dates provided by a user in the plan.
+
+To prevent models from ever being restated, set the [disable_restatement](models/overview.md#disable_restatement) attribute to `true`.
 
 See examples below for how to restate both based on model names and model tags.
 

--- a/sqlmesh/core/engine_adapter/trino.py
+++ b/sqlmesh/core/engine_adapter/trino.py
@@ -216,6 +216,7 @@ class TrinoEngineAdapter(
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
+        truncate: bool = False,
     ) -> None:
         if columns_to_types and self.current_catalog_type == "delta_lake":
             columns_to_types = self._to_delta_ts(columns_to_types)
@@ -235,6 +236,7 @@ class TrinoEngineAdapter(
             columns_to_types,
             table_description,
             column_descriptions,
+            truncate,
         )
 
     # delta_lake only supports two timestamp data types. This method converts other

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -115,6 +115,11 @@ class ModelKindMixin:
         """Whether or not this model only cares about execution time to render."""
         return self.is_view or self.is_full or self.is_scd_type_2
 
+    @property
+    def full_history_restatement_only(self) -> bool:
+        """Whether or not this model only supports restatement of full history."""
+        return self.is_incremental_unmanaged or self.is_incremental_by_unique_key or self.is_scd_type_2
+
 
 class ModelKindName(str, ModelKindMixin, Enum):
     """The kind of model, determining how this data is computed and stored in the warehouse."""
@@ -342,7 +347,7 @@ class IncrementalUnmanagedKind(_ModelKind):
     name: Literal[ModelKindName.INCREMENTAL_UNMANAGED] = ModelKindName.INCREMENTAL_UNMANAGED
     insert_overwrite: SQLGlotBool = False
     forward_only: SQLGlotBool = True
-    disable_restatement: Literal[True] = True
+    disable_restatement: SQLGlotBool = False
 
     @property
     def data_hash_values(self) -> t.List[t.Optional[str]]:

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -118,7 +118,9 @@ class ModelKindMixin:
     @property
     def full_history_restatement_only(self) -> bool:
         """Whether or not this model only supports restatement of full history."""
-        return self.is_incremental_unmanaged or self.is_incremental_by_unique_key or self.is_scd_type_2
+        return (
+            self.is_incremental_unmanaged or self.is_incremental_by_unique_key or self.is_scd_type_2
+        )
 
 
 class ModelKindName(str, ModelKindMixin, Enum):
@@ -347,7 +349,7 @@ class IncrementalUnmanagedKind(_ModelKind):
     name: Literal[ModelKindName.INCREMENTAL_UNMANAGED] = ModelKindName.INCREMENTAL_UNMANAGED
     insert_overwrite: SQLGlotBool = False
     forward_only: SQLGlotBool = True
-    disable_restatement: SQLGlotBool = False
+    disable_restatement: SQLGlotBool = True
 
     @property
     def data_hash_values(self) -> t.List[t.Optional[str]]:

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -675,7 +675,13 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         *,
         strict: bool = True,
     ) -> Interval:
-        end = execution_time or now() if self.depends_on_past else end
+        end = (
+            execution_time or now()
+            if self.depends_on_past or self.full_history_restatement_only
+            else end
+        )
+        if self.full_history_restatement_only and self.intervals:
+            start = self.intervals[0][0]
         return self.inclusive_exclusive(start, end, strict)
 
     def inclusive_exclusive(

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -1785,6 +1785,207 @@ FROM "inserted_rows"
     )
 
 
+def test_scd_type_2_truncate(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+
+    adapter.scd_type_2_by_column(
+        target_table="target",
+        source_table=t.cast(exp.Select, parse_one("SELECT id, name, price FROM source")),
+        unique_key=[exp.column("id")],
+        valid_from_name="test_valid_from",
+        valid_to_name="test_valid_to",
+        check_columns=[exp.column("name"), exp.column("price")],
+        columns_to_types={
+            "id": exp.DataType.build("INT"),
+            "name": exp.DataType.build("VARCHAR"),
+            "price": exp.DataType.build("DOUBLE"),
+            "test_valid_from": exp.DataType.build("TIMESTAMP"),
+            "test_valid_to": exp.DataType.build("TIMESTAMP"),
+        },
+        execution_time=datetime(2020, 1, 1, 0, 0, 0),
+        truncate=True,
+    )
+
+    assert (
+        adapter.cursor.execute.call_args[0][0]
+        == parse_one(
+            """
+CREATE OR REPLACE TABLE "target" AS
+WITH "source" AS (
+  SELECT DISTINCT ON ("id")
+    TRUE AS "_exists",
+    "id",
+    "name",
+    "price"
+  FROM (
+    SELECT
+      "id",
+      "name",
+      "price"
+    FROM "source"
+  ) AS "raw_source"
+), "static" AS (
+  SELECT
+    "id",
+    "name",
+    "price",
+    "test_valid_from",
+    "test_valid_to"
+  FROM "target"
+  WHERE
+    NOT "test_valid_to" IS NULL
+  LIMIT 0
+), "latest" AS (
+  SELECT
+    "id",
+    "name",
+    "price",
+    "test_valid_from",
+    "test_valid_to"
+  FROM "target"
+  WHERE
+    "test_valid_to" IS NULL
+  LIMIT 0
+), "deleted" AS (
+  SELECT
+    "static"."id",
+    "static"."name",
+    "static"."price",
+    "static"."test_valid_from",
+    "static"."test_valid_to"
+  FROM "static"
+  LEFT JOIN "latest"
+    ON "static"."id" = "latest"."id"
+  WHERE
+    "latest"."test_valid_to" IS NULL
+), "latest_deleted" AS (
+  SELECT
+    TRUE AS "_exists",
+    "id" AS "_key0",
+    MAX("test_valid_to") AS "test_valid_to"
+  FROM "deleted"
+  GROUP BY
+    "id"
+), "joined" AS (
+  SELECT
+    "source"."_exists",
+    "latest"."id" AS "t_id",
+    "latest"."name" AS "t_name",
+    "latest"."price" AS "t_price",
+    "latest"."test_valid_from" AS "t_test_valid_from",
+    "latest"."test_valid_to" AS "t_test_valid_to",
+    "source"."id" AS "id",
+    "source"."name" AS "name",
+    "source"."price" AS "price"
+  FROM "latest"
+  LEFT JOIN "source"
+    ON "latest"."id" = "source"."id"
+  UNION
+  SELECT
+    "source"."_exists",
+    "latest"."id" AS "t_id",
+    "latest"."name" AS "t_name",
+    "latest"."price" AS "t_price",
+    "latest"."test_valid_from" AS "t_test_valid_from",
+    "latest"."test_valid_to" AS "t_test_valid_to",
+    "source"."id" AS "id",
+    "source"."name" AS "name",
+    "source"."price" AS "price"
+  FROM "latest"
+  RIGHT JOIN "source"
+    ON "latest"."id" = "source"."id"
+), "updated_rows" AS (
+  SELECT
+    COALESCE("joined"."t_id", "joined"."id") AS "id",
+    COALESCE("joined"."t_name", "joined"."name") AS "name",
+    COALESCE("joined"."t_price", "joined"."price") AS "price",
+    COALESCE("t_test_valid_from", CAST('1970-01-01 00:00:00' AS TIMESTAMP)) AS "test_valid_from",
+    CASE
+      WHEN "joined"."_exists" IS NULL
+      OR (
+        (
+          NOT "t_id" IS NULL AND NOT "id" IS NULL
+        )
+        AND (
+          "name" <> "t_name"
+          OR (
+            "t_name" IS NULL AND NOT "name" IS NULL
+          )
+          OR (
+            NOT "t_name" IS NULL AND "name" IS NULL
+          )
+          OR "price" <> "t_price"
+          OR (
+            "t_price" IS NULL AND NOT "price" IS NULL
+          )
+          OR (
+            NOT "t_price" IS NULL AND "price" IS NULL
+          )
+        )
+      )
+      THEN CAST('2020-01-01 00:00:00' AS TIMESTAMP)
+      ELSE "t_test_valid_to"
+    END AS "test_valid_to"
+  FROM "joined"
+  LEFT JOIN "latest_deleted"
+    ON "joined"."id" = "latest_deleted"."_key0"
+), "inserted_rows" AS (
+  SELECT
+    "id",
+    "name",
+    "price",
+    CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS "test_valid_from",
+    CAST(NULL AS TIMESTAMP) AS "test_valid_to"
+  FROM "joined"
+  WHERE
+    (
+      NOT "t_id" IS NULL AND NOT "id" IS NULL
+    )
+    AND (
+      "name" <> "t_name"
+      OR (
+        "t_name" IS NULL AND NOT "name" IS NULL
+      )
+      OR (
+        NOT "t_name" IS NULL AND "name" IS NULL
+      )
+      OR "price" <> "t_price"
+      OR (
+        "t_price" IS NULL AND NOT "price" IS NULL
+      )
+      OR (
+        NOT "t_price" IS NULL AND "price" IS NULL
+      )
+    )
+)
+SELECT
+  "id",
+  "name",
+  "price",
+  "test_valid_from",
+  "test_valid_to"
+FROM "static"
+UNION ALL
+SELECT
+  "id",
+  "name",
+  "price",
+  "test_valid_from",
+  "test_valid_to"
+FROM "updated_rows"
+UNION ALL
+SELECT
+  "id",
+  "name",
+  "price",
+  "test_valid_from",
+  "test_valid_to"
+FROM "inserted_rows"
+    """
+        ).sql()
+    )
+
+
 def test_scd_type_2_by_column_star_check(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(EngineAdapter)
 


### PR DESCRIPTION
This update adds ability to restate model kinds for which restatements weren't supported in the past: incremental by unique key, unmanaged incremental (dbt incremental), and SCD Type 2.

When restating models of the aforementioned types, the entire model history will be reprocessed from scratch, making this operation equivalent to the full-refresh command in dbt. Start/end dates specified by a user in the plan will be ignored for such models.

For dbt projects we now rely on the [full_refresh ](https://docs.getdbt.com/reference/resource-configs/full_refresh) model configuration to determine whether the restatement should be disabled or not.