### PR TITLE
Chore: Allow usage of start_* / end_* macros in SCD2 models

### DIFF
--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -114,7 +114,7 @@ class ModelKindMixin:
     @property
     def only_execution_time(self) -> bool:
         """Whether or not this model only cares about execution time to render."""
-        return self.is_view or self.is_full or self.is_scd_type_2
+        return self.is_view or self.is_full
 
     @property
     def full_history_restatement_only(self) -> bool:


### PR DESCRIPTION
This update enables `start_*` / `end_*` macros in SCD 2 models.

When `invalidate_hard_deletes` is set to `false` and a user is confident that new records upstream are all within the `start_*` / `end_*` boundary, these macros can be used to significantly reduce the number of records scanned without negatively impacting the semantics of SCD2.