### PR TITLE
Fix: yet another edge case related to snowflake staged file syntax

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -416,7 +416,7 @@ def _parse_table_parts(
 
     if isinstance(table_arg, exp.Var) and table_arg.name.startswith(SQLMESH_MACRO_PREFIX):
         # Macro functions do not clash with the staged file syntax, so we can safely parse them
-        if "(" in table_arg.name:
+        if self._prev.token_type == TokenType.STRING or "(" in table_arg.name:
             self._retreat(index)
             return Parser._parse_table_parts(self, schema=schema, is_db_reference=is_db_reference)
 

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -157,7 +157,10 @@ def test_macro_var(macro_evaluator):
     macro_evaluator.locals = {"x": 1}
     macro_evaluator.dialect = "snowflake"
     e = parse_one("COPY INTO @'s3://example/foo_@{x}.csv' FROM a.b.c", read="snowflake")
-    assert macro_evaluator.transform(e).sql(dialect="snowflake") == "COPY INTO 's3://example/foo_1.csv' FROM a.b.c"
+    assert (
+        macro_evaluator.transform(e).sql(dialect="snowflake")
+        == "COPY INTO 's3://example/foo_1.csv' FROM a.b.c"
+    )
 
 
 def test_macro_str_replace(macro_evaluator):

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -154,6 +154,11 @@ def test_macro_var(macro_evaluator):
     assert e.find(exp.Parameter) is e.selects[0]
     assert e.sql(dialect="snowflake") == "SELECT $1 FROM @path (FILE_FORMAT => bla.foo)"
 
+    macro_evaluator.locals = {"x": 1}
+    macro_evaluator.dialect = "snowflake"
+    e = parse_one("COPY INTO @'s3://example/foo_@{x}.csv' FROM a.b.c", read="snowflake")
+    assert macro_evaluator.transform(e).sql(dialect="snowflake") == "COPY INTO 's3://example/foo_1.csv' FROM a.b.c"
+
 
 def test_macro_str_replace(macro_evaluator):
     expression = parse_one("""@'@val1, @val2'""")


### PR DESCRIPTION
We were previously parsing the table here `COPY INTO @'....' ....` as a staged file path because of the preceding `@`. We want this to be treated as a string template and be rendered accordingly, so it was problematic.

Thankfully, Snowflake's spec shows that staged files can either be like `@var....` or `'@....'`, so `@'...'` can also be unambiguously treated as SQLMesh's syntax.

Reference: https://docs.snowflake.com/en/user-guide/querying-stage
