### PR TITLE
Feat: extend CSV support with settings; update test docs

### DIFF
--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -10,7 +10,7 @@ A comprehensive suite of tests can empower data practitioners to work with confi
 
 A test suite is a [YAML file](https://learnxinyminutes.com/docs/yaml/) contained in the `tests/` folder of a SQLMesh project, whose name begins with `test` and ends with either `.yaml` or `.yml`. It can contain one or more uniquely named unit tests, each with a number of attributes that define its behavior.
 
-At minimum, a unit test must specify the model being tested, the input values for its upstream models, provided inline or through an external file (`.yaml` or `.csv`) , and the expected outputs for the target model's query and/or its [Common Table Expressions](glossary.md#cte). Other optional attributes include a description, the gateway to use, and a mapping that assigns values to [macro variables](macros/macro_variables.md) referenced in the model.
+At minimum, a unit test must specify the model being tested, the input values for its upstream models, and the expected outputs for the target model's query and/or its [Common Table Expressions](glossary.md#cte). Other optional attributes include a description, the gateway to use, and a mapping that assigns values to [macro variables](macros/macro_variables.md) referenced in the model.
 
 Learn more about the supported attributes in the [unit test structure section](#unit-test-structure).
 
@@ -110,47 +110,41 @@ test_example_full_model:
         num_orders: 2
 ```
 
-### Loading Inputs from CSV
+## Defining unit test data as CSV
 
-Defining the inputs can be specified in the YAML, but when testing with large datasets, loading the data from an external file, such as a CSV, can be more efficient. To achieve this, specify the `format` and the `path` as shown below:
+In unit tests, you can define data using CSV format, a common and user-friendly alternative to the more verbose YAML. Data in these supported formats can be specified inline or through external files, allowing for reuse across multiple tests.
 
-```yaml linenums="1" hl_lines="5-6"
+### Inline Data
+
+Both inputs and outputs can be formatted as CSV. You can provide the CSV data within the YAML under the `rows:` key:
+
+```yaml linenums="1"
 test_example_full_model:
-model: sqlmesh_example.full_model
-inputs:
-sqlmesh_example.incremental_model:
-format: csv
-path: filepath/test_data.csv
-outputs:
-query:
-rows:
-- item_id: 1
-num_orders: 2
-- item_id: 2
-num_orders: 1
+  model: sqlmesh_example.full_model
+  inputs:
+    sqlmesh_example.incremental_model:
+      format: csv
+      rows: |
+        id,item_id
+        1,1
+        2,1
+        3,2
 ```
 
-In addition, data can also be loaded from an external YAML file. When the `format` is omitted, this is the default behavior for files. Additionally, CSV data can be provided inline under the `rows` key:
+### External File
 
-```yaml linenums="1" hl_lines="5-10"
+To specify data using an external file, use the `path` attribute:
+
+```yaml linenums="1"
 test_example_full_model:
-model: sqlmesh_example.full_model
-inputs:
-sqlmesh_example.incremental_model:
-format: csv
-rows: |
-id,item_id
-1,1
-2,1
-3,2
-outputs:
-query:
-rows:
-- item_id: 1
-num_orders: 2
-- item_id: 2
-num_orders: 1
+  model: sqlmesh_example.full_model
+  inputs:
+    sqlmesh_example.incremental_model:
+      format: csv
+      path: filepath/test_data.csv
 ```
+
+In addition, data can also be loaded from an external YAML file. When the `format` is omitted, this is the default format for files.
 
 ## Omitting columns
 
@@ -504,15 +498,13 @@ When the input format is `csv`, the data can be specified inline under `rows` :
 
 ### `<test_name>.inputs.<upstream_model>.format`
   
-The optional `format` key allows for control over how the input data is loaded. The default behavior is YAML, while CSV is also supported.
+The optional `format` key allows for control over how the input data is loaded. The default format is YAML, while CSV is also supported.
 
 ```yaml linenums="1"
     <upstream_model>:
       format: csv
       path: filepath/test_data.csv
 ```
-
-When the `path` is defined, the data is loaded from the external file. Otherwise, it's loaded from the inline `rows`.
 
 ### `<test_name>.inputs.<upstream_model>.csv_settings`
   
@@ -529,6 +521,8 @@ When the`format` is CSV, you can control the behaviour of data loading under `cs
         <row1_value>#<row1_value>
         <row2_value>#<row2_value>
 ```
+
+[Learn more about the supported CSV settings](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html).
   
 ### `<test_name>.inputs.<upstream_model>.path`
 
@@ -538,9 +532,6 @@ The optional `path` key specifies the pathname of the data to be loaded.
     <upstream_model>:
       path: filepath/test_data.yaml
 ```
-
-When `format` is defined, it's used accordingly to load the data. Otherwise, the default behavior is YAML.
-
 
 ### `<test_name>.inputs.<upstream_model>.columns`
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -10,7 +10,7 @@ A comprehensive suite of tests can empower data practitioners to work with confi
 
 A test suite is a [YAML file](https://learnxinyminutes.com/docs/yaml/) contained in the `tests/` folder of a SQLMesh project, whose name begins with `test` and ends with either `.yaml` or `.yml`. It can contain one or more uniquely named unit tests, each with a number of attributes that define its behavior.
 
-At minimum, a unit test must specify the model being tested, the input values for its upstream models, and the expected outputs for the target model's query and/or its [Common Table Expressions](glossary.md#cte). Other optional attributes include a description, the gateway to use, and a mapping that assigns values to [macro variables](macros/macro_variables.md) referenced in the model.
+At minimum, a unit test must specify the model being tested, the input values for its upstream models, provided inline or through an external file (`.yaml` or `.csv`) , and the expected outputs for the target model's query and/or its [Common Table Expressions](glossary.md#cte). Other optional attributes include a description, the gateway to use, and a mapping that assigns values to [macro variables](macros/macro_variables.md) referenced in the model.
 
 Learn more about the supported attributes in the [unit test structure section](#unit-test-structure).
 
@@ -108,6 +108,48 @@ test_example_full_model:
       rows:
       - item_id: 1
         num_orders: 2
+```
+
+### Loading Inputs from CSV
+
+Defining the inputs can be specified in the YAML, but when testing with large datasets, loading the data from an external file, such as a CSV, can be more efficient. To achieve this, specify the `format` and the `path` as shown below:
+
+```yaml linenums="1" hl_lines="5-6"
+test_example_full_model:
+model: sqlmesh_example.full_model
+inputs:
+sqlmesh_example.incremental_model:
+format: csv
+path: filepath/test_data.csv
+outputs:
+query:
+rows:
+- item_id: 1
+num_orders: 2
+- item_id: 2
+num_orders: 1
+```
+
+In addition, data can also be loaded from an external YAML file. When the `format` is omitted, this is the default behavior for files. Additionally, CSV data can be provided inline under the `rows` key:
+
+```yaml linenums="1" hl_lines="5-10"
+test_example_full_model:
+model: sqlmesh_example.full_model
+inputs:
+sqlmesh_example.incremental_model:
+format: csv
+rows: |
+id,item_id
+1,1
+2,1
+3,2
+outputs:
+query:
+rows:
+- item_id: 1
+num_orders: 2
+- item_id: 2
+num_orders: 1
 ```
 
 ## Omitting columns
@@ -449,6 +491,56 @@ If `rows` is the only key under `<upstream_model>`, then it can be omitted:
       - <column_name>: <column_value>
       ...
 ```
+
+When the input format is `csv`, the data can be specified inline under `rows` :
+
+```yaml linenums="1"
+    <upstream_model>:
+      rows: |
+        <column1_name>,<column2_name>
+        <row1_value>,<row1_value>
+        <row2_value>,<row2_value>
+```
+
+### `<test_name>.inputs.<upstream_model>.format`
+  
+The optional `format` key allows for control over how the input data is loaded. The default behavior is YAML, while CSV is also supported.
+
+```yaml linenums="1"
+    <upstream_model>:
+      format: csv
+      path: filepath/test_data.csv
+```
+
+When the `path` is defined, the data is loaded from the external file. Otherwise, it's loaded from the inline `rows`.
+
+### `<test_name>.inputs.<upstream_model>.csv_settings`
+  
+When the`format` is CSV, you can control the behaviour of data loading under `csv_settings`:
+
+```yaml linenums="1"
+    <upstream_model>:
+      format: csv
+      csv_settings: 
+        sep: "#"
+        skip_blank_lines: true
+      rows: |
+        <column1_name>#<column2_name>
+        <row1_value>#<row1_value>
+        <row2_value>#<row2_value>
+```
+  
+### `<test_name>.inputs.<upstream_model>.path`
+
+The optional `path` key specifies the pathname of the data to be loaded.
+  
+```yaml linenums="1"
+    <upstream_model>:
+      path: filepath/test_data.yaml
+```
+
+When `format` is defined, it's used accordingly to load the data. Otherwise, the default behavior is YAML.
+
 
 ### `<test_name>.inputs.<upstream_model>.columns`
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -144,7 +144,7 @@ test_example_full_model:
       path: filepath/test_data.csv
 ```
 
-In addition, data can also be loaded from an external YAML file. When the `format` is omitted, this is the default format for files.
+In addition, data can also be loaded from an external YAML file. When `format` is omitted, this is the default format for files.
 
 ## Omitting columns
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -116,7 +116,7 @@ In unit tests, you can define data using the CSV format, a common alternative to
 
 ### Inline Data
 
-Both inputs and outputs can be formatted as CSV. You can provide the CSV data within the YAML under the `rows:` key:
+Both inputs and outputs can be formatted as CSV. You can provide the CSV data inline under the `rows:` key:
 
 ```yaml linenums="1"
 test_example_full_model:

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -112,7 +112,7 @@ test_example_full_model:
 
 ## Defining unit test data as CSV
 
-In unit tests, you can define data using CSV format, a common and user-friendly alternative to the more verbose YAML. Data in these supported formats can be specified inline or through external files, allowing for reuse across multiple tests.
+In unit tests, you can define data using the CSV format, a common alternative to YAML. Data in the supported formats can be specified inline or through external files, allowing for reuse across multiple tests.
 
 ### Inline Data
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -522,7 +522,7 @@ When the`format` is CSV, you can control the behaviour of data loading under `cs
         <row2_value>#<row2_value>
 ```
 
-[Learn more about the supported CSV settings](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html).
+Learn more about the [supported CSV settings](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html).
   
 ### `<test_name>.inputs.<upstream_model>.path`
 

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -330,16 +330,17 @@ class ModelTest(unittest.TestCase):
             rows = values.get("rows")
             query = values.get("query")
 
-            format = values.get("format")
+            fmt = values.get("format")
             path = values.get("path")
-            if format == "csv":
-                rows = pd.read_csv(path or StringIO(rows)).to_dict(orient="records")
-            elif format in (None, "yaml"):
+            if fmt == "csv":
+                csv_settings = values.get("csv_settings") or {}
+                rows = pd.read_csv(path or StringIO(rows), **csv_settings).to_dict(orient="records")
+            elif fmt in (None, "yaml"):
                 if path:
                     input_rows = yaml_load(Path(path))
                     rows = input_rows.get("rows") if isinstance(input_rows, dict) else input_rows
             else:
-                _raise_error(f"Unsupported data format '{format}' for '{name}'", self.path)
+                _raise_error(f"Unsupported data format '{fmt}' for '{name}'", self.path)
 
             if query is not None:
                 if rows is not None:

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -421,6 +421,14 @@ test_foo:
         id,name
         1,alice
         2,bob""",
+        """sushi.waiter_names: 
+      format: csv
+      csv_settings: 
+        sep: "#"
+      rows: |
+        id#name
+        1#alice
+        2#bob""",
     ],
 )
 def test_format_inline(sushi_context: Context, waiter_names_input: str) -> None:


### PR DESCRIPTION
This adds documentation for the support of file loading of inputs and extends the functionality of CSV loading with settings, as per @georgesittas suggestion!