### PR TITLE
Feat!: add ability to override the engine adapter of a unit test

### DIFF
--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -15,7 +15,7 @@ Tests within a suite file contain the following attributes:
 * The unique name of a test
 * The name of the model targeted by this test
 * [Optional] The test's description
-* [Optional] The test's gateway
+* [Optional] The gateway whose `test_connection` will be used to run this test
 * Test inputs, which are defined per upstream model or external table referenced by the target model. Each test input consists of the following:
     * The name of an upstream model or external table
     * The list of rows defined as a mapping from a column name to a value associated with it

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -400,7 +400,7 @@ The test would then be updated as follows:
 ```yaml linenums="1"
 test_example_full_model:
   gateway: spark_testing
-  # ... the other test attributes remain tne same
+  # ... the other test attributes remain the same
 ```
 
 ## Running tests

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -194,7 +194,7 @@ Usage: sqlmesh info [OPTIONS]
   Print information about a SQLMesh project.
 
   Includes counts of project models and macros and connection tests for the
-  data warehouse and test runner.
+  data warehouse.
 
 Options:
   --help  Show this message and exit.

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -580,7 +580,7 @@ def info(obj: Context) -> None:
     """
     Print information about a SQLMesh project.
 
-    Includes counts of project models and macros and connection tests for the data warehouse and test runner.
+    Includes counts of project models and macros and connection tests for the data warehouse.
     """
     obj.print_info()
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -324,11 +324,8 @@ class GenericContext(BaseContext, t.Generic[C]):
         self.concurrent_tasks = concurrent_tasks or self._connection_config.concurrent_tasks
         self._engine_adapter = engine_adapter or self._connection_config.create_engine_adapter()
 
-        test_connection_config = self.config.get_test_connection(
+        self._test_connection_config = self.config.get_test_connection(
             self.gateway, self.default_catalog, default_catalog_dialect=self.engine_adapter.DIALECT
-        )
-        self._test_engine_adapter = test_connection_config.create_engine_adapter(
-            register_comments_override=False
         )
 
         self._snapshot_evaluator: t.Optional[SnapshotEvaluator] = None
@@ -1343,19 +1340,25 @@ class GenericContext(BaseContext, t.Generic[C]):
             for dep, query in input_queries.items()
         }
 
