### PR TITLE
WIP: Add support for reusable SQL macros

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -661,7 +661,7 @@ def _is_command_statement(command: str, tokens: t.List[Token], pos: int) -> bool
         return False
 
 
-MACRO = "MACRO"
+MACRO_BEGIN = "MACRO_BEGIN"
 MACRO_END = "MACRO_END"
 
 
@@ -671,7 +671,7 @@ JINJA_END = "JINJA_END"
 
 
 def _is_sql_macro_begin(tokens: t.List[Token], pos: int) -> bool:
-    return tokens[pos].text.upper() == MACRO
+    return tokens[pos].text.upper() == MACRO_BEGIN
 
 
 def _is_sql_macro_end(tokens: t.List[Token], pos: int) -> bool:

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -37,6 +37,10 @@ class Model(exp.Expression):
     arg_types = {"expressions": True}
 
 
+class Macro(exp.Expression):
+    arg_types = {"expressions": True}
+
+
 class Audit(exp.Expression):
     arg_types = {"expressions": True}
 
@@ -524,6 +528,7 @@ def _create_parser(parser_type: t.Type[exp.Expression], table_keys: t.List[str])
 
 PARSERS = {
     "MODEL": _create_parser(Model, ["name"]),
+    "MACRO": _create_parser(Macro, ["name"]),
     "AUDIT": _create_parser(Audit, ["model"]),
     "METRIC": _create_parser(Metric, ["name"]),
 }

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -17,7 +17,13 @@ from sqlglot import exp, Dialect
 from sqlmesh.core import constants as c
 from sqlmesh.core.audit import Audit, load_multiple_audits
 from sqlmesh.core.dialect import parse, MACRO
