### PR TITLE
Feat: Gateway-specific external models

### DIFF
--- a/examples/sushi/config.py
+++ b/examples/sushi/config.py
@@ -87,6 +87,16 @@ map_config = Config(
     model_defaults=model_defaults,
 )
 
+# A config representing isolated systems with a gateway per system
+isolated_systems_config = Config(
+    gateways={
+        "dev": GatewayConfig(connection=DuckDBConnectionConfig()),
+        "test": GatewayConfig(connection=DuckDBConnectionConfig()),
+        "prod": GatewayConfig(connection=DuckDBConnectionConfig()),
+    },
+    default_gateway="dev",
+    model_defaults=model_defaults,
+)
 
 required_approvers_config = Config(
     default_connection=DuckDBConnectionConfig(),

--- a/examples/sushi/external_models/prod.yaml
+++ b/examples/sushi/external_models/prod.yaml
@@ -1,0 +1,6 @@
+- name: prod_raw.model1
+  description: Gateway-specific table defined in external model file
+  gateway: prod
+  columns:
+    customer_id: int
+    zip: text

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -340,9 +340,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         self._engine_adapter = engine_adapter or self._connection_config.create_engine_adapter()
 
         self._test_connection_config = self.config.get_test_connection(
-            self.gateway,
-            self.default_catalog,
-            default_catalog_dialect=self.engine_adapter.DIALECT,
+            self.gateway, self.default_catalog, default_catalog_dialect=self.engine_adapter.DIALECT
         )
 
         self._snapshot_evaluator: t.Optional[SnapshotEvaluator] = None
@@ -749,9 +747,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         if expand and not isinstance(expand, bool):
             expand = {
                 normalize_model_name(
-                    x,
-                    default_catalog=self.default_catalog,
-                    dialect=self.default_dialect,
+                    x, default_catalog=self.default_catalog, dialect=self.default_dialect
                 )
                 for x in expand
             }
@@ -952,7 +948,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             auto_apply if auto_apply is not None else self.config.plan.auto_apply,
             self.default_catalog,
             no_diff=no_diff if no_diff is not None else self.config.plan.no_diff,
-            no_prompts=(no_prompts if no_prompts is not None else self.config.plan.no_prompts),
+            no_prompts=no_prompts if no_prompts is not None else self.config.plan.no_prompts,
         )
 
         return plan_builder.build()
@@ -1101,8 +1097,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 )
             else:
                 default_end = self.state_sync.max_interval_end_for_environment(
-                    c.PROD,
-                    ensure_finalized_snapshots=self.config.plan.use_finalized_state,
+                    c.PROD, ensure_finalized_snapshots=self.config.plan.use_finalized_state
                 )
         else:
             default_end = None
@@ -1765,9 +1760,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             result, test_output = self._run_tests()
             if result.testsRun > 0:
                 self.console.log_test_results(
-                    result,
-                    test_output,
-                    self._test_connection_config._engine_adapter.DIALECT,
+                    result, test_output, self._test_connection_config._engine_adapter.DIALECT
                 )
             if not result.wasSuccessful():
                 raise PlanError(
@@ -1855,8 +1848,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         if unrestorable_snapshots:
             for snapshot in unrestorable_snapshots:
                 logger.info(
-                    "Found a unrestorable snapshot %s. Restamping the model...",
-                    snapshot.name,
+                    "Found a unrestorable snapshot %s. Restamping the model...", snapshot.name
                 )
                 node = local_nodes[snapshot.name]
                 nodes[snapshot.name] = node.copy(
@@ -1936,9 +1928,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             for user in self.users
         }
         self.notification_target_manager = NotificationTargetManager(
-            event_notifications,
-            user_notification_targets,
-            username=self.config.username,
+            event_notifications, user_notification_targets, username=self.config.username
         )
 
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -340,7 +340,9 @@ class GenericContext(BaseContext, t.Generic[C]):
         self._engine_adapter = engine_adapter or self._connection_config.create_engine_adapter()
 
         self._test_connection_config = self.config.get_test_connection(
-            self.gateway, self.default_catalog, default_catalog_dialect=self.engine_adapter.DIALECT
+            self.gateway,
+            self.default_catalog,
+            default_catalog_dialect=self.engine_adapter.DIALECT,
         )
 
         self._snapshot_evaluator: t.Optional[SnapshotEvaluator] = None
@@ -747,7 +749,9 @@ class GenericContext(BaseContext, t.Generic[C]):
         if expand and not isinstance(expand, bool):
             expand = {
                 normalize_model_name(
-                    x, default_catalog=self.default_catalog, dialect=self.default_dialect
+                    x,
+                    default_catalog=self.default_catalog,
+                    dialect=self.default_dialect,
                 )
                 for x in expand
             }
@@ -948,7 +952,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             auto_apply if auto_apply is not None else self.config.plan.auto_apply,
             self.default_catalog,
             no_diff=no_diff if no_diff is not None else self.config.plan.no_diff,
-            no_prompts=no_prompts if no_prompts is not None else self.config.plan.no_prompts,
+            no_prompts=(no_prompts if no_prompts is not None else self.config.plan.no_prompts),
         )
 
         return plan_builder.build()
@@ -1097,7 +1101,8 @@ class GenericContext(BaseContext, t.Generic[C]):
                 )
             else:
                 default_end = self.state_sync.max_interval_end_for_environment(
-                    c.PROD, ensure_finalized_snapshots=self.config.plan.use_finalized_state
+                    c.PROD,
+                    ensure_finalized_snapshots=self.config.plan.use_finalized_state,
                 )
         else:
             default_end = None
