### PR TITLE
Chore!: Use version instead of identifier in the seeds table

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1611,7 +1611,7 @@ class EngineAdapter:
                 raise UnsupportedCatalogOperationError(
                     "Tried to rename table across catalogs which is not supported"
                 )
-        self.execute(exp.rename_table(old_table_name, new_table_name))
+        self._rename_table(old_table_name, new_table_name)
 
     def get_data_objects(
         self, schema_name: SchemaName, object_names: t.Optional[t.Set[str]] = None
@@ -2028,6 +2028,13 @@ class EngineAdapter:
                     f"Column comments for table '{table.alias_or_name}' not registered - this may be due to limited permissions.",
                     exc_info=True,
                 )
+
+    def _rename_table(
+        self,
+        old_table_name: TableName,
+        new_table_name: TableName,
+    ) -> None:
+        self.execute(exp.rename_table(old_table_name, new_table_name))
 
     @classmethod
     def _select_columns(cls, columns: t.Iterable[str]) -> exp.Select:

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -222,3 +222,12 @@ class MSSQLEngineAdapter(
     def _to_sql(self, expression: exp.Expression, quote: bool = True, **kwargs: t.Any) -> str:
         sql = super()._to_sql(expression, quote=quote, **kwargs)
         return f"{sql};"
+
+    def _rename_table(
+        self,
+        old_table_name: TableName,
+        new_table_name: TableName,
+    ) -> None:
+        # The function that renames tables in MSSQL takes string literals as arguments instead of identifiers,
+        # so we shouldn't quote the identifiers.
+        self.execute(exp.rename_table(old_table_name, new_table_name), quote_identifiers=False)

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -142,3 +142,16 @@ class MySQLEngineAdapter(
                 f"Column comments for table '{table.alias_or_name}' not registered - this may be due to limited permissions.",
                 exc_info=True,
             )
+
+    def _rename_table(
+        self,
+        old_table_name: TableName,
+        new_table_name: TableName,
+    ) -> None:
+        old_table = exp.to_table(old_table_name)
+        new_table = exp.to_table(new_table_name)
+        if not new_table.db and old_table.db:
+            # In MySQL you need to provide the full target table name.
+            # Therefore we use the old schema name if one is not provided explicitly in the new name.
+            new_table.set("db", old_table.args["db"])
+        return super()._rename_table(old_table, new_table)

--- a/sqlmesh/migrations/v0049_replace_identifier_with_version_in_seeds_table.py
+++ b/sqlmesh/migrations/v0049_replace_identifier_with_version_in_seeds_table.py
@@ -1,0 +1,57 @@
+"""Use version instead of identifier in the seeds table."""
+
+from sqlglot import exp
+
+from sqlmesh.utils.migration import index_text_type
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+
+    snapshots_table = "_snapshots"
+    seeds_table = "_seeds"
+    new_seeds_table = f"{seeds_table}_v49"
+
+    if state_sync.schema:
+        snapshots_table = f"{state_sync.schema}.{snapshots_table}"
+        seeds_table = f"{state_sync.schema}.{seeds_table}"
+        new_seeds_table = f"{state_sync.schema}.{new_seeds_table}"
+
+    index_type = index_text_type(engine_adapter.dialect)
+
+    engine_adapter.drop_table(new_seeds_table)
+    engine_adapter.create_state_table(
+        new_seeds_table,
+        {
+            "name": exp.DataType.build(index_type),
+            "version": exp.DataType.build(index_type),
+            "content": exp.DataType.build("text"),
+        },
+        primary_key=("name", "version"),
+    )
+
+    name_col = exp.column("name", table="seeds")
+    version_col = exp.column("version", table="snapshots")
+    query = (
+        exp.select(
+            name_col,
+            version_col,
+            exp.func("MAX", exp.column("content", table="seeds")).as_("content"),
+        )
+        .from_(exp.to_table(seeds_table).as_("seeds"))
+        .join(
+            exp.to_table(snapshots_table).as_("snapshots"),
+            on=exp.and_(
+                exp.column("name", table="seeds").eq(exp.column("name", table="snapshots")),
+                exp.column("identifier", table="seeds").eq(
+                    exp.column("identifier", table="snapshots")
+                ),
+            ),
+        )
+        .where(exp.column("version", table="snapshots").is_(exp.null()).not_())
+        .group_by(name_col, version_col)
+    )
+
+    engine_adapter.insert_append(new_seeds_table, query)
+    engine_adapter.drop_table(seeds_table)
+    engine_adapter.rename_table(new_seeds_table, "_seeds")

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -516,3 +516,16 @@ def test_df_dates(make_mocked_engine_adapter: t.Callable):
             }
         )
     )
+
+
+def test_rename_table(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+    adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
+
+    adapter.rename_table("test_schema.old_name", "new_name")
+    adapter.rename_table("old_name", "new_name")
+
+    sql_calls = to_sql_calls(adapter)
+    assert sql_calls == [
+        "EXEC sp_rename 'test_schema.old_name', 'new_name';",
+        "EXEC sp_rename 'old_name', 'new_name';",
+    ]

--- a/tests/core/engine_adapter/test_mysql.py
+++ b/tests/core/engine_adapter/test_mysql.py
@@ -62,3 +62,18 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
         f"ALTER TABLE `test_table` COMMENT = '{truncated_table_comment}'",
         f"ALTER TABLE `test_table` MODIFY `a` INT COMMENT '{truncated_column_comment}'",
     ]
