### PR TITLE
Feat: Enable anonymized analytics for the SQLMesh core

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -283,4 +283,3 @@ You can disable collection of anonymized usage information with these methods:
 
 - Set the root `disable_anonymized_analytics: true` key in your SQLMesh project configuration file
 - Execute SQLMesh commands with an environment variable `SQLMESH__DISABLE_ANONYMIZED_ANALYTICS` set to `1`, `true`, `t`, `yes`, or `y`
-- Execute SQLMesh commands with an environment variable `DO_NOT_TRACK` set to `1`, `true`, `t`, `yes`, or `y`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -268,3 +268,19 @@ Example enabling debug mode for the CLI command `sqlmesh plan`:
     C:\> set SQLMESH_DEBUG=1
     C:\> sqlmesh plan
     ```
+
+## Anonymized usage information
+
+We strive to make SQLMesh the best data transformation tool on the market. Part of accomplishing that is continually fixing bugs, adding features, and improving SQLMesh's performance.
+
+We prioritize our development work based on the needs of SQLMesh users. Some users share their needs via our Slack or Github communities, but many do not. We have added some simple anonymized usage information (telemetry) to SQLMesh to ensure the needs of all users are heard.
+
+All information is anonymized with hash functions, so we could not link data to a specific company, user, or project even if we wanted to (which we don't!). No information is related to credentials or authentication.
+
+We collect anonymized information about SQLMesh project complexity and usage - for example, number of models, count of model kinds, project load time, whether an error occurred during a plan/run (no stacktraces or error message), and names (but not values) of the arguments passed to CLI commands.
+
+You can disable collection of anonymized usage information with these methods:
+
+- Set the root `disable_anonymized_analytics: true` key in your SQLMesh project configuration file
+- Execute SQLMesh commands with an environment variable `SQLMESH__DISABLE_ANONYMIZED_ANALYTICS` set to `1`, `true`, `t`, `yes`, or `y`
+- Execute SQLMesh commands with an environment variable `DO_NOT_TRACK` set to `1`, `true`, `t`, `yes`, or `y`

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -11,6 +11,7 @@ from sqlmesh import configure_logging
 from sqlmesh.cli import error_handler
 from sqlmesh.cli import options as opt
 from sqlmesh.cli.example_project import ProjectTemplate, init_example_project
+from sqlmesh.core.analytics import cli_analytics
 from sqlmesh.core.config import load_configs
 from sqlmesh.core.context import Context
 from sqlmesh.utils.date import TimeLike
@@ -121,6 +122,7 @@ def cli(
 )
 @click.pass_context
 @error_handler
+@cli_analytics
 def init(
     ctx: click.Context, sql_dialect: t.Optional[str] = None, template: t.Optional[str] = None
 ) -> None:
@@ -146,6 +148,7 @@ def init(
 @click.option("--no-format", is_flag=True, help="Disable fancy formatting of the query.")
 @click.pass_context
 @error_handler
+@cli_analytics
 def render(
     ctx: click.Context,
     model: str,
@@ -184,6 +187,7 @@ def render(
 )
 @click.pass_context
 @error_handler
+@cli_analytics
 def evaluate(
     ctx: click.Context,
     model: str,
@@ -250,6 +254,7 @@ def evaluate(
 )
 @click.pass_context
 @error_handler
+@cli_analytics
 def format(ctx: click.Context, **kwargs: t.Any) -> None:
     """Format all SQL models."""
     ctx.obj.format(**{k: v for k, v in kwargs.items() if v is not None})
@@ -259,6 +264,7 @@ def format(ctx: click.Context, **kwargs: t.Any) -> None:
 @click.argument("environment")
 @click.pass_context
 @error_handler
+@cli_analytics
 def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
     """Show the diff between the local state and the target environment."""
     if ctx.obj.diff(environment, detailed=True):
@@ -365,6 +371,7 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
 @opt.verbose
 @click.pass_context
 @error_handler
+@cli_analytics
 def plan(
     ctx: click.Context, verbose: bool, environment: t.Optional[str] = None, **kwargs: t.Any
 ) -> None:
@@ -395,6 +402,7 @@ def plan(
 )
 @click.pass_context
 @error_handler
+@cli_analytics
 def run(ctx: click.Context, environment: t.Optional[str] = None, **kwargs: t.Any) -> None:
     """Evaluate missing intervals for the target environment."""
     context = ctx.obj
@@ -413,6 +421,7 @@ def run(ctx: click.Context, environment: t.Optional[str] = None, **kwargs: t.Any
 )
 @click.pass_context
 @error_handler
+@cli_analytics
 def invalidate(ctx: click.Context, environment: str, **kwargs: t.Any) -> None:
     """Invalidate the target environment, forcing its removal during the next run of the janitor process."""
     context = ctx.obj
@@ -429,6 +438,7 @@ def invalidate(ctx: click.Context, environment: str, **kwargs: t.Any) -> None:
 )
 @click.pass_context
 @error_handler
+@cli_analytics
 def dag(ctx: click.Context, file: str, select_model: t.List[str]) -> None:
     """Render the DAG as an html file."""
     rendered_dag_path = ctx.obj.render_dag(file, select_model)
@@ -488,6 +498,7 @@ def dag(ctx: click.Context, file: str, select_model: t.List[str]) -> None:
 )
 @click.pass_obj
 @error_handler
+@cli_analytics
 def create_test(
     obj: Context,
     model: str,
@@ -522,6 +533,7 @@ def create_test(
 @click.argument("tests", nargs=-1)
 @click.pass_obj
 @error_handler
+@cli_analytics
 def test(
     obj: Context,
     k: t.List[str],
@@ -552,6 +564,7 @@ def test(
 @opt.execution_time
 @click.pass_obj
 @error_handler
+@cli_analytics
 def audit(
     obj: Context,
     models: t.Iterator[str],
@@ -567,6 +580,7 @@ def audit(
 @click.argument("sql")
 @click.pass_context
 @error_handler
+@cli_analytics
 def fetchdf(ctx: click.Context, sql: str) -> None:
     """Run a SQL query and display the results."""
     context = ctx.obj
@@ -576,6 +590,7 @@ def fetchdf(ctx: click.Context, sql: str) -> None:
 @cli.command("info")
 @click.pass_obj
 @error_handler
+@cli_analytics
 def info(obj: Context) -> None:
     """
     Print information about a SQLMesh project.
@@ -606,6 +621,7 @@ def info(obj: Context) -> None:
 )
 @click.pass_context
 @error_handler
+@cli_analytics
 def ui(ctx: click.Context, host: str, port: int, mode: str) -> None:
     """Start a browser-based SQLMesh UI."""
     try:
@@ -636,6 +652,7 @@ def ui(ctx: click.Context, host: str, port: int, mode: str) -> None:
 @cli.command("migrate")
 @click.pass_context
 @error_handler
+@cli_analytics
 def migrate(ctx: click.Context) -> None:
     """Migrate SQLMesh to the current running version."""
     ctx.obj.migrate()
@@ -644,6 +661,7 @@ def migrate(ctx: click.Context) -> None:
 @cli.command("rollback")
 @click.pass_obj
 @error_handler
+@cli_analytics
 def rollback(obj: Context) -> None:
     """Rollback SQLMesh to the previous migration."""
     obj.rollback()
@@ -652,6 +670,7 @@ def rollback(obj: Context) -> None:
 @cli.command("create_external_models")
 @click.pass_obj
 @error_handler
+@cli_analytics
 def create_external_models(obj: Context) -> None:
     """Create a schema file containing external model schemas."""
     obj.create_external_models()
@@ -685,6 +704,7 @@ def create_external_models(obj: Context) -> None:
 )
 @click.pass_obj
 @error_handler
+@cli_analytics
 def table_diff(
     obj: Context, source_to_target: str, model: t.Optional[str], **kwargs: t.Any
 ) -> None:
@@ -712,6 +732,7 @@ def table_diff(
 )
 @click.pass_obj
 @error_handler
+@cli_analytics
 def rewrite(obj: Context, sql: str, read: str = "", write: str = "") -> None:
     """Rewrite a SQL expression with semantic references into an executable query.
 
@@ -740,6 +761,7 @@ def rewrite(obj: Context, sql: str, read: str = "", write: str = "") -> None:
 @opt.verbose
 @click.pass_context
 @error_handler
+@cli_analytics
 def prompt(
     ctx: click.Context, prompt: str, evaluate: bool, temperature: float, verbose: bool
 ) -> None:
@@ -764,6 +786,7 @@ def prompt(
 @cli.command("clean")
 @click.pass_obj
 @error_handler
+@cli_analytics
 def clean(obj: Context) -> None:
     """Clears the SQLMesh cache and any build artifacts."""
     obj.clear_caches()
@@ -779,6 +802,7 @@ def clean(obj: Context) -> None:
 )
 @click.pass_obj
 @error_handler
+@cli_analytics
 def table_name(obj: Context, model_name: str, dev: bool) -> None:
     """Prints the name of the physical table for the given model."""
     print(obj.table_name(model_name, dev))

--- a/sqlmesh/core/analytics/__init__.py
+++ b/sqlmesh/core/analytics/__init__.py
@@ -13,8 +13,7 @@ from sqlmesh.utils import str_to_bool
 def init_collector() -> AnalyticsCollector:
     dispatcher = (
         NoopEventDispatcher()
-        if "DO_NOT_TRACK" in os.environ
-        or str_to_bool(os.getenv("SQLMESH__DISABLE_ANONYMIZED_ANALYTICS", "false"))
+        if str_to_bool(os.getenv("SQLMESH__DISABLE_ANONYMIZED_ANALYTICS", "false"))
         else AsyncEventDispatcher()
     )
     return AnalyticsCollector(dispatcher=dispatcher)

--- a/sqlmesh/core/analytics/__init__.py
+++ b/sqlmesh/core/analytics/__init__.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import atexit
+import os
+import typing as t
+from functools import wraps
+
+from sqlmesh.core.analytics.collector import AnalyticsCollector
+from sqlmesh.core.analytics.dispatcher import AsyncEventDispatcher, NoopEventDispatcher
+from sqlmesh.utils import str_to_bool
+
+
+def init_collector() -> AnalyticsCollector:
+    dispatcher = (
+        NoopEventDispatcher()
+        if "DO_NOT_TRACK" in os.environ
+        or str_to_bool(os.getenv("SQLMESH__DISABLE_ANONYMIZED_ANALYTICS", "false"))
+        else AsyncEventDispatcher()
+    )
+    return AnalyticsCollector(dispatcher=dispatcher)
+
+
+collector = init_collector()
+
+
+atexit.register(collector.shutdown, flush=True)
+
+
+def disable_analytics() -> None:
+    global collector
+    collector = AnalyticsCollector(dispatcher=NoopEventDispatcher())
+
+
+def cli_analytics(func: t.Callable[..., t.Any]) -> t.Callable[..., t.Any]:
+    @wraps(func)
+    def wrapper(*args: t.List[t.Any], **kwargs: t.Any) -> t.Any:
+        import click
+        from click.core import ParameterSource
+
+        arg_keys = set()
+        command_chain = []
+
+        cli_context: click.Context = click.get_current_context()
+        cli_context_cursor: t.Optional[click.Context] = cli_context
+        while cli_context_cursor:
+            arg_keys |= {
+                k
+                for k, source in cli_context_cursor._parameter_source.items()
+                if source == ParameterSource.COMMANDLINE
+            }
+            command_chain.append(cli_context_cursor.info_name)
+            cli_context_cursor = cli_context_cursor.parent
+
+        command_name, *parent_command_names = command_chain
+
+        common_context: t.Dict[str, t.Any] = {
+            "command_name": command_name,
+            "command_args": arg_keys,
+            "parent_command_names": parent_command_names,
+        }
+
+        if "github" in parent_command_names:
+            cicd_bot_config = None
+            github_controller = cli_context.obj.get("github")
+            if github_controller:
+                cicd_bot_config = github_controller._context.config.cicd_bot
+            collector.on_cicd_command(**common_context, cicd_bot_config=cicd_bot_config)
+        else:
+            collector.on_cli_command(**common_context)
+
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def python_api_analytics(func: t.Callable[..., t.Any]) -> t.Callable[..., t.Any]:
+    @wraps(func)
+    def wrapper(*args: t.List[t.Any], **kwargs: t.Any) -> t.Any:
+        import inspect
+
+        from sqlmesh import magics
+
+        should_log = True
+        for frame in inspect.stack():
+            if "click/" in frame.filename or frame.filename == magics.__file__:
+                # Magics and CLI are reported separately.
+                should_log = False
+                break
+
+        if should_log:
+            collector.on_python_api_command(command_name=func.__name__, command_args=kwargs)
+
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/sqlmesh/core/analytics/__init__.py
+++ b/sqlmesh/core/analytics/__init__.py
@@ -27,6 +27,7 @@ atexit.register(collector.shutdown, flush=True)
 
 def disable_analytics() -> None:
     global collector
+    collector.shutdown(flush=False)
     collector = AnalyticsCollector(dispatcher=NoopEventDispatcher())
 
 

--- a/sqlmesh/core/analytics/collector.py
+++ b/sqlmesh/core/analytics/collector.py
@@ -10,7 +10,7 @@ from sqlmesh.core import constants as c
 from sqlmesh.core.analytics.dispatcher import AsyncEventDispatcher, EventDispatcher
 from sqlmesh.utils import random_id
 from sqlmesh.utils.date import now_timestamp
-from sqlmesh.utils.hashing import sha256
+from sqlmesh.utils.hashing import md5
 from sqlmesh.utils.pydantic import PydanticModel
 from sqlmesh.utils.yaml import dump as yaml_dump
 from sqlmesh.utils.yaml import load as yaml_load
@@ -348,4 +348,4 @@ class User(PydanticModel):
 
 
 def _anonymize(value: str) -> str:
-    return sha256([value])
+    return md5([value])

--- a/sqlmesh/core/analytics/collector.py
+++ b/sqlmesh/core/analytics/collector.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import itertools
+import json
+import typing as t
+from functools import cached_property
+from pathlib import Path
+
+from sqlmesh.core import constants as c
+from sqlmesh.core.analytics.dispatcher import AsyncEventDispatcher, EventDispatcher
+from sqlmesh.utils import random_id
+from sqlmesh.utils.date import now_timestamp
+from sqlmesh.utils.hashing import sha256
+from sqlmesh.utils.pydantic import PydanticModel
+from sqlmesh.utils.yaml import dump as yaml_dump
+from sqlmesh.utils.yaml import load as yaml_load
+
+if t.TYPE_CHECKING:
+    from sqlmesh.cicd.config import CICDBotConfig
+    from sqlmesh.core.plan import Plan
+    from sqlmesh.core.snapshot import Snapshot
+
+
+class AnalyticsCollector:
+    def __init__(
+        self,
+        dispatcher: t.Optional[EventDispatcher] = None,
+        sqlmesh_path: t.Optional[Path] = None,
+    ):
+        self._dispatcher = dispatcher or AsyncEventDispatcher()
+        self._sqlmesh_path = sqlmesh_path or c.SQLMESH_PATH
+        self._process_id = random_id()
+        self._seq_num = itertools.count()
+
+    def on_cicd_command(
+        self,
+        *,
+        command_name: str,
+        command_args: t.Collection[str],
+        parent_command_names: t.Collection[str],
+        cicd_bot_config: t.Optional[CICDBotConfig],
+    ) -> None:
+        """Called when a CICD command is executed.
+
+        Args:
+            command_name: The name of the command.
+            command_args: The arguments of the command.
+            parent_command_names: The names of the parent commands.
+            cicd_config: The CICD bot configuration.
+        """
+        additional_args = {}
+        if cicd_bot_config is not None and getattr(cicd_bot_config, "FIELDS_FOR_ANALYTICS", None):
+            additional_args["cicd_bot_config"] = cicd_bot_config.dict(
+                include=cicd_bot_config.FIELDS_FOR_ANALYTICS, mode="json"
+            )
+        self._on_command(
+            "CICD_COMMAND",
+            command_name,
+            command_args,
+            parent_command_names=parent_command_names,
+            **additional_args,
+        )
+
+    def on_cli_command(
+        self,
+        *,
+        command_name: str,
+        command_args: t.Collection[str],
+        parent_command_names: t.Collection[str],
+    ) -> None:
+        """Called when a CLI command is executed.
+
+        Args:
+            command_name: The name of the command.
+            command_args: The arguments of the command.
+            parent_command_names: The names of the parent commands.
+        """
+        self._on_command(
+            "CLI_COMMAND", command_name, command_args, parent_command_names=parent_command_names
+        )
+
+    def on_magic_command(self, *, command_name: str, command_args: t.Collection[str]) -> None:
+        """Called when a Notebook magic command is executed.
+
+        Args:
+            command_name: The name of the command.
+            command_args: The arguments of the command.
+        """
+        self._on_command("MAGIC_COMMAND", command_name, command_args)
+
+    def on_python_api_command(self, *, command_name: str, command_args: t.Collection[str]) -> None:
+        """Called when a Python method is called directly.
+
+        Args:
+            command_name: The name of the command.
+            command_args: The arguments of the command.
+        """
+        self._on_command("PYTHON_API_COMMAND", command_name, command_args)
+
+    def on_project_loaded(
+        self,
+        *,
+        project_type: str,
+        models_count: int,
+        audits_count: int,
+        standalone_audits_count: int,
+        macros_count: int,
+        jinja_macros_count: int,
+        load_time_sec: float,
+        state_sync_fingerprint: str,
+        project_name: str,
+    ) -> None:
+        """Called when a project is loaded.
+
+        Args:
+            project_type: The type of the project. Eg. "dbt" or "native".
+            models_count: The number of models in the project.
+            audits_count: The number of audits in the project.
+            standalone_audits_count: The number of standalone audits in the project.
+            macros_count: The number of macros in the project.
+            jinja_macros_count: The number of Jinja macros in the project.
+            load_time_sec: The time it took to load the project in (fractional) seconds.
+            state_sync_fingerprint: The fingerprint of the state sync configuration.
+            project_name: The name of the project.
+        """
+        dbt_version = None
+        project_type = project_type.upper()
+        if project_type == "DBT":
+            from dbt import version
+
+            dbt_version = version.__version__
+
+        self._add_event(
+            "PROJECT_LOADED",
+            {
+                "project_type": project_type.upper(),
+                "models_count": models_count,
+                "audits_count": audits_count,
+                "standalone_audits_count": standalone_audits_count,
+                "macros_count": macros_count,
+                "jinja_macros_count": jinja_macros_count,
+                "load_time_ms": int(load_time_sec * 1000),
+                "state_sync_fingerprint": state_sync_fingerprint,
+                "project_name_hash": _anonymize(project_name),
+                "dbt_version": dbt_version,
+            },
+        )
+
+    def on_plan_apply_start(
+        self,
+        *,
+        plan: Plan,
+        engine_type: t.Optional[str],
+        state_sync_type: t.Optional[str],
+        scheduler_type: str,
+    ) -> None:
+        """Called after the plan application starts.
+
+        Args:
+            plan: The plan that is being applied.
+            engine_type: The type of the target engine.
+            state_sync_type: The type of the engine used to store the SQLMesh state.
+            scheduler_type: The type of the scheduler being used. Eg. "builtin" or "airflow".
+        """
+        self._add_event(
+            "PLAN_APPLY_START",
+            {
+                "plan_id": plan.plan_id,
+                "engine_type": engine_type.lower() if engine_type is not None else None,
+                "state_sync_type": state_sync_type.lower() if state_sync_type is not None else None,
+                "scheduler_type": scheduler_type.upper(),
+                "is_dev": plan.is_dev,
+                "skip_backfill": plan.skip_backfill,
+                "no_gaps": plan.no_gaps,
+                "forward_only": plan.forward_only,
+                "ensure_finalized_snapshots": plan.ensure_finalized_snapshots,
+                "has_restatements": bool(plan.restatements),
+                "directly_modified_count": len(plan.directly_modified),
+                "indirectly_modified_count": len(
+                    {s_id for s_ids in plan.indirectly_modified.values() for s_id in s_ids}
+                ),
+                "environment_name_hash": _anonymize(plan.environment_naming_info.name),
+            },
+        )
+
+    def on_plan_apply_end(self, *, plan_id: str, error: t.Optional[t.Any] = None) -> None:
+        """Called after the plan application ends.
+
+        Args:
+            plan_id: The ID of the plan that was applied.
+            error: The error that occurred during plan application, if any.
+        """
+        self._add_event(
+            "PLAN_APPLY_END",
+            {
+                "plan_id": plan_id,
+                "succeeded": error is None,
+                "error": type(error).__name__ if error else None,
+            },
+        )
+
+    def on_snapshots_created(self, *, new_snapshots: t.Collection[Snapshot], plan_id: str) -> None:
+        """Called after new snapshots were created and stored in the SQLMesh state.
+
+        Args:
+            new_snapshots: The list of new snapshots.
+            plan_id: The ID of the plan that created the snapshots.
+        """
+        if not new_snapshots:
+            return
+        snapshots = []
+        for snapshot in new_snapshots:
+            snapshots.append(
+                {
+                    "name_hash": _anonymize(snapshot.name),
+                    "identifier": snapshot.identifier,
+                    "version": snapshot.version,
+                    "node_type": snapshot.node_type.upper(),
+                    "model_kind": snapshot.model.kind.name.value if snapshot.is_model else None,
+                    "is_sql": snapshot.model.is_sql if snapshot.is_model else None,
+                    "change_category": (
+                        snapshot.change_category.name if snapshot.change_category else None
+                    ),
+                    "dialect": getattr(snapshot.node, "dialect", None),
+                    "audits_count": len(snapshot.model.audits) if snapshot.is_model else None,
+                    "effective_from_set": snapshot.effective_from is not None,
+                }
+            )
+        self._add_event("SNAPSHOTS_CREATED", {"plan_id": plan_id, "snapshots": snapshots})
+
+    def on_run_start(self, *, run_id: str, engine_type: str, state_sync_type: str) -> None:
+        """Called after a run starts.
+
+        Args:
+            run_id: The ID of the run.
+            engine_type: The type of the target engine.
+            state_sync_type: The type of the engine used to store the SQLMesh state.
+        """
+        self._add_event(
+            "RUN_START",
+            {
+                "run_id": run_id,
+                "engine_type": engine_type.lower(),
+                "state_sync_type": state_sync_type.lower(),
+            },
+        )
+
+    def on_run_end(self, *, run_id: str, error: t.Optional[t.Any] = None) -> None:
+        """Called after a run ends.
+
+        Args:
+            run_id: The ID of the run.
+            error: The error that occurred during the run, if any.
+        """
+        self._add_event(
+            "RUN_END",
+            {
+                "run_id": run_id,
+                "succeeded": error is None,
+                "error": type(error).__name__ if error else None,
+            },
+        )
+
+    def on_migration_end(
+        self,
+        *,
+        from_sqlmesh_version: str,
+        state_sync_type: str,
+        migration_time_sec: float,
+        error: t.Optional[t.Any] = None,
+    ) -> None:
+        """Called after the migration of the SQLMesh state ends.
+
+        Args:
+            from_sqlmesh_version: The version of SQLMesh from which the migration started.
+            state_sync_type: The type of the engine used to store the SQLMesh state.
+            migration_time_sec: The time it took to migrate the SQLMesh state in (fractional) seconds.
+            error: The error that occurred during the migration, if any.
+        """
+        self._add_event(
+            "MIGRATION_END",
+            {
+                "from_sqlmesh_version": from_sqlmesh_version,
+                "state_sync_type": state_sync_type,
+                "succeeded": error is None,
+                "error": type(error).__name__ if error else None,
+                "migration_time_ms": int(migration_time_sec * 1000),
+            },
+        )
+
+    def flush(self) -> None:
+        """Flushes the events to the dispatcher."""
+        self._dispatcher.flush()
+
+    def shutdown(self, flush: bool = True) -> None:
+        """Shuts down the collector."""
+        self._dispatcher.shutdown(flush=flush)
+
+    def _on_command(
+        self,
+        event_type: str,
+        command_name: str,
+        command_args: t.Collection[str],
+        **kwargs: t.Any,
+    ) -> None:
+        event = {
+            "command_name": command_name,
+            "command_args": list(command_args),
+            **kwargs,
+        }
+        self._add_event(event_type, event)
+
+    def _add_event(self, event_type: str, event: t.Dict[str, t.Any]) -> None:
+        self._dispatcher.add_event(
+            {
+                "user_id": self._user.id,
+                "process_id": self._process_id,
+                "seq_num": next(self._seq_num),
+                "event_type": event_type,
+                "client_ts": now_timestamp(),
+                "event": json.dumps(event),
+            }
+        )
+
+    @cached_property
+    def _user(self) -> User:
+        return User.load_or_create(self._sqlmesh_path)
+
+
+class User(PydanticModel):
+    id: str
+
+    @classmethod
+    def load_or_create(cls, sqlmesh_path: Path) -> User:
+        if not sqlmesh_path.exists():
+            sqlmesh_path.mkdir(parents=True, exist_ok=True)
+
+        user_path = sqlmesh_path / "user.yaml"
+        if user_path.exists():
+            raw_user = yaml_load(user_path, raise_if_empty=False)
+            if raw_user:
+                return cls.parse_obj(raw_user)
+
+        user = User(id=random_id())
+        with user_path.open("w") as fd:
+            yaml_dump(user.dict(), stream=fd)
+        return user
+
+
+def _anonymize(value: str) -> str:
+    return sha256([value])

--- a/sqlmesh/core/analytics/dispatcher.py
+++ b/sqlmesh/core/analytics/dispatcher.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import abc
+import gzip
+import json
+import logging
+import platform
+import typing as t
+from functools import cached_property
+from threading import Event, Lock, Thread
+from urllib.parse import urljoin
+
+import requests
+from sqlglot import __version__ as sqlglot_version
+
+from sqlmesh.utils.errors import ApiClientError, raise_for_status
+
+TOBIKO_COLLECTOR_URL = "https://analytics.tobikodata.com/v1/"
+
+logger = logging.getLogger(__name__)
+
+
+class EventEmitter:
+    """Emits events to a remote collector."""
+
+    def __init__(
+        self,
+        base_url: str = TOBIKO_COLLECTOR_URL,
+        read_timeout_sec: int = 10,
+        connect_timeout_sec: int = 10,
+    ):
+        from sqlmesh import __version__ as sqlmesh_version
+
+        self.base_url = base_url
+        self.read_timeout = read_timeout_sec
+        self.connect_timeout = connect_timeout_sec
+
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Content-Type": "application/json",
+                "Content-Encoding": "gzip",
+                "User-Agent": f"SQLMesh/{sqlmesh_version}",
+            }
+        )
+
+    def emit(self, events: t.List[t.Dict[str, t.Any]]) -> None:
+        url = urljoin(self.base_url, "sqlmesh/")
+        data = json.dumps({"events": events, "versions": self._versions}).encode("utf-8")
+        data = gzip.compress(data)
+        response = self._session.post(
+            url, data=data, timeout=(self.connect_timeout, self.read_timeout)
+        )
+        raise_for_status(response)
+
+    def close(self) -> None:
+        self._session.close()
+
+    @cached_property
+    def _versions(self) -> str:
+        import pydantic
+
+        from sqlmesh import __version__ as sqlmesh_version
+
+        versions = {
+            "sqlmesh": sqlmesh_version,
+            "sqlglot_version": sqlglot_version,
+            "python_version": platform.python_version(),
+            "pydantic_version": pydantic.__version__,
+            "os_name": platform.system(),
+            "platform": platform.platform(),
+        }
+        return json.dumps(versions)
+
+
+class EventDispatcher(abc.ABC):
+    """Dispatches events to an emitter."""
+
+    @abc.abstractmethod
+    def add_event(self, event: t.Dict[str, t.Any]) -> None:
+        """Add an event to be emitted.
+
+        Args:
+            event: The event data.
+        """
+
+    @abc.abstractmethod
+    def flush(self) -> None:
+        """Flushes the collected events to the emitter."""
+
+    @abc.abstractmethod
+    def shutdown(self, flush: bool = True) -> None:
+        """Shuts down this dispatcher and releases any resources.
+
+        Args:
+            flush: Whether to flush the collected events before shutting down.
+        """
+
+
+class AsyncEventDispatcher(EventDispatcher):
+    def __init__(
+        self,
+        emit_interval_sec: int = 5,
+        max_emit_interval_sec: int = 120,
+        max_queue_size: int = 50,
+        emitter: t.Optional[EventEmitter] = None,
+    ):
+        self._emit_interval_sec = emit_interval_sec
+        self._max_emit_interval_sec = max_emit_interval_sec
+        self._max_queue_size = max_queue_size
+        self._emitter = emitter
+
+        self._events: t.List[t.Dict[str, t.Any]] = []
+        self._events_lock = Lock()
+
+        self._shutdown_event = Event()
+        self._emitter_thread = Thread(target=self._run_flush, name="event-emitter", daemon=True)
+        self._emitter_thread.start()
+
+    @cached_property
+    def emitter(self) -> EventEmitter:
+        return self._emitter or EventEmitter()
+
+    def add_event(self, event: t.Dict[str, t.Any]) -> None:
+        self._add_events([event])
+
+    def flush(self) -> None:
+        with self._events_lock:
+            events_to_emit = self._events
+            self._events = []
+
+        if not events_to_emit:
+            return
+
+        logger.debug("Emitting %d events", len(events_to_emit))
+        try:
+            self.emitter.emit(events_to_emit)
+        except Exception as e:
+            logger.info("Failed to emit events: %s", e)
+            if isinstance(e, ApiClientError):
+                if e.code == 429 and self._emit_interval_sec < self._max_emit_interval_sec:
+                    self._emit_interval_sec = min(
+                        self._emit_interval_sec * 2, self._max_emit_interval_sec
+                    )
+                    logger.info(
+                        "Increasing the emit interval to %s seconds", self._emit_interval_sec
+                    )
+                elif e.code in (400, 403, 404, 405, 426):
+                    logger.info(
+                        "Non-retriable client error (%s) occurred, shutting down the event dispatcher",
+                        e.code,
+                    )
+                    self.shutdown(flush=False)
+                    return
+            self._add_events(events_to_emit, prepend=True)
+
+    def shutdown(self, flush: bool = True) -> None:
+        if self._shutdown_event.is_set():
+            return
+        logging.info("Shutting down the event dispatcher")
+        self._shutdown_event.set()
+        self._emitter_thread.join()
+        if flush and self._events:
+            # Reduce the connect timeout to avoid blocking the shutdown.
+            self.emitter.connect_timeout = 2
+            self.flush()
+        self.emitter.close()
+
+    def _add_events(self, events: t.List[t.Dict[str, t.Any]], prepend: bool = False) -> None:
+        with self._events_lock:
+            if not prepend:
+                self._events += events
+            else:
+                self._events = events + self._events
+
+            if len(self._events) > self._max_queue_size:
+                drop_count = len(self._events) - self._max_queue_size
+                logger.info("Event queue is full, dropping %s events", drop_count)
+                self._events = self._events[drop_count:]
+
+    def _run_flush(self) -> None:
+        while not self._shutdown_event.wait(self._emit_interval_sec):
+            self.flush()
+
+
+class NoopEventDispatcher(EventDispatcher):
+    def add_event(self, event: t.Dict[str, t.Any]) -> None:
+        logger.debug("Analytics is disabled, dropping event")
+
+    def flush(self) -> None:
+        pass
+
+    def shutdown(self, flush: bool = True) -> None:
+        pass

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -74,6 +74,7 @@ class Config(BaseConfig):
         plan: The plan configuration.
         migration: The migration configuration.
         variables: A dictionary of variables that can be used in models / macros.
+        disable_anonymized_analytics: Whether to disable the anonymized analytics collection.
     """
 
     gateways: t.Dict[str, GatewayConfig] = {"": GatewayConfig()}
@@ -111,6 +112,7 @@ class Config(BaseConfig):
     plan: PlanConfig = PlanConfig()
     migration: MigrationConfig = MigrationConfig()
     variables: t.Dict[str, t.Any] = {}
+    disable_anonymized_analytics: bool = False
 
     _FIELD_UPDATE_STRATEGY: t.ClassVar[t.Dict[str, UpdateStrategy]] = {
         "gateways": UpdateStrategy.KEY_UPDATE,

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -21,7 +21,7 @@ from sqlmesh.core.state_sync import EngineAdapterStateSync, StateSync
 from sqlmesh.schedulers.airflow.client import AirflowClient
 from sqlmesh.schedulers.airflow.mwaa_client import MWAAClient
 from sqlmesh.utils.errors import ConfigError
-from sqlmesh.utils.hashing import sha256
+from sqlmesh.utils.hashing import md5
 from sqlmesh.utils.pydantic import model_validator, model_validator_v1_args
 
 if t.TYPE_CHECKING:
@@ -97,7 +97,7 @@ class _EngineAdapterStateSyncSchedulerConfig(_SchedulerConfig):
         state_connection = (
             context.config.get_state_connection(context.gateway) or context._connection_config
         )
-        return sha256([state_connection.json(sort_keys=True)])
+        return md5([state_connection.json(sort_keys=True)])
 
 
 class BuiltInSchedulerConfig(_EngineAdapterStateSyncSchedulerConfig, BaseConfig):
@@ -151,7 +151,7 @@ class _BaseAirflowSchedulerConfig(_EngineAdapterStateSyncSchedulerConfig):
     def state_sync_fingerprint(self, context: GenericContext) -> str:
         if self.use_state_connection:
             return super().state_sync_fingerprint(context)
-        return sha256([self.airflow_url])
+        return md5([self.airflow_url])
 
     def create_plan_evaluator(self, context: GenericContext) -> PlanEvaluator:
         return AirflowPlanEvaluator(

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -21,6 +21,7 @@ from sqlmesh.core.state_sync import EngineAdapterStateSync, StateSync
 from sqlmesh.schedulers.airflow.client import AirflowClient
 from sqlmesh.schedulers.airflow.mwaa_client import MWAAClient
 from sqlmesh.utils.errors import ConfigError
+from sqlmesh.utils.hashing import sha256
 from sqlmesh.utils.pydantic import model_validator, model_validator_v1_args
 
 if t.TYPE_CHECKING:
@@ -67,6 +68,14 @@ class _SchedulerConfig(abc.ABC):
             context: The SQLMesh Context.
         """
 
+    @abc.abstractmethod
+    def state_sync_fingerprint(self, context: GenericContext) -> str:
+        """Returns the fingerprint of the State Sync configuration.
+
+        Args:
+            context: The SQLMesh Context.
+        """
+
 
 class _EngineAdapterStateSyncSchedulerConfig(_SchedulerConfig):
     def create_state_sync(self, context: GenericContext) -> StateSync:
@@ -83,6 +92,12 @@ class _EngineAdapterStateSyncSchedulerConfig(_SchedulerConfig):
         return EngineAdapterStateSync(
             engine_adapter, schema=schema, context_path=context.path, console=context.console
         )
+
+    def state_sync_fingerprint(self, context: GenericContext) -> str:
+        state_connection = (
+            context.config.get_state_connection(context.gateway) or context._connection_config
+        )
+        return sha256([state_connection.json(sort_keys=True)])
 
 
 class BuiltInSchedulerConfig(_EngineAdapterStateSyncSchedulerConfig, BaseConfig):
@@ -105,6 +120,7 @@ class BuiltInSchedulerConfig(_EngineAdapterStateSyncSchedulerConfig, BaseConfig)
 
 
 class _BaseAirflowSchedulerConfig(_EngineAdapterStateSyncSchedulerConfig):
+    airflow_url: str
     dag_run_poll_interval_secs: int
     dag_creation_poll_interval_secs: int
     dag_creation_max_retry_attempts: int
@@ -131,6 +147,11 @@ class _BaseAirflowSchedulerConfig(_EngineAdapterStateSyncSchedulerConfig):
             dag_run_poll_interval_secs=self.dag_run_poll_interval_secs,
             console=context.console,
         )
+
+    def state_sync_fingerprint(self, context: GenericContext) -> str:
+        if self.use_state_connection:
+            return super().state_sync_fingerprint(context)
+        return sha256([self.airflow_url])
 
     def create_plan_evaluator(self, context: GenericContext) -> PlanEvaluator:
         return AirflowPlanEvaluator(

--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -62,3 +62,5 @@ SQLMESH_BUILTIN = "__sqlmesh__builtin__"
 
 BUILTIN = "builtin"
 AIRFLOW = "airflow"
+DBT = "dbt"
+NATIVE = "native"

--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -58,3 +58,7 @@ GATEWAY = "gateway"
 
 SQLMESH_MACRO = "__sqlmesh__macro__"
 SQLMESH_BUILTIN = "__sqlmesh__builtin__"
+
+
+BUILTIN = "builtin"
+AIRFLOW = "airflow"

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -499,7 +499,7 @@ class GenericContext(BaseContext, t.Generic[C]):
 
         analytics.collector.on_project_loaded(
             project_type=(
-                "dbt" if type(self._loader).__name__.lower().startswith("dbt") else "native"
+                c.DBT if type(self._loader).__name__.lower().startswith(c.DBT) else c.NATIVE
             ),
             models_count=len(self._models),
             audits_count=len(self._audits),

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -52,7 +52,9 @@ import pandas as pd
 from sqlglot import exp
 from sqlglot.lineage import GraphHTML
 
+from sqlmesh.core import analytics
 from sqlmesh.core import constants as c
+from sqlmesh.core.analytics import python_api_analytics
 from sqlmesh.core.audit import Audit, StandaloneAudit
 from sqlmesh.core.config import CategorizerConfig, Config, load_configs
 from sqlmesh.core.config.loader import C
@@ -314,6 +316,9 @@ class GenericContext(BaseContext, t.Generic[C]):
 
         self.path, self.config = t.cast(t.Tuple[Path, C], next(iter(self.configs.items())))
 
+        if self.config.disable_anonymized_analytics:
+            analytics.disable_analytics()
+
         self.gateway = gateway
         self._scheduler = self.config.get_scheduler(self.gateway)
         self.environment_ttl = self.config.environment_ttl
@@ -382,6 +387,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             default_catalog=self.default_catalog,
         )
 
+    @python_api_analytics
     def upsert_model(self, model: t.Union[str, Model], **kwargs: t.Any) -> Model:
         """Update or insert a model.
 
@@ -467,6 +473,7 @@ class GenericContext(BaseContext, t.Generic[C]):
 
     def load(self, update_schemas: bool = True) -> GenericContext[C]:
         """Load all files in the context's path."""
+        load_start_ts = time.perf_counter()
         with sys_path(*self.configs):
             gc.disable()
             project = self._loader.load(self, update_schemas)
@@ -490,8 +497,23 @@ class GenericContext(BaseContext, t.Generic[C]):
                     f"Models and Standalone audits cannot have the same name: {duplicates}"
                 )
 
+        analytics.collector.on_project_loaded(
+            project_type=(
+                "dbt" if type(self._loader).__name__.lower().startswith("dbt") else "native"
+            ),
+            models_count=len(self._models),
+            audits_count=len(self._audits),
+            standalone_audits_count=len(self._standalone_audits),
+            macros_count=len(self._macros),
+            jinja_macros_count=len(self._jinja_macros.root_macros),
+            load_time_sec=time.perf_counter() - load_start_ts,
+            state_sync_fingerprint=self._scheduler.state_sync_fingerprint(self),
+            project_name=self.config.project,
+        )
+
         return self
 
+    @python_api_analytics
     def run(
         self,
         environment: t.Optional[str] = None,
@@ -675,6 +697,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             self._default_catalog = self._scheduler.get_default_catalog(self)
         return self._default_catalog
 
+    @python_api_analytics
     def render(
         self,
         model_or_snapshot: ModelOrSnapshot,
@@ -735,6 +758,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             **kwargs,
         )
 
+    @python_api_analytics
     def evaluate(
         self,
         model_or_snapshot: ModelOrSnapshot,
@@ -771,6 +795,7 @@ class GenericContext(BaseContext, t.Generic[C]):
 
         return df
 
+    @python_api_analytics
     def format(
         self,
         transpile: t.Optional[str] = None,
@@ -806,6 +831,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                     file.write("\n")
                 file.truncate()
 
+    @python_api_analytics
     def plan(
         self,
         environment: t.Optional[str] = None,
@@ -906,6 +932,7 @@ class GenericContext(BaseContext, t.Generic[C]):
 
         return plan_builder.build()
 
+    @python_api_analytics
     def plan_builder(
         self,
         environment: t.Optional[str] = None,
@@ -1129,6 +1156,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             plan_id=plan.plan_id,
         )
 
+    @python_api_analytics
     def invalidate_environment(self, name: str, sync: bool = False) -> None:
         """Invalidates the target environment by setting its expiration timestamp to now.
 
@@ -1144,6 +1172,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         else:
             self.console.log_success(f"Environment '{name}' has been invalidated.")
 
+    @python_api_analytics
     def diff(self, environment: t.Optional[str] = None, detailed: bool = False) -> bool:
         """Show a diff of the current context with a given environment.
 
@@ -1169,6 +1198,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         )
         return context_diff.has_changes
 
+    @python_api_analytics
     def table_diff(
         self,
         source: str,
@@ -1242,6 +1272,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             self.console.show_row_diff(table_diff.row_diff(), show_sample=show_sample)
         return table_diff
 
+    @python_api_analytics
     def get_dag(
         self, select_models: t.Optional[t.Collection[str]] = None, **options: t.Any
     ) -> GraphHTML:
@@ -1290,6 +1321,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             },
         )
 
+    @python_api_analytics
     def render_dag(self, path: str, select_models: t.Optional[t.Collection[str]] = None) -> None:
         """Render the dag as HTML and save it to a file.
 
@@ -1309,6 +1341,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         with open(path, "w", encoding="utf-8") as file:
             file.write(str(self.get_dag(select_models)))
 
+    @python_api_analytics
     def create_test(
         self,
         model: str,
@@ -1360,6 +1393,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         finally:
             test_adapter.close()
 
+    @python_api_analytics
     def test(
         self,
         match_patterns: t.Optional[t.List[str]] = None,
@@ -1416,6 +1450,7 @@ class GenericContext(BaseContext, t.Generic[C]):
 
         return result
 
+    @python_api_analytics
     def audit(
         self,
         start: TimeLike,
@@ -1482,6 +1517,7 @@ class GenericContext(BaseContext, t.Generic[C]):
 
         self.console.log_status_update("Done.")
 
+    @python_api_analytics
     def rewrite(self, sql: str, dialect: str = "") -> exp.Expression:
         """Rewrite a sql expression with semantic references into an executable query.
 
@@ -1501,6 +1537,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             dialect=dialect or self.default_dialect,
         )
 
+    @python_api_analytics
     def migrate(self) -> None:
         """Migrates SQLMesh to the current running version.
 
@@ -1519,6 +1556,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             raise e
         self.notification_target_manager.notify(NotificationEvent.MIGRATION_END)
 
+    @python_api_analytics
     def rollback(self) -> None:
         """Rolls back SQLMesh to the previous migration.
 
@@ -1526,6 +1564,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         """
         self._new_state_sync().rollback()
 
+    @python_api_analytics
     def create_external_models(self) -> None:
         """Create a schema file with all external models.
 
@@ -1552,6 +1591,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 max_workers=self.concurrent_tasks,
             )
 
+    @python_api_analytics
     def print_info(self) -> None:
         """Prints information about connections, models, macros, etc. to the console."""
         self.console.log_status_update(f"Models: {len(self.models)}")
@@ -1642,6 +1682,7 @@ class GenericContext(BaseContext, t.Generic[C]):
     def _apply(self, plan: Plan, circuit_breaker: t.Optional[t.Callable[[], bool]]) -> None:
         self._scheduler.create_plan_evaluator(self).evaluate(plan, circuit_breaker=circuit_breaker)
 
+    @python_api_analytics
     def table_name(self, model_name: str, dev: bool) -> str:
         """Returns the name of the pysical table for the given model name.
 

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -181,6 +181,10 @@ class StateReader(abc.ABC):
     def close(self) -> None:
         """Closes all open connections and releases all allocated resources."""
 
+    @abc.abstractmethod
+    def state_type(self) -> str:
+        """Returns the type of state sync."""
+
     def get_versions(self, validate: bool = True) -> Versions:
         """Get the current versions of the SQLMesh schema and libraries.
 

--- a/sqlmesh/integrations/github/cicd/command.py
+++ b/sqlmesh/integrations/github/cicd/command.py
@@ -5,6 +5,7 @@ import traceback
 
 import click
 
+from sqlmesh.core.analytics import cli_analytics
 from sqlmesh.integrations.github.cicd.controller import (
     GithubCheckConclusion,
     GithubCheckStatus,
@@ -47,6 +48,7 @@ def _check_required_approvers(controller: GithubController) -> bool:
 
 @github.command()
 @click.pass_context
+@cli_analytics
 def check_required_approvers(ctx: click.Context) -> None:
     """Checks if a required approver has provided approval on the PR."""
     _check_required_approvers(ctx.obj["github"])
@@ -75,6 +77,7 @@ def _run_tests(controller: GithubController) -> bool:
 
 @github.command()
 @click.pass_context
+@cli_analytics
 def run_tests(ctx: click.Context) -> None:
     """Runs the unit tests"""
     _run_tests(ctx.obj["github"])
@@ -99,6 +102,7 @@ def _update_pr_environment(controller: GithubController) -> bool:
 
 @github.command()
 @click.pass_context
+@cli_analytics
 def update_pr_environment(ctx: click.Context) -> None:
     """Creates or updates the PR environments"""
     _update_pr_environment(ctx.obj["github"])
@@ -125,6 +129,7 @@ def _gen_prod_plan(controller: GithubController) -> bool:
 
 @github.command()
 @click.pass_context
+@cli_analytics
 def gen_prod_plan(ctx: click.Context) -> None:
     """Generates the production plan"""
     controller = ctx.obj["github"]
@@ -151,6 +156,7 @@ def _deploy_production(controller: GithubController) -> bool:
 
 @github.command()
 @click.pass_context
+@cli_analytics
 def deploy_production(ctx: click.Context) -> None:
     """Deploys the production environment"""
     _deploy_production(ctx.obj["github"])
@@ -238,6 +244,7 @@ def _run_all(controller: GithubController) -> None:
 
 @github.command()
 @click.pass_context
+@cli_analytics
 def run_all(ctx: click.Context) -> None:
     """Runs all the commands in the correct order."""
     return _run_all(ctx.obj["github"])

--- a/sqlmesh/integrations/github/cicd/config.py
+++ b/sqlmesh/integrations/github/cicd/config.py
@@ -42,3 +42,15 @@ class GithubCICDBotConfig(BaseConfig):
         if values.get("command_namespace") and not values.get("enable_deploy_command"):
             raise ValueError("enable_deploy_command must be set if command_namespace is set")
         return values
+
+    FIELDS_FOR_ANALYTICS: t.ClassVar[t.Set[str]] = {
+        "invalidate_environment_after_deploy",
+        "enable_deploy_command",
+        "merge_method",
+        "command_namespace",
+        "auto_categorize_changes",
+        "default_pr_start",
+        "skip_pr_backfill",
+        "pr_include_unmodified",
+        "run_on_deploy_to_prod",
+    }

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -294,8 +294,8 @@ class GithubController:
 
         logger.debug(f"Initializing GithubController with paths: {paths} and config: {config}")
 
+        self.config = config
         self._paths = paths
-        self._config = config
         self._token = token
         self._event = event or GithubEvent.from_env()
         logger.debug(f"Github event: {json.dumps(self._event.payload)}")
@@ -325,7 +325,7 @@ class GithubController:
         logger.debug(f"Approvers: {', '.join(self._approvers)}")
         self._context: Context = Context(
             paths=self._paths,
-            config=self._config,
+            config=self.config,
             console=self._console,
         )
 
@@ -397,6 +397,7 @@ class GithubController:
                 skip_backfill=self.bot_config.skip_pr_backfill,
                 include_unmodified=self.bot_config.pr_include_unmodified,
             )
+        assert self._pr_plan_builder
         return self._pr_plan_builder.build()
 
     @property
@@ -409,6 +410,7 @@ class GithubController:
                 categorizer_config=self.bot_config.auto_categorize_changes,
                 run=self.bot_config.run_on_deploy_to_prod,
             )
+        assert self._prod_plan_builder
         return self._prod_plan_builder.build()
 
     @property
@@ -421,6 +423,7 @@ class GithubController:
                 skip_tests=True,
                 run=self.bot_config.run_on_deploy_to_prod,
             )
+        assert self._prod_plan_with_gaps_builder
         return self._prod_plan_with_gaps_builder.build()
 
     @property

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -6,7 +6,6 @@ import uuid
 from urllib.parse import urlencode, urljoin
 
 import requests
-from requests.models import Response
 
 from sqlmesh.core.console import Console
 from sqlmesh.core.environment import Environment
@@ -19,10 +18,10 @@ from sqlmesh.schedulers.airflow import common
 from sqlmesh.utils import unique
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.errors import (
-    ApiClientError,
     ApiServerError,
     NotFoundError,
     SQLMeshError,
+    raise_for_status,
 )
 from sqlmesh.utils.pydantic import PydanticModel
 
@@ -368,12 +367,3 @@ def _list_to_json(models: t.Collection[T], batch_size: t.Optional[int] = None) -
 
 def _json_query_param(value: t.Any) -> str:
     return json.dumps(value, separators=(",", ":"))
-
-
-def raise_for_status(response: Response) -> None:
-    if response.status_code == 404:
-        raise NotFoundError(response.text)
-    if 400 <= response.status_code < 500:
-        raise ApiClientError(response.text)
-    if 500 <= response.status_code < 600:
-        raise ApiServerError(response.text)

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -343,3 +343,7 @@ class HttpStateSync(StateSync):
 
     def close(self) -> None:
         """Closes all open connections and releases all allocated resources."""
+
+    def state_type(self) -> str:
+        """Returns the type of state sync."""
+        return "airflow_http"

--- a/sqlmesh/utils/hashing.py
+++ b/sqlmesh/utils/hashing.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
+import hashlib
 import typing as t
 import zlib
 
 
 def crc32(data: t.Iterable[t.Optional[str]]) -> str:
-    return str(zlib.crc32(";".join("" if d is None else d for d in data).encode("utf-8")))
+    return str(zlib.crc32(_safe_concat(data)))
+
+
+def sha256(data: t.Iterable[t.Optional[str]]) -> str:
+    return hashlib.sha256(_safe_concat(data)).hexdigest()
 
 
 def hash_data(data: t.Iterable[t.Optional[str]]) -> str:
     return crc32(data)
+
+
+def _safe_concat(data: t.Iterable[t.Optional[str]]) -> bytes:
+    return ";".join("" if d is None else d for d in data).encode("utf-8")

--- a/sqlmesh/utils/hashing.py
+++ b/sqlmesh/utils/hashing.py
@@ -9,8 +9,8 @@ def crc32(data: t.Iterable[t.Optional[str]]) -> str:
     return str(zlib.crc32(_safe_concat(data)))
 
 
-def sha256(data: t.Iterable[t.Optional[str]]) -> str:
-    return hashlib.sha256(_safe_concat(data)).hexdigest()
+def md5(data: t.Iterable[t.Optional[str]]) -> str:
+    return hashlib.md5(_safe_concat(data)).hexdigest()
 
 
 def hash_data(data: t.Iterable[t.Optional[str]]) -> str:

--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -139,6 +139,11 @@ class PydanticModel(pydantic.BaseModel):
         if include is None and self.__config__.extra != "allow":  # type: ignore
             # Workaround to support @cached_property in Pydantic v1.
             include = {f.name for f in self.all_field_infos().values()}  # type: ignore
+
+        mode = kwargs.pop("mode", None)
+        if mode == "json":
+            # Pydantic v1 doesn't support the 'json' mode for dict().
+            return json.loads(super().json(include=include, **kwargs))
         return super().dict(include=include, **kwargs)  # type: ignore
 
     def json(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+from sqlmesh.core.analytics import disable_analytics
+
+disable_analytics()

--- a/tests/core/analytics/test_collector.py
+++ b/tests/core/analytics/test_collector.py
@@ -1,0 +1,344 @@
+import json
+import typing as t
+from unittest.mock import call
+
+import pytest
+from pytest_mock.plugin import MockerFixture
+
+from sqlmesh.core.analytics.collector import AnalyticsCollector
+from sqlmesh.core.snapshot import SnapshotChangeCategory
+from sqlmesh.integrations.github.cicd.config import GithubCICDBotConfig
+from sqlmesh.utils.errors import SQLMeshError
+
+
+@pytest.fixture
+def collector(mocker: MockerFixture) -> AnalyticsCollector:
+    dispatcher_mock = mocker.Mock()
+    return AnalyticsCollector(dispatcher=dispatcher_mock)
+
+
+def test_on_project_loaded(collector: AnalyticsCollector, mocker: MockerFixture):
+    collector.on_project_loaded(
+        project_type="NATIVE",
+        models_count=1,
+        audits_count=2,
+        standalone_audits_count=3,
+        macros_count=4,
+        jinja_macros_count=5,
+        load_time_sec=1.123,
+        state_sync_fingerprint="test_fingerprint",
+        project_name="test_project",
+    )
+
+    collector.flush()
+
+    collector._dispatcher.add_event.assert_called_once_with(  # type: ignore
+        {
+            "user_id": mocker.ANY,
+            "process_id": collector._process_id,
+            "seq_num": 0,
+            "event_type": "PROJECT_LOADED",
+            "client_ts": mocker.ANY,
+            "event": '{"project_type": "NATIVE", "models_count": 1, "audits_count": 2, "standalone_audits_count": 3, "macros_count": 4, "jinja_macros_count": 5, "load_time_ms": 1123, "state_sync_fingerprint": "test_fingerprint", "project_name_hash": "ad62917b5e639fad064d4c72dd0eca227d2cccab83bac09ded995db314e5b200", "dbt_version": null}',
+        }
+    )
+
+
+def test_on_command(collector: AnalyticsCollector, mocker: MockerFixture):
+    collector.on_python_api_command(command_name="test_python_api", command_args=["arg_1", "arg_2"])
+    collector.on_magic_command(command_name="test_magic", command_args=["arg_1", "arg_2"])
+    collector.on_cli_command(
+        command_name="test_cli", command_args=["arg_1", "arg_2"], parent_command_names=[]
+    )
+
+    collector.flush()
+
+    common_fields = {
+        "user_id": mocker.ANY,
+        "process_id": collector._process_id,
+        "client_ts": mocker.ANY,
+    }
+
+    collector._dispatcher.add_event.assert_has_calls(  # type: ignore
+        [
+            call(
+                {
+                    "seq_num": 0,
+                    "event_type": "PYTHON_API_COMMAND",
+                    "event": '{"command_name": "test_python_api", "command_args": ["arg_1", "arg_2"]}',
+                    **common_fields,
+                }
+            ),
+            call(
+                {
+                    "seq_num": 1,
+                    "event_type": "MAGIC_COMMAND",
+                    "event": '{"command_name": "test_magic", "command_args": ["arg_1", "arg_2"]}',
+                    **common_fields,
+                }
+            ),
+            call(
+                {
+                    "seq_num": 2,
+                    "event_type": "CLI_COMMAND",
+                    "event": '{"command_name": "test_cli", "command_args": ["arg_1", "arg_2"], "parent_command_names": []}',
+                    **common_fields,
+                }
+            ),
+        ]
+    )
+
+
+def test_on_cicd_command(collector: AnalyticsCollector, mocker: MockerFixture):
+    collector.on_cicd_command(
+        command_name="test_cicd",
+        command_args=["arg_1", "arg_2"],
+        parent_command_names=["parent_a", "parent_b"],
+        cicd_bot_config=None,
+    )
+    collector.on_cicd_command(
+        command_name="test_cicd",
+        command_args=["arg_1", "arg_2"],
+        parent_command_names=["parent_a", "parent_b"],
+        cicd_bot_config=GithubCICDBotConfig(),
+    )
+
+    collector.flush()
+
+    common_fields = {
+        "user_id": mocker.ANY,
+        "process_id": collector._process_id,
+        "client_ts": mocker.ANY,
+    }
+
+    collector._dispatcher.add_event.assert_has_calls(  # type: ignore
+        [
+            call(
+                {
+                    "seq_num": 0,
+                    "event_type": "CICD_COMMAND",
+                    "event": '{"command_name": "test_cicd", "command_args": ["arg_1", "arg_2"], "parent_command_names": ["parent_a", "parent_b"]}',
+                    **common_fields,
+                }
+            ),
+            call(
+                {
+                    "seq_num": 1,
+                    "event_type": "CICD_COMMAND",
+                    "event": '{"command_name": "test_cicd", "command_args": ["arg_1", "arg_2"], "parent_command_names": ["parent_a", "parent_b"], "cicd_bot_config": {"invalidate_environment_after_deploy": true, "enable_deploy_command": false, "auto_categorize_changes": {"external": "off", "python": "off", "sql": "off", "seed": "off"}, "skip_pr_backfill": true, "run_on_deploy_to_prod": true}}',
+                    **common_fields,
+                }
+            ),
+        ]
+    )
+
+
+@pytest.mark.slow
+def test_on_plan_apply(
+    collector: AnalyticsCollector, mocker: MockerFixture, init_and_plan_context: t.Callable
+):
+    context, plan = init_and_plan_context("examples/sushi")
+
+    plan_id = plan.plan_id
+    collector.on_plan_apply_start(
+        plan=plan, engine_type="bigquery", state_sync_type="mysql", scheduler_type="builtin"
+    )
+    collector.on_plan_apply_end(plan_id=plan_id)
+    collector.on_plan_apply_end(plan_id=plan_id, error=SQLMeshError("test_error"))
+
+    collector.flush()
+
+    common_fields = {
+        "user_id": mocker.ANY,
+        "process_id": collector._process_id,
+        "client_ts": mocker.ANY,
+    }
+
+    collector._dispatcher.add_event.assert_has_calls(  # type: ignore
+        [
+            call(
+                {
+                    "seq_num": 0,
+                    "event_type": "PLAN_APPLY_START",
+                    "event": f'{{"plan_id": "{plan_id}", "engine_type": "bigquery", "state_sync_type": "mysql", "scheduler_type": "BUILTIN", "is_dev": false, "skip_backfill": false, "no_gaps": false, "forward_only": false, "ensure_finalized_snapshots": false, "has_restatements": false, "directly_modified_count": 17, "indirectly_modified_count": 0, "environment_name_hash": "6754af9632a2745e85c293e5aac0863370d9bd3330b9938c00cadfd215227d77"}}',
+                    **common_fields,
+                }
+            ),
+            call(
+                {
+                    "seq_num": 1,
+                    "event_type": "PLAN_APPLY_END",
+                    "event": f'{{"plan_id": "{plan_id}", "succeeded": true, "error": null}}',
+                    **common_fields,
+                }
+            ),
+            call(
+                {
+                    "seq_num": 2,
+                    "event_type": "PLAN_APPLY_END",
+                    "event": f'{{"plan_id": "{plan_id}", "succeeded": false, "error": "SQLMeshError"}}',
+                    **common_fields,
+                }
+            ),
+        ]
+    )
+
+
+@pytest.mark.slow
+def test_on_snapshots_created(
+    collector: AnalyticsCollector, mocker: MockerFixture, init_and_plan_context: t.Callable
+):
+    context, _ = init_and_plan_context("examples/sushi")
+
+    new_snapshots = [
+        context.get_snapshot("sushi.orders"),
+        context.get_snapshot("sushi.waiter_revenue_by_day"),
+        context.get_snapshot("sushi.top_waiters"),
+    ]
+    new_snapshots[0].categorize_as(SnapshotChangeCategory.FORWARD_ONLY)
+    new_snapshots[0].effective_from = "2024-01-01"
+    new_snapshots[0].version = "test_version"
+
+    new_snapshots[1].categorize_as(SnapshotChangeCategory.BREAKING)
+    new_snapshots[2].categorize_as(SnapshotChangeCategory.INDIRECT_BREAKING)
+
+    plan_id = "test_plan_id"
+
+    collector.on_snapshots_created(new_snapshots=new_snapshots, plan_id=plan_id)
+
+    collector.flush()
+
+    snapshots = [
+        {
+            "name_hash": "84215ae191517da5c59da03fa46ed6ce09b3f4d68008d2d9ef4e3e8bead0e588",
+            "identifier": new_snapshots[0].identifier,
+            "version": new_snapshots[0].version,
+            "node_type": "MODEL",
+            "model_kind": "INCREMENTAL_BY_TIME_RANGE",
+            "is_sql": False,
+            "change_category": "FORWARD_ONLY",
+            "dialect": "duckdb",
+            "audits_count": 0,
+            "effective_from_set": True,
+        },
+        {
+            "name_hash": "9877934ae555dd62818f87445d31878eee279654513f2a4972c2d0c77eac6c7b",
+            "identifier": new_snapshots[1].identifier,
+            "version": new_snapshots[1].version,
+            "node_type": "MODEL",
+            "model_kind": "INCREMENTAL_BY_TIME_RANGE",
+            "is_sql": True,
+            "change_category": "BREAKING",
+            "dialect": "duckdb",
+            "audits_count": 1,
+            "effective_from_set": False,
+        },
+        {
+            "name_hash": "43e722d38768169cee67b816fec067a9c573002858b46551ae463caa545de39a",
+            "identifier": new_snapshots[2].identifier,
+            "version": new_snapshots[2].version,
+            "node_type": "MODEL",
+            "model_kind": "VIEW",
+            "is_sql": True,
+            "change_category": "INDIRECT_BREAKING",
+            "dialect": "duckdb",
+            "audits_count": 1,
+            "effective_from_set": False,
+        },
+    ]
+
+    collector._dispatcher.add_event.assert_called_once_with(  # type: ignore
+        {
+            "seq_num": 0,
+            "event_type": "SNAPSHOTS_CREATED",
+            "event": f'{{"plan_id": "{plan_id}", "snapshots": {json.dumps(snapshots)}}}',
+            "user_id": mocker.ANY,
+            "process_id": collector._process_id,
+            "client_ts": mocker.ANY,
+        },
+    )
+
+
+def test_on_run(collector: AnalyticsCollector, mocker: MockerFixture):
+    run_id = "test_run_id"
+    collector.on_run_start(run_id=run_id, engine_type="bigquery", state_sync_type="mysql")
+    collector.on_run_end(run_id=run_id)
+    collector.on_run_end(run_id=run_id, error=SQLMeshError("test_error"))
+
+    collector.flush()
+
+    common_fields = {
+        "user_id": mocker.ANY,
+        "process_id": collector._process_id,
+        "client_ts": mocker.ANY,
+    }
+
+    collector._dispatcher.add_event.assert_has_calls(  # type: ignore
+        [
+            call(
+                {
+                    "seq_num": 0,
+                    "event_type": "RUN_START",
+                    "event": f'{{"run_id": "{run_id}", "engine_type": "bigquery", "state_sync_type": "mysql"}}',
+                    **common_fields,
+                }
+            ),
+            call(
+                {
+                    "seq_num": 1,
+                    "event_type": "RUN_END",
+                    "event": f'{{"run_id": "{run_id}", "succeeded": true, "error": null}}',
+                    **common_fields,
+                }
+            ),
+            call(
+                {
+                    "seq_num": 2,
+                    "event_type": "RUN_END",
+                    "event": f'{{"run_id": "{run_id}", "succeeded": false, "error": "SQLMeshError"}}',
+                    **common_fields,
+                }
+            ),
+        ]
+    )
+
+
+def test_on_migration(collector: AnalyticsCollector, mocker: MockerFixture):
+    collector.on_migration_end(
+        from_sqlmesh_version="0.0.0", state_sync_type="mysql", migration_time_sec=1.123
+    )
+    collector.on_migration_end(
+        from_sqlmesh_version="0.0.0",
+        state_sync_type="mysql",
+        error=SQLMeshError("test_error"),
+        migration_time_sec=1.321,
+    )
+
+    collector.flush()
+
+    common_fields = {
+        "user_id": mocker.ANY,
+        "process_id": collector._process_id,
+        "client_ts": mocker.ANY,
+    }
+
+    collector._dispatcher.add_event.assert_has_calls(  # type: ignore
+        [
+            call(
+                {
+                    "seq_num": 0,
+                    "event_type": "MIGRATION_END",
+                    "event": '{"from_sqlmesh_version": "0.0.0", "state_sync_type": "mysql", "succeeded": true, "error": null, "migration_time_ms": 1123}',
+                    **common_fields,
+                }
+            ),
+            call(
+                {
+                    "seq_num": 1,
+                    "event_type": "MIGRATION_END",
+                    "event": '{"from_sqlmesh_version": "0.0.0", "state_sync_type": "mysql", "succeeded": false, "error": "SQLMeshError", "migration_time_ms": 1321}',
+                    **common_fields,
+                }
+            ),
+        ]
+    )

--- a/tests/core/analytics/test_collector.py
+++ b/tests/core/analytics/test_collector.py
@@ -39,7 +39,7 @@ def test_on_project_loaded(collector: AnalyticsCollector, mocker: MockerFixture)
             "seq_num": 0,
             "event_type": "PROJECT_LOADED",
             "client_ts": mocker.ANY,
-            "event": '{"project_type": "NATIVE", "models_count": 1, "audits_count": 2, "standalone_audits_count": 3, "macros_count": 4, "jinja_macros_count": 5, "load_time_ms": 1123, "state_sync_fingerprint": "test_fingerprint", "project_name_hash": "ad62917b5e639fad064d4c72dd0eca227d2cccab83bac09ded995db314e5b200", "dbt_version": null}',
+            "event": '{"project_type": "NATIVE", "models_count": 1, "audits_count": 2, "standalone_audits_count": 3, "macros_count": 4, "jinja_macros_count": 5, "load_time_ms": 1123, "state_sync_fingerprint": "test_fingerprint", "project_name_hash": "6e72a69d5c5cca8f0400338441c022e4", "dbt_version": null}',
         }
     )
 
@@ -160,7 +160,7 @@ def test_on_plan_apply(
                 {
                     "seq_num": 0,
                     "event_type": "PLAN_APPLY_START",
-                    "event": f'{{"plan_id": "{plan_id}", "engine_type": "bigquery", "state_sync_type": "mysql", "scheduler_type": "BUILTIN", "is_dev": false, "skip_backfill": false, "no_gaps": false, "forward_only": false, "ensure_finalized_snapshots": false, "has_restatements": false, "directly_modified_count": 17, "indirectly_modified_count": 0, "environment_name_hash": "6754af9632a2745e85c293e5aac0863370d9bd3330b9938c00cadfd215227d77"}}',
+                    "event": f'{{"plan_id": "{plan_id}", "engine_type": "bigquery", "state_sync_type": "mysql", "scheduler_type": "BUILTIN", "is_dev": false, "skip_backfill": false, "no_gaps": false, "forward_only": false, "ensure_finalized_snapshots": false, "has_restatements": false, "directly_modified_count": 17, "indirectly_modified_count": 0, "environment_name_hash": "d6e4a9b6646c62fc48baa6dd6150d1f7"}}',
                     **common_fields,
                 }
             ),
@@ -210,7 +210,7 @@ def test_on_snapshots_created(
 
     snapshots = [
         {
-            "name_hash": "84215ae191517da5c59da03fa46ed6ce09b3f4d68008d2d9ef4e3e8bead0e588",
+            "name_hash": "e460a6c71eafe1037edc84a6fc253082",
             "identifier": new_snapshots[0].identifier,
             "version": new_snapshots[0].version,
             "node_type": "MODEL",
@@ -222,7 +222,7 @@ def test_on_snapshots_created(
             "effective_from_set": True,
         },
         {
-            "name_hash": "9877934ae555dd62818f87445d31878eee279654513f2a4972c2d0c77eac6c7b",
+            "name_hash": "86a8d86801fc831d207bd02ba0d5d90d",
             "identifier": new_snapshots[1].identifier,
             "version": new_snapshots[1].version,
             "node_type": "MODEL",
@@ -234,7 +234,7 @@ def test_on_snapshots_created(
             "effective_from_set": False,
         },
         {
-            "name_hash": "43e722d38768169cee67b816fec067a9c573002858b46551ae463caa545de39a",
+            "name_hash": "da096f341c6129f9b45da6cbe75d0b39",
             "identifier": new_snapshots[2].identifier,
             "version": new_snapshots[2].version,
             "node_type": "MODEL",

--- a/tests/core/analytics/test_dispatcher.py
+++ b/tests/core/analytics/test_dispatcher.py
@@ -1,0 +1,132 @@
+import gzip
+import json
+import typing as t
+
+import pytest
+from pytest_mock.plugin import MockerFixture
+
+from sqlmesh.core.analytics.dispatcher import AsyncEventDispatcher, EventEmitter
+from sqlmesh.utils.errors import ApiClientError, SQLMeshError
+
+
+@pytest.fixture
+def dispatcher(mocker: MockerFixture) -> t.Iterator[AsyncEventDispatcher]:
+    emitter_mock = mocker.Mock()
+    dispatcher = AsyncEventDispatcher(
+        emit_interval_sec=5, max_emit_interval_sec=15, emitter=emitter_mock
+    )
+    yield dispatcher
+    dispatcher.shutdown(flush=False)
+
+
+def test_emitter(mocker: MockerFixture):
+    emitter = EventEmitter(base_url="http://localhost/v1/")
+    emitter._session = mocker.Mock()
+    emitter._session.post.return_value.status_code = 200  # type: ignore
+
+    versions = json.dumps(emitter._versions)
+
+    emitter.emit([{"name": "event_a"}, {"name": "event_b"}])
+    emitter._session.post.assert_called_once_with(  # type: ignore
+        "http://localhost/v1/sqlmesh/",
+        data=gzip.compress(
+            f'{{"events": [{{"name": "event_a"}}, {{"name": "event_b"}}], "versions": {versions}}}'.encode(
+                "utf-8"
+            )
+        ),
+        timeout=(10, 10),
+    )
+
+
+def test_dispatcher_flush(dispatcher: AsyncEventDispatcher):
+    dispatcher.add_event({"name": "event_a"})
+    dispatcher.add_event({"name": "event_b"})
+
+    dispatcher.flush()
+
+    dispatcher.emitter.emit.assert_called_once_with([{"name": "event_a"}, {"name": "event_b"}])  # type: ignore
+    assert not dispatcher._events
+
+
+def test_dispatcher_shutdown_with_flush(dispatcher: AsyncEventDispatcher):
+    dispatcher.add_event({"name": "event_a"})
+    dispatcher.add_event({"name": "event_b"})
+
+    dispatcher.shutdown(flush=True)
+
+    # Make sure that shutdown happens only once.
+    dispatcher.shutdown(flush=True)
+
+    dispatcher.emitter.emit.assert_called_once_with([{"name": "event_a"}, {"name": "event_b"}])  # type: ignore
+    dispatcher.emitter.close.assert_called_once()  # type: ignore
+
+
+def test_dispatcher_shutdown_no_flush(dispatcher: AsyncEventDispatcher):
+    dispatcher.add_event({"name": "event_a"})
+    dispatcher.add_event({"name": "event_b"})
+
+    dispatcher.shutdown(flush=False)
+
+    # Make sure that shutdown happens only once.
+    dispatcher.shutdown(flush=False)
+
+    dispatcher.emitter.emit.assert_not_called()  # type: ignore
+    dispatcher.emitter.close.assert_called_once()  # type: ignore
+
+
+def test_dispatcher_max_queue_size(dispatcher: AsyncEventDispatcher):
+    dispatcher._max_queue_size = 3
+
+    dispatcher.add_event({"name": "event_a"})
+    dispatcher.add_event({"name": "event_b"})
+    dispatcher.add_event({"name": "event_c"})
+    dispatcher.add_event({"name": "event_d"})
+
+    assert len(dispatcher._events) == 3
+
+    dispatcher.flush()
+    assert not dispatcher._events
+
+    dispatcher.emitter.emit.side_effect = SQLMeshError("test_error")  # type: ignore
+
+    dispatcher.add_event({"name": "event_a"})
+    dispatcher.add_event({"name": "event_b"})
+    dispatcher.add_event({"name": "event_c"})
+    dispatcher.add_event({"name": "event_d"})
+
+    dispatcher.flush()
+    assert len(dispatcher._events) == 3
+
+
+def test_dispatcher_too_many_requests_response(dispatcher: AsyncEventDispatcher):
+    dispatcher.emitter.emit.side_effect = ApiClientError("test_error", 429)  # type: ignore
+
+    dispatcher.add_event({"name": "event_a"})
+
+    assert dispatcher._emit_interval_sec == 5
+
+    dispatcher.flush()
+
+    assert dispatcher._emit_interval_sec == 10
+
+    dispatcher.flush()
+
+    assert dispatcher._emit_interval_sec == 15
+
+    dispatcher.flush()
+
+    assert dispatcher._emit_interval_sec == 15
+
+
+def test_dispatcher_upgrade_required_response(dispatcher: AsyncEventDispatcher):
+    dispatcher.emitter.emit.side_effect = ApiClientError("test_error", 426)  # type: ignore
+
+    dispatcher.add_event({"name": "event_a"})
+
+    assert not dispatcher._shutdown_event.is_set()
+
+    dispatcher.flush()
+
+    assert dispatcher._shutdown_event.is_set()
+
+    dispatcher.emitter.close.assert_called_once()  # type: ignore


### PR DESCRIPTION
We prioritize our development work based on the needs of SQLMesh users. Some users share their needs via our Slack or Github communities, but many do not. We have added some simple anonymized usage information (telemetry) to SQLMesh to ensure the needs of all users are heard.

All information is anonymized with hash functions, so we could not link data to a specific company, user, or project even if we wanted to (which we don't!). No information is related to credentials or authentication.

We collect anonymized information about SQLMesh project complexity and usage - for example, number of models, count of model kinds, project load time, whether an error occurred during a plan/run (no stacktraces or error message), and names (but not values) of the arguments passed to CLI commands.

The collection of anonymized usage information can be disabled with these methods:

- Set the root `disable_anonymized_analytics: true` key in the SQLMesh project configuration file
- Execute SQLMesh commands with an environment variable `SQLMESH__DISABLE_ANONYMIZED_ANALYTICS` set to `1`, `true`, `t`, `yes`, or `y`
