### PR TITLE
fix: Fix test runner not displaying dots for successes (#2656)

### DIFF
--- a/sqlmesh/core/test/result.py
+++ b/sqlmesh/core/test/result.py
@@ -36,4 +36,5 @@ class ModelTextTestResult(unittest.TextTestResult):
         Args:
             test: The test case
         """
+        super().addSuccess(test)
         self.successes.append(test)


### PR DESCRIPTION
Since the introduction of the custom method `addSuccess` for `ModelTextTestResult` in d8ff3fd4c8946ab756609fc38c6d43552aea103e, the test runner stopped displaying dots for successful test cases.

This is due to the logging being part of the base implementation itself:

    # unittest.TextTestResult::addSuccess
    self.stream.write('.')
    self.stream.flush()

This patch adds a call the superclass implementation of `addSucess` to achieve the original behavior of reporting successes.

---

I actually wanted to add a test case for this change to ensure the behavior is maintained, but I couldn't find a reference point for tests that check the CLI output of `sqlmesh test`.  I can do so with some guidance. Thanks.