-from sqlmesh.core.macros import MacroRegistry, macro, _norm_var_arg_lambda, normalize_macro_name
+from sqlmesh.core.macros import (
+    MacroRegistry,
+    macro,
+    _norm_var_arg_lambda,
+    normalize_macro_name,
+    MacroEvaluator,
+)
 from sqlmesh.core.metric import Metric, MetricMeta, expand_metrics, load_metric_ddl
 from sqlmesh.core.model import (
     Model,
@@ -262,7 +268,7 @@ class SqlMeshLoader(Loader):
                             lambda_func = exp.Lambda(
                                 this=macro_func.expression[0], expressions=macro_func.expressions
                             )
-                            _, fn = _norm_var_arg_lambda(self, lambda_func)
+                            _, fn = _norm_var_arg_lambda(MacroEvaluator(), lambda_func)
                             standard_macros[macro_name] = lambda _, *args: fn(
                                 args[0] if len(args) == 1 else exp.Tuple(expressions=list(args))
                             )

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -322,7 +322,7 @@ class SqlMeshLoader(Loader):
                             raise ConfigError(
                                 f"Failed to parse a model definition at '{path}': {ex}."
                             )
-
+                    # breakpoint()
                     return load_sql_based_model(
                         expressions,
                         defaults=config.model_defaults.dict(),
@@ -338,7 +338,7 @@ class SqlMeshLoader(Loader):
                         variables=variables,
                         infer_names=config.model_naming.infer_names,
                     )
-
+                # breakpoint()
                 model = cache.get_or_load_model(path, _load)
                 models[model.fqn] = model
 

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -11,11 +11,12 @@ from pathlib import Path
 
 from sqlglot.errors import SchemaError, SqlglotError
 from sqlglot.schema import MappingSchema
+from sqlglot import exp
 
 from sqlmesh.core import constants as c
 from sqlmesh.core.audit import Audit, load_multiple_audits
 from sqlmesh.core.dialect import parse
-from sqlmesh.core.macros import MacroRegistry, macro
+from sqlmesh.core.macros import MacroRegistry, macro, _norm_var_arg_lambda, normalize_macro_name
 from sqlmesh.core.metric import Metric, MetricMeta, expand_metrics, load_metric_ddl
 from sqlmesh.core.model import (
     Model,
@@ -251,7 +252,36 @@ class SqlMeshLoader(Loader):
                     else macro_file_mtime
                 )
                 with open(path, "r", encoding="utf-8") as file:
-                    jinja_macros.add_macros(extractor.extract(file.read()))
+                    sql_file = file.read()
+                    jinja_macro_defs = extractor.extract(sql_file)
+                    if not jinja_macro_defs:
+
+                        def traverse_and_replace(node: exp.Lambda) -> exp.Expression:
+                            if isinstance(node, exp.Column):
+                                node = node.this
+                                return node
+                            elif hasattr(node, "args"):
+                                for key, value in node.args.items():
+                                    if isinstance(value, list):
+                                        node.args[key] = [traverse_and_replace(v) for v in value]
+                                    else:
+                                        node.args[key] = traverse_and_replace(value)
+                            return node
+
+                        parsed = parse(sql_file)
+                        for decl, macro_def in zip(parsed[0::2], parsed[1::2]):
+                            macro_name = decl.expressions[0].args["value"].this.this
+                            lambda_func = exp.Lambda(this=macro_def)
+                            lambda_func.set(
+                                "expressions", decl.expressions[1].args["value"].expressions
+                            )
+                            _, fn = _norm_var_arg_lambda(self, traverse_and_replace(lambda_func))
+                            standard_macros[macro_name] = lambda _, *args: fn(
+                                args[0] if len(args) == 1 else exp.Tuple(expressions=list(args))
+                            )
+                            macro(normalize_macro_name(macro_name))(standard_macros[macro_name])
+                    else:
+                        jinja_macros.add_macros(jinja_macro_defs)
 
         self._macros_max_mtime = macros_max_mtime
 

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -16,7 +16,7 @@ from sqlglot import exp, Dialect
 
 from sqlmesh.core import constants as c
 from sqlmesh.core.audit import Audit, load_multiple_audits
-from sqlmesh.core.dialect import parse, MACRO
+from sqlmesh.core.dialect import parse, MACRO_BEGIN
 from sqlmesh.core.macros import (
     MacroRegistry,
     macro,
@@ -261,7 +261,8 @@ class SqlMeshLoader(Loader):
                 with open(path, "r", encoding="utf-8") as file:
                     sql_file = file.read()
                     tokens = Dialect().tokenizer.tokenize(sql_file)
-                    if tokens[0].text == MACRO:
+
+                    if tokens[0].text == MACRO_BEGIN:
                         parsed = parse(sql=sql_file, tokens=tokens)
                         for macro_func in parsed:
                             macro_name = macro_func.this

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -322,7 +322,7 @@ class SqlMeshLoader(Loader):
                             raise ConfigError(
                                 f"Failed to parse a model definition at '{path}': {ex}."
                             )
-                    # breakpoint()
+
                     return load_sql_based_model(
                         expressions,
                         defaults=config.model_defaults.dict(),
@@ -338,7 +338,7 @@ class SqlMeshLoader(Loader):
                         variables=variables,
                         infer_names=config.model_naming.infer_names,
                     )
-                # breakpoint()
+
                 model = cache.get_or_load_model(path, _load)
                 models[model.fqn] = model
 

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -181,8 +181,8 @@ class MacroEvaluator:
     def send(
         self, name: str, *args: t.Any, **kwargs: t.Any
     ) -> t.Union[None, exp.Expression, t.List[exp.Expression]]:
-        func = self.macros.get(normalize_macro_name(name))
-
+        func = self.macros.get(normalize_macro_name(name)) or self.macros.get()
+        # breakpoint()
         if not callable(func):
             raise SQLMeshError(f"Macro '{name}' does not exist.")
 
@@ -319,6 +319,8 @@ class MacroEvaluator:
         return MacroStrTemplate(str(text)).safe_substitute(mapping)
 
     def evaluate(self, node: MacroFunc) -> exp.Expression | t.List[exp.Expression] | None:
+
+
         if isinstance(node, MacroDef):
             if isinstance(node.expression, exp.Lambda):
                 _, fn = _norm_var_arg_lambda(self, node.expression)
@@ -349,9 +351,10 @@ class MacroEvaluator:
                         )
 
                     args.append(e)
-
+            breakpoint()
             result = self.send(func.name, *args, **kwargs)
 
+            breakpoint()
         if result is None:
             return None
 

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -181,8 +181,8 @@ class MacroEvaluator:
     def send(
         self, name: str, *args: t.Any, **kwargs: t.Any
     ) -> t.Union[None, exp.Expression, t.List[exp.Expression]]:
-        func = self.macros.get(normalize_macro_name(name)) or self.macros.get()
-        # breakpoint()
+        func = self.macros.get(normalize_macro_name(name))
+
         if not callable(func):
             raise SQLMeshError(f"Macro '{name}' does not exist.")
 
@@ -319,8 +319,6 @@ class MacroEvaluator:
         return MacroStrTemplate(str(text)).safe_substitute(mapping)
 
     def evaluate(self, node: MacroFunc) -> exp.Expression | t.List[exp.Expression] | None:
-
-
         if isinstance(node, MacroDef):
             if isinstance(node.expression, exp.Lambda):
                 _, fn = _norm_var_arg_lambda(self, node.expression)
@@ -351,10 +349,9 @@ class MacroEvaluator:
                         )
 
                     args.append(e)
-            breakpoint()
+
             result = self.send(func.name, *args, **kwargs)
 
-            breakpoint()
         if result is None:
             return None
 

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -158,7 +158,10 @@ class MacroEvaluator:
         }
         self.python_env = python_env or {}
         self._jinja_env: t.Optional[Environment] = jinja_env
