### PR TITLE
Docs: move table of contents into left navbar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,8 @@ theme:
     - navigation.tracking
     - navigation.tabs
     - navigation.sections
+    - toc.integrate
+    - toc.follow
 plugins:
   - include-markdown
   - search


### PR DESCRIPTION
Currently, the docs site places a page's table of contents on the right side, separate from the cross-page navigation on the left. On mobile devices, the ToC is hidden and difficult to locate.

This PR integrates the ToC and cross-page navigation, such that the table of contents is inline with the cross-page nav.