### PR TITLE
Fix: Stop column description propagation if model cannot be found.

### DIFF
--- a/sqlmesh/core/lineage.py
+++ b/sqlmesh/core/lineage.py
@@ -90,6 +90,9 @@ def column_description(context: Context, model_name: str, column: str) -> t.Opti
     """Returns a column's description, inferring if needed."""
     model = context.get_model(model_name)
 
+    if not model:
+        return None
+
     if column in model.column_descriptions:
         return model.column_descriptions[column]
 


### PR DESCRIPTION
If column description propagation ran into an external model and the project doesn't have a schema yaml file, an exception would be raised since a model would be expected but not found.