-        self.macros = {normalize_macro_name(k): v.func for k, v in macro.get_registry().items()}
+        self.macros = {
+            normalize_macro_name(k): v.func if hasattr(v, "func") else v
+            for k, v in macro.get_registry().items()
+        }
         self._schema = schema
         self._resolve_tables = resolve_tables
         self.columns_to_types_called = False

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1967,6 +1967,7 @@ def _python_env(
     serialized_env = {}
 
     expressions = ensure_list(expressions)
+    # breakpoint()
     for expression in expressions:
         if not isinstance(expression, d.Jinja):
             for macro_func_or_var in expression.find_all(d.MacroFunc, d.MacroVar, exp.Identifier):
@@ -2003,7 +2004,7 @@ def _python_env(
     for macro_ref in jinja_macro_references or set():
         if macro_ref.package is None and macro_ref.name in macros:
             used_macros[macro_ref.name] = macros[macro_ref.name]
-
+    # breakpoint()
     for name, used_macro in used_macros.items():
         if isinstance(used_macro, Executable):
             serialized_env[name] = used_macro

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1967,7 +1967,6 @@ def _python_env(
     serialized_env = {}
 
     expressions = ensure_list(expressions)
-    # breakpoint()
     for expression in expressions:
         if not isinstance(expression, d.Jinja):
             for macro_func_or_var in expression.find_all(d.MacroFunc, d.MacroVar, exp.Identifier):
@@ -2004,7 +2003,7 @@ def _python_env(
     for macro_ref in jinja_macro_references or set():
         if macro_ref.package is None and macro_ref.name in macros:
             used_macros[macro_ref.name] = macros[macro_ref.name]
-    # breakpoint()
+
     for name, used_macro in used_macros.items():
         if isinstance(used_macro, Executable):
             serialized_env[name] = used_macro

--- a/sqlmesh/utils/jinja.py
+++ b/sqlmesh/utils/jinja.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from enum import Enum
 
 from jinja2 import Environment, Template, nodes
-from sqlglot import Dialect, Expression, Parser, TokenType
+from sqlglot import Dialect, Expression, Parser, TokenType, Token
 
 from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
@@ -55,7 +55,9 @@ class MacroReturnVal(Exception):
 
 
 class MacroExtractor(Parser):
-    def extract(self, jinja: str, dialect: str = "") -> t.Dict[str, MacroInfo]:
+    def extract(
+        self, jinja: str, dialect: str = "", tokens: t.Optional[t.List[Token]] = None
+    ) -> t.Dict[str, MacroInfo]:
         """Extract a dictionary of macro definitions from a jinja string.
 
         Args:
@@ -67,12 +69,11 @@ class MacroExtractor(Parser):
         """
         self.reset()
         self.sql = jinja
-        self._tokens = Dialect.get_or_raise(dialect).tokenizer.tokenize(jinja)
+        self._tokens = tokens or Dialect.get_or_raise(dialect).tokenizer.tokenize(jinja)
         self._index = -1
         self._advance()
 
         macros: t.Dict[str, MacroInfo] = {}
-
         while self._curr:
             if self._curr.token_type == TokenType.BLOCK_START:
                 macro_start = self._curr
@@ -91,7 +92,6 @@ class MacroExtractor(Parser):
                 )
 
             self._advance()
-
         return macros
 
     def _advance(self, times: int = 1) -> None:

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -6,6 +6,8 @@ from sqlmesh.core.dialect import (
     JinjaQuery,
     JinjaStatement,
     Model,
+    Macro,
+    MacroFunc,
     format_model_expressions,
     normalize_model_name,
     parse,
@@ -228,6 +230,25 @@ FROM foo
   @EACH(@columns, item -> @'@iteaoeuatnoehutoenahuoanteuhonateuhaoenthuaoentuhaeotnhaoem'),
   @'@foo'"""
     )
+
+
+def test_parse_sql_macro():
+    expressions = parse(
+        """MACRO_BEGIN pythag(a, b);
+    SQRT(POW(@a, 2) + POW(@b, 2));
+MACRO_END;
+MACRO_BEGIN foo(a, b);
+    @PYTHAG(@a, @b) + 3;
+MACRO_END;"""
+    )
+
+    assert len(expressions) == 2
+    assert expressions[0].this == "pythag"
+    assert isinstance(expressions[0], Macro)
+    assert isinstance(expressions[0].expression[0].this, exp.Add)
+    assert expressions[1].this == "foo"
+    assert isinstance(expressions[1], Macro)
+    assert isinstance(expressions[1].expression[0].this, MacroFunc)
 
 
 def test_text_diff():


### PR DESCRIPTION
This is WIP for supporting reusable SQL based macros: [#2505](https://github.com/TobikoData/sqlmesh/issues/2505)

This update would be an alternative to Jinja with user defined SQL macros in the `.sql` files under the `macros` directory. The provisional syntax is as follows:

```
MACRO_BEGIN pythag(a, b);
    SQRT(POW(@a, 2) + POW(@b, 2));
MACRO_END;
```