### PR TITLE
Adds plan id to apply notifications

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1111,18 +1111,25 @@ class GenericContext(BaseContext, t.Generic[C]):
         if plan.uncategorized:
             raise UncategorizedPlanError("Can't apply a plan with uncategorized changes.")
         self.notification_target_manager.notify(
-            NotificationEvent.APPLY_START, environment=plan.environment_naming_info.name
+            NotificationEvent.APPLY_START,
+            environment=plan.environment_naming_info.name,
+            plan_id=plan.plan_id,
         )
         try:
             self._apply(plan, circuit_breaker)
         except Exception as e:
             self.notification_target_manager.notify(
-                NotificationEvent.APPLY_FAILURE, traceback.format_exc()
+                NotificationEvent.APPLY_FAILURE,
+                environment=plan.environment_naming_info.name,
+                plan_id=plan.plan_id,
+                exc=traceback.format_exc(),
             )
             logger.error(f"Apply Failure: {traceback.format_exc()}")
             raise e
         self.notification_target_manager.notify(
-            NotificationEvent.APPLY_END, environment=plan.environment_naming_info.name
+            NotificationEvent.APPLY_END,
+            environment=plan.environment_naming_info.name,
+            plan_id=plan.plan_id,
         )
 
     def invalidate_environment(self, name: str, sync: bool = False) -> None:

--- a/sqlmesh/core/notification_target.py
+++ b/sqlmesh/core/notification_target.py
@@ -114,23 +114,29 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
         """
 
     @notify(NotificationEvent.APPLY_START)
-    def notify_apply_start(self, environment: str) -> None:
+    def notify_apply_start(self, environment: str, plan_id: str) -> None:
         """Notify when an apply starts.
 
         Args:
             environment: The target environment of the plan.
+            plan_id: plan_id that is being applied.
         """
-        self.send(NotificationStatus.INFO, f"Plan apply started for environment `{environment}`.")
+        self.send(
+            NotificationStatus.INFO,
+            f"Plan {plan_id} apply started for environment `{environment}`.",
+        )
 
     @notify(NotificationEvent.APPLY_END)
-    def notify_apply_end(self, environment: str) -> None:
+    def notify_apply_end(self, environment: str, plan_id: str) -> None:
         """Notify when an apply ends.
 
         Args:
             environment: The target environment of the plan.
+            plan_id: plan_id that was applied.
         """
         self.send(
-            NotificationStatus.SUCCESS, f"Plan apply finished for environment `{environment}`."
+            NotificationStatus.SUCCESS,
+            f"Plan {plan_id} apply finished for environment `{environment}`.",
         )
 
     @notify(NotificationEvent.RUN_START)
@@ -164,13 +170,19 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
         self.send(NotificationStatus.SUCCESS, "SQLMesh migration finished.")
 
     @notify(NotificationEvent.APPLY_FAILURE)
-    def notify_apply_failure(self, exc: str) -> None:
+    def notify_apply_failure(self, environment: str, plan_id: str, exc: str) -> None:
         """Notify in the case of an apply failure.
 
         Args:
+            environment: The target environment of the run.
+            plan_id: The plan id of the failed apply
             exc: The exception stack trace.
         """
-        self.send(NotificationStatus.FAILURE, "Plan apply failed.", exc=exc)
+        self.send(
+            NotificationStatus.FAILURE,
+            f"Plan {plan_id} in environment `{environment}` apply failed.",
+            exc=exc,
+        )
 
     @notify(NotificationEvent.RUN_FAILURE)
     def notify_run_failure(self, exc: str) -> None:

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -32,7 +32,6 @@ from sqlmesh.core.user import User
 from sqlmesh.schedulers.airflow import common as airflow_common
 from sqlmesh.schedulers.airflow.client import AirflowClient, BaseAirflowClient
 from sqlmesh.schedulers.airflow.mwaa_client import MWAAClient
-from sqlmesh.utils import random_id
 from sqlmesh.utils.errors import SQLMeshError
 
 logger = logging.getLogger(__name__)
@@ -302,7 +301,7 @@ class BaseAirflowPlanEvaluator(PlanEvaluator):
     def evaluate(
         self, plan: Plan, circuit_breaker: t.Optional[t.Callable[[], bool]] = None
     ) -> None:
-        plan_request_id = random_id()
+        plan_request_id = plan.plan_id
         self._apply_plan(plan, plan_request_id)
 
         if self.blocking:


### PR DESCRIPTION
Makes changes to how apply notifications are called in context.py to include plan_id. Also modifies the Airflow plan_request_id to be the same as plan_id so that apply notifications can include links to the Airflow job. All of this will help our users find logs when they want to see what SQL queries SQL Mesh runs or track down an error. 
Currently when a SQL Mesh apply fails with Airflow acting as scheduler, the stack trace sent to the notification integration doesn't include any information about why the apply failed. Getting the actual stack trace out of airflow and into the notification would be very complicated, so a good work around is just to include a link to the DAG so users can quickly explore the logs for their run.