### PR TITLE
Fix(motherduck): filter on catalog name in DuckDB _get_data_objects query

### DIFF
--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -94,7 +94,9 @@ class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin)
                 .as_("type"),
             )
             .from_(exp.to_table("information_schema.tables"))
-            .where(exp.column("table_schema").eq(schema_name))
+            .where(
+                exp.column("table_catalog").eq(catalog), exp.column("table_schema").eq(schema_name)
+            )
         )
         if object_names:
             query = query.where(exp.column("table_name").isin(*object_names))


### PR DESCRIPTION
SQLMesh determines which objects exist in an engine by querying its metadata.

In most engines, the metadata tables are scoped to the current database/catalog. For example, the metadata view `information_schema.tables` will only contain entries for the catalog returned by `SELECT CURRENT_CATALOG()`.

Unlike DuckDB, In Motherduck `information_schema.tables` is NOT scoped and returns objects for all databases/catalogs. If the same project has run in multiple catalogs, a table name collision can occur.

This PR adds the catalog name to the DuckDB _get_data_objects `WHERE` clause. This properly scopes the query for Motherduck and is a no-op for DuckDB.