### PR TITLE
Fix: Pass variable overrides when parsing profiles and dbt_project yamls

### DIFF
--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -277,11 +277,11 @@ class ManifestHelper:
         return manifest
 
     def _load_project(self, profile: Profile) -> Project:
-        project_renderer = DbtProjectYamlRenderer(profile)
+        project_renderer = DbtProjectYamlRenderer(profile, cli_vars=self.variable_overrides)
         return Project.from_project_root(str(self.project_path), project_renderer)
 
     def _load_profile(self) -> Profile:
-        profile_renderer = ProfileRenderer({})
+        profile_renderer = ProfileRenderer(cli_vars=self.variable_overrides)
         raw_profiles = read_profile(str(self.profiles_path))
         return Profile.from_raw_profiles(
             raw_profiles=raw_profiles,

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -284,6 +284,7 @@ def test_variables(assert_exp_eq, sushi_test_project):
 
     # Finally, check that variable scoping & overwriting (some_var) works as expected
     expected_sushi_variables = {
+        "start": "Jan 1 2022",
         "yet_another_var": 1,
         "top_waiters:limit": 10,
         "top_waiters:revenue": "revenue",
@@ -295,6 +296,7 @@ def test_variables(assert_exp_eq, sushi_test_project):
         "yet_another_var": 1,
         "customers:bla": False,
         "customers:customer_id": "customer_id",
+        "start": "Jan 1 2022",
         "top_waiters:limit": 10,
         "top_waiters:revenue": "revenue",
         "customers:boo": ["a", "b"],
@@ -745,6 +747,7 @@ def test_db_type_to_quote_policy():
 def test_variable_override():
     project_root = "tests/fixtures/dbt/sushi_test"
     project = Project.load(
-        DbtContext(project_root=Path(project_root)), variables={"yet_another_var": 2}
+        DbtContext(project_root=Path(project_root)),
+        variables={"yet_another_var": 2, "start": "2021-01-01"},
     )
     assert project.packages["sushi"].variables["yet_another_var"] == 2

--- a/tests/dbt/test_manifest.py
+++ b/tests/dbt/test_manifest.py
@@ -17,7 +17,13 @@ pytestmark = pytest.mark.dbt
 def test_manifest_helper(caplog):
     project_path = Path("tests/fixtures/dbt/sushi_test")
     profile = Profile.load(DbtContext(project_path))
-    helper = ManifestHelper(project_path, project_path, "sushi", profile.target)
+    helper = ManifestHelper(
+        project_path,
+        project_path,
+        "sushi",
+        profile.target,
+        variable_overrides={"start": "2020-01-01"},
+    )
 
     assert helper.models()["top_waiters"].dependencies == Dependencies(
         refs={"sushi.waiter_revenue_by_day", "waiter_revenue_by_day"},
@@ -96,7 +102,13 @@ def test_manifest_helper(caplog):
 def test_tests_referencing_disabled_models():
     project_path = Path("tests/fixtures/dbt/sushi_test")
     profile = Profile.load(DbtContext(project_path))
-    helper = ManifestHelper(project_path, project_path, "sushi", profile.target)
+    helper = ManifestHelper(
+        project_path,
+        project_path,
+        "sushi",
+        profile.target,
+        variable_overrides={"start": "2020-01-01"},
+    )
 
     assert "disabled_model" not in helper.models()
     assert "not_null_disabled_model_one" not in helper.tests()
@@ -107,7 +119,13 @@ def test_variable_override():
     project_path = Path("tests/fixtures/dbt/sushi_test")
     profile = Profile.load(DbtContext(project_path))
 
-    helper = ManifestHelper(project_path, project_path, "sushi", profile.target)
+    helper = ManifestHelper(
+        project_path,
+        project_path,
+        "sushi",
+        profile.target,
+        variable_overrides={"start": "2020-01-01"},
+    )
     assert helper.models()["top_waiters"].limit_value == 10
 
     helper = ManifestHelper(
@@ -115,6 +133,6 @@ def test_variable_override():
         project_path,
         "sushi",
         profile.target,
-        variable_overrides={"top_waiters:limit": 1},
+        variable_overrides={"top_waiters:limit": 1, "start": "2020-01-01"},
     )
     assert helper.models()["top_waiters"].limit_value == 1

--- a/tests/fixtures/dbt/sushi_test/config.py
+++ b/tests/fixtures/dbt/sushi_test/config.py
@@ -3,7 +3,10 @@ from pathlib import Path
 from sqlmesh.core.config import AirflowSchedulerConfig
 from sqlmesh.dbt.loader import sqlmesh_config
 
-config = sqlmesh_config(Path(__file__).parent)
+variables = {"start": "Jan 1 2022"}
+
+
+config = sqlmesh_config(Path(__file__).parent, variables=variables)
 
 
 test_config = config
@@ -12,4 +15,5 @@ test_config = config
 airflow_config = sqlmesh_config(
     Path(__file__).parent,
     default_scheduler=AirflowSchedulerConfig(),
+    variables=variables,
 )

--- a/tests/fixtures/dbt/sushi_test/dbt_project.yml
+++ b/tests/fixtures/dbt/sushi_test/dbt_project.yml
@@ -20,7 +20,7 @@ clean-targets:         # directories to be removed by `dbt clean`
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
 
 models:
-  +start: Jan 1 2022
+  +start: "{{ var('start') }}"
   sushi:
     +materialized: table
     +pre-hook:


### PR DESCRIPTION
Previously we weren't passing variables into parsers for `profiles.yaml` and `dbt_project.yaml`.