### PR TITLE
fix: remove write race conditions in cache operations

### DIFF
--- a/sqlmesh/utils/cache.py
+++ b/sqlmesh/utils/cache.py
@@ -65,7 +65,7 @@ class FileCache(t.Generic[T]):
         # delete all old cache files
         for file in self._path.glob("*"):
             if not file.stem.startswith(self._cache_version) or file.stat().st_mtime < threshold:
-                file.unlink()
+                file.unlink(missing_ok=True)
 
     def get_or_load(self, name: str, entry_id: str = "", *, loader: t.Callable[[], T]) -> T:
         """Returns an existing cached entry or loads and caches a new one.
@@ -114,8 +114,7 @@ class FileCache(t.Generic[T]):
             entry_id: The unique entry identifier. Used for cache invalidation.
             value: The value to store in the cache.
         """
-        if not self._path.exists():
-            self._path.mkdir(parents=True)
+        self._path.mkdir(parents=True, exist_ok=True)
         if not self._path.is_dir():
             raise SQLMeshError(f"Cache path '{self._path}' is not a directory.")
 


### PR DESCRIPTION
Prior to this change we had race conditions where we checked for the state of things on the filesystem and then based on that state took an action assuming that state remained true. https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use

This updates the cache to either remove the check or keep if it required but be ok if the the desired state has already been reached. 