### PR TITLE
chore: use ping to validate connections

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         ],
         "dev": [
             f"apache-airflow=={os.environ.get('AIRFLOW_VERSION', '2.9.1')}",
-            "agate==1.7.1",
+            # "agate==1.7.1",
             "beautifulsoup4",
             "ruff~=0.4.0",
             "cryptography~=42.0.4",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         ],
         "dev": [
             f"apache-airflow=={os.environ.get('AIRFLOW_VERSION', '2.9.1')}",
-            # "agate==1.7.1",
+            "agate==1.7.1",
             "beautifulsoup4",
             "ruff~=0.4.0",
             "cryptography~=42.0.4",
@@ -96,7 +96,7 @@ setup(
             "dbt-databricks",
             "dbt-redshift",
             "dbt-snowflake",
-            "dbt-sqlserver",
+            "dbt-sqlserver>=1.7.0",
             "dbt-trino",
         ],
         "dbt": [

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -97,6 +97,10 @@ class ConnectionConfig(abc.ABC, BaseConfig):
             },
         )
 
+    def connection_validator(self) -> t.Callable[[], None]:
+        """A function that validates the connection configuration"""
+        return self.create_engine_adapter()._ping
+
     def create_engine_adapter(self, register_comments_override: bool = False) -> EngineAdapter:
         """Returns a new instance of the Engine Adapter."""
         return self._engine_adapter(

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -99,7 +99,7 @@ class ConnectionConfig(abc.ABC, BaseConfig):
 
     def connection_validator(self) -> t.Callable[[], None]:
         """A function that validates the connection configuration"""
-        return self.create_engine_adapter()._ping
+        return self.create_engine_adapter().ping
 
     def create_engine_adapter(self, register_comments_override: bool = False) -> EngineAdapter:
         """Returns a new instance of the Engine Adapter."""

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1611,11 +1611,11 @@ class GenericContext(BaseContext, t.Generic[C]):
         self.console.log_status_update(f"Models: {len(self.models)}")
         self.console.log_status_update(f"Macros: {len(self._macros) - len(macro.get_registry())}")
 
-        self._try_connection("data warehouse", self._engine_adapter)
+        self._try_connection("data warehouse", self._engine_adapter._ping)
 
         state_connection = self.config.get_state_connection(self.gateway)
         if state_connection:
-            self._try_connection("state backend", state_connection.create_engine_adapter())
+            self._try_connection("state backend", state_connection.connection_validator())
 
     def close(self) -> None:
         """Releases all resources allocated by this context."""
@@ -1868,10 +1868,10 @@ class GenericContext(BaseContext, t.Generic[C]):
         expired_environments = self.state_sync.delete_expired_environments()
         cleanup_expired_views(self.engine_adapter, expired_environments, console=self.console)
 
-    def _try_connection(self, connection_name: str, engine_adapter: EngineAdapter) -> None:
+    def _try_connection(self, connection_name: str, validator: t.Callable[[], None]) -> None:
         connection_name = connection_name.capitalize()
         try:
-            engine_adapter.fetchall("SELECT 1")
+            validator()
             self.console.log_status_update(f"{connection_name} connection [green]succeeded[/green]")
         except Exception as ex:
             self.console.log_error(f"{connection_name} connection failed. {ex}")

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1611,7 +1611,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         self.console.log_status_update(f"Models: {len(self.models)}")
         self.console.log_status_update(f"Macros: {len(self._macros) - len(macro.get_registry())}")
 
-        self._try_connection("data warehouse", self._engine_adapter._ping)
+        self._try_connection("data warehouse", self._engine_adapter.ping)
 
         state_connection = self.config.get_state_connection(self.gateway)
         if state_connection:

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1756,7 +1756,7 @@ class EngineAdapter:
         if self._pre_ping:
             try:
                 logger.debug("Pinging the database to check the connection")
-                self._ping()
+                self.ping()
             except Exception:
                 logger.info("Connection to the database was lost. Reconnecting...")
                 self._connection_pool.close()
@@ -2058,7 +2058,7 @@ class EngineAdapter:
     ) -> None:
         self.execute(exp.rename_table(old_table_name, new_table_name))
 
-    def _ping(self) -> None:
+    def ping(self) -> None:
         try:
             self._execute(exp.select("1").sql(dialect=self.dialect))
         finally:

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -145,5 +145,5 @@ class MySQLEngineAdapter(
                 exc_info=True,
             )
 
-    def _ping(self) -> None:
+    def ping(self) -> None:
         self._connection_pool.get().ping(reconnect=False)


### PR DESCRIPTION
Prior to this change we had connection validation defined in two places. This brings them together. It also provides a way to do connection validation at the configuration level. 