### PR TITLE
Fix: use MacroEvaluator dialect in certain builtin macros

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -680,10 +680,13 @@ def star(
 
     exclude = {e.name for e in except_.expressions}
     quoted = quote_identifiers.this
+    table_identifier = alias.name or relation.name
 
     return [
         exp.cast(
-            exp.column(column, table=alias.name, quoted=quoted), type_, dialect=evaluator.dialect
+            exp.column(column, table=table_identifier, quoted=quoted),
+            type_,
+            dialect=evaluator.dialect,
         ).as_(f"{prefix.this}{column}{suffix.this}", quoted=quoted)
         for column, type_ in evaluator.columns_to_types(relation).items()
         if column not in exclude

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -682,9 +682,9 @@ def star(
     quoted = quote_identifiers.this
 
     return [
-        exp.cast(exp.column(column, table=alias.name, quoted=quoted), type_).as_(
-            f"{prefix.this}{column}{suffix.this}", quoted=quoted
-        )
+        exp.cast(
+            exp.column(column, table=alias.name, quoted=quoted), type_, dialect=evaluator.dialect
+        ).as_(f"{prefix.this}{column}{suffix.this}", quoted=quoted)
         for column, type_ in evaluator.columns_to_types(relation).items()
         if column not in exclude
     ]
@@ -794,7 +794,7 @@ def union(
     }
 
     projections = [
-        exp.cast(column, type_).as_(column)
+        exp.cast(column, type_, dialect=evaluator.dialect).as_(column)
         for column, type_ in evaluator.columns_to_types(tables[0]).items()
         if column in columns
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import pandas as pd
 import pytest
 from pytest_mock.plugin import MockerFixture
 from sqlglot import exp, maybe_parse, parse_one
+from sqlglot.dialects.dialect import DialectType
 from sqlglot.helper import ensure_list
 
 from sqlmesh.core.config import DuckDBConnectionConfig
@@ -281,9 +282,11 @@ def init_and_plan_context(copy_to_temp_path, mocker) -> t.Callable:
 
 @pytest.fixture
 def assert_exp_eq() -> t.Callable:
-    def _assert_exp_eq(source: exp.Expression | str, expected: exp.Expression | str) -> None:
-        source_exp = maybe_parse(source)
-        expected_exp = maybe_parse(expected)
+    def _assert_exp_eq(
+        source: exp.Expression | str, expected: exp.Expression | str, dialect: DialectType = None
+    ) -> None:
+        source_exp = maybe_parse(source, dialect=dialect)
+        expected_exp = maybe_parse(expected, dialect=dialect)
 
         if not source_exp:
             raise ValueError(f"Could not parse {source}")
@@ -291,7 +294,9 @@ def assert_exp_eq() -> t.Callable:
             raise ValueError(f"Could not parse {expected}")
 
         if source_exp != expected_exp:
-            assert source_exp.sql(pretty=True) == expected_exp.sql(pretty=True)
+            assert source_exp.sql(dialect=dialect, pretty=True) == expected_exp.sql(
+                dialect=dialect, pretty=True
+            )
             assert source_exp == expected_exp
 
     return _assert_exp_eq

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -3,7 +3,7 @@ import typing as t
 from unittest import mock
 
 import pytest
-from sqlglot import exp, parse_one
+from sqlglot import MappingSchema, exp, parse_one
 
 from sqlmesh.core.dialect import StagedFilePath
 from sqlmesh.core.macros import MacroEvaluator, macro
@@ -33,7 +33,15 @@ def macro_evaluator() -> MacroEvaluator:
     )
 
 
-def test_case(macro_evaluator):
+def test_star(assert_exp_eq) -> None:
+    sql = """SELECT @STAR(foo) FROM foo"""
+    expected_sql = """SELECT CAST([foo].[a] AS DATETIMEOFFSET) AS [a] FROM foo"""
+    schema = MappingSchema({"foo": {"a": "datetimeoffset"}}, dialect="tsql")
+    evaluator = MacroEvaluator(schema=schema, dialect="tsql")
+    assert_exp_eq(evaluator.transform(parse_one(sql, read="tsql")), expected_sql, dialect="tsql")
+
+
+def test_case(macro_evaluator: MacroEvaluator) -> None:
     assert macro.get_registry()["upper"]
 
 


### PR DESCRIPTION
Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1713786694499789