### PR TITLE
fix: remove remaining dynamic overwrite modes

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -556,9 +556,6 @@ class DatabricksConnectionConfig(ConnectionConfig):
                 values["databricks_connect_access_token"] = access_token
             if not values.get("databricks_connect_cluster_id"):
                 values["databricks_connect_cluster_id"] = http_path.split("/")[-1]
-        if not values.get("session_configuration"):
-            values["session_configuration"] = {}
-        values["session_configuration"]["spark.sql.sources.partitionOverwriteMode"] = "dynamic"
         return values
 
     @property

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -105,7 +105,6 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
             catalog = self._extra_config.get("catalog")
             if catalog:
                 self.set_current_catalog(catalog)
-            self._spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
         return self._spark
 
     def _fetch_native_df(


### PR DESCRIPTION
Dynamic overwrite mode is no longer needed now that we have switched over to replace where for Databricks: https://github.com/TobikoData/sqlmesh/pull/2571