### PR TITLE
Fix: Skip preview for metadata-only changes

### DIFF
--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -321,7 +321,13 @@ class PlanBuilder:
             restate_models = {
                 s.name
                 for s in self._context_diff.new_snapshots.values()
-                if s.is_materialized and (self._forward_only or s.model.forward_only)
+                if s.is_materialized
+                and (self._forward_only or s.model.forward_only)
+                and (
+                    # Metadata changes should not be previewed.
+                    self._context_diff.directly_modified(s.name)
+                    or self._context_diff.indirectly_modified(s.name)
+                )
             }
             is_preview = True
 


### PR DESCRIPTION
Before this update SQLMesh would compute a preview for metadata-only changes in dev because those are categorized as forward-only.

With this fix we ensure that previews are only computed for directly / indirectly modified snapshots.