### PR TITLE
Fix: format CAST as :: less aggressively

### DIFF
--- a/examples/wursthall/models/src/customer_details.py
+++ b/examples/wursthall/models/src/customer_details.py
@@ -50,7 +50,7 @@ def execute(
         for _ in range(random.choice(range(10, 20))):
             customer_details.append(
                 CustomerDetails(
-                    id=faker.uuid4(),
+                    id=t.cast(str, faker.uuid4()),
                     name=faker.name(),
                     phone=faker.phone_number(),
                     email=faker.ascii_email(),

--- a/examples/wursthall/models/src/customer_details.py
+++ b/examples/wursthall/models/src/customer_details.py
@@ -50,7 +50,7 @@ def execute(
         for _ in range(random.choice(range(10, 20))):
             customer_details.append(
                 CustomerDetails(
-                    id=t.cast(str, faker.uuid4()),
+                    id=str(faker.uuid4()),
                     name=faker.name(),
                     phone=faker.phone_number(),
                     email=faker.ascii_email(),

--- a/examples/wursthall/models/src/order_item_details.py
+++ b/examples/wursthall/models/src/order_item_details.py
@@ -79,7 +79,7 @@ def execute(
         faker = Faker()
         order_ds = order_date.strftime("%Y-%m-%d")
         for _ in range(random.choice(range(50, 100))):
-            order_item_id = t.cast(str, faker.uuid4())
+            order_item_id = str(faker.uuid4())
             table_id = np.random.choice(range(0, 20))
             is_registered_customer = np.random.choice([True, False], p=[0.1, 0.9])
             if is_registered_customer:

--- a/examples/wursthall/models/src/order_item_details.py
+++ b/examples/wursthall/models/src/order_item_details.py
@@ -79,7 +79,7 @@ def execute(
         faker = Faker()
         order_ds = order_date.strftime("%Y-%m-%d")
         for _ in range(random.choice(range(50, 100))):
-            order_item_id = faker.uuid4()
+            order_item_id = t.cast(str, faker.uuid4())
             table_id = np.random.choice(range(0, 20))
             is_registered_customer = np.random.choice([True, False], p=[0.1, 0.9])
             if is_registered_customer:

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -582,7 +582,13 @@ def format_model_expressions(
     *statements, query = expressions
 
     def cast_to_colon(node: exp.Expression) -> exp.Expression:
-        if isinstance(node, exp.Cast) and not node.args.get("format"):
+        if isinstance(node, exp.Cast) and not any(
+            # Only convert CAST into :: if it doesn't have additional args set, otherwise this
+            # conversion could alter the semantics (eg. changing SAFE_CAST in BigQuery to CAST)
+            arg
+            for name, arg in node.args.items()
+            if name not in ("this", "to")
+        ):
             this = node.this
 
             if not isinstance(this, (exp.Binary, exp.Unary)) or isinstance(this, exp.Paren):

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -1279,7 +1279,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         batches = self._snapshot_batches(name_versions)
 
         if not name_versions:
-            yield exp.false()
+            return exp.false()
         elif self.engine_adapter.SUPPORTS_TUPLE_IN:
             for versions in batches:
                 yield t.cast(

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -1279,7 +1279,7 @@ class EngineAdapterStateSync(CommonStateSyncMixin, StateSync):
         batches = self._snapshot_batches(name_versions)
 
         if not name_versions:
-            return exp.false()
+            yield exp.false()
         elif self.engine_adapter.SUPPORTS_TUPLE_IN:
             for versions in batches:
                 yield t.cast(

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -173,6 +173,27 @@ JINJA_QUERY_BEGIN;
 JINJA_END;"""
     )
 
+    x = format_model_expressions(
+        parse(
+            """
+            MODEL(name a.b, kind FULL, dialect bigquery);
+            SELECT SAFE_CAST('bla' AS INT64) AS FOO
+            """
+        ),
+        dialect="bigquery",
+    )
+    assert (
+        x
+        == """MODEL (
+  name a.b,
+  kind FULL,
+  dialect bigquery
+);
+
+SELECT
+  SAFE_CAST('bla' AS INT64) AS FOO"""
+    )
+
 
 def test_macro_format():
     assert parse_one("@EACH(ARRAY(1,2), x -> x)").sql() == "@EACH(ARRAY(1, 2), x -> x)"


### PR DESCRIPTION
Fixes #2554

I went with the `any` approach instead of `.. and not args.get("safe")` to ensure we there are no future regressions if we were to add new args to `Cast`.