### PR TITLE
Feat: improve cicd comment message format

### DIFF
--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -279,7 +279,7 @@ class GithubEvent:
 
 
 class GithubController:
-    BOT_HEADER_MSG = "**SQLMesh Bot Info**"
+    BOT_HEADER_MSG = ":robot: **SQLMesh Bot Info** :robot:"
     MAX_BYTE_LENGTH = 65535
 
     def __init__(
@@ -565,7 +565,7 @@ class GithubController:
                 "Please check PR and resolve any issues."
             )
         plan_summary = f"""<details>
-  <summary>Prod Plan Being Applied</summary>
+  <summary>:ship: Prod Plan Being Applied</summary>
 
 {self.get_plan_summary(self.prod_plan)}
 </details>
@@ -814,9 +814,16 @@ class GithubController:
                     table_header = h("thead", [h("tr", row) for row in header_rows])
                     table_body = h("tbody", [h("tr", row) for row in body_rows])
                     summary = str(h("table", [table_header, table_body]))
+                vde_title = (
+                    "- :eyes: To **review** this PR's changes, use virtual data environment:"
+                )
+                comment_value = f"{vde_title}\n  - `{self.pr_environment_name}`"
+                if self.bot_config.enable_deploy_command:
+                    comment_value += "\n- :arrow_forward: To apply this PR's plan to prod, comment:\n  - `/deploy`"
+                dedup_regex = vde_title.replace("*", r"\*") + r".*"
                 updated_comment, _ = self.update_sqlmesh_comment_info(
-                    value=f"- {check_title}",
-                    dedup_regex=rf"- {check_title_static}.*",
+                    value=comment_value,
+                    dedup_regex=dedup_regex,
                 )
                 if updated_comment:
                     self._append_output("created_pr_environment", "true")

--- a/tests/integrations/github/cicd/test_github_commands.py
+++ b/tests/integrations/github/cicd/test_github_commands.py
@@ -138,10 +138,11 @@ def test_run_all_success_with_approvers_approved(
 
     assert len(created_comments) == 1
     assert created_comments[0].body.startswith(
-        """**SQLMesh Bot Info**
-- PR Virtual Data Environment: myoverride_2
+        """:robot: **SQLMesh Bot Info** :robot:
+- :eyes: To **review** this PR's changes, use virtual data environment:
+  - `myoverride_2`
 <details>
-  <summary>Prod Plan Being Applied</summary>
+  <summary>:ship: Prod Plan Being Applied</summary>
 
 **New environment `prod` will be created from `prod`**"""
     )
