### PR TITLE
fix: databricks catalog with session support

### DIFF
--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -144,7 +144,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
 
             try:
                 # Note: Spark 3.4+ Only API
-                return super().get_current_catalog()
+                return self.spark.catalog.currentCatalog()
             except (Py4JError, SparkConnectGrpcException):
                 pass
         result = self.fetchone(exp.select(self.CURRENT_CATALOG_EXPRESSION))
@@ -164,7 +164,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
 
             try:
                 # Note: Spark 3.4+ Only API
-                super().set_current_catalog(catalog_name)
+                self.spark.catalog.setCurrentCatalog(catalog_name)
             except (Py4JError, SparkConnectGrpcException):
                 pass
 


### PR DESCRIPTION
Recent PR moved catalog related operations to the spark connection level: https://github.com/TobikoData/sqlmesh/pull/2428

This doesn't work then when calling super since Databricks does not use the same connection as spark. The default behavior is different anyways (Spark default catalog is `spark_catalog` while Databricks is `hive_metastore`) so it probably just makes sense to not share functionality between these two anymore.

I do assume that the user is using a Databricks release of Spark 3.4 or greater but that should be a safer assumption than it would be for Spark users. 