### PR TITLE
feat!: make star macro more flexible

### DIFF
--- a/docs/concepts/macros/sqlmesh_macros.md
+++ b/docs/concepts/macros/sqlmesh_macros.md
@@ -592,7 +592,9 @@ WHERE
 
 `@STAR` is named after SQL's star operator `*`, but it allows you to programmatically generate a set of column selections and aliases instead of just selecting all available columns. A query may use more than one `@STAR` and may also include explicit column selections.
 
-`@STAR` uses SQLMesh's knowledge of each table's columns and data types to generate the appropriate column list. The resulting query always `CAST`s columns to their data type in the source table.
+`@STAR` uses SQLMesh's knowledge of each table's columns and data types to generate the appropriate column list. 
+If the column data types are known then the resulting query `CAST`s columns to their data type in the source table.
+Otherwise, the columns will be listed without any casting. 
 
 `@STAR` supports the following arguments, in this order:
 

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -36,7 +36,17 @@ def macro_evaluator() -> MacroEvaluator:
 def test_star(assert_exp_eq) -> None:
     sql = """SELECT @STAR(foo) FROM foo"""
     expected_sql = """SELECT CAST([foo].[a] AS DATETIMEOFFSET) AS [a] FROM foo"""
-    schema = MappingSchema({"foo": {"a": "datetimeoffset"}}, dialect="tsql")
+    schema = MappingSchema(
+        {"foo": {"a": exp.DataType.build("datetimeoffset", dialect="tsql")}}, dialect="tsql"
+    )
+    evaluator = MacroEvaluator(schema=schema, dialect="tsql")
+    assert_exp_eq(evaluator.transform(parse_one(sql, read="tsql")), expected_sql, dialect="tsql")
+
+
+def test_start_no_column_types(assert_exp_eq) -> None:
+    sql = """SELECT @STAR(foo) FROM foo"""
+    expected_sql = """SELECT [foo].[a] AS [a] FROM foo"""
+    schema = MappingSchema({"foo": {"a": exp.DataType.build("UNKNOWN")}}, dialect="tsql")
     evaluator = MacroEvaluator(schema=schema, dialect="tsql")
     assert_exp_eq(evaluator.transform(parse_one(sql, read="tsql")), expected_sql, dialect="tsql")
 


### PR DESCRIPTION
Prior to this change Start macro required the types to be known since it always did a cast of the selected columns to their desired type. This change makes it so if we don't know the columns to types then we just put in the columns otherwise we will do the cast. Therefore now to use the macro we just have to know the columns of the model being referenced.

An alternative implementation would have been to check if each column has a type and if so cast, otherwise select but decided to just do an all or nothing approach. 

Consider this breaking because if someone starts using this feature then their models would not be compatible with someone using an earlier release. 