### PR TITLE
Fix: Always use full target name when renaming tables and rely on SQLGLot to remove schema where needed

### DIFF
--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -6,7 +6,6 @@ import typing as t
 import pandas as pd
 from sqlglot import exp
 
-from sqlmesh.core.engine_adapter.mixins import RenameTableFullTargetNameMixin
 from sqlmesh.core.engine_adapter.shared import (
     CatalogSupport,
     DataObject,
@@ -30,7 +29,7 @@ logger = logging.getLogger(__name__)
         "_get_data_objects": CatalogSupport.REQUIRES_SET_CATALOG,
     }
 )
-class DatabricksEngineAdapter(SparkEngineAdapter, RenameTableFullTargetNameMixin):
+class DatabricksEngineAdapter(SparkEngineAdapter):
     DIALECT = "databricks"
     INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
     SUPPORTS_CLONING = True

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -246,18 +246,3 @@ class NonTransactionalTruncateMixin(EngineAdapter):
         if self._connection_pool.is_transaction_active:
             return self.execute(exp.Delete(this=exp.to_table(table_name)))
         super()._truncate_table(table_name)
-
-
-class RenameTableFullTargetNameMixin(EngineAdapter):
-    def _rename_table(
-        self,
-        old_table_name: TableName,
-        new_table_name: TableName,
-    ) -> None:
-        old_table = exp.to_table(old_table_name)
-        new_table = exp.to_table(new_table_name)
-        if not new_table.db and old_table.db:
-            # In MySQL and Snowflake you need to provide the full target table name.
-            # Therefore we use the old schema name if one is not provided explicitly in the new name.
-            new_table.set("db", old_table.args["db"])
-        return super()._rename_table(old_table, new_table)

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -10,7 +10,6 @@ from sqlmesh.core.engine_adapter.mixins import (
     LogicalMergeMixin,
     NonTransactionalTruncateMixin,
     PandasNativeFetchDFSupportMixin,
-    RenameTableFullTargetNameMixin,
 )
 from sqlmesh.core.engine_adapter.shared import (
     CommentCreationTable,
@@ -31,7 +30,6 @@ class MySQLEngineAdapter(
     LogicalMergeMixin,
     PandasNativeFetchDFSupportMixin,
     NonTransactionalTruncateMixin,
-    RenameTableFullTargetNameMixin,
 ):
     DEFAULT_BATCH_SIZE = 200
     DIALECT = "mysql"

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -10,10 +10,7 @@ from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 from sqlglot.optimizer.qualify_columns import quote_identifiers
 
 from sqlmesh.core.dialect import to_schema
-from sqlmesh.core.engine_adapter.mixins import (
-    GetCurrentCatalogFromFunctionMixin,
-    RenameTableFullTargetNameMixin,
-)
+from sqlmesh.core.engine_adapter.mixins import GetCurrentCatalogFromFunctionMixin
 from sqlmesh.core.engine_adapter.shared import (
     CatalogSupport,
     DataObject,
@@ -35,7 +32,7 @@ if t.TYPE_CHECKING:
         "drop_schema": CatalogSupport.REQUIRES_SET_CATALOG,
     }
 )
-class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, RenameTableFullTargetNameMixin):
+class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
     DIALECT = "snowflake"
     SUPPORTS_MATERIALIZED_VIEWS = True
     SUPPORTS_MATERIALIZED_VIEW_SCHEMA = True

--- a/sqlmesh/migrations/v0049_replace_identifier_with_version_in_seeds_table.py
+++ b/sqlmesh/migrations/v0049_replace_identifier_with_version_in_seeds_table.py
@@ -54,4 +54,4 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter.insert_append(new_seeds_table, query)
     engine_adapter.drop_table(seeds_table)
-    engine_adapter.rename_table(new_seeds_table, "_seeds")
+    engine_adapter.rename_table(new_seeds_table, seeds_table)

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -103,18 +103,3 @@ def test_get_current_database(make_mocked_engine_adapter: t.Callable):
 
     assert adapter.get_current_database() == "test_database"
     assert to_sql_calls(adapter) == ["SELECT CURRENT_DATABASE()"]
-
-
-def test_rename_table(make_mocked_engine_adapter: t.Callable):
-    adapter = make_mocked_engine_adapter(DatabricksEngineAdapter)
-
-    adapter.rename_table("test_schema.old_name", "new_name")
-    adapter.rename_table("test_schema.old_name", "new_test_schema.new_name")
-    adapter.rename_table("old_name", "new_name")
-
-    sql_calls = to_sql_calls(adapter)
-    assert sql_calls == [
-        "ALTER TABLE `test_schema`.`old_name` RENAME TO `test_schema`.`new_name`",
-        "ALTER TABLE `test_schema`.`old_name` RENAME TO `new_test_schema`.`new_name`",
-        "ALTER TABLE `old_name` RENAME TO `new_name`",
-    ]

--- a/tests/core/engine_adapter/test_mysql.py
+++ b/tests/core/engine_adapter/test_mysql.py
@@ -62,18 +62,3 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
         f"ALTER TABLE `test_table` COMMENT = '{truncated_table_comment}'",
         f"ALTER TABLE `test_table` MODIFY `a` INT COMMENT '{truncated_column_comment}'",
     ]
-
-
-def test_rename_table(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
-    adapter = make_mocked_engine_adapter(MySQLEngineAdapter)
-
-    adapter.rename_table("test_schema.old_name", "new_name")
-    adapter.rename_table("test_schema.old_name", "new_test_schema.new_name")
-    adapter.rename_table("old_name", "new_name")
-
-    sql_calls = to_sql_calls(adapter)
-    assert sql_calls == [
-        "ALTER TABLE `test_schema`.`old_name` RENAME TO `test_schema`.`new_name`",
-        "ALTER TABLE `test_schema`.`old_name` RENAME TO `new_test_schema`.`new_name`",
-        "ALTER TABLE `old_name` RENAME TO `new_name`",
-    ]

--- a/tests/core/engine_adapter/test_snowflake.py
+++ b/tests/core/engine_adapter/test_snowflake.py
@@ -143,18 +143,3 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
         """COMMENT ON TABLE "test_table" IS 'table description'""",
         """ALTER TABLE "test_table" ALTER COLUMN "a" COMMENT 'a column description'""",
     ]
-
-
-def test_rename_table(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
-    adapter = make_mocked_engine_adapter(SnowflakeEngineAdapter)
-
-    adapter.rename_table("test_schema.old_name", "new_name")
-    adapter.rename_table("test_schema.old_name", "new_test_schema.new_name")
-    adapter.rename_table("old_name", "new_name")
-
-    sql_calls = to_sql_calls(adapter)
-    assert sql_calls == [
-        'ALTER TABLE "test_schema"."old_name" RENAME TO "test_schema"."new_name"',
-        'ALTER TABLE "test_schema"."old_name" RENAME TO "new_test_schema"."new_name"',
-        'ALTER TABLE "old_name" RENAME TO "new_name"',
-    ]


### PR DESCRIPTION
Removing redundant code in favor of just specifying a full target table name when renaming and relying on SQLGLot to remove the schema portion of the name where applicable.