### PR TITLE
Fix: Avoid using concat_ws when there's only one key is present

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -2027,7 +2027,7 @@ class EngineAdapter:
             columns_to_types = self.columns(target_table)
 
         temp_table = self._get_temp_table(target_table)
-        key_exp = exp.func("CONCAT_WS", "'__SQLMESH_DELIM__'", *key)
+        key_exp = exp.func("CONCAT_WS", "'__SQLMESH_DELIM__'", *key) if len(key) > 1 else key[0]
         column_names = list(columns_to_types or [])
 
         with self.transaction():

--- a/tests/core/engine_adapter/test_mixins.py
+++ b/tests/core/engine_adapter/test_mixins.py
@@ -28,15 +28,13 @@ def test_logical_merge(make_mocked_engine_adapter: t.Callable, mocker: MockerFix
             "ts": exp.DataType(this=exp.DataType.Type.TIMESTAMP),
             "val": exp.DataType(this=exp.DataType.Type.INT),
         },
-        unique_key=["id"],
+        unique_key=[parse_one("id")],
     )
 
     adapter.cursor.execute.assert_has_calls(
         [
             call('''CREATE TABLE "temporary" AS SELECT "id", "ts", "val" FROM "source"'''),
-            call(
-                """DELETE FROM "target" WHERE CONCAT_WS('__SQLMESH_DELIM__', "id") IN (SELECT CONCAT_WS('__SQLMESH_DELIM__', "id") FROM "temporary")"""
-            ),
+            call("""DELETE FROM "target" WHERE "id" IN (SELECT "id" FROM "temporary")"""),
             call(
                 'INSERT INTO "target" ("id", "ts", "val") SELECT DISTINCT ON ("id") "id", "ts", "val" FROM "temporary"'
             ),
@@ -53,7 +51,7 @@ def test_logical_merge(make_mocked_engine_adapter: t.Callable, mocker: MockerFix
             "ts": exp.DataType(this=exp.DataType.Type.TIMESTAMP),
             "val": exp.DataType(this=exp.DataType.Type.INT),
         },
-        unique_key=["id", "ts"],
+        unique_key=[parse_one("id"), parse_one("ts")],
     )
 
     adapter.cursor.execute.assert_has_calls(


### PR DESCRIPTION
For example, MSSQL requires 3 arguments to the CONCAT_WS function: https://learn.microsoft.com/en-us/sql/t-sql/functions/concat-ws-transact-sql?view=sql-server-ver15