### PR TITLE
Chore: update ibis example

### DIFF
--- a/examples/ibis/models/ibis_full_model_python.py
+++ b/examples/ibis/models/ibis_full_model_python.py
@@ -7,12 +7,12 @@ from constants import DB_PATH  # type: ignore
 from sqlglot import exp
 
 from sqlmesh import ExecutionContext, model
-from sqlmesh.core.model import FullKind
+from sqlmesh.core.model import ModelKindName
 
 
 @model(
     "ibis.ibis_full_model_python",
-    kind=FullKind(),
+    kind=dict(name=ModelKindName.FULL),
     columns={
         "item_id": "int",
         "num_orders": "int",
@@ -33,7 +33,7 @@ def execute(
     con = ibis.duckdb.connect(DB_PATH)
 
     # retrieve table
-    incremental_model = con.table(name=upstream_model.name, schema=upstream_model.db)
+    incremental_model = con.table(name=upstream_model.name, database=upstream_model.db)
 
     # build query
     count = incremental_model.id.nunique()

--- a/examples/ibis/models/ibis_full_model_sql.py
+++ b/examples/ibis/models/ibis_full_model_sql.py
@@ -17,7 +17,7 @@ def entrypoint(evaluator: MacroEvaluator) -> str:
     incremental_model = UnboundTable(
         name="incremental_model",
         schema={"id": "int32", "item_id": "int32", "ds": "varchar"},
-        namespace=Namespace(database="local", schema="ibis"),
+        namespace=Namespace(catalog="local", database="ibis"),
     ).to_expr()
 
     # build query


### PR DESCRIPTION
Came across a couple of warnings / errors when trying to run `sqlmesh plan` for the ibis example. I took a quick look and it seems like there was a breaking change in ibis (see [here](https://github.com/ibis-project/ibis/blob/03811a324f19d71863c873696dedc2b15f242aa4/ibis/expr/operations/relations.py#L363)). We also didn't update the example since refactoring how kinds are set for python models.