### PR TITLE
Fix: Parsing of session properties when only one key-value pair is provided

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1887,6 +1887,8 @@ def _resolve_session_properties(
     if isinstance(provided, dict):
         session_properties = {k: exp.Literal.string(k).eq(v) for k, v in provided.items()}
     elif provided:
+        if isinstance(provided, exp.Paren):
+            provided = exp.Tuple(expressions=[provided.this])
         session_properties = {expr.this.name: expr for expr in provided}
     else:
         session_properties = {}

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2833,6 +2833,24 @@ def test_model_session_properties(sushi_context):
         "unquoted_identifier": exp.column("unquoted_identifier", quoted=False),
     }
 
+    model = load_sql_based_model(
+        d.parse(
+            """
+        MODEL (
+            name test_schema.test_model,
+            session_properties (
+                'warehouse' = 'test_warehouse'
+            )
+        );
+        SELECT a FROM tbl;
+        """,
+            default_dialect="snowflake",
+        )
+    )
+    assert model.session_properties == {
+        "warehouse": "test_warehouse",
+    }
+
 
 def test_model_jinja_macro_rendering():
     expressions = d.parse(


### PR DESCRIPTION
Expression
```
session_properties (
    'warehouse' = 'test_warehouse'
)
```
is being parsed into the `exp.Paren` expression instead of `exp.Tuple` which was not accounted for while merging the model's values with the default ones.