### PR TITLE
Fix: convert pyspark/snowpark dataframes into pandas when testing

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -618,10 +618,9 @@ class PythonModelTest(ModelTest):
         time_ctx = freeze_time(self._execution_time) if self._execution_time else nullcontext()
         with patch.dict(self._test_adapter_dialect.generator_class.TRANSFORMS, self._transforms):
             with t.cast(AbstractContextManager, time_ctx):
-                return t.cast(
-                    pd.DataFrame,
-                    next(self.model.render(context=self.context, **self.body.get("vars", {}))),
-                )
+                df = next(self.model.render(context=self.context, **self.body.get("vars", {})))
+                assert not isinstance(df, exp.Expression)
+                return df if isinstance(df, pd.DataFrame) else df.toPandas()
 
 
 def generate_test(

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -1420,10 +1420,7 @@ def test_pyspark_python_model() -> None:
         },
     )
     config = Config(
-        gateways=GatewayConfig(
-            connection=spark_connection_config,
-            test_connection=spark_connection_config,
-        ),
+        gateways=GatewayConfig(test_connection=spark_connection_config),
         model_defaults=ModelDefaultsConfig(dialect="spark"),
     )
     context = Context(config=config)

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -201,9 +201,9 @@ def test_evaluate(notebook, loaded_sushi_context):
 def test_format(notebook, sushi_context):
     with capture_output():
         test_model_path = sushi_context.path / "models" / "test_model.sql"
-        test_model_path.write_text("MODEL(name db.test); SELECT 1 AS foo FROM table")
+        test_model_path.write_text("MODEL(name db.test); SELECT 1 AS foo FROM t")
         sushi_context.load()
-    assert test_model_path.read_text() == "MODEL(name db.test); SELECT 1 AS foo FROM table"
+    assert test_model_path.read_text() == "MODEL(name db.test); SELECT 1 AS foo FROM t"
     with capture_output() as output:
         notebook.run_line_magic(magic_name="format", line="")
 
@@ -218,7 +218,7 @@ def test_format(notebook, sushi_context):
 
 SELECT
   1 AS foo
-FROM table"""
+FROM t"""
     )
 
 


### PR DESCRIPTION
Some `pd.DataFrame` methods such as `apply` are not supported by pyspark / snowpark dataframes, which caused issues in unit tests because we assumed we'd get back pandas dataframes from the python models, and that's not always the case.

This PR fixes the issue by converting pyspark / snowpark dataframes into pandas ones for unit tests, so that there's a single representation to work with => keep the implementation simpler.