### PR TITLE
Fix: quote escape commit message during trigger private tests

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -231,7 +231,8 @@ jobs:
         - run:
             name: Trigger private tests
             command: |
-              echo "export COMMIT_MESSAGE=\"$(git log --format=%s -n 1 $CIRCLE_SHA1)\"" >> "$BASH_ENV"
+              echo 'export COMMIT_MESSAGE="$(git log --format=%s -n 1 $CIRCLE_SHA1)"' >> "$BASH_ENV"
+              echo 'export FORMATTED_COMMIT_MESSAGE="${COMMIT_MESSAGE//\"/\\\"}"' >> "$BASH_ENV"
               source "$BASH_ENV"
               curl --request POST \
                 --url $TOBIKO_PRIVATE_CIRCLECI_URL \
@@ -245,7 +246,7 @@ jobs:
                     "sqlmesh_branch":"'$CIRCLE_BRANCH'",
                     "sqlmesh_commit_author":"'$CIRCLE_USERNAME'",
                     "sqlmesh_commit_hash":"'$CIRCLE_SHA1'",
-                    "sqlmesh_commit_message":"'"$COMMIT_MESSAGE"'"
+                    "sqlmesh_commit_message":"'"$FORMATTED_COMMIT_MESSAGE"'"
                     }
                 }'
 


### PR DESCRIPTION
First we need to single quote the `$COMMIT_MESSAGE` definition so that bash does not actually execute the command during assignment but rather stores the entire string as-is in the env file. We then have to do a parameter expansion on `$COMMIT_MESSAGE` to properly replace any instances of double quotes with escaped double quotes. This allows the commit message to be safely passed into JSON. 

Note that when a commit is reverted, the default message is `Revert "<original_message>"`, and those double quotes will need to be escaped. Otherwise they get interpreted as special characters by bash.