### PR TITLE
 Feat: Full support for Duckdb attach options

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -248,7 +248,6 @@ class DuckDBConnectionConfig(BaseDuckDBConnectionConfig):
 
     database: t.Optional[str] = None
     catalogs: t.Optional[t.Dict[str, t.Union[str, DuckDBAttachOptions]]] = None
-    # catalogs: t.Optional[t.Dict[str, str]] = None
 
     type_: Literal["duckdb"] = Field(alias="type", default="duckdb")
 
@@ -1284,9 +1283,7 @@ CONNECTION_CONFIG_TO_TYPE = {
     # Map all subclasses of ConnectionConfig to the value of their `type_` field.
     tpe.all_field_infos()["type_"].default: tpe
     for tpe in subclasses(
-        __name__,
-        ConnectionConfig,
-        exclude=(ConnectionConfig, BaseDuckDBConnectionConfig),
+        __name__, ConnectionConfig, exclude=(ConnectionConfig, BaseDuckDBConnectionConfig)
     )
 }
 

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -177,7 +177,10 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
 
                     if isinstance(path, AttachOptions):
                         attach_path = path.path
-                        options.append(path.type)
+                        # 'duckdb' is actually not a supported type, but we'd like to allow it for
+                        # fully qualified attach options or integration testing, similar to duckdb-dbt
+                        if path.type != "duckdb":
+                            options.append(path.type)
 
                         if path.read_only:
                             options.append("READ_ONLY")

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -172,17 +172,17 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
                     identify=True, dialect="duckdb"
                 )
                 try:
-                    attach_patch = path
+                    attach_path = path
                     options = []
 
                     if isinstance(path, AttachOptions):
-                        attach_patch = path.path
+                        attach_path = path.path
                         options.append(path.type)
 
                         if path.read_only:
                             options.append("READ_ONLY")
 
-                    query = f"ATTACH '{attach_patch}' AS {alias}"
+                    query = f"ATTACH '{attach_path}' AS {alias}"
                     if options:
                         query += f" ({', '.join(options)})"
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -204,14 +204,12 @@ config = Config(default_connection=DuckDBConnectionConfig())
     )
 
     with pytest.raises(
-        ConfigError,
-        match=r"^Default model SQL dialect is a required configuration parameter.*",
+        ConfigError, match=r"^Default model SQL dialect is a required configuration parameter.*"
     ):
         load_config_from_paths(Config, project_paths=[tmp_path / "config.yaml"])
 
     with pytest.raises(
-        ConfigError,
-        match=r"^Default model SQL dialect is a required configuration parameter.*",
+        ConfigError, match=r"^Default model SQL dialect is a required configuration parameter.*"
     ):
         load_config_from_paths(Config, project_paths=[tmp_path / "config.py"])
 
@@ -342,10 +340,7 @@ model_defaults:
     [
         (
             "'^dev$': dev_catalog\n    '^other$': other_catalog",
-            {
-                re.compile("^dev$"): "dev_catalog",
-                re.compile("^other$"): "other_catalog",
-            },
+            {re.compile("^dev$"): "dev_catalog", re.compile("^other$"): "other_catalog"},
             "duckdb",
             "",
         ),
@@ -483,15 +478,13 @@ def test_variables():
         "UPPERCASE_VAR": 2,
     }
     config = Config(
-        variables=variables,
-        gateways={"local": GatewayConfig(variables=gateway_variables)},
+        variables=variables, gateways={"local": GatewayConfig(variables=gateway_variables)}
     )
     assert config.variables == variables
     assert config.get_gateway("local").variables == {"uppercase_var": 2}
 
     with pytest.raises(
-        ConfigError,
-        match="Unsupported variable value type: <class 'sqlglot.expressions.Column'>",
+        ConfigError, match="Unsupported variable value type: <class 'sqlglot.expressions.Column'>"
     ):
         Config(variables={"invalid_var": exp.column("sqlglot_expr")})
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -13,6 +13,7 @@ from sqlmesh.core.config import (
     GatewayConfig,
     ModelDefaultsConfig,
 )
+from sqlmesh.core.config.connection import DuckDBAttachOptions
 from sqlmesh.core.config.feature_flag import DbtFeatureFlag, FeatureFlag
 from sqlmesh.core.config.loader import (
     load_config_from_env,
@@ -495,8 +496,8 @@ def test_variables():
         Config(variables={"invalid_var": exp.column("sqlglot_expr")})
 
 
-def test_load_duckdb_attach_config(tmp_path_factory):
-    config_path = tmp_path_factory.mktemp("yaml_config") / "config_duckdb_attach.yaml"
+def test_load_duckdb_attach_config(tmp_path):
+    config_path = tmp_path / "config_duckdb_attach.yaml"
     with open(config_path, "w", encoding="utf-8") as fd:
         fd.write(
             """
@@ -518,7 +519,23 @@ model_defaults:
         """
         )
 
-    assert load_config_from_paths(
+    config = load_config_from_paths(
         Config,
         project_paths=[config_path],
     )
+
+    assert config.gateways["another_gateway"].connection.catalogs.get("memory") == ":memory:"
+
+    attach_config_1 = config.gateways["another_gateway"].connection.catalogs.get("sqlite")
+
+    assert isinstance(attach_config_1, DuckDBAttachOptions)
+    assert attach_config_1.type == "sqlite"
+    assert attach_config_1.path == "test.db"
+    assert attach_config_1.read_only is False
+
+    attach_config_2 = config.gateways["another_gateway"].connection.catalogs.get("postgres")
+
+    assert isinstance(attach_config_2, DuckDBAttachOptions)
+    assert attach_config_2.type == "postgres"
+    assert attach_config_2.path == "dbname=postgres user=postgres host=127.0.0.1"
+    assert attach_config_2.read_only is True


### PR DESCRIPTION
This PR adds additional config surface to allow for DuckDB's attach options to be leveraged, similar to duckdb-dbt.

Ref: #2336

cc @eakmanrq 