@@ -264,10 +265,11 @@ def test_run_all_success_with_approvers_approved_merge_delete(
 
     assert len(created_comments) == 1
     assert created_comments[0].body.startswith(
-        """**SQLMesh Bot Info**
-- PR Virtual Data Environment: hello_world_2
+        """:robot: **SQLMesh Bot Info** :robot:
+- :eyes: To **review** this PR's changes, use virtual data environment:
+  - `hello_world_2`
 <details>
-  <summary>Prod Plan Being Applied</summary>
+  <summary>:ship: Prod Plan Being Applied</summary>
 
 **New environment `prod` will be created from `prod`**"""
     )
@@ -390,7 +392,9 @@ def test_run_all_missing_approval(
     assert len(created_comments) == 1
     assert (
         created_comments[0].body
-        == """**SQLMesh Bot Info**\n- PR Virtual Data Environment: hello_world_2"""
+        == """:robot: **SQLMesh Bot Info** :robot:
+- :eyes: To **review** this PR's changes, use virtual data environment:
+  - `hello_world_2`"""
     )
     with open(github_output_file, "r", encoding="utf-8") as f:
         output = f.read()
@@ -902,10 +906,11 @@ def test_prod_update_failure(
 
     assert len(created_comments) == 1
     assert created_comments[0].body.startswith(
-        """**SQLMesh Bot Info**
-- PR Virtual Data Environment: hello_world_2
+        """:robot: **SQLMesh Bot Info** :robot:
+- :eyes: To **review** this PR's changes, use virtual data environment:
+  - `hello_world_2`
 <details>
-  <summary>Prod Plan Being Applied</summary>
+  <summary>:ship: Prod Plan Being Applied</summary>
 
 **New environment `prod` will be created from `prod`**"""
     )
@@ -1095,10 +1100,13 @@ def test_comment_command_deploy_prod(
 
     assert len(created_comments) == 1
     assert created_comments[0].body.startswith(
-        """**SQLMesh Bot Info**
-- PR Virtual Data Environment: hello_world_2
+        """:robot: **SQLMesh Bot Info** :robot:
+- :eyes: To **review** this PR's changes, use virtual data environment:
+  - `hello_world_2`
+- :arrow_forward: To apply this PR's plan to prod, comment:
+  - `/deploy`
 <details>
-  <summary>Prod Plan Being Applied</summary>
+  <summary>:ship: Prod Plan Being Applied</summary>
 
 **New environment `prod` will be created from `prod`**"""
     )

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -317,8 +317,8 @@ update_sqlmesh_comment_info_params = [
         [],
         "test1",
         None,
-        "**SQLMesh Bot Info**\ntest1",
-        "**SQLMesh Bot Info**\ntest1",
+        ":robot: **SQLMesh Bot Info** :robot:\ntest1",
+        ":robot: **SQLMesh Bot Info** :robot:\ntest1",
     ),
     (
         "Existing comments that are not related, one is created and then updated with value",
@@ -328,43 +328,43 @@ update_sqlmesh_comment_info_params = [
         ],
         "test1",
         None,
-        "**SQLMesh Bot Info**\ntest1",
-        "**SQLMesh Bot Info**\ntest1",
+        ":robot: **SQLMesh Bot Info** :robot:\ntest1",
+        ":robot: **SQLMesh Bot Info** :robot:\ntest1",
     ),
     (
         "Existing bot comment, that is updated and create comment is not called",
         [
-            MockIssueComment(body="**SQLMesh Bot Info**\ntest2"),
+            MockIssueComment(body=":robot: **SQLMesh Bot Info** :robot:\ntest2"),
             MockIssueComment(body="test3"),
         ],
         "test1",
         None,
-        "**SQLMesh Bot Info**\ntest2\ntest1",
+        ":robot: **SQLMesh Bot Info** :robot:\ntest2\ntest1",
         None,
     ),
     (
         "Existing bot comment, that is not updated because of dedup_regex and create comment is not called",
         [
-            MockIssueComment(body="**SQLMesh Bot Info**\ntest2"),
+            MockIssueComment(body=":robot: **SQLMesh Bot Info** :robot:\ntest2"),
             MockIssueComment(body="test3"),
         ],
         "test1",
         "test2",
-        "**SQLMesh Bot Info**\ntest2",
+        ":robot: **SQLMesh Bot Info** :robot:\ntest2",
         None,
     ),
     (
         "Ensure comments are truncated if they are too long",
         [
-            MockIssueComment(body="**SQLMesh Bot Info**\ntest1"),
+            MockIssueComment(body=":robot: **SQLMesh Bot Info** :robot:\ntest1"),
         ],
         # Making sure that although we will be under the character limit of `65535` we will still truncate
         # because the byte size of this character is 3 and therefore we will be over the limit since it is based
         # on bytes on not characters (despite what the error message may say)
         "桜" * 65000,
         None,
-        # ((Max Byte Length) - (Length of "**SQLMesh Bot Info**\ntest1\n")) / (Length of "桜")
-        "**SQLMesh Bot Info**\ntest1\n" + ("桜" * int((65535 - 27) / 3)),
+        # ((Max Byte Length) - (Length of ":robot: **SQLMesh Bot Info** :robot:\ntest1\n")) / (Length of "桜")
+        ":robot: **SQLMesh Bot Info** :robot:\ntest1\n" + ("桜" * int((65535 - 43) / 3)),
         None,
     ),
 ]

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -227,10 +227,11 @@ def test_merge_pr_has_non_breaking_change(
     assert len(created_comments) == 1
     assert (
         created_comments[0].body
-        == f"""**SQLMesh Bot Info**
-- PR Virtual Data Environment: hello_world_2
+        == f""":robot: **SQLMesh Bot Info** :robot:
+- :eyes: To **review** this PR's changes, use virtual data environment:
+  - `hello_world_2`
 <details>
-  <summary>Prod Plan Being Applied</summary>
+  <summary>:ship: Prod Plan Being Applied</summary>
 
 {expected_prod_plan_summary}
 </details>
@@ -425,10 +426,11 @@ def test_merge_pr_has_non_breaking_change_diff_start(
     assert len(created_comments) == 1
     assert (
         created_comments[0].body
-        == f"""**SQLMesh Bot Info**
-- PR Virtual Data Environment: hello_world_2
+        == f""":robot: **SQLMesh Bot Info** :robot:
+- :eyes: To **review** this PR's changes, use virtual data environment:
+  - `hello_world_2`
 <details>
-  <summary>Prod Plan Being Applied</summary>
+  <summary>:ship: Prod Plan Being Applied</summary>
 
 {expected_prod_plan}
 </details>
@@ -735,9 +737,9 @@ def test_merge_pr_has_no_changes(
     assert len(created_comments) == 1
     assert (
         created_comments[0].body
-        == f"""**SQLMesh Bot Info**
+        == f""":robot: **SQLMesh Bot Info** :robot:
 <details>
-  <summary>Prod Plan Being Applied</summary>
+  <summary>:ship: Prod Plan Being Applied</summary>
 
 {expected_prod_plan_summary}
 </details>
@@ -921,8 +923,9 @@ def test_no_merge_since_no_deploy_signal(
     assert len(created_comments) == 1
     assert (
         created_comments[0].body
-        == """**SQLMesh Bot Info**
-- PR Virtual Data Environment: hello_world_2"""
+        == """:robot: **SQLMesh Bot Info** :robot:
+- :eyes: To **review** this PR's changes, use virtual data environment:
+  - `hello_world_2`"""
     )
 
     with open(github_output_file, "r", encoding="utf-8") as f:
@@ -1080,8 +1083,9 @@ def test_no_merge_since_no_deploy_signal_no_approvers_defined(
     assert len(created_comments) == 1
     assert (
         created_comments[0].body
-        == """**SQLMesh Bot Info**
-- PR Virtual Data Environment: hello_world_2"""
+        == """:robot: **SQLMesh Bot Info** :robot:
+- :eyes: To **review** this PR's changes, use virtual data environment:
+  - `hello_world_2`"""
     )
 
     with open(github_output_file, "r", encoding="utf-8") as f:
@@ -1257,10 +1261,13 @@ def test_deploy_comment_pre_categorized(
     assert len(created_comments) == 1
     assert (
         created_comments[0].body
-        == f"""**SQLMesh Bot Info**
-- PR Virtual Data Environment: hello_world_2
+        == f""":robot: **SQLMesh Bot Info** :robot:
+- :eyes: To **review** this PR's changes, use virtual data environment:
+  - `hello_world_2`
+- :arrow_forward: To apply this PR's plan to prod, comment:
+  - `/deploy`
 <details>
-  <summary>Prod Plan Being Applied</summary>
+  <summary>:ship: Prod Plan Being Applied</summary>
 
 {expected_prod_plan}
 </details>
@@ -1613,10 +1620,11 @@ def test_overlapping_changes_models(
     assert len(created_comments) == 1
     assert (
         created_comments[0].body
-        == f"""**SQLMesh Bot Info**
-- PR Virtual Data Environment: hello_world_2
+        == f""":robot: **SQLMesh Bot Info** :robot:
+- :eyes: To **review** this PR's changes, use virtual data environment:
+  - `hello_world_2`
 <details>
-  <summary>Prod Plan Being Applied</summary>
+  <summary>:ship: Prod Plan Being Applied</summary>
 
 {expected_prod_plan_summary}
 </details>
@@ -1791,10 +1799,11 @@ def test_pr_delete_model(
     assert len(created_comments) == 1
     assert (
         created_comments[0].body
-        == f"""**SQLMesh Bot Info**
-- PR Virtual Data Environment: hello_world_2
+        == f""":robot: **SQLMesh Bot Info** :robot:
+- :eyes: To **review** this PR's changes, use virtual data environment:
+  - `hello_world_2`
 <details>
-  <summary>Prod Plan Being Applied</summary>
+  <summary>:ship: Prod Plan Being Applied</summary>
 
 {expected_prod_plan_summary}
 </details>


### PR DESCRIPTION
Old format:
<img width="368" alt="Screenshot 2024-06-06 at 9 47 25 AM" src="https://github.com/TobikoData/sqlmesh/assets/6326532/33d7ed76-0784-47c6-8db4-409c9790a0ce">

New format:
<img width="491" alt="Screenshot 2024-06-06 at 9 54 26 AM" src="https://github.com/TobikoData/sqlmesh/assets/6326532/598a482f-7cdf-4d0d-9f36-63930975b793">



The bullet about issuing a `deploy` command will only show up if the project has the deploy command configured.
