### PR TITLE
Fix: handle self-referencing models in unit tests

### DIFF
--- a/examples/sushi/tests/test_customer_revenue_lifetime.yaml
+++ b/examples/sushi/tests/test_customer_revenue_lifetime.yaml
@@ -1,0 +1,27 @@
+test_customer_revenue_lifetime:
+  model: sushi.customer_revenue_lifetime
+  inputs:
+    sushi.order_items:
+      rows:
+        - order_id: 1
+          item_id: 12
+          quantity: 1
+          event_date: 2000-01-02
+    sushi.items:
+      rows:
+        - id: 12
+          price: 3.99
+          event_date: 2000-01-02
+    sushi.orders:
+      rows:
+        - id: 1
+          customer_id: 123
+          event_date: 2000-01-02
+  outputs:
+    query:
+      rows:
+        - customer_id: 123
+          revenue: 3.99
+          event_date: 2000-01-02
+  vars:
+    end: 2000-01-02

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -326,6 +326,9 @@ class ModelTest(unittest.TestCase):
                 for name, values in sources.items()
             }
 
+        normalized_model_name = self._normalize_model_name(self.body["model"])
+        self.body["model"] = normalized_model_name
+
         if inputs:
             inputs = _normalize_sources(inputs)
             for name, values in inputs.items():
@@ -348,6 +351,9 @@ class ModelTest(unittest.TestCase):
                 if depends_on not in inputs:
                     _raise_error(f"Incomplete test, missing input model '{depends_on}'", self.path)
 
+            if self.model.depends_on_self and normalized_model_name not in inputs:
+                inputs[normalized_model_name] = {"rows": []}
+
             self.body["inputs"] = inputs
 
         if ctes:
@@ -355,8 +361,6 @@ class ModelTest(unittest.TestCase):
 
         if query or query == []:
             outputs["query"] = _normalize_rows(query, self.model.name, partial=partial)
-
-        self.body["model"] = self._normalize_model_name(self.body["model"])
 
     def _test_fixture_table(self, name: str) -> exp.Table:
         table = self._fixture_table_cache.get(name)

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -966,7 +966,7 @@ test_py_model:
 def test_successes(sushi_context: Context) -> None:
     results = sushi_context.test()
     successful_tests = [success.test_name for success in results.successes]  # type: ignore
