### PR TITLE
Fix: Use end-bounded missing intervals when checking for gaps during the promotion

### DIFF
--- a/sqlmesh/core/state_sync/common.py
+++ b/sqlmesh/core/state_sync/common.py
@@ -293,7 +293,9 @@ class CommonStateSyncMixin(StateSync):
                 end = prev_snapshot.intervals[-1][1]
 
                 if start < end:
-                    missing_intervals = target_snapshot.missing_intervals(start, end)
+                    missing_intervals = target_snapshot.missing_intervals(
+                        start, end, end_bounded=True
+                    )
 
                     if missing_intervals:
                         raise SQLMeshError(


### PR DESCRIPTION
We should ignore `lookback` and `allow_partials` attributes when checking the missing intervals for gaps during the promotion process. Setting `end_bounded` to `True` achieves exactly this.