### PR TITLE
Chore: Don't store the seed's content in the state

### DIFF
--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -119,28 +119,10 @@ class ContextDiff(PydanticModel):
             if snapshot.snapshot_id not in added
             and snapshot.fingerprint != remote_snapshot_name_to_info[snapshot.name].fingerprint
         }
-        modified_local_seed_snapshot_ids = {
-            s.snapshot_id
-            for s in snapshots.values()
-            if s.is_seed and s.name in modified_snapshot_name_to_snapshot_info
-        }
-        modified_remote_snapshot_ids = {
-            s.snapshot_id for s in modified_snapshot_name_to_snapshot_info.values()
-        }
 
-        stored = {
-            **state_reader.get_snapshots(
-                [
-                    snapshot.snapshot_id
-                    for snapshot in snapshots.values()
-                    if snapshot.snapshot_id not in modified_local_seed_snapshot_ids
-                ]
-            ),
-            **state_reader.get_snapshots(
-                modified_remote_snapshot_ids | modified_local_seed_snapshot_ids,
-                hydrate_seeds=True,
-            ),
-        }
+        stored = state_reader.get_snapshots(
+            [*snapshots.values(), *modified_snapshot_name_to_snapshot_info.values()]
+        )
 
         merged_snapshots = {}
         modified_snapshots = {}

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -183,7 +183,9 @@ class ModelMeta(_Node):
 
         return partitions
 
-    @field_validator("columns_to_types_", mode="before")
+    @field_validator(
+        "columns_to_types_", "derived_columns_to_types", mode="before", check_fields=False
+    )
     @field_validator_v1_args
     def _columns_validator(
         cls, v: t.Any, values: t.Dict[str, t.Any]

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from sqlmesh.core import constants as c
 from sqlmesh.core.console import Console, get_console
 from sqlmesh.core.environment import EnvironmentNamingInfo
-from sqlmesh.core.model import SeedModel
 from sqlmesh.core.notification_target import (
     NotificationEvent,
     NotificationTargetManager,
@@ -161,11 +160,6 @@ class Scheduler:
             self.snapshots[p_sid].name: self.snapshots[p_sid] for p_sid in snapshot.parents
         }
         snapshots[snapshot.name] = snapshot
-
-        if isinstance(snapshot.node, SeedModel) and not snapshot.node.is_hydrated:
-            snapshot = self.state_sync.get_snapshots([snapshot], hydrate_seeds=True)[
-                snapshot.snapshot_id
-            ]
 
         is_deployable = deployability_index.is_deployable(snapshot)
 

--- a/sqlmesh/core/selector.py
+++ b/sqlmesh/core/selector.py
@@ -80,9 +80,7 @@ class Selector:
             )
             env_models = {
                 s.name: s.model
-                for s in self._state_reader.get_snapshots(
-                    environment_snapshot_infos, hydrate_seeds=True
-                ).values()
+                for s in self._state_reader.get_snapshots(environment_snapshot_infos).values()
                 if s.is_model
             }
 

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -86,14 +86,12 @@ class StateReader(abc.ABC):
     def get_snapshots(
         self,
         snapshot_ids: t.Optional[t.Iterable[SnapshotIdLike]],
-        hydrate_seeds: bool = False,
     ) -> t.Dict[SnapshotId, Snapshot]:
         """Bulk fetch snapshots given the corresponding snapshot ids.
 
         Args:
             snapshot_ids: Iterable of snapshot ids to get. If not provided all
                 available snapshots will be returned.
-            hydrate_seeds: Whether to hydrate seed snapshots with the content.
 
         Returns:
             A dictionary of snapshot ids to snapshots for ones that could be found.

--- a/sqlmesh/core/state_sync/cache.py
+++ b/sqlmesh/core/state_sync/cache.py
@@ -52,12 +52,10 @@ class CachingStateSync(DelegatingStateSync):
         return snapshot
 
     def get_snapshots(
-        self,
-        snapshot_ids: t.Optional[t.Iterable[SnapshotIdLike]],
-        hydrate_seeds: bool = False,
+        self, snapshot_ids: t.Optional[t.Iterable[SnapshotIdLike]]
     ) -> t.Dict[SnapshotId, Snapshot]:
         if snapshot_ids is None:
-            return self.state_sync.get_snapshots(snapshot_ids, hydrate_seeds)
+            return self.state_sync.get_snapshots(snapshot_ids)
 
         existing = {}
         missing = set()
@@ -72,17 +70,10 @@ class CachingStateSync(DelegatingStateSync):
                 self.snapshot_cache[snapshot_id] = (False, expire_at)
                 missing.add(snapshot_id)
             elif snapshot:
-                if (
-                    hydrate_seeds
-                    and isinstance(snapshot.node, SeedModel)
-                    and not snapshot.node.is_hydrated
-                ):
-                    missing.add(snapshot_id)
-                else:
-                    existing[snapshot_id] = snapshot
+                existing[snapshot_id] = snapshot
 
         if missing:
-            existing.update(self.state_sync.get_snapshots(missing, hydrate_seeds))
+            existing.update(self.state_sync.get_snapshots(missing))
 
         for snapshot_id, snapshot in existing.items():
             cached = self._from_cache(snapshot_id, now)

--- a/sqlmesh/core/state_sync/common.py
+++ b/sqlmesh/core/state_sync/common.py
@@ -90,9 +90,8 @@ class CommonStateSyncMixin(StateSync):
     def get_snapshots(
         self,
         snapshot_ids: t.Optional[t.Iterable[SnapshotIdLike]],
-        hydrate_seeds: bool = False,
     ) -> t.Dict[SnapshotId, Snapshot]:
-        return self._get_snapshots(snapshot_ids, hydrate_seeds=hydrate_seeds)
+        return self._get_snapshots(snapshot_ids)
 
     def get_environment(self, environment: str) -> t.Optional[Environment]:
         return self._get_environment(environment)
@@ -323,7 +322,6 @@ class CommonStateSyncMixin(StateSync):
         self,
         snapshot_ids: t.Optional[t.Iterable[SnapshotIdLike]] = None,
         lock_for_update: bool = False,
-        hydrate_seeds: bool = False,
         hydrate_intervals: bool = True,
     ) -> t.Dict[SnapshotId, Snapshot]:
         """Fetches specified snapshots.
