### PR TITLE
Fix: allow this_model to be used as a sqlmesh native macro var

### DIFF
--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -101,11 +101,12 @@ class BaseExpressionRenderer:
 
         if self._model_fqn and "this_model" not in kwargs:
             if snapshots:
-                kwargs["this_model"] = self._to_table_mapping(
-                    [snapshots[self._model_fqn]], deployability_index
-                )
+                mapping = self._to_table_mapping([snapshots[self._model_fqn]], deployability_index)
+                resolved_name = next(iter(mapping.values())) if mapping else self._model_fqn
             else:
-                kwargs["this_model"] = self._model_fqn
+                resolved_name = self._model_fqn
+
+            kwargs["this_model"] = exp.to_table(resolved_name)
 
         expressions = [self._expression]
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -3748,9 +3748,7 @@ def test_this_model() -> None:
         SELECT '{{ this_model }}' as x
         JINJA_END;
 
-        JINJA_STATEMENT_BEGIN;
-        COPY {{ this_model }} TO 'b';
-        JINJA_END;
+        DELETE FROM db.other_table WHERE col IN (SELECT x FROM @this_model);
         """
     )
     model = load_sql_based_model(expressions)
@@ -3758,4 +3756,7 @@ def test_this_model() -> None:
     assert model.render_query_or_raise().sql() == '''SELECT '"db"."table"' AS "x"'''
 
     assert model.render_pre_statements()[0].sql() == """COPY "db"."table" TO 'a'"""
-    assert model.render_post_statements()[0].sql() == """COPY "db"."table" TO 'b'"""
+    assert (
+        model.render_post_statements()[0].sql()
+        == """DELETE FROM "db"."other_table" WHERE "col" IN (SELECT "x" FROM "db"."table")"""
+    )


### PR DESCRIPTION
The updated test currently fails in main:

```
E         Skipping 54 identical leading characters in diff, use -v to show
E         - "x" FROM "db"."table")
E         + "x" FROM """db"".""table""")
E         ?          ++    + +       ++
```

I also saw a different error when I was testing locally with a duckdb project, which makes sense because we stored a dict in the macro evaluator's `locals` and then `exp.convert`ed it into a `MAP`:

```
duckdb.duckdb.CatalogException: Catalog Error: Table Function with name map does not exist!
Did you mean "range"?
LINE 1: ...table" ("col") SELECT * FROM MAP(['"db"."dev"."table"'], [...
                                                  ^
```