@@ -1625,6 +1630,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 adapter=self._engine_adapter,
                 state_reader=self.state_reader,
                 dialect=config.model_defaults.dialect,
+                gateway=self.gateway,
                 max_workers=self.concurrent_tasks,
             )
 
@@ -1759,7 +1765,9 @@ class GenericContext(BaseContext, t.Generic[C]):
             result, test_output = self._run_tests()
             if result.testsRun > 0:
                 self.console.log_test_results(
-                    result, test_output, self._test_connection_config._engine_adapter.DIALECT
+                    result,
+                    test_output,
+                    self._test_connection_config._engine_adapter.DIALECT,
                 )
             if not result.wasSuccessful():
                 raise PlanError(
@@ -1847,7 +1855,8 @@ class GenericContext(BaseContext, t.Generic[C]):
         if unrestorable_snapshots:
             for snapshot in unrestorable_snapshots:
                 logger.info(
-                    "Found a unrestorable snapshot %s. Restamping the model...", snapshot.name
+                    "Found a unrestorable snapshot %s. Restamping the model...",
+                    snapshot.name,
                 )
                 node = local_nodes[snapshot.name]
                 nodes[snapshot.name] = node.copy(
@@ -1927,7 +1936,9 @@ class GenericContext(BaseContext, t.Generic[C]):
             for user in self.users
         }
         self.notification_target_manager = NotificationTargetManager(
-            event_notifications, user_notification_targets, username=self.config.username
+            event_notifications,
+            user_notification_targets,
+            username=self.config.username,
         )
 
 

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -180,7 +180,7 @@ class Loader(abc.ABC):
     def _load_metrics(self) -> UniqueKeyDict[str, MetricMeta]:
         return UniqueKeyDict("metrics")
 
-    def _load_external_models(self, gateway: t.Optional[str]) -> UniqueKeyDict[str, Model]:
+    def _load_external_models(self, gateway: t.Optional[str] = None) -> UniqueKeyDict[str, Model]:
         models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")
         for context_path, config in self._context.configs.items():
             external_models_yaml = Path(context_path / c.EXTERNAL_MODELS_YAML)

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1386,6 +1386,7 @@ class ExternalModel(_Model):
     """The model definition which represents an external source/table."""
 
     source_type: Literal["external"] = "external"
+    gateway: t.Optional[str] = None
 
     def is_breaking_change(self, previous: Model) -> t.Optional[bool]:
         if not isinstance(previous, ExternalModel):

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1806,7 +1806,7 @@ def create_external_model(
     path: Path = Path(),
     defaults: t.Optional[t.Dict[str, t.Any]] = None,
     **kwargs: t.Any,
-) -> Model:
+) -> ExternalModel:
     """Creates an external model.
 
     Args:
@@ -1815,14 +1815,17 @@ def create_external_model(
         dialect: The dialect to serialize.
         path: An optional path to the model definition file.
     """
-    return _create_model(
+    return t.cast(
         ExternalModel,
-        name,
-        defaults=defaults,
-        dialect=dialect,
-        path=path,
-        kind=ModelKindName.EXTERNAL.value,
-        **kwargs,
+        _create_model(
+            ExternalModel,
+            name,
+            defaults=defaults,
+            dialect=dialect,
+            path=path,
+            kind=ModelKindName.EXTERNAL.value,
+            **kwargs,
+        ),
     )
 
 

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -87,7 +87,7 @@ class DbtLoader(Loader):
         )
 
     def _load_models(
-        self, macros: MacroRegistry, jinja_macros: JinjaMacroRegistry
+        self, macros: MacroRegistry, jinja_macros: JinjaMacroRegistry, gateway: t.Optional[str]
     ) -> UniqueKeyDict[str, Model]:
         models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -676,3 +676,27 @@ def test_load_external_models(copy_to_temp_path):
 
     # from external_models/model2.yaml
     assert "raw.model2" in external_model_names
+
+    # from external_models/prod.yaml, should not show unless --gateway=prod
+    assert "prod_raw.model1" not in external_model_names
+
+
+def test_load_gateway_specific_external_models(copy_to_temp_path):
+    path = copy_to_temp_path("examples/sushi")
+
+    def _get_external_model_names(gateway=None):
+        context = Context(paths=path, config="isolated_systems_config", gateway=gateway)
+
+        external_model_names = [
+            m.name for m in context.models.values() if m.kind.name == ModelKindName.EXTERNAL
+        ]
+
+        assert len(external_model_names) > 0
+
+        return external_model_names
+
+    # default gateway is dev, prod model should not show
+    assert "prod_raw.model1" not in _get_external_model_names()
+
+    # gateway explicitly set to prod; prod model should now show
+    assert "prod_raw.model1" in _get_external_model_names(gateway="prod")


### PR DESCRIPTION
Add an optional `gateway: ` key to the external models definitions which allows gateway-specific external models and addresses the problems highlighted in issue #2689 

After this change, the behaviour is as follows:
`sqlmesh create_external_models` - no change, current behaviour. Models get written without the new `gateway: ` key.
`sqlmesh --gateway dev create_external_models` - Models get written with `gateway: dev`
`sqlmesh --gateway prod create_external_models` - Models get written with `gateway: prod`. The `gateway: dev` models remain in the file.

When running plans:
`sqlmesh plan` - will pick up all external models with no `gateway: ` set, plus any external models with `gateway: <default gateway>`
`sqlmesh --gateway dev plan` - will pick up all external models with no `gateway: ` set, plus any external models with `gateway: dev`
