### PR TITLE
fix: monospace `plan_id`

### DIFF
--- a/sqlmesh/core/notification_target.py
+++ b/sqlmesh/core/notification_target.py
@@ -123,7 +123,7 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
         """
         self.send(
             NotificationStatus.INFO,
-            f"Plan {plan_id} apply started for environment `{environment}`.",
+            f"Plan `{plan_id}` apply started for environment `{environment}`.",
         )
 
     @notify(NotificationEvent.APPLY_END)
@@ -136,7 +136,7 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
         """
         self.send(
             NotificationStatus.SUCCESS,
-            f"Plan {plan_id} apply finished for environment `{environment}`.",
+            f"Plan `{plan_id}` apply finished for environment `{environment}`.",
         )
 
     @notify(NotificationEvent.RUN_START)
@@ -180,7 +180,7 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
         """
         self.send(
             NotificationStatus.FAILURE,
-            f"Plan {plan_id} in environment `{environment}` apply failed.",
+            f"Plan `{plan_id}` in environment `{environment}` apply failed.",
             exc=exc,
         )
 

--- a/tests/core/test_notification_target.py
+++ b/tests/core/test_notification_target.py
@@ -38,7 +38,7 @@ def test_notify(notification_target_manager_with_spy):
     spy.assert_called_once_with(
         mock.ANY,
         NotificationStatus.INFO,
-        "Plan a-plan-id apply started for environment `prod`.",
+        "Plan `a-plan-id` apply started for environment `prod`.",
     )
 
     spy.reset_mock()
@@ -46,7 +46,7 @@ def test_notify(notification_target_manager_with_spy):
     spy.assert_called_once_with(
         mock.ANY,
         NotificationStatus.SUCCESS,
-        "Plan a-plan-id apply finished for environment `prod`.",
+        "Plan `a-plan-id` apply finished for environment `prod`.",
     )
 
     # No notification target configured for APPLY_FAILURE event
@@ -65,7 +65,7 @@ def test_notify_user(notification_target_manager_with_spy):
     spy.assert_called_once_with(
         mock.ANY,
         NotificationStatus.INFO,
-        "Plan a-plan-id apply started for environment `prod`.",
+        "Plan `a-plan-id` apply started for environment `prod`.",
     )
 
     # No notification target configured for APPLY_END event for test_user


### PR DESCRIPTION
This should properly format the plan id in this message:
<img width="582" alt="Screenshot 2024-05-08 at 14 50 45" src="https://github.com/TobikoData/sqlmesh/assets/484152/3e15d4a5-7af2-4c6e-b7cf-3d24a75c96da">
