### PR TITLE
fix!: change databricks to replace where

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1105,7 +1105,6 @@ class EngineAdapter:
                         insert_exp = exp.insert(
                             query,
                             table,
-                            # Change once Databricks supports REPLACE WHERE with columns
                             columns=(
                                 list(columns_to_types)
                                 if not insert_overwrite_strategy.is_replace_where
@@ -1114,7 +1113,7 @@ class EngineAdapter:
                             overwrite=insert_overwrite_strategy.is_insert_overwrite,
                         )
                         if insert_overwrite_strategy.is_replace_where:
-                            insert_exp.set("where", where)
+                            insert_exp.set("where", where or exp.true())
                         self.execute(insert_exp)
 
     def update_table(

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 )
 class DatabricksEngineAdapter(SparkEngineAdapter):
     DIALECT = "databricks"
-    INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
+    INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.REPLACE_WHERE
     SUPPORTS_CLONING = True
     SUPPORTS_MATERIALIZED_VIEWS = True
     SUPPORTS_MATERIALIZED_VIEW_SCHEMA = True

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -36,7 +36,7 @@ def test_replace_query_exists(mocker: MockFixture, make_mocked_engine_adapter: t
     adapter.replace_query("test_table", parse_one("SELECT a FROM tbl"), {"a": "int"})
 
     assert to_sql_calls(adapter) == [
-        "INSERT OVERWRITE TABLE `test_table` (`a`) SELECT `a` FROM `tbl`",
+        "INSERT INTO `test_table` REPLACE WHERE TRUE SELECT `a` FROM `tbl`",
     ]
 
 
@@ -70,7 +70,7 @@ def test_replace_query_pandas_exists(mocker: MockFixture, make_mocked_engine_ada
     )
 
     assert to_sql_calls(adapter) == [
-        "INSERT OVERWRITE TABLE `test_table` (`a`, `b`) SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `t`(`a`, `b`)",
+        "INSERT INTO `test_table` REPLACE WHERE TRUE SELECT CAST(`a` AS INT) AS `a`, CAST(`b` AS INT) AS `b` FROM VALUES (1, 4), (2, 5), (3, 6) AS `t`(`a`, `b`)",
     ]
 
 


### PR DESCRIPTION
Behavior Change: Prior to this change if using Databricks and doing an `INCREMENTAL_BY_TIME_RANGE` and lets say you were loading `2024-01-01` through `2024-01-10`. If your new data was missing `2024-01-02` then that partition would be untouched in the target table if it already exists. Now `2024-01-02` will be deleted. We don't document anywhere that users should expect this behavior and I don't anticipate this to be an issue.

As Databricks rolls out new products they seem to consistently lack support for dynamic insert overwrite support. Therefore we are going to switch Databricks to now do REPLACE WHERE by default.

In testing REPLACE WHERE behaves like DELETE FROM ... WHERE...; INSERT INTO...;. 

Example:

Table:

| id | ds                 |
|----|------------|
| 1  | 2024-01-01 |

Run this:
```sql
INSERT INTO table REPLACE WHERE TRUE SELECT id, ds FROM VALUES (2, '2024-01-02')
```

Results in

| id | ds                 |
|----|------------|
| 2  | 2022-01-02 |

Also tested the behavior change above and it functioned like a DELETE FROM ... WHERE...

Since REPLACE WHERE doesn't support providing columns we are relying on this function which will detect if the columns in `columns_to_types` doesn't match what is in the query: https://github.com/TobikoData/sqlmesh/blob/d7caf8ee138143c8ea1c39970048fe541898dbc8/sqlmesh/core/engine_adapter/base.py#L1955-L1977

Ran manual tests and also verified that the integration tests for Databricks passed. 