### PR TITLE
Fix: Make sure that we don't attempt to create two seed records with the same version in state

### DIFF
--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -39,6 +39,7 @@ from sqlmesh.core.snapshot import (
     Intervals,
     Node,
     Snapshot,
+    SnapshotChangeCategory,
     SnapshotFingerprint,
     SnapshotId,
     SnapshotIdLike,
@@ -215,7 +216,10 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         snapshots_to_store = []
 
         for snapshot in snapshots:
-            if isinstance(snapshot.node, SeedModel):
+            if isinstance(snapshot.node, SeedModel) and snapshot.change_category in (
+                SnapshotChangeCategory.BREAKING,
+                SnapshotChangeCategory.NON_BREAKING,
+            ):
                 seed_model = t.cast(SeedModel, snapshot.node)
                 seed_contents.append(
                     {


### PR DESCRIPTION
This may happen when a metadata change is applied to a seed model, in which case the version will remain the same.

Without this fix we may violate the primary key constraint for databases that support it, or otherwise create duplicated records.