### PR TITLE
fix: add support for untyped snowflake arrays

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -27,7 +27,6 @@ from sqlmesh.utils.pandas import columns_to_types_from_df
 if t.TYPE_CHECKING:
     from sqlglot._typing import E
 
-    from sqlmesh.utils.pandas import PandasNamedTuple
 
 SQLMESH_MACRO_PREFIX = "@"
 
@@ -837,7 +836,7 @@ def extend_sqlglot() -> None:
 
 
 def select_from_values(
-    values: t.List[PandasNamedTuple],
+    values: t.List[t.Tuple[t.Any, ...]],
     columns_to_types: t.Dict[str, exp.DataType],
     batch_size: int = 0,
     alias: str = "t",
@@ -867,7 +866,7 @@ def select_from_values(
 
 
 def select_from_values_for_batch_range(
-    values: t.List[PandasNamedTuple],
+    values: t.List[t.Tuple[t.Any, ...]],
     columns_to_types: t.Dict[str, exp.DataType],
     batch_start: int,
     batch_end: int,

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -55,7 +55,6 @@ if t.TYPE_CHECKING:
         QueryOrDF,
     )
     from sqlmesh.core.node import IntervalUnit
-    from sqlmesh.utils.pandas import PandasNamedTuple
 
 logger = logging.getLogger(__name__)
 
@@ -1061,7 +1060,7 @@ class EngineAdapter:
 
     def _values_to_sql(
         self,
-        values: t.List[PandasNamedTuple],
+        values: t.List[t.Tuple[t.Any, ...]],
         columns_to_types: t.Dict[str, exp.DataType],
         batch_start: int,
         batch_end: int,

--- a/sqlmesh/utils/pandas.py
+++ b/sqlmesh/utils/pandas.py
@@ -1,21 +1,10 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 
 import numpy as np
 import pandas as pd
 from sqlglot import exp
-
-if t.TYPE_CHECKING:
-    # https://github.com/python/mypy/issues/1153
-    if sys.version_info >= (3, 9):
-        try:
-            from pandas.core.frame import _PandasNamedTuple as PandasNamedTuple
-        except ImportError:
-            PandasNamedTuple = t.Tuple[t.Any, ...]  # type: ignore
-    else:
-        PandasNamedTuple = t.Tuple[t.Any, ...]
 
 
 PANDAS_TYPE_MAPPINGS = {

--- a/tests/core/test_schema_diff.py
+++ b/tests/core/test_schema_diff.py
@@ -659,6 +659,57 @@ def test_schema_diff_calculate_type_transitions():
             ],
             dict(support_positional_add=True, support_nested_operations=True),
         ),
+        # untyped array to support Snowflake
+        (
+            "STRUCT<id INT, ids ARRAY>",
+            "STRUCT<id INT, ids ARRAY>",
+            [],
+            {},
+        ),
+        # Primitive to untyped array
+        (
+            "STRUCT<id INT, ids INT>",
+            "STRUCT<id INT, ids ARRAY>",
+            [
+                TableAlterOperation.drop(
+                    [
+                        TableAlterColumn.primitive("ids"),
+                    ],
+                    "STRUCT<id INT>",
+                    "INT",
+                ),
+                TableAlterOperation.add(
+                    [
+                        TableAlterColumn.primitive("ids"),
+                    ],
+                    "ARRAY",
+                    expected_table_struct="STRUCT<id INT, ids ARRAY>",
+                ),
+            ],
+            {},
+        ),
+        # untyped array to primitive
+        (
+            "STRUCT<id INT, ids ARRAY>",
+            "STRUCT<id INT, ids INT>",
+            [
+                TableAlterOperation.drop(
+                    [
+                        TableAlterColumn.array_of_primitive("ids"),
+                    ],
+                    "STRUCT<id INT>",
+                    "ARRAY",
+                ),
+                TableAlterOperation.add(
+                    [
+                        TableAlterColumn.array_of_primitive("ids"),
+                    ],
+                    "INT",
+                    expected_table_struct="STRUCT<id INT, ids INT>",
+                ),
+            ],
+            {},
+        ),
         # Precision VARCHAR is a no-op with no changes
         (
             "STRUCT<id INT, address VARCHAR(120)>",


### PR DESCRIPTION
Prior to this change the schema differ assumed all arrays had a type which isn't true for Snowflake. This adds proper support for "untyped" arrays.

Also did some cleanup where old `self` referenced weren't renamed when methods were changed to classmethods. 