### PR TITLE
fix: Github action bot handle test exceptions

### DIFF
--- a/sqlmesh/integrations/github/cicd/command.py
+++ b/sqlmesh/integrations/github/cicd/command.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import traceback
 
 import click
 
@@ -65,7 +66,9 @@ def _run_tests(controller: GithubController) -> bool:
         return result.wasSuccessful()
     except Exception:
         controller.update_test_check(
-            status=GithubCheckStatus.COMPLETED, conclusion=GithubCheckConclusion.FAILURE
+            status=GithubCheckStatus.COMPLETED,
+            conclusion=GithubCheckConclusion.FAILURE,
+            output=traceback.format_exc(),
         )
         return False
 

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -646,24 +646,24 @@ class GithubController:
         """
 
         def conclusion_handler(
-            _: GithubCheckConclusion, result: unittest.result.TestResult, output: str
+            conclusion: GithubCheckConclusion, result: unittest.result.TestResult, output: str
         ) -> t.Tuple[GithubCheckConclusion, str, t.Optional[str]]:
-            if not result:
-                return GithubCheckConclusion.SKIPPED, "Skipped Tests", None
-
-            # Clear out console
-            self._console.consume_captured_output()
-            self._console.log_test_results(
-                result, output, self._context._test_engine_adapter.dialect
-            )
-            test_summary = self._console.consume_captured_output()
-            test_title = "Tests Passed" if result.wasSuccessful() else "Tests Failed"
-            test_conclusion = (
-                GithubCheckConclusion.SUCCESS
-                if result.wasSuccessful()
-                else GithubCheckConclusion.FAILURE
-            )
-            return test_conclusion, test_title, test_summary
+            if result:
+                # Clear out console
+                self._console.consume_captured_output()
+                self._console.log_test_results(
+                    result, output, self._context._test_engine_adapter.dialect
+                )
+                test_summary = self._console.consume_captured_output()
+                test_title = "Tests Passed" if result.wasSuccessful() else "Tests Failed"
+                test_conclusion = (
+                    GithubCheckConclusion.SUCCESS
+                    if result.wasSuccessful()
+                    else GithubCheckConclusion.FAILURE
+                )
+                return test_conclusion, test_title, test_summary
+            test_title = "Skipped Tests" if conclusion.is_skipped else "Tests Failed"
+            return conclusion, test_title, output
 
         self._update_check_handler(
             check_name="SQLMesh - Run Unit Tests",


### PR DESCRIPTION
Prior to this PR if a test had an exception when executing, not a failure which means the tests didn't pass, the bot would incorrectly report this as "skipped" instead of a failure. Now the bot will properly categorize this as a failure and output the exception in the status summary.

Also updated another test to verify the error output upon failure.