### PR TITLE
#2335 Add support for session properties in model defaults

### DIFF
--- a/docs/guides/isolated_systems.md
+++ b/docs/guides/isolated_systems.md
@@ -137,6 +137,6 @@ In isolated systems, SQLMesh's virtual data environments operate normally *withi
 
 In the non-production system, computations will be reused across preview environments. However, the system's data are not representative of the production data and will not be reused by the production system.
 
-In the production system, the CI/CD bot will execute the necessary computations when a pull request is submitted if it is configured for [synchronized deployments](../integrations/github.md#synchronized-vs-desynchronized-deployments). Merging to main and applying the changes to `prod` reuses the preview computations and only requires a virtual update.
+In the production system, the CI/CD bot will execute the necessary computations when a pull request is submitted if it is configured for [synchronized deployment](../integrations/github.md#synchronized-vs-desynchronized-deployments). Merging to main and applying the changes to `prod` reuses the preview computations and only requires a virtual update.
 
-Learn more about synchronized and desynchronized deployments [here](../integrations/github.md#synchronized-vs-desynchronized-deployments).
+This approach enables true [blue-green deployment](https://en.m.wikipedia.org/wiki/Blue%E2%80%93green_deployment). Deploying to production occurs with no system downtime because virtual updates only require swapping views. If issues are identified after changes have been pushed to production, reverting is quick and painless because it just swaps the views back.

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1897,7 +1897,7 @@ def _resolve_custom_session_properties(
                 session_properties[k] = exp.Literal.string(k).eq(v)
 
     if session_properties:
-        return exp.Tuple(expressions=session_properties.values())
+        return exp.Tuple(expressions=list(session_properties.values()))
 
     return None
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1877,21 +1877,19 @@ def _split_sql_model_statements(
     return query, expressions[:pos], expressions[pos + 1 :]
 
 
-def _resolve_custom_session_params(defaults: t.Dict[str, t.Any], **kwargs: t.Any): 
-    if  kwargs.get("session_properties") and defaults and defaults.get("session_properties"):
+def _resolve_custom_session_params(
+    defaults: t.Dict[str, t.Any] | None, **kwargs: t.Dict[str, t.Any]
+) -> None:
+    if kwargs.get("session_properties") and defaults and defaults.get("session_properties"):
         session_properties = kwargs["session_properties"]
         session_props = {expr.this.name for expr in session_properties}
         for k, v in defaults["session_properties"].items():
             if k not in session_props:
                 new_eq = exp.EQ(
-                    this=exp.Literal(this=k),
-                    expression=exp.Column(
-                    this=exp.Identifier(this=v)
-                    )
+                    this=exp.Literal(this=k), expression=exp.Column(this=exp.Identifier(this=v))
                 )
                 session_properties.expressions.append(new_eq)
         kwargs["session_properties"] = session_properties
-
 
 
 def _validate_model_fields(klass: t.Type[_Model], provided_fields: t.Set[str], path: Path) -> None:

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1884,14 +1884,14 @@ def _resolve_custom_session_properties(
     defaults: t.Optional[t.Dict[str, t.Any]],
     provided: t.Optional[exp.Expression] | t.Optional[t.Dict[str, t.Any]],
 ) -> t.Optional[exp.Expression]:
-    if provided is not None and isinstance(provided, dict):
+    if isinstance(provided, dict):
         session_properties = {k: exp.Literal.string(k).eq(v) for k, v in provided.items()}
     else:
         session_properties = (
             {expr.this.name: expr for expr in provided} if provided is not None else {}
         )
 
-    if defaults is not None and defaults.get("session_properties") is not None:
+    if defaults and defaults.get("session_properties"):
         for k, v in defaults["session_properties"].items():
             if k not in session_properties:
                 session_properties[k] = exp.Literal.string(k).eq(v)

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2735,7 +2735,36 @@ def test_session_properties_on_model_and_project(sushi_context):
         "some_float": 0.1,
         "quoted_identifier": exp.column("quoted identifier", quoted=True),
         "unquoted_identifier": exp.column("unquoted_identifier", quoted=False),
-        "project_level_property": exp.column("project_property", quoted=False),
+        "project_level_property": "project_property",
+    }
+
+
+def test_project_level_session_properties(sushi_context):
+    model_defaults = ModelDefaultsConfig(
+        session_properties={
+            "some_bool": False,
+            "some_float": 0.1,
+            "project_level_property": "project_property",
+        }
+    )
+
+    model = load_sql_based_model(
+        d.parse(
+            """
+        MODEL (
+            name test_schema.test_model,
+        );
+        SELECT a FROM tbl;
+        """,
+            default_dialect="snowflake",
+        ),
+        defaults=model_defaults.dict(),
+    )
+
+    assert model.session_properties == {
+        "some_bool": False,
+        "some_float": 0.1,
+        "project_level_property": "project_property",
     }
 
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2699,14 +2699,14 @@ def test_model_table_properties_conflicts() -> None:
 
 
 def test_session_properties_on_model_and_project(sushi_context):
-    model_defaults=ModelDefaultsConfig(
-        session_properties = {
+    model_defaults = ModelDefaultsConfig(
+        session_properties={
             "some_bool": False,
             "quoted_identifier": "value_you_wont_see",
-            "project_level_property": "project_property"
+            "project_level_property": "project_property",
         }
     )
-    
+
     model = load_sql_based_model(
         d.parse(
             """
@@ -2737,6 +2737,7 @@ def test_session_properties_on_model_and_project(sushi_context):
         "unquoted_identifier": exp.column("unquoted_identifier", quoted=False),
         "project_level_property": exp.column("project_property", quoted=False),
     }
+
 
 def test_model_session_properties(sushi_context):
     assert sushi_context.models['"memory"."sushi"."items"'].session_properties == {

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1554,6 +1554,28 @@ def test_python_model_depends_on() -> None:
     assert m.depends_on == {'"foo"."bar"'}
 
 
+def test_python_model_with_session_props():
+    @model(
+        name="python_model_prop",
+        kind="full",
+        columns={"some_col": "int"},
+        session_properties={"some_string": "string_prop", "some_bool": True, "some_float": 1.0},
+    )
+    def python_model_prop(context, **kwargs):
+        context.table("foo")
+
+    m = model.get_registry()["python_model_prop"].model(
+        module_path=Path("."),
+        path=Path("."),
+        dialect="duckdb",
+    )
+    assert m.session_properties == {
+        "some_string": "string_prop",
+        "some_bool": True,
+        "some_float": 1.0,
+    }
+
+
 def test_python_models_returning_sql(assert_exp_eq) -> None:
     config = Config(model_defaults=ModelDefaultsConfig(dialect="snowflake"))
     context = Context(config=config)


### PR DESCRIPTION
This should allow you to set session_properties on the project configuration which will then be propagated on the models. If custom properties are also set on the specific model, those will not be overwritten by the default ones. It might need some more work when adding the default props to handle quoted/unquoted identifiers better; right now, it sets them by default as quoted=False. 