-    assert len(successful_tests) == 2
+    assert len(successful_tests) == 3
     assert "test_order_items" in successful_tests
     assert "test_customer_revenue_by_day" in successful_tests
 

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -129,7 +129,7 @@ def test_merge_pr_has_non_breaking_change(
     assert test_checks_runs[2]["output"]["title"] == "Tests Passed"
     assert (
         test_checks_runs[2]["output"]["summary"].strip()
-        == "**Successfully Ran `2` Tests Against `duckdb`**"
+        == "**Successfully Ran `3` Tests Against `duckdb`**"
     )
 
     assert "SQLMesh - PR Environment Synced" in controller._check_run_mapping
@@ -327,7 +327,7 @@ def test_merge_pr_has_non_breaking_change_diff_start(
     assert test_checks_runs[2]["output"]["title"] == "Tests Passed"
     assert (
         test_checks_runs[2]["output"]["summary"].strip()
-        == "**Successfully Ran `2` Tests Against `duckdb`**"
+        == "**Successfully Ran `3` Tests Against `duckdb`**"
     )
 
     assert "SQLMesh - PR Environment Synced" in controller._check_run_mapping
@@ -529,7 +529,7 @@ def test_merge_pr_has_non_breaking_change_no_categorization(
     assert test_checks_runs[2]["output"]["title"] == "Tests Passed"
     assert (
         test_checks_runs[2]["output"]["summary"].strip()
-        == "**Successfully Ran `2` Tests Against `duckdb`**"
+        == "**Successfully Ran `3` Tests Against `duckdb`**"
     )
 
     assert "SQLMesh - PR Environment Synced" in controller._check_run_mapping
@@ -676,7 +676,7 @@ def test_merge_pr_has_no_changes(
     assert test_checks_runs[2]["output"]["title"] == "Tests Passed"
     assert (
         test_checks_runs[2]["output"]["summary"].strip()
-        == "**Successfully Ran `2` Tests Against `duckdb`**"
+        == "**Successfully Ran `3` Tests Against `duckdb`**"
     )
 
     assert "SQLMesh - PR Environment Synced" in controller._check_run_mapping
@@ -842,7 +842,7 @@ def test_no_merge_since_no_deploy_signal(
     assert test_checks_runs[2]["output"]["title"] == "Tests Passed"
     assert (
         test_checks_runs[2]["output"]["summary"].strip()
-        == "**Successfully Ran `2` Tests Against `duckdb`**"
+        == "**Successfully Ran `3` Tests Against `duckdb`**"
     )
 
     assert "SQLMesh - PR Environment Synced" in controller._check_run_mapping
@@ -1025,7 +1025,7 @@ def test_no_merge_since_no_deploy_signal_no_approvers_defined(
     assert test_checks_runs[2]["output"]["title"] == "Tests Passed"
     assert (
         test_checks_runs[2]["output"]["summary"].strip()
-        == "**Successfully Ran `2` Tests Against `duckdb`**"
+        == "**Successfully Ran `3` Tests Against `duckdb`**"
     )
 
     assert "SQLMesh - PR Environment Synced" in controller._check_run_mapping
@@ -1201,7 +1201,7 @@ def test_deploy_comment_pre_categorized(
     assert test_checks_runs[2]["output"]["title"] == "Tests Passed"
     assert (
         test_checks_runs[2]["output"]["summary"].strip()
-        == "**Successfully Ran `2` Tests Against `duckdb`**"
+        == "**Successfully Ran `3` Tests Against `duckdb`**"
     )
 
     assert "SQLMesh - PR Environment Synced" in controller._check_run_mapping
@@ -1378,7 +1378,7 @@ def test_error_msg_when_applying_plan_with_bug(
     assert test_checks_runs[2]["output"]["title"] == "Tests Passed"
     assert (
         test_checks_runs[2]["output"]["summary"].strip()
-        == "**Successfully Ran `2` Tests Against `duckdb`**"
+        == "**Successfully Ran `3` Tests Against `duckdb`**"
     )
 
     assert "SQLMesh - PR Environment Synced" in controller._check_run_mapping
@@ -1539,7 +1539,7 @@ def test_overlapping_changes_models(
     assert test_checks_runs[2]["output"]["title"] == "Tests Passed"
     assert (
         test_checks_runs[2]["output"]["summary"].strip()
-        == "**Successfully Ran `2` Tests Against `duckdb`**"
+        == "**Successfully Ran `3` Tests Against `duckdb`**"
     )
 
     assert "SQLMesh - PR Environment Synced" in controller._check_run_mapping
@@ -1760,7 +1760,7 @@ def test_capture_console_errors(
     assert test_checks_runs[2]["output"]["title"] == "Tests Passed"
     assert (
         test_checks_runs[2]["output"]["summary"].strip()
-        == "**Successfully Ran `2` Tests Against `duckdb`**"
+        == "**Successfully Ran `3` Tests Against `duckdb`**"
     )
 
     assert "SQLMesh - PR Environment Synced" in controller._check_run_mapping

--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -513,7 +513,7 @@ def test_test(web_sushi_context: Context) -> None:
     response = client.get("/api/commands/test")
     assert response.status_code == 200
     response_json = response.json()
-    assert response_json["tests_run"] == 2
+    assert response_json["tests_run"] == 3
     assert response_json["failures"] == []
 
     # Single test


### PR DESCRIPTION
Fixes #2476

Prior to this fix we wouldn't create a fixture for the tested model if it referenced itself, leading to a crash when we'd run the query against the test connection. This PR addresses this issue, so that:

- when the model is included in the inputs, the fixture is created as always
- when it is not included, we add it as an empty table