### PR TITLE
Chore!: bump sqlglot to v24.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=24.0.2",
+        "sqlglot[rs]~=24.1.0",
     ],
     extras_require={
         "bigquery": [

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -590,5 +590,5 @@ def test_conditional_statement():
     )
     assert (
         q.sql("snowflake")
-        == "@IF(TRUE, COPY INTO 's3://example/data.csv' FROM EXTRA.EXAMPLE.TABLE STORAGE_INTEGRATION = S3_INTEGRATION FILE_FORMAT = (TYPE = CSV COMPRESSION = NONE NULL_IF = ('') FIELD_OPTIONALLY_ENCLOSED_BY = '\"') HEADER = TRUE OVERWRITE = TRUE SINGLE = TRUE /* this is a comment */)"
+        == "@IF(TRUE, COPY INTO 's3://example/data.csv' FROM EXTRA.EXAMPLE.TABLE STORAGE_INTEGRATION = S3_INTEGRATION FILE_FORMAT = (TYPE=CSV COMPRESSION=NONE NULL_IF=('') FIELD_OPTIONALLY_ENCLOSED_BY='\"') HEADER = TRUE OVERWRITE = TRUE SINGLE = TRUE /* this is a comment */)"
     )


### PR DESCRIPTION
May do another iteration make the property spacing consistent, i.e. don't generate `k = v` for some of them and `k=v` for others. This should be easy to fix as part of a patch, so I didn't want to prioritize it now.