### PR TITLE
chore: split up get snapshots operations

### DIFF
--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -2193,6 +2193,8 @@ def test_snapshot_batching(state_sync, mocker, make_snapshot):
                 ).json(),
                 "a",
                 "1",
+                "1",
+                None,
             ],
             [
                 make_snapshot(
@@ -2200,6 +2202,8 @@ def test_snapshot_batching(state_sync, mocker, make_snapshot):
                 ).json(),
                 "a",
                 "2",
+                "2",
+                None,
             ],
         ],
         [
@@ -2209,6 +2213,8 @@ def test_snapshot_batching(state_sync, mocker, make_snapshot):
                 ).json(),
                 "a",
                 "3",
+                "3",
+                None,
             ],
         ],
     ]


### PR DESCRIPTION
Took two operations that `_get_snapshots` currently does, which are creating an expression to get the snapshots and parse the response into a snapshot, into a method and a function. This was done to make these operations accessible elsewhere without having to call the whole method. 