### PR TITLE
Fix pytest warning on test fixture

### DIFF
--- a/tests/schedulers/airflow/test_dag_generator.py
+++ b/tests/schedulers/airflow/test_dag_generator.py
@@ -19,6 +19,8 @@ from sqlmesh.utils.date import to_datetime
 
 
 class TestSubmitOperator(BaseOperator):
+    __test__ = False  # prevent pytest trying to collect this as a test class
+
     def __init__(
         self,
         *,


### PR DESCRIPTION
This fixes the following warning when collecting tests:

```
PytestCollectionWarning: cannot collect test class 'TestSubmitOperator' because it has a __init__ constructor (from: tests/schedulers/airflow/test_dag_generator.py)
```