@@ -331,7 +329,6 @@ class CommonStateSyncMixin(StateSync):
         Args:
             snapshot_ids: The collection of IDs of snapshots to fetch
             lock_for_update: Lock the snapshot rows for future update
-            hydrate_seeds: Whether to hydrate seed snapshots with the content.
             hydrate_intervals: Whether to hydrate result snapshots with intervals.
 
         Returns:

--- a/sqlmesh/migrations/v0050_drop_seeds_table.py
+++ b/sqlmesh/migrations/v0050_drop_seeds_table.py
@@ -1,0 +1,11 @@
+"""Drop the seeds table."""
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+
+    seeds_table = "_seeds"
+    if state_sync.schema:
+        seeds_table = f"{state_sync.schema}.{seeds_table}"
+
+    engine_adapter.drop_table(seeds_table)

--- a/sqlmesh/schedulers/airflow/api.py
+++ b/sqlmesh/schedulers/airflow/api.py
@@ -123,11 +123,7 @@ def get_snapshots() -> Response:
             )
             return _success(common.SnapshotIdsResponse(snapshot_ids=existing_snapshot_ids))
 
-        hydrate_seeds = "hydrate_seeds" in request.args
-        snapshots = list(
-            state_sync.get_snapshots(snapshot_ids, hydrate_seeds=hydrate_seeds).values()
-        )
-
+        snapshots = list(state_sync.get_snapshots(snapshot_ids).values())
         return _success(common.SnapshotsResponse(snapshots=snapshots))
 
 

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -233,11 +233,7 @@ class AirflowClient(BaseAirflowClient):
         )
         raise_for_status(response)
 
-    def get_snapshots(
-        self, snapshot_ids: t.Optional[t.List[SnapshotId]], hydrate_seeds: bool = False
-    ) -> t.List[Snapshot]:
-        flags = ["hydrate_seeds"] if hydrate_seeds else []
-
+    def get_snapshots(self, snapshot_ids: t.Optional[t.List[SnapshotId]]) -> t.List[Snapshot]:
         output = []
 
         if snapshot_ids is not None:
@@ -246,12 +242,12 @@ class AirflowClient(BaseAirflowClient):
             ):
                 output.extend(
                     common.SnapshotsResponse.parse_obj(
-                        self._get(SNAPSHOTS_PATH, *flags, ids=ids_batch)
+                        self._get(SNAPSHOTS_PATH, ids=ids_batch)
                     ).snapshots
                 )
             return output
 
-        return common.SnapshotsResponse.parse_obj(self._get(SNAPSHOTS_PATH, *flags)).snapshots
+        return common.SnapshotsResponse.parse_obj(self._get(SNAPSHOTS_PATH)).snapshots
 
     def snapshots_exist(self, snapshot_ids: t.List[SnapshotId]) -> t.Set[SnapshotId]:
         output = set()

