### PR TITLE
chore: add interval inclusive/exclusive method

### DIFF
--- a/sqlmesh/core/state_sync/cache.py
+++ b/sqlmesh/core/state_sync/cache.py
@@ -129,15 +129,18 @@ class CachingStateSync(DelegatingStateSync):
         self.snapshot_cache.clear()
         return self.state_sync.delete_expired_snapshots()
 
-    def add_interval(
+    def add_inclusive_exclusive_interval(
         self,
-        snapshot: Snapshot,
-        start: TimeLike,
-        end: TimeLike,
+        snapshot_id: SnapshotId,
+        snapshot_version: str,
+        start_ts: int,
+        end_ts: int,
         is_dev: bool = False,
     ) -> None:
-        self.snapshot_cache.pop(snapshot.snapshot_id, None)
-        self.state_sync.add_interval(snapshot, start, end, is_dev)
+        self.snapshot_cache.pop(snapshot_id, None)
+        self.state_sync.add_inclusive_exclusive_interval(
+            snapshot_id, snapshot_version, start_ts, end_ts, is_dev
+        )
 
     def remove_interval(
         self,

--- a/sqlmesh/core/state_sync/cache.py
+++ b/sqlmesh/core/state_sync/cache.py
@@ -11,7 +11,7 @@ from sqlmesh.core.snapshot import (
     SnapshotInfoLike,
     SnapshotTableCleanupTask,
 )
-from sqlmesh.core.snapshot.definition import Interval
+from sqlmesh.core.snapshot.definition import Interval, SnapshotIntervals
 from sqlmesh.core.state_sync.base import DelegatingStateSync, StateSync
 from sqlmesh.utils.date import TimeLike, now_timestamp
 
@@ -129,18 +129,9 @@ class CachingStateSync(DelegatingStateSync):
         self.snapshot_cache.clear()
         return self.state_sync.delete_expired_snapshots()
 
-    def add_inclusive_exclusive_interval(
-        self,
-        snapshot_id: SnapshotId,
-        snapshot_version: str,
-        start_ts: int,
-        end_ts: int,
-        is_dev: bool = False,
-    ) -> None:
-        self.snapshot_cache.pop(snapshot_id, None)
-        self.state_sync.add_inclusive_exclusive_interval(
-            snapshot_id, snapshot_version, start_ts, end_ts, is_dev
-        )
+    def _add_snapshot_intervals(self, snapshot_intervals: SnapshotIntervals) -> None:
+        self.snapshot_cache.pop(snapshot_intervals.snapshot_id, None)
+        self.state_sync._add_snapshot_intervals(snapshot_intervals)
 
     def remove_interval(
         self,

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -627,43 +627,45 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         super().add_interval(snapshot, start, end, is_dev)
 
     @transactional()
-    def add_inclusive_exclusive_interval(
-        self,
-        snapshot_id: SnapshotId,
-        snapshot_version: str,
-        start_ts: int,
-        end_ts: int,
-        is_dev: bool = False,
-    ) -> None:
-        if start_ts >= end_ts:
-            logger.info(
-                "Skipping partial interval (%s, %s) for snapshot %s",
-                start_ts,
-                end_ts,
-                snapshot_id,
-            )
-            return
+    def _add_snapshot_intervals(self, snapshot_intervals: SnapshotIntervals) -> None:
+        def remove_partial_intervals(
+            intervals: t.List[Interval], snapshot_id: SnapshotId, *, is_dev: bool
+        ) -> t.List[Interval]:
+            results = []
+            for start_ts, end_ts in intervals:
+                if start_ts < end_ts:
+                    logger.info(
+                        "Adding %s (%s, %s) for snapshot %s",
+                        "dev interval" if is_dev else "interval",
+                        start_ts,
+                        end_ts,
+                        snapshot_id,
+                    )
+                    results.append((start_ts, end_ts))
+                else:
+                    logger.info(
+                        "Skipping partial interval (%s, %s) for snapshot %s",
+                        start_ts,
+                        end_ts,
+                        snapshot_intervals.snapshot_id,
+                    )
+            return results
 
-        logger.info(
-            "Adding %s (%s, %s) for snapshot %s",
-            "dev interval" if is_dev else "interval",
-            start_ts,
-            end_ts,
-            snapshot_id,
+        snapshot_intervals = snapshot_intervals.copy(
+            update={
+                "intervals": remove_partial_intervals(
+                    snapshot_intervals.intervals, snapshot_intervals.snapshot_id, is_dev=False
+                ),
+                "dev_intervals": remove_partial_intervals(
+                    snapshot_intervals.dev_intervals, snapshot_intervals.snapshot_id, is_dev=True
+                ),
+            }
         )
-        snapshot_intervals = SnapshotIntervals(
-            name=snapshot_id.name,
-            identifier=snapshot_id.identifier,
-            version=snapshot_version,
-            # These are ignored since the intervals explicitly provided are the ones added
-            intervals=[],
-            dev_intervals=[],
-        )
+        if not snapshot_intervals.intervals and not snapshot_intervals.dev_intervals:
+            return
         self.engine_adapter.insert_append(
             self.intervals_table,
-            _intervals_to_df(
-                [(snapshot_intervals, (start_ts, end_ts))], is_dev=is_dev, is_removed=False
-            ),
+            _snapshot_interval_to_df(snapshot_intervals, is_removed=False),
             columns_to_types=self._interval_columns_to_types,
         )
 
@@ -1327,6 +1329,27 @@ def _intervals_to_df(
                 is_removed=is_removed,
             )
             for s, interval in snapshot_intervals
+        ]
+    )
+
+
+def _snapshot_interval_to_df(
+    snapshot_intervals: SnapshotIntervals,
+    is_removed: bool = False,
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            _interval_to_df(
+                snapshot_intervals,
+                start_ts,
+                end_ts,
+                is_dev=is_dev,
+                is_removed=is_removed,
+            )
+            for is_dev in (False, True)
+            for start_ts, end_ts in getattr(
+                snapshot_intervals, "dev_intervals" if is_dev else "intervals"
+            )
         ]
     )
 

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -219,6 +219,16 @@ class HttpStateSync(StateSync):
         """
         raise NotImplementedError("Adding intervals is not supported by the Airflow state sync.")
 
+    def add_inclusive_exclusive_interval(
+        self,
+        snapshot_id: SnapshotId,
+        snapshot_version: str,
+        start_ts: int,
+        end_ts: int,
+        is_dev: bool = False,
+    ) -> None:
+        raise NotImplementedError("Adding intervals is not supported by the Airflow state sync.")
+
     def remove_interval(
         self,
         snapshot_intervals: t.Sequence[t.Tuple[SnapshotInfoLike, Interval]],

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -12,7 +12,7 @@ from sqlmesh.core.snapshot import (
     SnapshotInfoLike,
     SnapshotTableCleanupTask,
 )
-from sqlmesh.core.snapshot.definition import Interval
+from sqlmesh.core.snapshot.definition import Interval, SnapshotIntervals
 from sqlmesh.core.state_sync import StateSync, Versions
 from sqlmesh.core.state_sync.base import PromotionResult
 from sqlmesh.schedulers.airflow.client import AirflowClient
@@ -219,14 +219,7 @@ class HttpStateSync(StateSync):
         """
         raise NotImplementedError("Adding intervals is not supported by the Airflow state sync.")
 
-    def add_inclusive_exclusive_interval(
-        self,
-        snapshot_id: SnapshotId,
-        snapshot_version: str,
-        start_ts: int,
-        end_ts: int,
-        is_dev: bool = False,
-    ) -> None:
+    def _add_snapshot_intervals(self, snapshot_intervals: SnapshotIntervals) -> None:
         raise NotImplementedError("Adding intervals is not supported by the Airflow state sync.")
 
     def remove_interval(


### PR DESCRIPTION
Prior to this change the contract to add an interval was that you must provide a whole snapshot in order to add an interval when really intervals just need snapshot name, identifier, and version. This change provides an endpoint that just requires those minimal fields. Once split out, the functionality of `add_interval` is really just called `inclusive_exclusive` on a snapshot which would likely be universal across all state syncs. Therefore it was converted to not be abstract anymore and call the new `add_inclusive_exclusive_interval` method. 