### PR TITLE
Fix: manually convert test input string if db returns datetime.xxx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ install-doc:
 	pip3 install -r ./docs/requirements.txt
 
 install-engine-test:
-	pip3 install -e ".[dev,web,slack,mysql,postgres,databricks,redshift,bigquery,snowflake,trino,mssql,motherduck]"
+	pip3 install -e ".[dev,web,slack,mysql,postgres,databricks,redshift,bigquery,snowflake,trino,mssql]"
 
 install-pre-commit:
 	pre-commit install

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -485,15 +485,7 @@ def config() -> Config:
                 pytest.mark.xdist_group("engine_integration_databricks"),
             ],
         ),
-        pytest.param(
-            "motherduck",
-            marks=[
-                pytest.mark.motherduck,
-                pytest.mark.engine,
-                pytest.mark.remote,
-                pytest.mark.xdist_group("engine_integration_motherduck"),
-            ],
-        ),
+        # TODO: add motherduck tests once they support DuckDB>=0.10.0
         pytest.param(
             "redshift",
             marks=[


### PR DESCRIPTION
SQLMesh `test` input values are specified in YAML, so it is not possible to correctly infer all intended data types from the raw values.

`test`s work by creating an `expected` pandas dataframe from the YAML and creating an `actual` pandas dataframe from the query results returned by the database. We prevent type mismatches by converting the `expected` df columns to the `actual` df types.

If a test query returns `datetime.xxx` values, the `actual` pandas column type is generic `object` and the type conversion is a noop. Therefore, for pandas `object` columns we examine an `actual` sentinel value and, if it is `datetime.xxx`, manually convert the `expected` column to the correct type. It is safe to assume the `actual` column contains a single type because it is returned by a database call.