### PR TITLE
fix!: add implicit dialect to pydantic models in python

### DIFF
--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -4,6 +4,7 @@ import typing as t
 from pathlib import Path
 
 from sqlglot import exp
+from sqlglot.dialects.dialect import DialectType
 
 from sqlmesh.core import constants as c
 from sqlmesh.core.dialect import MacroFunc
@@ -17,6 +18,7 @@ class model(registry_decorator):
     """Specifies a function is a python based model."""
 
     registry_name = "python_models"
+    _dialect: DialectType = None
 
     def __init__(self, name: str, is_sql: bool = False, **kwargs: t.Any) -> None:
         if not name:

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -27,8 +27,6 @@ from sqlmesh.utils.pydantic import (
     field_validator,
     field_validator_v1_args,
     get_dialect,
-    model_validator,
-    model_validator_v1_args,
 )
 
 if sys.version_info >= (3, 9):

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -558,6 +558,8 @@ def _model_kind_validator(cls: t.Type, v: t.Any, values: t.Dict[str, t.Any]) -> 
     dialect = get_dialect(values)
 
     if isinstance(v, _ModelKind):
+        if hasattr(v, "dialect") and v.dialect is None:
+            v.dialect = dialect
         return t.cast(ModelKind, v)
 
     if isinstance(v, (d.ModelKind, dict)):

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -259,7 +259,9 @@ def _kind_dialect_validator(cls: t.Type, v: t.Optional[str]) -> str:
     return v
 
 
-kind_dialect_validator = field_validator("dialect", mode="before")(_kind_dialect_validator)
+kind_dialect_validator = field_validator("dialect", mode="before", always=True)(
+    _kind_dialect_validator
+)
 
 
 class _Incremental(_ModelKind):

--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -79,8 +79,8 @@ def get_dialect(values: t.Any) -> str:
     """Extracts dialect from a dict or pydantic obj, defaulting to the globally set dialect.
 
     Python models allow users to instantiate pydantic models by hand. This is problematic
-    because the validators kick in with the SQLGLot dialect. To default Pydantic Models used
-    in python models to the project default dialect, we set a class variable on the model
+    because the validators kick in with the SQLGLot dialect. To instantiate Pydantic Models used
+    in python models using the project default dialect, we set a class variable on the model
     registry and use that here.
     """
 

--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -75,6 +75,21 @@ def parse_obj_as(type_: T, obj: t.Any) -> T:
     return pydantic.tools.parse_obj_as(type_, obj)  # type: ignore
 
 
+def get_dialect(values: t.Any) -> str:
+    """Extracts dialect from a dict or pydantic obj, defaulting to the globally set dialect.
+
+    Python models allow users to instantiate pydantic models by hand. This is problematic
+    because the validators kick in with the SQLGLot dialect. To default Pydantic Models used
+    in python models to the project default dialect, we set a class variable on the model
+    registry and use that here.
+    """
+
+    from sqlmesh.core.model import model
+
+    dialect = (values if isinstance(values, dict) else values.data).get("dialect")
+    return model._dialect if dialect is None else dialect
+
+
 def _expression_encoder(e: exp.Expression) -> str:
     return e.meta.get("sql") or e.sql(dialect=e.meta.get("dialect"))
 
@@ -294,8 +309,7 @@ def _get_field(
     v: t.Any,
     values: t.Any,
 ) -> exp.Expression:
-    values = values if isinstance(values, dict) else values.data
-    dialect = values.get("dialect")
+    dialect = get_dialect(values)
 
     if isinstance(v, exp.Expression):
         expression = v
@@ -315,8 +329,7 @@ def _get_fields(
     v: t.Any,
     values: t.Any,
 ) -> t.List[exp.Expression]:
-    values = values if isinstance(values, dict) else values.data
-    dialect = values.get("dialect")
+    dialect = get_dialect(values)
 
     if isinstance(v, (exp.Tuple, exp.Array)):
         expressions: t.List[exp.Expression] = v.expressions

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -3916,7 +3916,8 @@ def test_python_model_dialect():
         dialect="snowflake",
     )
 
-    assert m.time_column.json() == '{"column":"\\"X\\"","format":"%y%m%d"}'
+    assert m.time_column.column.sql() == '"X"'
+    assert m.time_column.format == "%y%m%d"
 
     @model(
         name="b",
@@ -3932,6 +3933,7 @@ def test_python_model_dialect():
         dialect="snowflake",
     )
 
-    assert m.time_column.json() == '{"column":"\\"Y\\"","format":"%Y-%m-%d"}'
+    assert m.time_column.column.sql() == '"Y"'
+    assert m.time_column.format == "%Y-%m-%d"
 
     model._dialect = None

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -109,7 +109,6 @@ def test_json(snapshot: Snapshot):
                 "batch_size": 30,
                 "forward_only": False,
                 "disable_restatement": False,
-                "dialect": "spark",
             },
             "mapping_schema": {},
             "start": "2020-01-01",
@@ -631,7 +630,7 @@ def test_fingerprint(model: Model, parent_model: Model):
     fingerprint = fingerprint_from_node(model, nodes={})
 
     original_fingerprint = SnapshotFingerprint(
-        data_hash="3582214120",
+        data_hash="3163676913",
         metadata_hash="892368116",
     )
 

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -109,7 +109,7 @@ def test_json(snapshot: Snapshot):
                 "batch_size": 30,
                 "forward_only": False,
                 "disable_restatement": False,
-                "dialect": "",
+                "dialect": "spark",
             },
             "mapping_schema": {},
             "start": "2020-01-01",
@@ -631,7 +631,7 @@ def test_fingerprint(model: Model, parent_model: Model):
     fingerprint = fingerprint_from_node(model, nodes={})
 
     original_fingerprint = SnapshotFingerprint(
-        data_hash="3163676913",
+        data_hash="3582214120",
         metadata_hash="892368116",
     )
 
@@ -730,7 +730,7 @@ def test_fingerprint_jinja_macros(model: Model):
         }
     )
     original_fingerprint = SnapshotFingerprint(
-        data_hash="2664333317",
+        data_hash="2973224250",
         metadata_hash="892368116",
     )
 


### PR DESCRIPTION
python models allow users to create various pydantic models that contain sql queries. these sql queries are by default parsed as sqlglot dialect which has unintended consequences.

we now set the config default dialect while loading these python models which allows the pydantic validators to set the expected dialect