### PR TITLE
fix: push snapshots before updating intervals

### DIFF
--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -99,9 +99,8 @@ class BuiltInPlanEvaluator(PlanEvaluator):
                 after_promote_snapshots = all_names - before_promote_snapshots
                 deployability_index_for_evaluation = DeployabilityIndex.all_deployable()
 
-            update_intervals_for_new_snapshots(plan.new_snapshots, self.state_sync)
-
             self._push(plan, deployability_index_for_creation)
+            update_intervals_for_new_snapshots(plan.new_snapshots, self.state_sync)
             self._restate(plan)
             self._backfill(
                 plan,


### PR DESCRIPTION
Prior to this we would add a reference to the intervals tables to a snapshot that doesn't exist when doing forward-only changes. This flips the order so we first add the snapshot and then start adding intervals. 