### PR TITLE
Fix: Propagate table properties as options when creating views in BQ

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -568,6 +568,8 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
                 ),
             )
 
+        properties.extend(self._table_properties_to_expressions(table_properties))
+
         if properties:
             return exp.Properties(expressions=properties)
         return None


### PR DESCRIPTION
BigQuery supports the `OPTIONS` clause when creating views. Previously we weren't propagating `table_properties` set at the model level into the view creation statement.