### PR TITLE
fix: performance for selectors

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -124,6 +124,16 @@ class SnapshotId(PydanticModel, frozen=True):
         """Helper method to return self."""
         return self
 
+    def __eq__(self, other: t.Any) -> bool:
+        return (
+            isinstance(other, self.__class__)
+            and self.name == other.name
+            and self.identifier == other.identifier
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.__class__, self.name, self.identifier))
+
     def __lt__(self, other: SnapshotId) -> bool:
         return self.name < other.name
 

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -167,7 +167,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
         "models_to_backfill": ['"test_model"'],
         "end_bounded": False,
         "ensure_finalized_snapshots": False,
-        "directly_modified_snapshots": [snapshot.snapshot_id],
+        "directly_modified_snapshots": [{"identifier": "1736759018", "name": '"test_model"'}],
         "indirectly_modified_snapshots": {},
         "removed_snapshots": [],
     }


### PR DESCRIPTION
selectors causes a lot of dag snapshot_id comparisons with upstream. pydantic is very slow with __eq__, i saw a 50 sec -> 7 sec drop.