### PR TITLE
External models default yaml

### DIFF
--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -47,6 +47,7 @@ EXTERNAL_MODELS = "external_models"
 SEEDS = "seeds"
 TESTS = "tests"
 CACHE = ".cache"
+EXTERNAL_MODELS_DEFAULT_YAML = "external_models.yaml"
 SCHEMA_YAML = "schema.yaml"
 
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -81,7 +81,7 @@ from sqlmesh.core.notification_target import (
 from sqlmesh.core.plan import Plan, PlanBuilder
 from sqlmesh.core.reference import ReferenceGraph
 from sqlmesh.core.scheduler import Scheduler
-from sqlmesh.core.schema_loader import create_schema_file
+from sqlmesh.core.schema_loader import create_external_models_file
 from sqlmesh.core.selector import Selector
 from sqlmesh.core.snapshot import (
     DeployabilityIndex,
@@ -1607,8 +1607,8 @@ class GenericContext(BaseContext, t.Generic[C]):
             self.load(update_schemas=False)
 
         for path, config in self.configs.items():
-            create_schema_file(
-                path=path / c.SCHEMA_YAML,
+            create_external_models_file(
+                path=path / c.EXTERNAL_MODELS_DEFAULT_YAML,
                 models=UniqueKeyDict(
                     "models",
                     {

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -183,12 +183,16 @@ class Loader(abc.ABC):
         models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")
         for context_path, config in self._context.configs.items():
             schema_path = Path(context_path / c.SCHEMA_YAML)
+            external_models_default_path = context_path / c.EXTERNAL_MODELS_DEFAULT_YAML
             external_models_path = context_path / c.EXTERNAL_MODELS
 
             paths_to_load = []
             if schema_path.exists():
                 paths_to_load.append(schema_path)
 
+            if external_models_default_path.exists():
+                paths_to_load.append(external_models_default_path)
+                
             if external_models_path.exists() and external_models_path.is_dir():
                 paths_to_load.extend(external_models_path.glob("*.yaml"))
 

--- a/sqlmesh/core/schema_loader.py
+++ b/sqlmesh/core/schema_loader.py
@@ -16,7 +16,7 @@ from sqlmesh.utils import UniqueKeyDict, yaml
 logger = logging.getLogger(__name__)
 
 
-def create_schema_file(
+def create_external_models_file(
     path: Path,
     models: UniqueKeyDict[str, Model],
     adapter: EngineAdapter,
@@ -24,7 +24,7 @@ def create_schema_file(
     dialect: DialectType,
     max_workers: int = 1,
 ) -> None:
-    """Create or replace a YAML file with model schemas.
+    """Create or replace a YAML file with schemas of all external models.
 
     Args:
         path: The path to store the YAML file.

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -142,7 +142,7 @@ class ModelTest(unittest.TestCase):
                             _raise_error(
                                 f"Failed to infer the data type of column '{col}' for '{name}'. This issue can be "
                                 "mitigated by casting the column in the model definition, setting its type in "
-                                "schema.yaml if it's an external model, setting the model's 'columns' property, "
+                                "external_models.yaml if it's an external model, setting the model's 'columns' property, "
                                 "or setting its 'columns' mapping in the test itself",
                                 self.path,
                             )

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -668,7 +668,7 @@ def test_load_external_models(copy_to_temp_path):
 
     assert len(external_model_names) > 0
 
-    # from schema.yaml in root dir
+    # from external_models.yaml in root dir
     assert "raw.demographics" in external_model_names
 
     # from external_models/model1.yaml

--- a/tests/core/test_schema_loader.py
+++ b/tests/core/test_schema_loader.py
@@ -114,7 +114,7 @@ def test_no_internal_model_conversion(tmp_path: Path, make_snapshot, mocker: Moc
     model_a = SqlModel(name="a", query=parse_one("select * FROM model_b, tbl_c"))
     model_b = SqlModel(name="b", query=parse_one("select * FROM `tbl-d`", read="bigquery"))
 
-    schema_file = tmp_path / c.SCHEMA_YAML
+    schema_file = tmp_path / c.EXTERNAL_MODELS_DEFAULT_YAML
     create_schema_file(
         schema_file,
         {  # type: ignore
@@ -144,7 +144,7 @@ def test_missing_table(tmp_path: Path):
     context = Context(paths=[str(tmp_path.absolute())], config=config)
     model = SqlModel(name="a", query=parse_one("select * FROM tbl_source"))
 
-    schema_file = tmp_path / c.SCHEMA_YAML
+    schema_file = tmp_path / c.EXTERNAL_MODELS_YAML
     logger = logging.getLogger("sqlmesh.core.schema_loader")
     with patch.object(logger, "warning") as mock_logger:
         create_schema_file(

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -843,7 +843,7 @@ test_foo:
         expected_msg=(
             """Failed to infer the data type of column 'value' for '"raw"'. This issue can """
             "be mitigated by casting the column in the model definition, setting its type in "
-            "schema.yaml if it's an external model, setting the model's 'columns' property, "
+            "external_models.yaml if it's an external model, setting the model's 'columns' property, "
             "or setting its 'columns' mapping in the test itself\n"
         ),
     )

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -600,7 +600,7 @@ def test_migrate(
 
 @pytest.mark.slow
 def test_create_external_models(notebook, loaded_sushi_context):
-    external_model_file = loaded_sushi_context.path / "schema.yaml"
+    external_model_file = loaded_sushi_context.path / "external_models.yaml"
     external_model_file.unlink()
     assert not external_model_file.exists()
     loaded_sushi_context.load()

--- a/web/client/src/library/components/editor/EditorFooter.tsx
+++ b/web/client/src/library/components/editor/EditorFooter.tsx
@@ -130,6 +130,7 @@ function getFileType(path?: string): FileType {
   if (path.startsWith('metrics')) return EnumFileType.Metric
   if (['config.yaml', 'config.yml', 'config.py'].includes(path))
     return EnumFileType.Config
+  if (['external_models.yaml', 'external_models.yml'].includes(path)) return EnumFileType.Schema
   if (['schema.yaml', 'schema.yml'].includes(path)) return EnumFileType.Schema
 
   return EnumFileType.Unknown


### PR DESCRIPTION
As discussed, renaming `schema.yaml` to `external_models.yaml` for consistency.

This was all the references I could find in this repo. 
I can update the example repos too.

Open invitation to nitpick as much as you want. Happy to take on any/all feedback.