### PR TITLE
Fix: Add a category for metadata-only changes

### DIFF
--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -569,7 +569,7 @@ class PlanBuilder:
                         )
                     else:
                         # Metadata updated.
-                        snapshot.categorize_as(SnapshotChangeCategory.FORWARD_ONLY)
+                        snapshot.categorize_as(SnapshotChangeCategory.METADATA)
 
             elif s_id in self._context_diff.added and self._is_new_snapshot(snapshot):
                 snapshot.categorize_as(
@@ -689,8 +689,7 @@ class PlanBuilder:
                 candidate.snapshot_id not in self._context_diff.new_snapshots
                 and promoted.is_forward_only
                 and not promoted.is_paused
-                and not candidate.is_forward_only
-                and not candidate.is_indirect_non_breaking
+                and not candidate.reuses_previous_version
                 and promoted.version == candidate.version
             ):
                 raise PlanError(

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -674,7 +674,7 @@ class SnapshotEvaluator:
                     self.adapter.drop_table(tmp_table_name)
             else:
                 table_deployability_flags = [False]
-                if not snapshot.is_indirect_non_breaking and not snapshot.is_forward_only:
+                if not snapshot.reuses_previous_version:
                     table_deployability_flags.append(True)
                 for is_table_deployable in table_deployability_flags:
                     evaluation_strategy.create(

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -413,11 +413,11 @@ def test_metadata_changed_regular_plan_preview_enabled(init_and_plan_context: t.
     assert len(plan.new_snapshots) == 2
     assert (
         plan.context_diff.snapshots[snapshot.snapshot_id].change_category
-        == SnapshotChangeCategory.FORWARD_ONLY
+        == SnapshotChangeCategory.METADATA
     )
     assert (
         plan.context_diff.snapshots[top_waiters_snapshot.snapshot_id].change_category
-        == SnapshotChangeCategory.FORWARD_ONLY
+        == SnapshotChangeCategory.METADATA
     )
     assert not plan.missing_intervals
     assert not plan.restatements


### PR DESCRIPTION
Coupling metadata and forward-only changes was a design mistake.

The forward-only category has a bunch of implications on how data is computed and reused. For example, table deployability, data previews, etc decisions are directly linked to this category.

However, none of these features apply to metadata changes. I've already seen quite a few unexpected behaviors related to the fact that metadata updates were categorized as forward-only which led to redundant computations in both dev and prod. 

This update introduces a new category dedicated specifically to metadata-only changes.