### PR TITLE
Feat: Improve the CLI output of the table diff command

### DIFF
--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -88,24 +88,20 @@ $ sqlmesh table_diff prod:dev sqlmesh_example.incremental_model --show-sample
 Schema Diff Between 'PROD' and 'DEV' environments for model 'sqlmesh_example.incremental_model':
 └── Schemas match
 
-
 Row Counts:
-├──  COMMON: 6 rows
-├──  PROD ONLY: 1 rows
-└──  DEV ONLY: 0 rows
+├──  FULL MATCH: 6 rows (92.31%)
+└──  PROD ONLY: 1 rows
 
 COMMON ROWS column comparison stats:
          pct_match
-item_id       83.3
+item_id      100.0
 
 
 COMMON ROWS sample data differences:
- id         ds  PROD__item_id  DEV__item_id
-  3 2020-01-03              3           4.0
-
+  All joined rows match
 
 PROD ONLY sample rows:
- id         ds  item_id
+ id event_date  item_id
   1 2020-01-01        2
 ```
 
@@ -124,29 +120,26 @@ Recall that SQLMesh models are accessible via views in the database. In the `pro
 We can replicate the comparison in the previous section by comparing the model views directly. Because we are passing the view names directly, the command needs to manually specify that the join should be on the `id` and `ds` columns with the `-o id -o ds` flags.
 
 ```bash linenums="1"
-$ sqlmesh table_diff sqlmesh_example.incremental_model:sqlmesh_example__dev.incremental_model -o id -o ds --show-sample
+$ sqlmesh table_diff sqlmesh_example.incremental_model:sqlmesh_example__dev.incremental_model -o id -o event_date --show-sample
 
 Schema Diff Between 'SQLMESH_EXAMPLE.INCREMENTAL_MODEL' and 'SQLMESH_EXAMPLE__DEV.INCREMENTAL_MODEL':
 └── Schemas match
 
 
 Row Counts:
-├──  COMMON: 6 rows
-├──  SQLMESH_EXAMPLE.INCREMENTAL_MODEL ONLY: 1 rows
-└──  SQLMESH_EXAMPLE__DEV.INCREMENTAL_MODEL ONLY: 0 rows
+├──  FULL MATCH: 6 rows (92.31%)
+└──  SQLMESH_EXAMPLE.INCREMENTAL_MODEL ONLY: 1 rows
 
 COMMON ROWS column comparison stats:
          pct_match
-item_id       83.3
+item_id      100.0
 
 
 COMMON ROWS sample data differences:
- id         ds  s__item_id  t__item_id
-  3 2020-01-03           3         4.0
-
+  All joined rows match
 
 SQLMESH_EXAMPLE.INCREMENTAL_MODEL ONLY sample rows:
- id         ds  item_id
+ id event_date  item_id
   1 2020-01-01        2
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -389,13 +389,16 @@ Usage: sqlmesh table_diff [OPTIONS] SOURCE:TARGET [MODEL]
   Show the diff between two tables.
 
 Options:
-  -o, --on TEXT    The column to join on. Can be specified multiple times. The
-                   model grain will be used if not specified.
-  --where TEXT     An optional where statement to filter results.
-  --limit INTEGER  The limit of the sample dataframe.
-  --show-sample    Show a sample of the rows that differ. With many columns,
-                   the output can be very wide.
-  --help           Show this message and exit.
+  -o, --on TEXT           The column to join on. Can be specified multiple
+                          times. The model grain will be used if not
+                          specified.
+  --where TEXT            An optional where statement to filter results.
+  --limit INTEGER         The limit of the sample dataframe.
+  --show-sample           Show a sample of the rows that differ. With many
+                          columns, the output can be very wide.
+  -d, --decimals INTEGER  The number of decimal places to keep when comparing
+                          floating point columns. Default: 3
+  --help                  Show this message and exit.
 ```
 
 ## table_name

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -702,6 +702,13 @@ def create_external_models(obj: Context) -> None:
     is_flag=True,
     help="Show a sample of the rows that differ. With many columns, the output can be very wide.",
 )
+@click.option(
+    "-d",
+    "--decimals",
+    type=int,
+    default=3,
+    help="The number of decimal places to keep when comparing floating point columns. Default: 3",
+)
 @click.pass_obj
 @error_handler
 @cli_analytics

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -966,9 +966,22 @@ class TerminalConsole(Console):
             target_name = row_diff.target_alias.upper()
 
         tree = Tree("[b]Row Counts:[/b]")
