### PR TITLE
Fix: The broken reference check shouldn't check removed external models

### DIFF
--- a/sqlmesh/core/model/__init__.py
+++ b/sqlmesh/core/model/__init__.py
@@ -4,6 +4,7 @@ from sqlmesh.core.model.cache import (
 )
 from sqlmesh.core.model.decorator import model as model
 from sqlmesh.core.model.definition import (
+    ExternalModel as ExternalModel,
     Model as Model,
     PythonModel as PythonModel,
     SeedModel as SeedModel,

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -698,9 +698,9 @@ class PlanBuilder:
 
     def _ensure_no_broken_references(self) -> None:
         for snapshot in self._context_diff.snapshots.values():
-            broken_references = {x.name for x in self._context_diff.removed_snapshots} & {
-                x for x in snapshot.node.depends_on
-            }
+            broken_references = {
+                x.name for x in self._context_diff.removed_snapshots.values() if not x.is_external
+            } & {x for x in snapshot.node.depends_on}
             if broken_references:
                 broken_references_msg = ", ".join(f"'{x}'" for x in broken_references)
                 raise PlanError(


### PR DESCRIPTION
External models are not technically managed by SQLMesh, and so if the reference is removed from the `schema.yaml` file we shouldn't fail the plan.