### PR TITLE
Feat: allow partial schema inference in unit test

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -109,7 +109,7 @@ class ModelTest(unittest.TestCase):
             known_columns_to_types.update(values.get("columns", {}))
 
             rows = values["rows"]
-            if not all_types_are_known and rows:
+            if (not all_types_are_known or not known_columns_to_types) and rows:
                 for col, value in rows[0].items():
                     if col not in known_columns_to_types:
                         v_type = annotate_types(exp.convert(value)).type or type(value).__name__
@@ -120,7 +120,7 @@ class ModelTest(unittest.TestCase):
                                 f"Failed to infer the data type of column '{col}' for '{name}'. This issue can be "
                                 "mitigated by casting the column in the model definition, setting its type in "
                                 "schema.yaml if it's an external model, setting the model's 'columns' property, "
-                                "or setting its 'columns' mapping in the test itself"
+                                "or setting its 'columns' mapping in the test itself",
                                 self.path,
                             )
 

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -118,9 +118,9 @@ class ModelTest(unittest.TestCase):
                         if not type_is_known(v_type):
                             _raise_error(
                                 f"Failed to infer the data type of column '{col}' for '{name}'. This issue can be "
-                                "mitigated by cast the column in the model definition, setting its type in schema.yaml "
-                                "if it's an external model, setting the model's 'columns' property, or setting its "
-                                "'columns' mapping in the test itself"
+                                "mitigated by casting the column in the model definition, setting its type in "
+                                "schema.yaml if it's an external model, setting the model's 'columns' property, "
+                                "or setting its 'columns' mapping in the test itself"
                                 self.path,
                             )
 

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -103,13 +103,15 @@ class ModelTest(unittest.TestCase):
                 known_columns_to_types = {
                     c: t for c, t in inferred_columns_to_types.items() if type_is_known(t)
                 }
-                all_types_are_known = len(known_columns_to_types) == len(inferred_columns_to_types)
+                all_types_are_known = bool(inferred_columns_to_types) and (
+                    len(known_columns_to_types) == len(inferred_columns_to_types)
+                )
 
             # Types specified in the test take precedence over the corresponding inferred ones
             known_columns_to_types.update(values.get("columns", {}))
 
             rows = values["rows"]
-            if (not all_types_are_known or not known_columns_to_types) and rows:
+            if not all_types_are_known and rows:
                 for col, value in rows[0].items():
                     if col not in known_columns_to_types:
                         v_type = annotate_types(exp.convert(value)).type or type(value).__name__

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -117,7 +117,7 @@ class ModelTest(unittest.TestCase):
 
                         if not type_is_known(v_type):
                             _raise_error(
-                                f"Failed to infer the data type of column '{col}' for the input fixture '{table_name}'. "
+                                f"Failed to infer the data type of column '{col}' for the input fixture '{name}'. "
                                 f"Try to cast it to the target type or set the model's 'columns' property",
                                 self.path,
                             )

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -117,8 +117,10 @@ class ModelTest(unittest.TestCase):
 
                         if not type_is_known(v_type):
                             _raise_error(
-                                f"Failed to infer the data type of column '{col}' for the input fixture '{name}'. "
-                                f"Try to cast it to the target type or set the model's 'columns' property",
+                                f"Failed to infer the data type of column '{col}' for '{name}'. This issue can be "
+                                "mitigated by cast the column in the model definition, setting its type in schema.yaml "
+                                "if it's an external model, setting the model's 'columns' property, or setting its "
+                                "'columns' mapping in the test itself"
                                 self.path,
                             )
 

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -548,6 +548,56 @@ test_foo:
     )
 
 
+def test_partially_inferred_schemas(sushi_context: Context, mocker: MockerFixture) -> None:
+    parent = _create_model(
+        "SELECT a, b, s::ROW(d DATE) AS s FROM sushi.unknown",
+        meta="MODEL (name sushi.parent, kind FULL, dialect trino)",
+        default_catalog="memory",
+    )
+    parent = t.cast(SqlModel, sushi_context.upsert_model(parent))
+
+    child = _create_model(
+        "SELECT a, b, s.d AS d FROM sushi.parent",
+        meta="MODEL (name sushi.child, kind FULL)",
+        default_catalog="memory",
+    )
+    child = t.cast(SqlModel, sushi_context.upsert_model(child))
+
+    body = load_yaml(
+        """
+test_child:
+  model: sushi.child
+  inputs:
+    sushi.parent:
+      - a: 1
+        b: bla
+        s:
+          d: 2020-01-01
+  outputs:
+    query:
+      - a: 1
+        b: bla
+        d: 2020-01-01
+        """
+    )
+    test = _create_test(body, "test_child", child, sushi_context)
+
+    random_id = "jzngz56a"
+    test._test_id = random_id
+
+    spy_execute = mocker.spy(test.engine_adapter, "_execute")
+    _check_successful_or_raise(test.run())
+
+    spy_execute.assert_any_call(
+        f'CREATE OR REPLACE VIEW "memory"."sushi"."parent__fixture__{random_id}" ("s", "a", "b") AS '
+        "SELECT "
+        'CAST("s" AS STRUCT("d" DATE)) AS "s", '
+        'CAST("a" AS INT) AS "a", '
+        'CAST("b" AS TEXT) AS "b" '
+        """FROM (VALUES ({'d': CAST('2020-01-01' AS DATE)}, 1, 'bla')) AS "t"("s", "a", "b")"""
+    )
+
+
 def test_missing_column_failure(sushi_context: Context, full_model_without_ctes: SqlModel) -> None:
     _check_successful_or_raise(
         _create_test(

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -598,6 +598,32 @@ test_child:
     )
 
 
+def test_uninferrable_schema() -> None:
+    result = _create_test(
+        body=load_yaml(
+            """
+test_foo:
+  model: sushi.foo
+  inputs:
+    raw:
+      - value: null
+  outputs:
+    query:
+      - value: null
+            """
+        ),
+        test_name="test_foo",
+        model=_create_model("SELECT value FROM raw"),
+        context=Context(config=Config(model_defaults=ModelDefaultsConfig(dialect="duckdb"))),
+    ).run()
+
+    expected_failure_msg = (
+        "TestError: Failed to infer the data type of column 'value' for the input fixture "
+        """'"raw"'. Try to cast it to the target type or set the model's 'columns' property"""
+    )
+    _check_successful_or_raise(result, expected_msg=expected_failure_msg)
+
+
 def test_missing_column_failure(sushi_context: Context, full_model_without_ctes: SqlModel) -> None:
     _check_successful_or_raise(
         _create_test(


### PR DESCRIPTION
Prior to this change, if there was at least one unknown type in the schema of an input model we would try to infer all of its column types again using a combination of `convert` and `annotate_types`, thus ignoring the types that we'd previously correctly inferred.

However, relying solely on the `convert` and `annotate_types` approach is problematic, because the former is dialect/type-agnostic and thus it would always convert dictionaries into `MAP`s, which led to type mismatch errors (eg. when we would expect `STRUCT`s instead).

This PR ensures we leverage the inferred types, and only fall back to the above strategy for the columns that have unknown types. It also enforces that we'll only create an input fixture if its inferred schema contains known types.

This will open a path for users to fix invalid conversion issues by simply casting their nested objects into the appropriate types.