### PR TITLE
 Fix!: set default catalog for unit test fixtures, create new schema for them

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -364,8 +364,12 @@ class ModelTest(unittest.TestCase):
         table = self._fixture_table_cache.get(name)
         if not table:
             table = exp.to_table(name, dialect=self.dialect)
+
+            # We change both the schema and the catalog, so we need to ensure there are no name clashes
+            table.this.set("this", "__".join(part.name for part in table.parts))
             table.set("db", exp.to_identifier(self._test_schema))
             table.set("catalog", exp.to_identifier(self.default_catalog))
+
             self._fixture_table_cache[name] = table
 
         return table

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -141,8 +141,7 @@ class ModelTest(unittest.TestCase):
     def tearDown(self) -> None:
         """Drop all fixture tables."""
         if not self.preserve_fixtures:
-            for name in self.body.get("inputs", {}):
-                self.engine_adapter.drop_view(self._fixture_table_cache[name])
+            self.engine_adapter.drop_schema(self._test_schema, cascade=True)
 
     def assert_equal(
         self,

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -70,7 +70,7 @@ class ModelTest(unittest.TestCase):
 
         self._validate_and_normalize_test()
 
-        # This ID is appended to each input fixture name to avoid concurrency issues
+        # This ID is appended to the test schema to avoid concurrency issues
         self._test_id = random_id(short=True)
 
         self._engine_adapter_dialect = Dialect.get_or_raise(self.engine_adapter.dialect)
@@ -131,10 +131,9 @@ class ModelTest(unittest.TestCase):
                         known_columns_to_types[col] = v_type
 
             test_fixture_table = self._test_fixture_table(name)
-            if test_fixture_table.db:
-                self.engine_adapter.create_schema(
-                    schema_(test_fixture_table.args["db"], test_fixture_table.args.get("catalog"))
-                )
+            self.engine_adapter.create_schema(
+                schema_(test_fixture_table.args["db"], test_fixture_table.args.get("catalog"))
+            )
 
             df = _create_df(rows, columns=known_columns_to_types)
             self.engine_adapter.create_view(test_fixture_table, df, known_columns_to_types)
@@ -366,7 +365,7 @@ class ModelTest(unittest.TestCase):
         table = self._fixture_table_cache.get(name)
         if not table:
             table = exp.to_table(name, dialect=self.dialect)
-            table.this.set("this", f"{table.this.this}__fixture__{self._test_id}")
+            table.set("db", exp.to_identifier(f"sqlmesh_test_{self._test_id}"))
             self._fixture_table_cache[name] = table
 
         return table

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -70,8 +70,8 @@ class ModelTest(unittest.TestCase):
 
         self._validate_and_normalize_test()
 
-        # This ID is appended to the test schema to avoid concurrency issues
-        self._test_id = random_id(short=True)
+        # The test schema name is randomized to avoid concurrency issues
+        self._test_schema = f"sqlmesh_test_{random_id(short=True)}"
 
         self._engine_adapter_dialect = Dialect.get_or_raise(self.engine_adapter.dialect)
         self._transforms = self._engine_adapter_dialect.generator_class.TRANSFORMS
@@ -365,7 +365,7 @@ class ModelTest(unittest.TestCase):
         table = self._fixture_table_cache.get(name)
         if not table:
             table = exp.to_table(name, dialect=self.dialect)
-            table.set("db", exp.to_identifier(f"sqlmesh_test_{self._test_id}"))
+            table.set("db", exp.to_identifier(self._test_schema))
             table.set("catalog", exp.to_identifier(self.default_catalog))
             self._fixture_table_cache[name] = table
 

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -366,6 +366,7 @@ class ModelTest(unittest.TestCase):
         if not table:
             table = exp.to_table(name, dialect=self.dialect)
             table.set("db", exp.to_identifier(f"sqlmesh_test_{self._test_id}"))
+            table.set("catalog", exp.to_identifier(self.default_catalog))
             self._fixture_table_cache[name] = table
 
         return table

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -582,7 +582,7 @@ test_child:
     _check_successful_or_raise(test.run())
 
     spy_execute.assert_any_call(
-        f'CREATE OR REPLACE VIEW "memory"."sqlmesh_test_jzngz56a"."parent" ("s", "a", "b") AS '
+        f'CREATE OR REPLACE VIEW "memory"."sqlmesh_test_jzngz56a"."memory__sushi__parent" ("s", "a", "b") AS '
         "SELECT "
         'CAST("s" AS STRUCT("d" DATE)) AS "s", '
         'CAST("a" AS INT) AS "a", '

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -136,7 +136,7 @@ test_foo:
 
     assert len(test._fixture_table_cache) == len(sushi_context.models) + 1
     for table in test._fixture_table_cache.values():
-        assert table.name.endswith(f"__fixture__{random_id}")
+        assert table.db == f"sqlmesh_test_{random_id}"
 
 
 def test_ctes_only(sushi_context: Context, full_model_with_two_ctes: SqlModel) -> None:
@@ -589,7 +589,7 @@ test_child:
     _check_successful_or_raise(test.run())
 
     spy_execute.assert_any_call(
-        f'CREATE OR REPLACE VIEW "memory"."sushi"."parent__fixture__{random_id}" ("s", "a", "b") AS '
+        f'CREATE OR REPLACE VIEW "memory"."sqlmesh_test_{random_id}"."parent" ("s", "a", "b") AS '
         "SELECT "
         'CAST("s" AS STRUCT("d" DATE)) AS "s", '
         'CAST("a" AS INT) AS "a", '

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -973,14 +973,14 @@ test_foo:
   model: sushi.foo
   inputs:
     c.db.external:
-      - c: 1
+      - x: 1
   outputs:
     query:
-      - c: 1
+      - x: 1
             """
         ),
         test_name="test_foo",
-        model=_create_model("SELECT c FROM c.db.external"),
+        model=_create_model("SELECT x FROM c.db.external"),
         context=sushi_context,
     )
 

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import typing as t
 from pathlib import Path
+from unittest.mock import call
 
 import pandas as pd
 import pytest
@@ -914,15 +915,21 @@ test_foo:
         ),
         context=Context(config=Config(model_defaults=ModelDefaultsConfig(dialect="duckdb"))),
     )
+    test._test_schema = f"sqlmesh_test_jzngz56a"
 
     spy_execute = mocker.spy(test.engine_adapter, "_execute")
     _check_successful_or_raise(test.run())
 
-    spy_execute.assert_called_with(
-        "SELECT "
-        """CAST('2023-01-01 12:05:03+00:00' AS DATE) AS "cur_date", """
-        """CAST('2023-01-01 12:05:03+00:00' AS TIME) AS "cur_time", """
-        '''CAST('2023-01-01 12:05:03+00:00' AS TIMESTAMP) AS "cur_timestamp"''',
+    spy_execute.assert_has_calls(
+        [
+            call(
+                "SELECT "
+                """CAST('2023-01-01 12:05:03+00:00' AS DATE) AS "cur_date", """
+                """CAST('2023-01-01 12:05:03+00:00' AS TIME) AS "cur_time", """
+                '''CAST('2023-01-01 12:05:03+00:00' AS TIMESTAMP) AS "cur_timestamp"'''
+            ),
+            call('DROP SCHEMA IF EXISTS "sqlmesh_test_jzngz56a" CASCADE'),
+        ]
     )
 
     @model("py_model", columns={"ts1": "timestamptz", "ts2": "timestamptz"})

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -575,15 +575,13 @@ test_child:
         """
     )
     test = _create_test(body, "test_child", child, sushi_context)
-
-    random_id = "jzngz56a"
-    test._test_id = random_id
+    test._test_schema = "sqlmesh_test_jzngz56a"
 
     spy_execute = mocker.spy(test.engine_adapter, "_execute")
     _check_successful_or_raise(test.run())
 
     spy_execute.assert_any_call(
-        f'CREATE OR REPLACE VIEW "memory"."sqlmesh_test_{random_id}"."parent" ("s", "a", "b") AS '
+        f'CREATE OR REPLACE VIEW "memory"."sqlmesh_test_jzngz56a"."parent" ("s", "a", "b") AS '
         "SELECT "
         'CAST("s" AS STRUCT("d" DATE)) AS "s", '
         'CAST("a" AS INT) AS "a", '
@@ -983,15 +981,13 @@ test_foo:
         model=_create_model("SELECT x FROM c.db.external"),
         context=sushi_context,
     )
-
-    random_id = "jzngz56a"
-    test._test_id = random_id
+    test._test_schema = f"sqlmesh_test_jzngz56a"
     _check_successful_or_raise(test.run())
 
     assert len(test._fixture_table_cache) == len(sushi_context.models) + 1
     for table in test._fixture_table_cache.values():
         assert table.catalog == "memory"
-        assert table.db == f"sqlmesh_test_{random_id}"
+        assert table.db == f"sqlmesh_test_jzngz56a"
 
 
 def test_test_generation(tmp_path: Path) -> None:


### PR DESCRIPTION
We currently create unit test fixtures within the specified catalog of the corresponding models, which can lead to permission issues for some external models.

This PR:
- Sets each input's catalog to the default one, for which we should have write access
- Sets each input's schema to a new testing schema, to ensure consistency and environment isolation

To avoid name clashes, we now generate fixture names using the format: `[original_catalog__][original_shema__]name`.