-        generate_test(
-            model=self.get_model(model, raise_if_missing=True),
-            input_queries=input_queries,
-            models=self._models,
-            engine_adapter=self._engine_adapter,
-            test_engine_adapter=self._test_engine_adapter,
-            project_path=self.path,
-            overwrite=overwrite,
-            variables=variables,
-            path=path,
-            name=name,
-            include_ctes=include_ctes,
-        )
+        try:
+            test_adapter = self._test_connection_config.create_engine_adapter(
+                register_comments_override=False
+            )
+            generate_test(
+                model=self.get_model(model, raise_if_missing=True),
+                input_queries=input_queries,
+                models=self._models,
+                engine_adapter=self._engine_adapter,
+                test_engine_adapter=test_adapter,
+                project_path=self.path,
+                overwrite=overwrite,
+                variables=variables,
+                path=path,
+                name=name,
+                include_ctes=include_ctes,
+            )
+        finally:
+            test_adapter.close()
 
     def test(
         self,
@@ -1376,7 +1379,6 @@ class GenericContext(BaseContext, t.Generic[C]):
             result = run_model_tests(
                 tests=tests,
                 models=self._models,
-                engine_adapter=self._test_engine_adapter,
                 config=self.config,
                 gateway=self.gateway,
                 dialect=self.default_dialect,
@@ -1402,7 +1404,6 @@ class GenericContext(BaseContext, t.Generic[C]):
             result = run_tests(
                 model_test_metadata=test_meta,
                 models=self._models,
-                engine_adapter=self._test_engine_adapter,
                 config=self.config,
                 gateway=self.gateway,
                 dialect=self.default_dialect,
@@ -1562,8 +1563,6 @@ class GenericContext(BaseContext, t.Generic[C]):
         if state_connection:
             self._try_connection("state backend", state_connection.create_engine_adapter())
 
-        self._try_connection("test", self._test_engine_adapter)
-
     def close(self) -> None:
         """Releases all resources allocated by this context."""
         self.snapshot_evaluator.close()
@@ -1675,11 +1674,11 @@ class GenericContext(BaseContext, t.Generic[C]):
     def _run_plan_tests(
         self, skip_tests: bool = False
     ) -> t.Tuple[t.Optional[unittest.result.TestResult], t.Optional[str]]:
-        if self._test_engine_adapter and not skip_tests:
+        if not skip_tests:
             result, test_output = self._run_tests()
             if result.testsRun > 0:
                 self.console.log_test_results(
-                    result, test_output, self._test_engine_adapter.dialect
+                    result, test_output, self._test_connection_config._engine_adapter.DIALECT
                 )
             if not result.wasSuccessful():
                 raise PlanError(

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1372,42 +1372,46 @@ class GenericContext(BaseContext, t.Generic[C]):
         else:
             verbosity = 1
 
-        try:
-            if tests:
-                result = run_model_tests(
-                    tests=tests,
-                    models=self._models,
-                    engine_adapter=self._test_engine_adapter,
-                    dialect=self.default_dialect,
-                    verbosity=verbosity,
-                    patterns=match_patterns,
-                    preserve_fixtures=preserve_fixtures,
-                    default_catalog=self.default_catalog,
-                )
-            else:
-                test_meta = []
+        if tests:
+            result = run_model_tests(
+                tests=tests,
+                models=self._models,
+                engine_adapter=self._test_engine_adapter,
+                config=self.config,
+                gateway=self.gateway,
+                dialect=self.default_dialect,
+                verbosity=verbosity,
+                patterns=match_patterns,
+                preserve_fixtures=preserve_fixtures,
+                stream=stream,
+                default_catalog=self.default_catalog,
+                default_catalog_dialect=self.engine_adapter.DIALECT,
+            )
+        else:
+            test_meta = []
 
-                for path, config in self.configs.items():
-                    test_meta.extend(
-                        get_all_model_tests(
-                            path / c.TESTS,
-                            patterns=match_patterns,
-                            ignore_patterns=config.ignore_patterns,
-                        )
+            for path, config in self.configs.items():
+                test_meta.extend(
+                    get_all_model_tests(
+                        path / c.TESTS,
+                        patterns=match_patterns,
+                        ignore_patterns=config.ignore_patterns,
                     )
-
-                result = run_tests(
-                    test_meta,
-                    models=self._models,
-                    engine_adapter=self._test_engine_adapter,
-                    dialect=self.default_dialect,
-                    verbosity=verbosity,
-                    preserve_fixtures=preserve_fixtures,
-                    stream=stream,
-                    default_catalog=self.default_catalog,
                 )
-        finally:
-            self._test_engine_adapter.close()
+
+            result = run_tests(
+                model_test_metadata=test_meta,
+                models=self._models,
+                engine_adapter=self._test_engine_adapter,
+                config=self.config,
+                gateway=self.gateway,
+                dialect=self.default_dialect,
+                verbosity=verbosity,
+                preserve_fixtures=preserve_fixtures,
+                stream=stream,
+                default_catalog=self.default_catalog,
+                default_catalog_dialect=self.engine_adapter.DIALECT,
+            )
 
         return result
 

--- a/sqlmesh/core/test/__init__.py
+++ b/sqlmesh/core/test/__init__.py
@@ -23,7 +23,6 @@ if t.TYPE_CHECKING:
 def run_tests(
     model_test_metadata: list[ModelTestMetadata],
     models: UniqueKeyDict[str, Model],
-    engine_adapter: EngineAdapter,
     config: C,
     gateway: t.Optional[str] = None,
     dialect: str | None = None,
@@ -38,12 +37,11 @@ def run_tests(
     Args:
         model_test_metadata: A list of ModelTestMetadata named tuples.
         models: All models to use for expansion and mapping of physical locations.
-        engine_adapter: The engine adapter to use.
         verbosity: The verbosity level.
         preserve_fixtures: Preserve the fixture tables in the testing database, useful for debugging.
     """
+    testing_adapter_by_gateway: t.Dict[str, EngineAdapter] = {}
     default_gateway = gateway or config.default_gateway
-    testing_adapter_by_gateway = {default_gateway: engine_adapter}
 
     try:
         tests = []
@@ -88,7 +86,6 @@ def run_tests(
 def run_model_tests(
     tests: list[str],
     models: UniqueKeyDict[str, Model],
-    engine_adapter: EngineAdapter,
     config: C,
     gateway: t.Optional[str] = None,
     dialect: str | None = None,
@@ -104,7 +101,6 @@ def run_model_tests(
     Args:
         tests: A list of tests to run, e.g. [tests/test_orders.yaml::test_single_order]
         models: All models to use for expansion and mapping of physical locations.
-        engine_adapter: The engine adapter to use.
         verbosity: The verbosity level.
         patterns: A list of patterns to match against.
         preserve_fixtures: Preserve the fixture tables in the testing database, useful for debugging.
@@ -125,7 +121,6 @@ def run_model_tests(
     return run_tests(
         loaded_tests,
         models,
-        engine_adapter,
         config,
         gateway=gateway,
         dialect=dialect,

--- a/sqlmesh/core/test/discovery.py
+++ b/sqlmesh/core/test/discovery.py
@@ -26,9 +26,7 @@ class ModelTestMetadata(PydanticModel):
         return self.fully_qualified_test_name.__hash__()
 
 
-def load_model_test_file(
-    path: pathlib.Path,
-) -> dict[str, ModelTestMetadata]:
+def load_model_test_file(path: pathlib.Path) -> dict[str, ModelTestMetadata]:
     """Load a single model test file.
 
     Args:

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -668,7 +668,7 @@ class GithubController:
                 # Clear out console
                 self._console.consume_captured_output()
                 self._console.log_test_results(
-                    result, output, self._context._test_engine_adapter.dialect
+                    result, output, self._context._test_connection_config._engine_adapter.DIALECT
                 )
                 test_summary = self._console.consume_captured_output()
                 test_title = "Tests Passed" if result.wasSuccessful() else "Tests Failed"

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -1102,7 +1102,6 @@ def test_gateway(copy_to_temp_path: t.Callable, mocker: MockerFixture) -> None:
 
     _check_successful_or_raise(context.test())
 
->>>>>>> 8cdefe4b (Feat: add ability to override the engine adapter of a unit test)
 
 def test_test_generation(tmp_path: Path) -> None:
     init_example_project(tmp_path, dialect="duckdb")

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -510,12 +510,11 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
 
     assert not output.stdout
     assert not output.stderr
-    assert len(output.outputs) == 4
+    assert len(output.outputs) == 3
     assert convert_all_html_output_to_text(output) == [
         "Models: 16",
         "Macros: 5",
         "Data warehouse connection succeeded",
-        "Test connection succeeded",
     ]
     assert get_all_html_output(output) == [
         str(
@@ -552,20 +551,6 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
                 "pre",
                 {"style": RICH_PRE_STYLE},
                 "Data warehouse connection "
-                + str(
-                    h(
-                        "span",
-                        {"style": SUCCESS_STYLE},
-                        "succeeded",
-                    )
-                ),
-            )
-        ),
-        str(
-            h(
-                "pre",
-                {"style": RICH_PRE_STYLE},
-                "Test connection "
                 + str(
                     h(
                         "span",

--- a/web/server/api/endpoints/commands.py
+++ b/web/server/api/endpoints/commands.py
@@ -154,7 +154,7 @@ async def test(
             origin="API -> commands -> test",
         )
     context.console.log_test_results(
-        result, test_output.getvalue(), context._test_engine_adapter.dialect
+        result, test_output.getvalue(), context._test_connection_config._engine_adapter.DIALECT
     )
     return models.TestResult(
         errors=[


### PR DESCRIPTION
Addresses the 11th item in https://github.com/TobikoData/sqlmesh/issues/1637

