### PR TITLE
Feat: unpin motherduck duckdb version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,9 +112,6 @@ setup(
             "langchain",
             "openai",
         ],
-        "motherduck": [
-            "duckdb<0.10.0",
-        ],
         "mssql": [
             "pymssql",
         ],


### PR DESCRIPTION
Motherduck only supported DuckDB v0.9.2 until 2024-05-15, and the SQLMesh Motherduck extra enforced that constraint. This PR unpins Motherduck's DuckDB version by removing the extra.

Motherduck now supports DuckDB v0.10.2 and multiple versions of DuckDB in each project. All new accounts must use >=0.10.2 and have multi-version support by default.

> Starting with DuckDB Version 0.10.2, MotherDuck supports using multiple versions of DuckDB at a time. For example, you could use DuckDB 0.10.3 in the CLI and DuckDB 1.0 in Python.

https://motherduck.com/docs/key-tasks/upgrading-to-DuckDB-0.10