### PR TITLE
Chore: pass dialect in builders used within sushi python models

### DIFF
--- a/examples/sushi/config.py
+++ b/examples/sushi/config.py
@@ -38,7 +38,7 @@ bigquery_config = Config(
         )
     },
     default_gateway="gcp",
-    model_defaults=ModelDefaultsConfig(dialect="bigquery"),
+    model_defaults=ModelDefaultsConfig(dialect="duckdb"),
 )
 
 # A configuration used for SQLMesh tests.

--- a/examples/sushi/config.py
+++ b/examples/sushi/config.py
@@ -32,12 +32,12 @@ config = Config(
 
 bigquery_config = Config(
     gateways={
-        "gcp": GatewayConfig(
+        "bq": GatewayConfig(
             connection=BigQueryConnectionConfig(),
             state_connection=DuckDBConnectionConfig(database=f"{DATA_DIR}/bigquery.duckdb"),
         )
     },
-    default_gateway="gcp",
+    default_gateway="bq",
     model_defaults=ModelDefaultsConfig(dialect="duckdb"),
 )
 

--- a/examples/sushi/models/order_items.py
+++ b/examples/sushi/models/order_items.py
@@ -50,6 +50,8 @@ def execute(
     **kwargs: t.Any,
 ) -> t.Generator[pd.DataFrame, None, None]:
     orders_table = context.table("sushi.orders")
+    engine_dialect = context.engine_adapter.dialect
+
     items_table = get_items_table(context)
 
     rng = random.Random()
@@ -59,7 +61,9 @@ def execute(
 
         # Generate query with sqlglot dialect/quoting
         orders = context.fetchdf(
-            exp.select("*").from_(orders_table).where(f"event_date = CAST('{to_ds(dt)}' AS DATE)"),
+            exp.select("*")
+            .from_(orders_table, dialect=engine_dialect)
+            .where(f"event_date = CAST('{to_ds(dt)}' AS DATE)"),
             quote_identifiers=True,
         )
 
@@ -68,7 +72,9 @@ def execute(
 
         # Generate query with sqlglot dialect/quoting
         items = context.fetchdf(
-            exp.select("*").from_(items_table).where(f"event_date = CAST('{to_ds(dt)}' AS DATE)"),
+            exp.select("*")
+            .from_(items_table, dialect=engine_dialect)
+            .where(f"event_date = CAST('{to_ds(dt)}' AS DATE)"),
             quote_identifiers=True,
         )
 

--- a/examples/sushi/models/raw_marketing.py
+++ b/examples/sushi/models/raw_marketing.py
@@ -33,8 +33,12 @@ def execute(
 ) -> pd.DataFrame:
     # Generate query with sqlglot dialect/quoting
     existing_table = context.table("sushi.raw_marketing")
+    engine_dialect = context.engine_adapter.dialect
+
     df_existing = context.fetchdf(
-        exp.select("customer_id", "status", "updated_at").from_(existing_table),
+        exp.select("customer_id", "status", "updated_at").from_(
+            existing_table, dialect=engine_dialect
+        ),
         quote_identifiers=True,
     )
 


### PR DESCRIPTION
Prior to this change, the `from_` builder would produce a `ParseError` when run against specific engines. The bug was spotted for BigQuery, because we'd pass a backtick-quoted name in the builder, which can't be parsed by the sqlglot base dialect.