### PR TITLE
docs: column name consistency

### DIFF
--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -29,21 +29,21 @@ For example, we could make two modifications to the [SQLMesh quickstart](../quic
 MODEL (
     name sqlmesh_example.incremental_model,
     kind INCREMENTAL_BY_TIME_RANGE (
-        time_column ds
+        time_column event_date
     ),
     start '2020-01-01',
     cron '@daily',
-    grain (id, ds)
+    grain (id, event_date)
 );
 
 SELECT
     id,
     CASE WHEN item_id = 3 THEN 4 ELSE item_id END as item_id, -- Change item_id 3 to 4
-    ds,
+    event_date,
 FROM
     sqlmesh_example.seed_model
 WHERE
-    ds between @start_ds and @end_ds
+    event_date between @start_ds and @end_ds
     AND id != 1 -- Remove row whose item_id is 1
 ```
 


### PR DESCRIPTION
This model does not match the model created by `sqlmesh init bigquery`. Looks like accidentally missed in an update.