### PR TITLE
Fix: Ignore non-restateable models and print out a warning instead of failing the plan

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1004,10 +1004,6 @@ class GenericContext(BaseContext, t.Generic[C]):
         expanded_restate_models = None
         if restate_models is not None:
             expanded_restate_models = model_selector.expand_model_selections(restate_models)
-            if not expanded_restate_models:
-                self.console.log_error(
-                    f"Provided restated models do not match any models. No models will be included in plan. Provided: {', '.join(restate_models)}"
-                )
 
         snapshots = self._snapshots(models_override)
         context_diff = self._context_diff(
@@ -1083,6 +1079,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             ),
             end_bounded=not run,
             ensure_finalized_snapshots=self.config.plan.use_finalized_state,
+            console=self.console,
         )
 
     def apply(

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from datetime import datetime
 from functools import cached_property
 
+from sqlmesh.core.console import Console, get_console
 from sqlmesh.core.config import (
     AutoCategorizationMode,
     CategorizerConfig,
@@ -88,6 +89,7 @@ class PlanBuilder:
         enable_preview: bool = False,
         end_bounded: bool = False,
         ensure_finalized_snapshots: bool = False,
+        console: t.Optional[Console] = None,
     ):
         self._context_diff = context_diff
         self._no_gaps = no_gaps
@@ -101,12 +103,13 @@ class PlanBuilder:
         self._categorizer_config = categorizer_config or CategorizerConfig()
         self._auto_categorization_enabled = auto_categorization_enabled
         self._include_unmodified = include_unmodified
-        self._restate_models = set(restate_models or [])
+        self._restate_models = set(restate_models) if restate_models is not None else None
         self._effective_from = effective_from
         self._execution_time = execution_time
         self._backfill_models = backfill_models
         self._end = end or default_end
         self._apply = apply
+        self._console = console or get_console()
 
         self._start = start
         if not self._start and self._forward_only_preview_needed:
@@ -286,9 +289,14 @@ class PlanBuilder:
                 return False
             return not snapshot.is_symbolic and not snapshot.is_seed
 
-        restatements: t.Dict[SnapshotId, Interval] = {}
-        dummy_interval = (sys.maxsize, -sys.maxsize)
         restate_models = self._restate_models
+        if restate_models == set():
+            self._console.log_error(
+                "Provided restated models do not match any models. No models will be included in plan."
+            )
+            return {}
+
+        restatements: t.Dict[SnapshotId, Interval] = {}
         forward_only_preview_needed = self._forward_only_preview_needed
         if not restate_models and forward_only_preview_needed:
             # Add model names for new forward-only snapshots to the restatement list
@@ -298,18 +306,25 @@ class PlanBuilder:
                 for s in self._context_diff.new_snapshots.values()
                 if s.is_materialized and (self._forward_only or s.model.forward_only)
             }
+
         if not restate_models:
-            return restatements
+            return {}
 
         # Add restate snapshots and their downstream snapshots
+        dummy_interval = (sys.maxsize, -sys.maxsize)
         for model_fqn in restate_models:
             snapshot = self._model_fqn_to_snapshot.get(model_fqn)
-            if not snapshot or (
-                not forward_only_preview_needed and not is_restateable_snapshot(snapshot)
-            ):
-                raise PlanError(
-                    f"Cannot restate from '{model_fqn}'. Either such model doesn't exist, no other materialized model references it, or restatement was disabled for this model."
-                )
+            if not snapshot:
+                raise PlanError(f"Cannot restate model '{model_fqn}'. Model does not exist.")
+            if not forward_only_preview_needed:
+                if not self._is_dev and snapshot.disable_restatement:
+                    self._console.log_error(
+                        f"Cannot restate model '{model_fqn}'. Restatement is disabled for this model."
+                    )
+                    continue
+                elif snapshot.is_symbolic or snapshot.is_seed:
+                    continue
+
             restatements[snapshot.snapshot_id] = dummy_interval
             for downstream_s_id in dag.downstream(snapshot.snapshot_id):
                 if is_restateable_snapshot(self._context_diff.snapshots[downstream_s_id]):
@@ -632,7 +647,9 @@ class PlanBuilder:
                 )
 
     def _ensure_no_new_snapshots_with_restatements(self) -> None:
-        if self._restate_models and self._context_diff.new_snapshots:
+        if self._restate_models is not None and (
+            self._context_diff.new_snapshots or self._context_diff.modified_snapshots
+        ):
             raise PlanError(
                 "Model changes and restatements can't be a part of the same plan. "
                 "Revert or apply changes before proceeding with restatements."


### PR DESCRIPTION
Previously SQLMesh would fail the plan if the restatement list contained a model which couldn't be restated.

When this behavior is combined with selectors, it results in a subpar experience, as the selector expression may encompass a large set of models, only a small portion of which cannot be restated.

This update changes the behavior so that an error is printed out for models that are part of the restatement list but cannot be restated instead failing the plan. It also completely ignores symbolic and seed models, as restating those is a no-op