### PR TITLE
fix: use more robust way of identifying std macros

### DIFF
--- a/docs/concepts/macros/sqlmesh_macros.md
+++ b/docs/concepts/macros/sqlmesh_macros.md
@@ -1514,7 +1514,7 @@ def stamped(evaluator, query: exp.Select) -> exp.Subquery:
 # SELECT * FROM @stamped('SELECT a, b, c')
 ```
 
-When coercion fails, there will always be a warning logged but we will not crash. We believe the macro should be flexible by default, meaning the default behavior is preserved if we cannot coerce. Give that, the user can express whatever level of additional checks they want. For example, if you would like to raise an error when the coercion fails, you can use an `assert` statement. For example:
+When coercion fails, there will always be a warning logged but we will not crash. We believe the macro system should be flexible by default, meaning the default behavior is preserved if we cannot coerce. Given that, the user can express whatever level of additional checks they want. For example, if you would like to raise an error when the coercion fails, you can use an `assert` statement. For example:
 
 ```python linenums="1"
 @macro()

--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -55,3 +55,6 @@ DEFAULT_SCHEMA = "default"
 SQLMESH_VARS = "__sqlmesh__vars__"
 VAR = "var"
 GATEWAY = "gateway"
+
+SQLMESH_MACRO = "__sqlmesh__macro__"
+SQLMESH_BUILTIN = "__sqlmesh__builtin__"

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -222,7 +222,6 @@ class SqlMeshLoader(Loader):
         """Loads all user defined macros."""
         # Store a copy of the macro registry
         standard_macros = macro.get_registry()
-
         jinja_macros = JinjaMacroRegistry()
         extractor = MacroExtractor()
 

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -169,7 +169,7 @@ class MacroEvaluator:
         for k, v in self.python_env.items():
             if v.is_definition:
                 self.macros[normalize_macro_name(k)] = self.env[v.name or k]
-            elif v.is_import and getattr(self.env.get(k), "__sqlmesh_macro__", None):
+            elif v.is_import and getattr(self.env.get(k), c.SQLMESH_MACRO, None):
                 self.macros[normalize_macro_name(k)] = self.env[k]
             elif v.is_value:
                 self.locals[k] = self.env[k]
@@ -543,7 +543,7 @@ class macro(registry_decorator):
         wrapper = super().__call__(func)
 
         # This is used to identify macros at runtime to unwrap during serialization.
-        setattr(wrapper, "__sqlmesh_macro__", True)
+        setattr(wrapper, c.SQLMESH_MACRO, True)
         return wrapper
 
 
@@ -1064,3 +1064,7 @@ def var(
 def normalize_macro_name(name: str) -> str:
     """Prefix macro name with @ and upcase"""
     return f"@{name.upper()}"
+
+
+for m in macro.get_registry().values():
+    setattr(m, c.SQLMESH_BUILTIN, True)

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1942,7 +1942,7 @@ def _python_env(
     for name, macro in used_macros.items():
         if isinstance(macro, Executable):
             serialized_env[name] = macro
-        elif not macro.func.__module__.startswith("sqlmesh."):
+        elif not hasattr(macro, c.SQLMESH_BUILTIN):
             build_env(macro.func, env=python_env, name=name, path=module_path)
 
     serialized_env.update(serialize_env(python_env, path=module_path))

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from astor import to_source
 
+from sqlmesh.core import constants as c
 from sqlmesh.utils import format_exception, unique
 from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.pydantic import PydanticModel
@@ -276,7 +277,7 @@ def build_env(
     if name not in env:
         # We only need to add the undecorated code of @macro() functions in env, which
         # is accessible through the `__wrapped__` attribute added by functools.wraps
-        env[name] = obj.__wrapped__ if hasattr(obj, "__sqlmesh_macro__") else obj
+        env[name] = obj.__wrapped__ if hasattr(obj, c.SQLMESH_MACRO) else obj
 
         if (
             obj_module

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -1,7 +1,4 @@
-import functools
-import sys
 import typing as t
-from unittest import mock
 
 import pytest
 from sqlglot import MappingSchema, exp, parse_one
@@ -9,7 +6,7 @@ from sqlglot import MappingSchema, exp, parse_one
 from sqlmesh.core.dialect import StagedFilePath
 from sqlmesh.core.macros import SQL, MacroEvaluator, macro
 from sqlmesh.utils.errors import SQLMeshError
-from sqlmesh.utils.metaprogramming import Executable, ExecutableKind
+from sqlmesh.utils.metaprogramming import Executable
 
 
 @pytest.fixture
@@ -93,35 +90,6 @@ def test_start_no_column_types(assert_exp_eq) -> None:
 
 def test_case(macro_evaluator: MacroEvaluator) -> None:
     assert macro.get_registry()["upper"]
-
-
-def test_external_macro() -> None:
-    def foo(evaluator: MacroEvaluator) -> str:
-        return "foo"
-
-    @functools.wraps(foo)
-    def wrapper(*args, **kwargs):
-        return foo(*args, **kwargs)
-
-    # Mimic a SQLMesh macro definition by setting the func's metadata appropriately
-    setattr(wrapper, "__sqlmesh_macro__", True)
-
-    sys.modules["pkg"] = mock.Mock()
-    with mock.patch("pkg.foo", wrapper):
-        evaluator = MacroEvaluator(
-            python_env={
-                "foo": Executable(
-                    payload="from pkg import foo",
-                    kind=ExecutableKind.IMPORT,
-                    name=None,
-                    path=None,
-                    alias=None,
-                )
-            }
-        )
-
-        assert "@FOO" in evaluator.macros
-        assert evaluator.macros["@FOO"](evaluator) == "foo"
 
 
 def test_macro_var(macro_evaluator):


### PR DESCRIPTION
hardcoding the module name of a macro func is brittle. this now labels any macro that is already loaded as builtin.