### PR TITLE
fix: don't lower selection

### DIFF
--- a/sqlmesh/core/selector.py
+++ b/sqlmesh/core/selector.py
@@ -192,7 +192,7 @@ class Selector:
             selection,
             include_upstream,
             include_downstream,
-        ) = self._get_value_and_dependency_inclusion(selection.lower())
+        ) = self._get_value_and_dependency_inclusion(selection)
 
         matched_models = set()
 

--- a/tests/core/test_selector.py
+++ b/tests/core/test_selector.py
@@ -374,6 +374,19 @@ def test_expand_model_selections(
     assert selector.expand_model_selections(selections) == output
 
 
+def test_model_selection_normalized(mocker: MockerFixture, make_snapshot):
+    models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")
+    model = SqlModel(
+        name="`db.test_Model`",
+        query=d.parse_one("SELECT 1 AS a"),
+        tags=["tag1"],
+        dialect="bigquery",
+    )
+    models[model.fqn] = model
+    selector = Selector(mocker.Mock(), models, dialect="bigquery")
+    assert selector.expand_model_selections(["db.test_Model"]) == {'"db"."test_Model"'}
+
+
 @pytest.mark.parametrize(
     "expressions, expected_fqns",
     [


### PR DESCRIPTION
Prior to this change we would lower the selection and then return that lowered selection and use it to check for matching model fqns. This would result in case-sensitive model names not being correctly picked up.

The selector is overwritten by the returned value since part of getting the values is removing any prefix/postfix that exists. I'm not sure why it was lowered in the first place so just removed it.