### PR TITLE
Fix: render audit condition when used in a @WHERE(@condition) clause

### DIFF
--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -1853,7 +1853,7 @@ def test_audit_wap(adapter_mock, make_snapshot):
     not_null_query = call_args[0][0][0]
     assert (
         not_null_query.sql(dialect="spark")
-        == "SELECT COUNT(*) FROM (SELECT * FROM (SELECT * FROM `spark_catalog`.`test_schema`.`test_table`.`branch_wap_test_wap_id` AS `branch_wap_test_wap_id`) AS `_q_0` WHERE `a` IS NULL) AS audit"
+        == "SELECT COUNT(*) FROM (SELECT * FROM (SELECT * FROM `spark_catalog`.`test_schema`.`test_table`.`branch_wap_test_wap_id` AS `branch_wap_test_wap_id`) AS `_q_0` WHERE `a` IS NULL AND TRUE) AS audit"
     )
 
     custom_audit_query = call_args[1][0][0]


### PR DESCRIPTION
The `@WHERE(@condition)` clauses weren't being rendered when eg. `condition` was `item_id IS NULL`, because the macro evaluator evaluated the condition as `exp.to_column('item_id') is None` which is false.