### PR TITLE
Fix: Do not visit nodes that are not tables during CLL generation

### DIFF
--- a/web/server/api/endpoints/lineage.py
+++ b/web/server/api/endpoints/lineage.py
@@ -86,7 +86,7 @@ def create_lineage_adjacency_list(
                 if table:
                     column_name = get_column_name(d)
                     dependencies[table].add(column_name)
-                    if not d.downstream and (table, column_name) not in visited:
+                    if isinstance(d.expression, exp.Table) and (table, column_name) not in visited:
                         nodes.append((table, column_name))
                         visited.add((table, column_name))
 


### PR DESCRIPTION
Queries with constants for columns appear as leaf nodes in CLL but they don't have tables (after qualify), so we should stop the traversal.