### PR TITLE
Fix: Capture bultin macro dependencies when loading dbt projects

### DIFF
--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -379,16 +379,19 @@ class ManifestHelper:
                     source = ".".join(args)
                     if not self._is_disabled_source(source):
                         dependencies.sources.add(source)
+                dependencies.macros.append(MacroReference(name="source"))
             elif call_name[0] == "ref":
                 args = [jinja_call_arg_name(arg) for arg in node.args]
                 if args and all(arg for arg in args):
                     ref = ".".join(args)
                     if not self._is_disabled_ref(ref):
                         dependencies.refs.add(ref)
+                dependencies.macros.append(MacroReference(name="ref"))
             elif call_name[0] == "var":
                 args = [jinja_call_arg_name(arg) for arg in node.args]
                 if args and args[0]:
                     dependencies.variables.add(args[0])
+                dependencies.macros.append(MacroReference(name="var"))
             elif len(call_name) == 1:
                 macro_name = call_name[0]
                 if macro_name in BUILTIN_CALLS:

--- a/tests/dbt/test_manifest.py
+++ b/tests/dbt/test_manifest.py
@@ -28,11 +28,12 @@ def test_manifest_helper(caplog):
     assert helper.models()["top_waiters"].dependencies == Dependencies(
         refs={"sushi.waiter_revenue_by_day", "waiter_revenue_by_day"},
         variables={"top_waiters:revenue", "top_waiters:limit"},
+        macros=[MacroReference(name="ref"), MacroReference(name="var")],
     )
     assert helper.models()["top_waiters"].materialized == "view"
 
     assert helper.models()["waiters"].dependencies == Dependencies(
-        macros={MacroReference(name="incremental_by_time")},
+        macros={MacroReference(name="incremental_by_time"), MacroReference(name="source")},
         sources={"streaming.orders"},
     )
     assert helper.models()["waiters"].materialized == "ephemeral"
@@ -57,6 +58,7 @@ def test_manifest_helper(caplog):
     waiter_as_customer_by_day_config = helper.models()["waiter_as_customer_by_day"]
     assert waiter_as_customer_by_day_config.dependencies == Dependencies(
         refs={"waiters", "waiter_names", "customers"},
+        macros=[MacroReference(name="ref")],
     )
     assert waiter_as_customer_by_day_config.materialized == "incremental"
     assert waiter_as_customer_by_day_config.incremental_strategy == "delete+insert"
@@ -70,6 +72,7 @@ def test_manifest_helper(caplog):
             MacroReference(name="test_dependencies"),
             MacroReference(package="customers", name="duckdb__current_engine"),
             MacroReference(package="dbt", name="run_query"),
+            MacroReference(name="source"),
         },
         sources={"streaming.items", "streaming.orders", "streaming.order_items"},
         variables={"yet_another_var"},
@@ -82,6 +85,7 @@ def test_manifest_helper(caplog):
     assert helper.models("customers")["customers"].dependencies == Dependencies(
         sources={"raw.orders"},
         variables={"customers:customer_id"},
+        macros=[MacroReference(name="source"), MacroReference(name="var")],
     )
 
     assert set(helper.macros()["incremental_by_time"].info.depends_on) == {


### PR DESCRIPTION
We need this in order to capture references to user-provided `ref`, `source`, `var` macros that override the builtin ones.

In older versions of dbt references to these macros are not reflected in the manifest.