### PR TITLE
Fix: Improve the depends_on_past definition

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1051,6 +1051,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
 
         This represents a superset of the following types of models:
         1. Models that depend on themselves but can be restated from an arbitrary point in time (any start date) as long as interval batches are processed sequentially.
+           An example of this can be an INCREMENTAL_BY_TIME_RANGE model that references previous records from itself.
         2. Models that can only be restated from the beginning of history *and* their interval batches must be processed sequentially.
         """
         return self.depends_on_self or self.full_history_restatement_only

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -2006,16 +2006,16 @@ def test_ignored_snapshots(context_fixture: Context, request):
     context = request.getfixturevalue(context_fixture)
     environment = "dev"
     apply_to_environment(context, environment)
-    # Make breaking change to model upstream of a depends_on_past model
+    # Make breaking change to model upstream of a depends_on_self model
     context.upsert_model("sushi.order_items", stamp="1")
-    # Apply the change starting at a date later then the beginning of the downstream depends_on_past model
+    # Apply the change starting at a date later then the beginning of the downstream depends_on_self model
     plan = apply_to_environment(
         context, environment, choice=SnapshotChangeCategory.BREAKING, plan_start="2 days ago"
     )
     revenue_lifetime_snapshot = context.get_snapshot(
         "sushi.customer_revenue_lifetime", raise_if_missing=True
     )
-    # Validate that the depends_on_past model is ignored
+    # Validate that the depends_on_self model is ignored
     assert plan.ignored == {revenue_lifetime_snapshot.snapshot_id}
     # Validate that the table was really ignored
     metadata = DuckDBMetadata.from_context(context)

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -172,7 +172,7 @@ def test_model_multiple_select_statements():
     "query, error",
     [
         ("y::int, x::int AS y", "duplicate"),
-        # ("* FROM db.table", "require inferrable column types"),
+        ("* FROM db.table", "require inferrable column types"),
     ],
 )
 def test_model_validation(query, error):

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -1133,7 +1133,7 @@ def test_revert_to_previous_value(make_snapshot, mocker: MockerFixture):
 
 test_add_restatement_fixtures = [
     (
-        "No dependencies single depends on past",
+        "No dependencies single depends on self",
         {
             '"a"': {},
             '"b"': {},
@@ -1149,7 +1149,7 @@ test_add_restatement_fixtures = [
         },
     ),
     (
-        "Simple dependency with leaf depends on past",
+        "Simple dependency with leaf depends on self",
         {
             '"a"': {},
             '"b"': {'"a"'},
@@ -1165,7 +1165,7 @@ test_add_restatement_fixtures = [
         },
     ),
     (
-        "Simple dependency with root depends on past",
+        "Simple dependency with root depends on self",
         {
             '"a"': {},
             '"b"': {'"a"'},
@@ -1181,7 +1181,7 @@ test_add_restatement_fixtures = [
         },
     ),
     (
-        "Two unrelated subgraphs with root depends on past",
+        "Two unrelated subgraphs with root depends on self",
         {
             '"a"': {},
             '"b"': {},
@@ -1201,7 +1201,7 @@ test_add_restatement_fixtures = [
         },
     ),
     (
-        "Simple root depends on past with adjusted execution time",
+        "Simple root depends on self with adjusted execution time",
         {
             '"a"': {},
             '"b"': {'"a"'},
@@ -1221,7 +1221,7 @@ test_add_restatement_fixtures = [
         a -> c -> d
         b -> c -> e -> g
         b -> f -> g
-        c depends on past
+        c depends on self
         restate a and b
         """,
         {
@@ -1253,7 +1253,7 @@ test_add_restatement_fixtures = [
         a -> c -> d
         b -> c -> e -> g
         b -> f -> g
-        c depends on past
+        c depends on self
         restate e
         """,
         {
@@ -1279,13 +1279,13 @@ test_add_restatement_fixtures = [
 
 
 @pytest.mark.parametrize(
-    "graph,depends_on_past_names,restatement_names,start,end,execution_time,expected",
+    "graph,depends_on_self_names,restatement_names,start,end,execution_time,expected",
     [test[1:] for test in test_add_restatement_fixtures],
     ids=[test[0] for test in test_add_restatement_fixtures],
 )
 def test_add_restatements(
     graph: t.Dict[str, t.Set[str]],
-    depends_on_past_names: t.Set[str],
+    depends_on_self_names: t.Set[str],
     restatement_names: t.Set[str],
     start: str,
     end: str,
@@ -1306,7 +1306,7 @@ def test_add_restatements(
                 start="1 week ago",
                 query=parse_one(
                     f"SELECT 1 FROM {snapshot_name}"
-                    if snapshot_name in depends_on_past_names
+                    if snapshot_name in depends_on_self_names
                     else "SELECT 1"
                 ),
                 depends_on=depends_on,
@@ -1352,7 +1352,7 @@ def test_dev_plan_depends_past(make_snapshot, mocker: MockerFixture):
     snapshot = make_snapshot(
         SqlModel(
             name="a",
-            # self reference query so it depends_on_past
+            # self reference query so it depends_on_self
             query=parse_one("select 1, ds FROM a"),
             start="2023-01-01",
             kind=IncrementalByTimeRangeKind(time_column="ds"),
@@ -1378,9 +1378,9 @@ def test_dev_plan_depends_past(make_snapshot, mocker: MockerFixture):
         ),
     )
     unrelated_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
-    assert snapshot.depends_on_past
-    assert not snapshot_child.depends_on_past
-    assert not unrelated_snapshot.depends_on_past
+    assert snapshot.depends_on_self
+    assert not snapshot_child.depends_on_self
+    assert not unrelated_snapshot.depends_on_self
     assert snapshot_child.model.depends_on == {'"a"'}
     assert snapshot_child.parents == (snapshot.snapshot_id,)
     assert unrelated_snapshot.model.depends_on == set()
@@ -1442,7 +1442,7 @@ def test_dev_plan_depends_past_non_deployable(make_snapshot, mocker: MockerFixtu
     snapshot = make_snapshot(
         SqlModel(
             name="a",
-            # self reference query so it depends_on_past
+            # self reference query so it depends_on_self
             query=parse_one("select 1, ds FROM a"),
             start="2023-01-01",
             kind=IncrementalByTimeRangeKind(time_column="ds"),
@@ -1480,9 +1480,9 @@ def test_dev_plan_depends_past_non_deployable(make_snapshot, mocker: MockerFixtu
     )
     unrelated_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
 
-    assert updated_snapshot.depends_on_past
-    assert not snapshot_child.depends_on_past
-    assert not unrelated_snapshot.depends_on_past
+    assert updated_snapshot.depends_on_self
+    assert not snapshot_child.depends_on_self
+    assert not unrelated_snapshot.depends_on_self
     assert snapshot_child.model.depends_on == {'"a"'}
     assert snapshot_child.parents == (updated_snapshot.snapshot_id,)
     assert unrelated_snapshot.model.depends_on == set()

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -1382,7 +1382,7 @@ def test_is_valid_start(make_snapshot):
         ),
     )
     snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
-    assert snapshot.depends_on_past
+    assert snapshot.depends_on_self
     assert snapshot.is_valid_start("2023-01-01", "2023-01-01")
     assert snapshot.is_valid_start("2023-01-01", "2023-01-02")
     assert snapshot.is_valid_start("2023-01-02", "2023-01-01 10:00:00")

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -47,7 +47,7 @@ def snapshot(make_snapshot, random_name) -> Snapshot:
 
 
 @pytest.fixture
-def depends_on_past_snapshot(make_snapshot, random_name) -> Snapshot:
+def depends_on_self_snapshot(make_snapshot, random_name) -> Snapshot:
     name = random_name()
     result = make_snapshot(
         create_sql_model(
@@ -67,7 +67,7 @@ def depends_on_past_snapshot(make_snapshot, random_name) -> Snapshot:
         ("snapshot", [(to_datetime("2022-01-01"), to_datetime("2022-01-05"))], False),
         ("snapshot", [(to_datetime("2022-01-01"), to_datetime("2022-01-05"))], True),
         (
-            "depends_on_past_snapshot",
+            "depends_on_self_snapshot",
             [
                 (to_datetime("2022-01-01"), to_datetime("2022-01-02")),
                 (to_datetime("2022-01-02"), to_datetime("2022-01-03")),
@@ -204,7 +204,7 @@ def test_create_plan_dag_spec(
             [(to_datetime("2022-01-02"), to_datetime("2022-01-04"))],
         ),
         (
-            "depends_on_past_snapshot",
+            "depends_on_self_snapshot",
             [
                 (to_datetime("2022-01-02"), to_datetime("2022-01-03")),
                 (to_datetime("2022-01-03"), to_datetime("2022-01-04")),


### PR DESCRIPTION
Previously we only considered the following models to be dependent on their past:
1. `INCREMENTAL_BY_UNIQUE_KEY` models.
2. Models that reference self in their queries.

There are, however, more cases when the model depends on its past, like eg. SCD2 and `IncrementalUnmanaged` models. This update extends the definition of the `depends_on_past` property to encompass these.