### PR TITLE
fix: reenable depends on self check

### DIFF
--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -172,7 +172,7 @@ def test_model_multiple_select_statements():
     "query, error",
     [
         ("y::int, x::int AS y", "duplicate"),
-        # ("* FROM db.table", "require inferrable column types"),
+        ("* FROM db.table", "require inferrable column types"),
     ],
 )
 def test_model_validation(query, error):
@@ -191,6 +191,24 @@ def test_model_validation(query, error):
     with pytest.raises(ConfigError) as ex:
         model.validate_definition()
     assert error in str(ex.value)
+
+
+def test_model_with_depends_on_self():
+    expressions = d.parse(
+        f"""
+        MODEL (
+            name db.table,
+            kind FULL,
+            depends_on  [db.table],
+        );
+
+        SELECT x
+        from y
+        """
+    )
+
+    model = load_sql_based_model(expressions)
+    model.validate_definition()
 
 
 def test_model_union_query(sushi_context, assert_exp_eq):


### PR DESCRIPTION
add a new depends on self property that doesn't include manual depends_on, only those that are actually referenced in the query.

a manual depends_on without an actual self reference means that a query can still operate with a ctas so we don't need to raise an error.