-        tree.add(f" [b][blue]COMMON[/blue]:[/b] {row_diff.join_count} rows")
-        tree.add(f" [b][yellow]{source_name} ONLY[/yellow]:[/b] {row_diff.s_only_count} rows")
-        tree.add(f" [b][green]{target_name} ONLY[/green]:[/b] {row_diff.t_only_count} rows")
+        if row_diff.full_match_count:
+            tree.add(
+                f" [b][cyan]FULL MATCH[/cyan]:[/b] {row_diff.full_match_count} rows ({row_diff.full_match_pct}%)"
+            )
+        if row_diff.partial_match_count:
+            tree.add(
+                f" [b][blue]PARTIAL MATCH[/blue]:[/b] {row_diff.partial_match_count} rows ({row_diff.partial_match_pct}%)"
+            )
+        if row_diff.s_only_count:
+            tree.add(
+                f" [b][yellow]{source_name} ONLY[/yellow]:[/b] {row_diff.s_only_count} rows ({row_diff.s_only_pct}%)"
+            )
+        if row_diff.t_only_count:
+            tree.add(
+                f" [b][green]{target_name} ONLY[/green]:[/b] {row_diff.t_only_count} rows ({row_diff.t_only_pct}%)"
+            )
         self.console.print("\n", tree)
 
         self.console.print("\n[b][blue]COMMON ROWS[/blue] column comparison stats:[/b]")

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1206,6 +1206,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         limit: int = 20,
         show: bool = True,
         show_sample: bool = True,
+        decimals: int = 3,
     ) -> TableDiff:
         """Show a diff between two tables.
 
@@ -1219,6 +1220,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             limit: The limit of the sample dataframe.
             show: Show the table diff output in the console.
             show_sample: Show the sample dataframe in the console. Requires show=True.
+            decimals: The number of decimal places to keep when comparing floating point columns.
 
         Returns:
             The TableDiff object containing schema and summary differences.
@@ -1263,6 +1265,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             target_alias=target_alias,
             model_name=model.name if model_or_snapshot else None,
             limit=limit,
+            decimals=decimals,
         )
         if show:
             self.console.show_schema_diff(table_diff.schema_diff())

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -228,8 +228,8 @@ class TableDiff:
 
             def _column_expr(name: str, table: str) -> exp.Expression:
                 if matched_columns[name].this in exp.DataType.FLOAT_TYPES:
-                    return exp.Round(
-                        this=exp.column(name, table), decimals=exp.Literal.number(self.decimals)
+                    return exp.func(
+                        "ROUND", exp.column(name, table), exp.Literal.number(self.decimals)
                     )
                 return exp.column(name, table)
 

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -601,7 +601,7 @@ class SQLMeshMagics(Magics):
     @argument(
         "--decimals",
         type=int,
-        default=20,
+        default=3,
         help="The number of decimal places to keep when comparing floating point columns. Default: 3",
     )
     @line_magic

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -598,6 +598,12 @@ class SQLMeshMagics(Magics):
         action="store_true",
         help="Show a sample of the rows that differ. With many columns, the output can be very wide.",
     )
+    @argument(
+        "--decimals",
+        type=int,
+        default=20,
+        help="The number of decimal places to keep when comparing floating point columns. Default: 3",
+    )
     @line_magic
     @pass_sqlmesh_context
     def table_diff(self, context: Context, line: str) -> None:
@@ -615,6 +621,7 @@ class SQLMeshMagics(Magics):
             where=args.where,
             limit=args.limit,
             show_sample=args.show_sample,
+            decimals=args.decimals,
         )
 
     @magic_arguments()

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -636,9 +636,7 @@ def test_table_diff(notebook, loaded_sushi_context, convert_all_html_output_to_t
         """Schema Diff Between 'DEV' and 'PROD' environments for model 'sushi.top_waiters':
 └── Schemas match""",
         """Row Counts:
-├──  COMMON: 8 rows
-├──  DEV ONLY: 0 rows
-└──  PROD ONLY: 0 rows""",
+└──  FULL MATCH: 8 rows (100.0%)""",
         """COMMON ROWS column comparison stats:""",
         """pct_match
 revenue      100.0""",


### PR DESCRIPTION
The following improvements have been introduced:
- Split `COMMON`, which represented the number of joined rows ,into `FULL MATCH` and `PARTIAL MATCH` to show the number of rows that are identical vs the number of rows with only  a partial match accordingly.
- Add percentage values for `FULL MATCHES` and `PARTIAL MATCHES`.
- Only display the number of rows if it's not 0.
- Add ability to set the number of decimal places to use when comparing floating point columns. This is set to 3 by default.

<img width="982" alt="Screenshot 2024-05-21 at 10 46 42 AM" src="https://github.com/TobikoData/sqlmesh/assets/7747479/5468e743-75fa-4d0a-91cd-8c27a5751c94">

