### PR TITLE
Fix: Deployability index calculation for forward-only models that have been already categorized

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1259,13 +1259,16 @@ class DeployabilityIndex(PydanticModel, frozen=True):
             if deployable and node in snapshots:
                 snapshot = snapshots[node]
                 # Capture uncategorized snapshot which represents a forward-only model.
-                is_forward_only_model = (
-                    snapshot.previous_versions and snapshot.is_model and snapshot.model.forward_only
+                is_uncategorized_forward_only_model = (
+                    snapshot.change_category is None
+                    and snapshot.previous_versions
+                    and snapshot.is_model
+                    and snapshot.model.forward_only
                 )
                 if (
                     snapshot.is_forward_only
                     or snapshot.is_indirect_non_breaking
-                    or is_forward_only_model
+                    or is_uncategorized_forward_only_model
                 ):
                     # FORWARD_ONLY and INDIRECT_NON_BREAKING snapshots are not deployable by nature.
                     this_deployable = False
@@ -1275,7 +1278,8 @@ class DeployabilityIndex(PydanticModel, frozen=True):
                 else:
                     this_deployable = True
                 children_deployable = not (
-                    snapshot.is_paused and (snapshot.is_forward_only or is_forward_only_model)
+                    snapshot.is_paused
+                    and (snapshot.is_forward_only or is_uncategorized_forward_only_model)
                 )
             else:
                 this_deployable, children_deployable = False, False

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -1637,15 +1637,46 @@ def test_deployability_index_uncategorized_forward_only_model(make_snapshot):
     snapshot_b = make_snapshot(SqlModel(name="b", query=parse_one("SELECT 1")))
     snapshot_b.parents = (snapshot_a.snapshot_id,)
 
-    deplyability_index = DeployabilityIndex.create(
+    deployability_index = DeployabilityIndex.create(
         {s.snapshot_id: s for s in [snapshot_a, snapshot_b]}
     )
 
-    assert not deplyability_index.is_deployable(snapshot_a)
-    assert not deplyability_index.is_deployable(snapshot_b)
+    assert not deployability_index.is_deployable(snapshot_a)
+    assert not deployability_index.is_deployable(snapshot_b)
 
-    assert not deplyability_index.is_representative(snapshot_a)
-    assert not deplyability_index.is_representative(snapshot_b)
+    assert not deployability_index.is_representative(snapshot_a)
+    assert not deployability_index.is_representative(snapshot_b)
+
+
+def test_deployability_index_categorized_forward_only_model(make_snapshot):
+    model_a = SqlModel(
+        name="a",
+        query=parse_one("SELECT 1, ds"),
+        kind=IncrementalByTimeRangeKind(time_column="ds", forward_only=True),
+    )
+
+    snapshot_a_old = make_snapshot(model_a)
+    snapshot_a_old.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    snapshot_a = make_snapshot(model_a)
+    snapshot_a.previous_versions = snapshot_a_old.all_versions
+    snapshot_a.categorize_as(SnapshotChangeCategory.METADATA)
+
+    snapshot_b = make_snapshot(SqlModel(name="b", query=parse_one("SELECT 1")))
+    snapshot_b.parents = (snapshot_a.snapshot_id,)
+    snapshot_b.categorize_as(SnapshotChangeCategory.METADATA)
+
+    # The fact that the model is forward only should be ignored if an actual category
+    # has been assigned.
+    deployability_index = DeployabilityIndex.create(
+        {s.snapshot_id: s for s in [snapshot_a, snapshot_b]}
+    )
+
+    assert deployability_index.is_deployable(snapshot_a)
+    assert deployability_index.is_deployable(snapshot_b)
+
+    assert deployability_index.is_representative(snapshot_a)
+    assert deployability_index.is_representative(snapshot_b)
 
 
 def test_deployability_index_missing_parent(make_snapshot):


### PR DESCRIPTION
Before this change, SQLMesh would incorrectly classify a snapshot of a forward-only model as non-deployable, even though the change category assigned to that snapshot was `METADATA`.