### PR TITLE
Feat: Support macros in the MODEL statement

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -235,7 +235,9 @@ class MacroEvaluator:
         """
         mapping = {}
 
-        for k, v in chain(self.locals.items(), local_variables.items()):
+        variables = self.locals.get(c.SQLMESH_VARS, {})
+
+        for k, v in chain(variables.items(), self.locals.items(), local_variables.items()):
             # try to convert all variables into sqlglot expressions
             # because they're going to be converted into strings in sql
             # we use bare Exception instead of ValueError because there's

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1905,7 +1905,7 @@ def _python_env(
     for expression in expressions:
         if not isinstance(expression, d.Jinja):
             for macro_func_or_var in expression.find_all(d.MacroFunc, d.MacroVar, exp.Identifier):
-                if isinstance(macro_func_or_var, d.MacroFunc):
+                if macro_func_or_var.__class__ is d.MacroFunc:
                     name = macro_func_or_var.this.name.lower()
                     if name in macros:
                         used_macros[name] = macros[name]
@@ -1919,7 +1919,7 @@ def _python_env(
                                     path,
                                 )
                             used_variables.add(args[0].this.lower())
-                elif isinstance(macro_func_or_var, d.MacroVar):
+                elif macro_func_or_var.__class__ is d.MacroVar:
                     name = macro_func_or_var.name.lower()
                     if name in macros:
                         used_macros[name] = macros[name]
@@ -1928,8 +1928,10 @@ def _python_env(
                 elif (
                     isinstance(macro_func_or_var, exp.Identifier) and "@" in macro_func_or_var.this
                 ):
-                    for m in MacroStrTemplate.pattern.findall(macro_func_or_var.this):
-                        var_name = m[2] or m[1]
+                    for _, identifier, braced_identifier, _ in MacroStrTemplate.pattern.findall(
+                        macro_func_or_var.this
+                    ):
+                        var_name = braced_identifier or identifier
                         if var_name in variables:
                             used_variables.add(var_name)
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1455,7 +1455,6 @@ def load_sql_based_model(
         path=path,
         jinja_macro_registry=jinja_macros,
         python_env=meta_python_env,
-        only_execution_time=True,
         default_catalog=default_catalog,
         quote_identifiers=False,
     )
@@ -1905,7 +1904,7 @@ def _python_env(
     expressions = ensure_list(expressions)
     for expression in expressions:
         if not isinstance(expression, d.Jinja):
-            for macro_func_or_var in expression.find_all(d.MacroFunc, d.MacroVar):
+            for macro_func_or_var in expression.find_all(d.MacroFunc, d.MacroVar, exp.Identifier):
                 if macro_func_or_var.__class__ is d.MacroFunc:
                     name = macro_func_or_var.this.name.lower()
                     if name in macros:
@@ -1926,6 +1925,20 @@ def _python_env(
                         used_macros[name] = macros[name]
                     elif name in variables:
                         used_variables.add(name)
+                elif (
+                    macro_func_or_var.__class__ is exp.Identifier and "@" in macro_func_or_var.this
+                ):
+                    var_name = None
+                    macro_template = macro_func_or_var.this
+                    at_idx = macro_template.index("@")
+                    if at_idx + 1 < len(macro_template) and macro_template[at_idx + 1] == "{":
+                        block_end_idx = macro_template.find("}", at_idx + 2)
+                        if block_end_idx > 0:
+                            var_name = macro_template[at_idx + 2 : block_end_idx]
+                    else:
+                        var_name = macro_template[at_idx + 1 :]
+                    if var_name is not None and var_name in variables:
+                        used_variables.add(var_name)
 
     for macro_ref in jinja_macro_references or set():
         if macro_ref.package is None and macro_ref.name in macros:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -3815,7 +3815,7 @@ def test_macros_in_model_statement(sushi_context, assert_exp_eq):
     expressions = d.parse(
         """
         MODEL (
-            name @{gateway}.test_model,
+            name @{gateway}__@{gateway}.test_model,
             kind INCREMENTAL_BY_TIME_RANGE (
                 time_column @{time_column}
 
@@ -3830,7 +3830,7 @@ def test_macros_in_model_statement(sushi_context, assert_exp_eq):
     model = load_sql_based_model(
         expressions, variables={"gateway": "test_gateway", "time_column": "a"}
     )
-    assert model.name == "test_gateway.test_model"
+    assert model.name == "test_gateway__test_gateway.test_model"
     assert model.time_column
     assert model.time_column.column == exp.column("a", quoted=True)
     assert model.start == "2023-01-01"

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -938,7 +938,7 @@ def test_render_definition():
             owner owner_name,
             dialect spark,
             kind INCREMENTAL_BY_TIME_RANGE (
-                time_column (a, 'yyyymmdd')
+                time_column (`a`, 'yyyymmdd')
             ),
             storage_format iceberg,
             partitioned_by `a`,


### PR DESCRIPTION
This update allow users to easily parameterize their model names and other attributes by using macros and variables inside the `MODEL` statement. Thus the following example is now a valid definition:
```
MODEL (
    name @{gateway}.test_model
);
```