### PR TITLE
Chore: increase engine adapter test time limit to 40m

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -221,7 +221,7 @@ jobs:
       - run:
           name: Run tests
           command: make engine-docker-test
-          no_output_timeout: 30m
+          no_output_timeout: 40m
 
   trigger_private_tests:
       docker:


### PR DESCRIPTION
It seems like 30m [didn't do the trick ](https://app.circleci.com/pipelines/github/TobikoData/sqlmesh/13699/workflows/25296291-0dc5-4fd3-979c-676b523c1f3f/jobs/101977).