### PR TITLE
Feat: enable duckdb>=0.10 comment registration

### DIFF
--- a/docs/concepts/models/overview.md
+++ b/docs/concepts/models/overview.md
@@ -130,7 +130,8 @@ This table lists each engine's support for `TABLE` and `VIEW` object comments:
 | ------------ | ---------------- | --------------- |
 | BigQuery     | Y                | Y               |
 | Databricks   | Y                | Y               |
-| DuckDB       | N                | N               |
+| DuckDB v0.9  | N                | N               |
+| DuckDB v0.10 | Y                | Y               |
 | MySQL        | Y                | Y               |
 | MSSQL        | N                | N               |
 | Postgres     | Y                | Y               |

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import typing as t
-
+from duckdb import __version__ as duckdb_version
 from sqlglot import exp
 
 from sqlmesh.core.engine_adapter.mixins import (
@@ -17,6 +17,7 @@ from sqlmesh.core.engine_adapter.shared import (
     SourceQuery,
     set_catalog,
 )
+from sqlmesh.utils import major_minor
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import SchemaName, TableName
@@ -28,8 +29,17 @@ class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin)
     DIALECT = "duckdb"
     SUPPORTS_TRANSACTIONS = False
     CATALOG_SUPPORT = CatalogSupport.FULL_SUPPORT
-    COMMENT_CREATION_TABLE = CommentCreationTable.UNSUPPORTED
-    COMMENT_CREATION_VIEW = CommentCreationView.UNSUPPORTED
+
+    # TODO: remove once we stop supporting DuckDB 0.9
+    duckdb_0_9 = major_minor(duckdb_version) < (0, 10)
+    COMMENT_CREATION_TABLE = (
+        CommentCreationTable.UNSUPPORTED
+        if duckdb_0_9
+        else CommentCreationTable.COMMENT_COMMAND_ONLY
+    )
+    COMMENT_CREATION_VIEW = (
+        CommentCreationView.UNSUPPORTED if duckdb_0_9 else CommentCreationView.COMMENT_COMMAND_ONLY
+    )
 
     def set_current_catalog(self, catalog: str) -> None:
         """Sets the catalog name of the current connection."""

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -269,6 +269,17 @@ class TestContext:
                     schema_name = '{schema_name}'
                     AND table_name = '{table_name}'
             """
+        elif self.dialect == "duckdb":
+            kind = "table" if table_kind == "BASE TABLE" else "view"
+            query = f"""
+                SELECT
+                    {kind}_name,
+                    comment
+                FROM duckdb_{kind}s()
+                WHERE
+                    schema_name = '{schema_name}'
+                    AND {kind}_name = '{table_name}'
+            """
 
         result = self.engine_adapter.fetchall(query)
 
@@ -353,6 +364,16 @@ class TestContext:
         elif self.dialect == "trino":
             query = f"SHOW COLUMNS FROM {schema_name}.{table_name}"
             comment_index = 3
+        elif self.dialect == "duckdb":
+            query = f"""
+                SELECT
+                    column_name,
+                    comment
+                FROM duckdb_columns()
+                WHERE
+                    schema_name = '{schema_name}'
+                    AND table_name = '{table_name}'
+            """
 
         result = self.engine_adapter.fetchall(query)
 


### PR DESCRIPTION
DuckDB supports table and view comments beginning with v0.10. This PR enables comment registration if the local version of DuckDB is >=0.10.