### PR TITLE
Fix: force-lowercase dialect names, normalize macro columns_to_types

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -402,14 +402,12 @@ class MacroEvaluator:
             self.columns_to_types_called = True
             return {"__schema_unavailable_at_load__": exp.DataType.build("unknown")}
 
-        if isinstance(model_name, exp.Column):
-            model_name = exp.table_(
-                model_name.this,
-                db=model_name.args.get("table"),
-                catalog=model_name.args.get("db"),
-            )
-
-        columns_to_types = self._schema.find(exp.to_table(model_name))
+        normalized_model_name = normalize_model_name(
+            model_name,
+            default_catalog=self.default_catalog,
+            dialect=self.dialect,
+        )
+        columns_to_types = self._schema.find(exp.to_table(normalized_model_name))
         if columns_to_types is None:
             raise SQLMeshError(f"Schema for model '{model_name}' can't be statically determined.")
 

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -144,9 +144,16 @@ class ModelMeta(_Node):
 
         return v
 
-    @field_validator("dialect", "storage_format", mode="before")
-    def _string_validator(cls, v: t.Any) -> t.Optional[str]:
+    @field_validator("storage_format", mode="before")
+    def _storage_format_validator(cls, v: t.Any) -> t.Optional[str]:
         return str_or_exp_to_str(v)
+
+    @field_validator("dialect", mode="before")
+    def _dialect_validator(cls, v: t.Any) -> t.Optional[str]:
+        # dialects are parsed as identifiers and may get normalized as uppercase,
+        # so this ensures they'll be stored as lowercase
+        dialect = str_or_exp_to_str(v)
+        return dialect and dialect.lower()
 
     @field_validator("partitioned_by_", mode="before")
     @field_validator_v1_args

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1802,6 +1802,12 @@ def test_case_sensitivity(assert_exp_eq):
         """,
     )
 
+    model = load_sql_based_model(
+        d.parse("MODEL (name test, dialect hive); SELECT 1 AS c"),
+        dialect="snowflake",
+    )
+    assert model.dialect == "hive"
+
 
 def test_batch_size_validation():
     expressions = d.parse(


### PR DESCRIPTION
This fixes a couple of bugs I came across while trying to get the sushi project to run in snowflake.