--- a/sqlmesh/schedulers/airflow/operators/targets.py
+++ b/sqlmesh/schedulers/airflow/operators/targets.py
@@ -10,7 +10,6 @@ from sqlalchemy.orm import Session
 
 from sqlmesh.core.engine_adapter import create_engine_adapter
 from sqlmesh.core.environment import EnvironmentNamingInfo
-from sqlmesh.core.model import SeedModel
 from sqlmesh.core.snapshot import (
     DeployabilityIndex,
     Snapshot,
@@ -148,15 +147,8 @@ class SnapshotEvaluationTarget(BaseTarget[commands.EvaluateCommandPayload], Pyda
             )
 
     def _get_command_payload(self, context: Context) -> t.Optional[commands.EvaluateCommandPayload]:
-        snapshot = self.snapshot
-        if isinstance(snapshot.node, SeedModel) and not snapshot.node.is_hydrated:
-            with util.scoped_state_sync() as state_sync:
-                snapshot = state_sync.get_snapshots([snapshot], hydrate_seeds=True)[
-                    snapshot.snapshot_id
-                ]
-
         return commands.EvaluateCommandPayload(
-            snapshot=snapshot,
+            snapshot=self.snapshot,
             parent_snapshots=self.parent_snapshots,
             start=self._get_start(context),
             end=self._get_end(context),

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -105,7 +105,6 @@ class HttpStateSync(StateSync):
     def get_snapshots(
         self,
         snapshot_ids: t.Optional[t.Iterable[SnapshotIdLike]],
-        hydrate_seeds: bool = False,
     ) -> t.Dict[SnapshotId, Snapshot]:
         """Gets multiple snapshots from the rest api.
 
@@ -115,8 +114,7 @@ class HttpStateSync(StateSync):
         on the production server.
         """
         snapshots = self._client.get_snapshots(
-            [s.snapshot_id for s in snapshot_ids] if snapshot_ids is not None else None,
-            hydrate_seeds=hydrate_seeds,
+            [s.snapshot_id for s in snapshot_ids] if snapshot_ids is not None else None
         )
         return {snapshot.snapshot_id: snapshot for snapshot in snapshots}
 

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -1801,7 +1801,6 @@ def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
             "physical.sqlmesh._environments",
             "physical.sqlmesh._intervals",
             "physical.sqlmesh._plan_dags",
-            "physical.sqlmesh._seeds",
             "physical.sqlmesh._snapshots",
             "physical.sqlmesh._versions",
         }
@@ -1822,7 +1821,6 @@ def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
             "physical.sqlmesh._environments",
             "physical.sqlmesh._intervals",
             "physical.sqlmesh._plan_dags",
-            "physical.sqlmesh._seeds",
             "physical.sqlmesh._snapshots",
             "physical.sqlmesh._versions",
         }
@@ -1843,7 +1841,6 @@ def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
             "physical.sqlmesh._environments",
             "physical.sqlmesh._intervals",
             "physical.sqlmesh._plan_dags",
-            "physical.sqlmesh._seeds",
             "physical.sqlmesh._snapshots",
             "physical.sqlmesh._versions",
         }
@@ -1865,7 +1862,6 @@ def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
             "physical.sqlmesh._environments",
             "physical.sqlmesh._intervals",
             "physical.sqlmesh._plan_dags",
-            "physical.sqlmesh._seeds",
             "physical.sqlmesh._snapshots",
             "physical.sqlmesh._versions",
         }

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -1562,16 +1562,7 @@ def test_overlapping_changes_models(
 ```
 - `sushi.waiter_names`
 ```diff
---- 
 
-+++ 
-
-@@ -9,4 +9,5 @@
-
- 7,Iaroslav
- 8,Emma
- 9,Maia
-+10,Trey
 ```
 
 **Indirectly Modified:**

--- a/tests/schedulers/airflow/operators/test_targets.py
+++ b/tests/schedulers/airflow/operators/test_targets.py
@@ -129,8 +129,6 @@ def test_evaluation_target_execute_seed_model(
 
     add_interval_mock.assert_called_once_with(snapshot, interval_ds, interval_ds, is_dev=False)
 
-    get_snapshots_mock.assert_called_once_with([snapshot], hydrate_seeds=True)
-
     evaluator_evaluate_mock.assert_called_once_with(
         snapshot,
         start=interval_ds,


### PR DESCRIPTION
Closes #2668

We only really need to store the seed's content in order for the diffing to work at plan time. It appears that this convenience feature cannot justify the storage and compute overhead it incurs, especially for larger seed files.

This update ensures that we no longer rely on the seed's content stored in the state.