### PR TITLE
Fix: read model file for %model magic instead of rendering defn

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1670,7 +1670,7 @@ def create_seed_model(
         path=path,
         seed=seed,
         kind=seed_kind,
-        depends_on=kwargs.pop("depends_on", set()),
+        depends_on=kwargs.pop("depends_on", None),
         python_env=python_env,
         jinja_macros=jinja_macros,
         pre_statements=pre_statements,


### PR DESCRIPTION
Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1713796905603349

Prior to this change, we would render the definition of the model targeted by the `%model` magic and then replace the cell with `%%model <name>\n<rendered definition>`. This was problematic because we were adding the default model property values to its definition, leading to (at least) visually unexpected results.

This PR makes it so that the first time we execute the `%model` magic, we read the model's definition directly from its file, so that the replaced cell then reflects the user's query more closely (auto-formatted appropriately).