### PR TITLE
feat: support `condition` argument in `forall` audit

### DIFF
--- a/sqlmesh/core/audit/builtin.py
+++ b/sqlmesh/core/audit/builtin.py
@@ -83,16 +83,21 @@ HAVING COUNT(*) <= @threshold
 # ))
 forall_audit = ModelAudit(
     name="forall",
+    defaults={"condition": exp.null()},
     query="""
 SELECT *
 FROM @this_model
-WHERE @REDUCE(
-  @EACH(
-    @criteria,
-    c -> NOT (c)
-  ),
-  (l, r) -> l OR r
-)
+WHERE
+  @AND(
+    @REDUCE(
+      @EACH(
+        @criteria,
+        c -> NOT (c)
+      ),
+      (l, r) -> l OR r
+    ),
+    @condition,
+  )
     """,
 )
 

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -490,6 +490,16 @@ def test_forall_audit(model: Model):
         == """SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" BETWEEN '1970-01-01' AND '1970-01-01') AS "_q_0" WHERE NOT ("a" >= "b") OR NOT ("c" + "d" - "e" < 1.0)"""
     )
 
+    rendered_query_a = builtin.forall_audit.render_query(
+        model,
+        criteria=[parse_one("a >= b"), parse_one("c + d - e < 1.0")],
+        condition=parse_one("f = 42"),
+    )
+    assert (
+        rendered_query_a.sql()
+        == """SELECT * FROM (SELECT * FROM "db"."test_model" AS "test_model" WHERE "ds" BETWEEN '1970-01-01' AND '1970-01-01') AS "_q_0" WHERE (NOT ("a" >= "b") OR NOT ("c" + "d" - "e" < 1.0)) AND "f" = 42"""
+    )
+
 
 def test_accepted_range_audit(model: Model):
     rendered_query = builtin.accepted_range_audit.render_query(


### PR DESCRIPTION
This isn't strictly necessary since you can add the condition in the `criteria`. But there are several advantages to supporting `condition`:

1. it makes `forall` consistent with other audits
2. it is simpler to reason about, consider `foreall(criteria=[f != 42 OR a > b])` vs `forall(criteria=[a > b], condition=(f=42))`
3. more concise if you want to apply multiple criteria to the same subset of rows