+
+
+def test_rename_table(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+    adapter = make_mocked_engine_adapter(MySQLEngineAdapter)
+
+    adapter.rename_table("test_schema.old_name", "new_name")
+    adapter.rename_table("test_schema.old_name", "new_test_schema.new_name")
+    adapter.rename_table("old_name", "new_name")
+
+    sql_calls = to_sql_calls(adapter)
+    assert sql_calls == [
+        "ALTER TABLE `test_schema`.`old_name` RENAME TO `test_schema`.`new_name`",
+        "ALTER TABLE `test_schema`.`old_name` RENAME TO `new_test_schema`.`new_name`",
+        "ALTER TABLE `old_name` RENAME TO `new_name`",
+    ]

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -1044,6 +1044,40 @@ def test_delete_expired_snapshots(state_sync: EngineAdapterStateSync, make_snaps
     assert not state_sync.get_snapshots(None)
 
 
+def test_delete_expired_snapshots_seed(
+    state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
+):
+    now_ts = now_timestamp()
+
+    snapshot = make_snapshot(
+        SeedModel(
+            name="a",
+            kind=SeedKind(path="./path/to/seed"),
+            seed=Seed(content="header\n1\n2"),
+            column_hashes={"header": "hash"},
+            depends_on=set(),
+        ),
+    )
+    snapshot.ttl = "in 10 seconds"
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+    snapshot.updated_ts = now_ts - 15000
+
+    state_sync.push_snapshots([snapshot])
+    assert set(state_sync.get_snapshots(None)) == {snapshot.snapshot_id}
+    assert state_sync.engine_adapter.fetchall(
+        "SELECT name, version, content FROM sqlmesh._seeds"
+    ) == [
+        (snapshot.name, snapshot.version, snapshot.model.seed.content),
+    ]
+
+    assert state_sync.delete_expired_snapshots() == [
+        SnapshotTableCleanupTask(snapshot=snapshot.table_info, dev_table_only=False),
+    ]
+
+    assert not state_sync.get_snapshots(None)
+    assert not state_sync.engine_adapter.fetchall("SELECT * FROM sqlmesh._seeds")
+
+
 def test_delete_expired_snapshots_batching(
     state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
 ):
@@ -1580,6 +1614,8 @@ def test_migrate_rows(state_sync: EngineAdapterStateSync, mocker: MockerFixture)
             "expiration_ts": exp.DataType.build("bigint"),
         },
     )
+
+    state_sync.engine_adapter.drop_table("sqlmesh._seeds")
 
     old_snapshots = state_sync.engine_adapter.fetchdf("select * from sqlmesh._snapshots")
     old_environments = state_sync.engine_adapter.fetchdf("select * from sqlmesh._environments")
@@ -2124,28 +2160,29 @@ def test_snapshot_batching(state_sync, mocker, make_snapshot):
     state_sync.SNAPSHOT_BATCH_SIZE = 2
     state_sync.engine_adapter = mock
 
+    snapshot_a = make_snapshot(SqlModel(name="a", query=parse_one("select 1")), "1")
+    snapshot_b = make_snapshot(SqlModel(name="a", query=parse_one("select 2")), "2")
+    snapshot_c = make_snapshot(SqlModel(name="a", query=parse_one("select 3")), "3")
+
     state_sync.delete_snapshots(
         (
-            SnapshotId(name="a", identifier="1"),
-            SnapshotId(name="a", identifier="2"),
-            SnapshotId(name="a", identifier="3"),
+            snapshot_a,
+            snapshot_b,
+            snapshot_c,
         )
     )
     calls = mock.delete_from.call_args_list
     assert mock.delete_from.call_args_list == [
         call(
             exp.to_table("sqlmesh._snapshots"),
-            where=parse_one("(name, identifier) in (('a', '1'), ('a', '2'))"),
-        ),
-        call(
-            exp.to_table("sqlmesh._seeds"),
-            where=parse_one("(name, identifier) in (('a', '1'), ('a', '2'))"),
+            where=parse_one(
+                f"(name, identifier) in (('\"a\"', '{snapshot_b.identifier}'), ('\"a\"', '{snapshot_a.identifier}'))"
+            ),
         ),
         call(
             exp.to_table("sqlmesh._snapshots"),
-            where=parse_one("(name, identifier) in (('a', '3'))"),
+            where=parse_one(f"(name, identifier) in (('\"a\"', '{snapshot_c.identifier}'))"),
         ),
-        call(exp.to_table("sqlmesh._seeds"), where=parse_one("(name, identifier) in (('a', '3'))")),
     ]
 
     mock.fetchall.side_effect = [


### PR DESCRIPTION
This is a re-introduction of #2481 which I had to revert because of issues with MSSQL and MySQL surfaced in the engine adapter integration tests. I've added fixes for table renaming API to support these engines.

Previous description: 
The contents of the seed are only different if the snapshot's version is different too. Therefore, it doesn't make sense to store seed content by the (name, identifier) tuple since it leads to duplication and more complexity and inefficiencies downstream. For example, we don't need to migrate seed records if we were to store them by (name, version), since only identifiers change during the migration.