### PR TITLE
Fix: Start date for dev plans with enabled previews in which a new forward-only model has been added

### DIFF
--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -736,7 +736,7 @@ class PlanBuilder:
                 self._enable_preview
                 and any(
                     snapshot.model.forward_only
-                    for snapshot in self._context_diff.new_snapshots.values()
+                    for snapshot, _ in self._context_diff.modified_snapshots.values()
                     if snapshot.is_model
                 )
             )


### PR DESCRIPTION
When a dev plan contains only new models without any modifications to existing ones, the plan's start should be computed normally rather than being set to 1 day ago, even if the preview is enabled.




