### PR TITLE
Feat: make SchemaDiffer precision aware

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -74,8 +74,8 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
         },
         support_coercing_compatible_types=True,
         parameterized_type_defaults={
-            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (38, 9), 1: (0,)},
-            exp.DataType.build("BIGDECIMAL", dialect=DIALECT).this: {0: (76.76, 38), 1: (0,)},
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(38, 9), (0,)],
+            exp.DataType.build("BIGDECIMAL", dialect=DIALECT).this: [(76.76, 38), (0,)],
         },
         types_with_unlimited_length={
             # parameterized `STRING(n)` can ALTER to unparameterized `STRING`

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -73,6 +73,20 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
             },
         },
         support_coercing_compatible_types=True,
+        parameterized_type_defaults={
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (38, 9), 1: (0,)},
+            exp.DataType.build("BIGDECIMAL", dialect=DIALECT).this: {0: (76.76, 38), 1: (0,)},
+        },
+        types_with_unlimited_length={
+            # parameterized `STRING(n)` can ALTER to unparameterized `STRING`
+            exp.DataType.build("STRING", dialect=DIALECT).this: {
+                exp.DataType.build("STRING", dialect=DIALECT).this,
+            },
+            # parameterized `BYTES(n)` can ALTER to unparameterized `BYTES`
+            exp.DataType.build("BYTES", dialect=DIALECT).this: {
+                exp.DataType.build("BYTES", dialect=DIALECT).this,
+            },
+        },
     )
 
     @property

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -39,7 +39,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
         support_nested_operations=True,
         array_element_selector="element",
         parameterized_type_defaults={
-            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (10, 0), 1: (0,)},
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(10, 0), (0,)],
         },
     )
     CATALOG_SUPPORT = CatalogSupport.FULL_SUPPORT

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -38,6 +38,9 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
         support_positional_add=True,
         support_nested_operations=True,
         array_element_selector="element",
+        parameterized_type_defaults={
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (10, 0), 1: (0,)},
+        },
     )
     CATALOG_SUPPORT = CatalogSupport.FULL_SUPPORT
     SUPPORTS_ROW_LEVEL_OP = True

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -18,6 +18,7 @@ from sqlmesh.core.engine_adapter.shared import (
     set_catalog,
 )
 from sqlmesh.utils import major_minor
+from sqlmesh.core.schema_diff import SchemaDiffer
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import SchemaName, TableName
@@ -29,6 +30,11 @@ class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin)
     DIALECT = "duckdb"
     SUPPORTS_TRANSACTIONS = False
     CATALOG_SUPPORT = CatalogSupport.FULL_SUPPORT
+    SCHEMA_DIFFER = SchemaDiffer(
+        parameterized_type_defaults={
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (18, 3), 1: (0,)},
+        },
+    )
 
     # TODO: remove once we stop supporting DuckDB 0.9
     COMMENT_CREATION_TABLE, COMMENT_CREATION_VIEW = (

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -32,7 +32,7 @@ class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin)
     CATALOG_SUPPORT = CatalogSupport.FULL_SUPPORT
     SCHEMA_DIFFER = SchemaDiffer(
         parameterized_type_defaults={
-            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (18, 3), 1: (0,)},
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(18, 3), (0,)],
         },
     )
 

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -26,6 +26,7 @@ from sqlmesh.core.engine_adapter.shared import (
     SourceQuery,
     set_catalog,
 )
+from sqlmesh.core.schema_diff import SchemaDiffer
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import SchemaName, TableName
@@ -48,6 +49,25 @@ class MSSQLEngineAdapter(
     COMMENT_CREATION_TABLE = CommentCreationTable.UNSUPPORTED
     COMMENT_CREATION_VIEW = CommentCreationView.UNSUPPORTED
     SUPPORTS_REPLACE_TABLE = False
+    SCHEMA_DIFFER = SchemaDiffer(
+        parameterized_type_defaults={
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (18, 0), 1: (0,)},
+            exp.DataType.build("BINARY", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("VARBINARY", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("VARCHAR", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("NCHAR", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("NVARCHAR", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("TIME", dialect=DIALECT).this: {0: (7,)},
+            exp.DataType.build("DATETIME2", dialect=DIALECT).this: {0: (7,)},
+            exp.DataType.build("DATETIMEOFFSET", dialect=DIALECT).this: {0: (7,)},
+        },
+        types_with_max_parameter={
+            exp.DataType.build("VARBINARY", dialect=DIALECT).this,
+            exp.DataType.build("VARCHAR", dialect=DIALECT).this,
+            exp.DataType.build("NVARCHAR", dialect=DIALECT).this,
+        },
+    )
 
     def columns(
         self,

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -62,10 +62,10 @@ class MSSQLEngineAdapter(
             exp.DataType.build("DATETIME2", dialect=DIALECT).this: {0: (7,)},
             exp.DataType.build("DATETIMEOFFSET", dialect=DIALECT).this: {0: (7,)},
         },
-        types_with_max_parameter={
-            exp.DataType.build("VARBINARY", dialect=DIALECT).this,
-            exp.DataType.build("VARCHAR", dialect=DIALECT).this,
-            exp.DataType.build("NVARCHAR", dialect=DIALECT).this,
+        max_parameter_length={
+            exp.DataType.build("VARBINARY", dialect=DIALECT).this: 2147483647,
+            exp.DataType.build("VARCHAR", dialect=DIALECT).this: 2147483647,
+            exp.DataType.build("NVARCHAR", dialect=DIALECT).this: 2147483647,
         },
     )
 

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -51,19 +51,19 @@ class MSSQLEngineAdapter(
     SUPPORTS_REPLACE_TABLE = False
     SCHEMA_DIFFER = SchemaDiffer(
         parameterized_type_defaults={
-            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (18, 0), 1: (0,)},
-            exp.DataType.build("BINARY", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("VARBINARY", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("VARCHAR", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("NCHAR", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("NVARCHAR", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("TIME", dialect=DIALECT).this: {0: (7,)},
-            exp.DataType.build("DATETIME2", dialect=DIALECT).this: {0: (7,)},
-            exp.DataType.build("DATETIMEOFFSET", dialect=DIALECT).this: {0: (7,)},
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(18, 0), (0,)],
+            exp.DataType.build("BINARY", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("VARBINARY", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("CHAR", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("VARCHAR", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("NCHAR", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("NVARCHAR", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("TIME", dialect=DIALECT).this: [(7,)],
+            exp.DataType.build("DATETIME2", dialect=DIALECT).this: [(7,)],
+            exp.DataType.build("DATETIMEOFFSET", dialect=DIALECT).this: [(7,)],
         },
         max_parameter_length={
-            exp.DataType.build("VARBINARY", dialect=DIALECT).this: 2147483647,
+            exp.DataType.build("VARBINARY", dialect=DIALECT).this: 2147483647,  # 2 GB
             exp.DataType.build("VARCHAR", dialect=DIALECT).this: 2147483647,
             exp.DataType.build("NVARCHAR", dialect=DIALECT).this: 2147483647,
         },

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -42,15 +42,15 @@ class MySQLEngineAdapter(
     SUPPORTS_REPLACE_TABLE = False
     SCHEMA_DIFFER = SchemaDiffer(
         parameterized_type_defaults={
-            exp.DataType.build("BIT", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("BINARY", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (10, 0), 1: (0,)},
-            exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("NCHAR", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("TEXT", dialect=DIALECT).this: {0: (65535,)},
-            exp.DataType.build("TIME", dialect=DIALECT).this: {0: (0,)},
-            exp.DataType.build("DATETIME", dialect=DIALECT).this: {0: (0,)},
-            exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: {0: (0,)},
+            exp.DataType.build("BIT", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("BINARY", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(10, 0), (0,)],
+            exp.DataType.build("CHAR", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("NCHAR", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("TEXT", dialect=DIALECT).this: [(65535,)],
+            exp.DataType.build("TIME", dialect=DIALECT).this: [(0,)],
+            exp.DataType.build("DATETIME", dialect=DIALECT).this: [(0,)],
+            exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: [(0,)],
         },
     )
 

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -18,6 +18,7 @@ from sqlmesh.core.engine_adapter.shared import (
     DataObjectType,
     set_catalog,
 )
+from sqlmesh.core.schema_diff import SchemaDiffer
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import SchemaName, TableName
@@ -39,6 +40,18 @@ class MySQLEngineAdapter(
     MAX_TABLE_COMMENT_LENGTH = 2048
     MAX_COLUMN_COMMENT_LENGTH = 1024
     SUPPORTS_REPLACE_TABLE = False
+    SCHEMA_DIFFER = SchemaDiffer(
+        parameterized_type_defaults={
+            exp.DataType.build("BIT", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("BINARY", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (10, 0), 1: (0,)},
+            exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("TEXT", dialect=DIALECT).this: {0: (65535,)},
+            exp.DataType.build("TIME", dialect=DIALECT).this: {0: (0,)},
+            exp.DataType.build("DATETIME", dialect=DIALECT).this: {0: (0,)},
+            exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: {0: (0,)},
+        },
+    )
 
     def get_current_catalog(self) -> t.Optional[str]:
         """Returns the catalog name of the current connection."""

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -46,6 +46,7 @@ class MySQLEngineAdapter(
             exp.DataType.build("BINARY", dialect=DIALECT).this: {0: (1,)},
             exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (10, 0), 1: (0,)},
             exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("NCHAR", dialect=DIALECT).this: {0: (1,)},
             exp.DataType.build("TEXT", dialect=DIALECT).this: {0: (65535,)},
             exp.DataType.build("TIME", dialect=DIALECT).this: {0: (0,)},
             exp.DataType.build("DATETIME", dialect=DIALECT).this: {0: (0,)},

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import typing as t
-
 from sqlglot import exp
 
 from sqlmesh.core.engine_adapter.base_postgres import BasePostgresEngineAdapter
@@ -11,6 +10,7 @@ from sqlmesh.core.engine_adapter.mixins import (
     PandasNativeFetchDFSupportMixin,
 )
 from sqlmesh.core.engine_adapter.shared import set_catalog
+from sqlmesh.core.schema_diff import SchemaDiffer
 
 if t.TYPE_CHECKING:
     from sqlmesh.core.engine_adapter._typing import DF
@@ -29,6 +29,44 @@ class PostgresEngineAdapter(
     HAS_VIEW_BINDING = True
     CURRENT_CATALOG_EXPRESSION = exp.column("current_catalog")
     SUPPORTS_REPLACE_TABLE = False
+    SCHEMA_DIFFER = SchemaDiffer(
+        # user may pass a parameterize-able type with 0, 1, or 2 parameters present (depending on the type)
+        #  - this dictionary's keys are the underlying exp.DataType.Type data types returned by sqlglot
+        #  - each key's value is a dictionary whose keys are the number of parameters provided by the user
+        #      and whose values are a tuple containing the default values for the omitted parameters
+        #  - the default values are in the order they are specified in the data type string
+        #  - parameters are appended to existing parameters (e.g., "DECIMAL(10)" -> `(0,)` -> `DECIMAL(10,0)`)
+        parameterized_type_defaults={
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {1: (0,)},
+            exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("TIME", dialect=DIALECT).this: {0: (6,)},
+            exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: {0: (6,)},
+            exp.DataType.build("INTERVAL", dialect=DIALECT).this: {0: (6,)},
+        },
+        # keys are an unlimited length type, values are the types that can always ALTER to the key type
+        types_with_unlimited_length={
+            exp.DataType.build("TEXT", dialect=DIALECT).this: {
+                exp.DataType.build("VARCHAR", dialect=DIALECT).this,
+                exp.DataType.build("CHAR", dialect=DIALECT).this,
+                exp.DataType.build("BPCHAR", dialect=DIALECT).this,
+            },
+            # all can ALTER to unparameterized `VARCHAR`
+            exp.DataType.build("VARCHAR", dialect=DIALECT).this: {
+                exp.DataType.build("VARCHAR", dialect=DIALECT).this,
+                exp.DataType.build("CHAR", dialect=DIALECT).this,
+                exp.DataType.build("BPCHAR", dialect=DIALECT).this,
+                exp.DataType.build("TEXT", dialect=DIALECT).this,
+            },
+            # parameterized `BPCHAR(n)` can ALTER to unparameterized `BPCHAR`
+            exp.DataType.build("BPCHAR", dialect=DIALECT).this: {
+                exp.DataType.build("BPCHAR", dialect=DIALECT).this
+            },
+            # parameterized `DECIMAL(n)` can ALTER to unparameterized `DECIMAL`
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {
+                exp.DataType.build("DECIMAL", dialect=DIALECT).this
+            },
+        },
+    )
 
     def _fetch_native_df(
         self, query: t.Union[exp.Expression, str], quote_identifiers: bool = False

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -31,11 +31,14 @@ class PostgresEngineAdapter(
     SUPPORTS_REPLACE_TABLE = False
     SCHEMA_DIFFER = SchemaDiffer(
         parameterized_type_defaults={
-            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {1: (0,)},
+            # DECIMAL without precision is "up to 131072 digits before the decimal point; up to 16383 digits after the decimal point"
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {
+                0: (131072 + 16383, 16383),
+                1: (0,),
+            },
             exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
             exp.DataType.build("TIME", dialect=DIALECT).this: {0: (6,)},
             exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: {0: (6,)},
-            exp.DataType.build("INTERVAL", dialect=DIALECT).this: {0: (6,)},
         },
         types_with_unlimited_length={
             # all can ALTER to `TEXT`
@@ -44,7 +47,7 @@ class PostgresEngineAdapter(
                 exp.DataType.build("CHAR", dialect=DIALECT).this,
                 exp.DataType.build("BPCHAR", dialect=DIALECT).this,
             },
-            # all can ALTER to unparameterized version of `VARCHAR`
+            # all can ALTER to unparameterized `VARCHAR`
             exp.DataType.build("VARCHAR", dialect=DIALECT).this: {
                 exp.DataType.build("VARCHAR", dialect=DIALECT).this,
                 exp.DataType.build("CHAR", dialect=DIALECT).this,
@@ -54,10 +57,6 @@ class PostgresEngineAdapter(
             # parameterized `BPCHAR(n)` can ALTER to unparameterized `BPCHAR`
             exp.DataType.build("BPCHAR", dialect=DIALECT).this: {
                 exp.DataType.build("BPCHAR", dialect=DIALECT).this
-            },
-            # parameterized `DECIMAL(n)` can ALTER to unparameterized `DECIMAL`
-            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {
-                exp.DataType.build("DECIMAL", dialect=DIALECT).this
             },
         },
     )

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -30,12 +30,6 @@ class PostgresEngineAdapter(
     CURRENT_CATALOG_EXPRESSION = exp.column("current_catalog")
     SUPPORTS_REPLACE_TABLE = False
     SCHEMA_DIFFER = SchemaDiffer(
-        # user may pass a parameterize-able type with 0, 1, or 2 parameters present (depending on the type)
-        #  - this dictionary's keys are the underlying exp.DataType.Type data types returned by sqlglot
-        #  - each key's value is a dictionary whose keys are the number of parameters provided by the user
-        #      and whose values are a tuple containing the default values for the omitted parameters
-        #  - the default values are in the order they are specified in the data type string
-        #  - parameters are appended to existing parameters (e.g., "DECIMAL(10)" -> `(0,)` -> `DECIMAL(10,0)`)
         parameterized_type_defaults={
             exp.DataType.build("DECIMAL", dialect=DIALECT).this: {1: (0,)},
             exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
@@ -43,14 +37,14 @@ class PostgresEngineAdapter(
             exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: {0: (6,)},
             exp.DataType.build("INTERVAL", dialect=DIALECT).this: {0: (6,)},
         },
-        # keys are an unlimited length type, values are the types that can always ALTER to the key type
         types_with_unlimited_length={
+            # all can ALTER to `TEXT`
             exp.DataType.build("TEXT", dialect=DIALECT).this: {
                 exp.DataType.build("VARCHAR", dialect=DIALECT).this,
                 exp.DataType.build("CHAR", dialect=DIALECT).this,
                 exp.DataType.build("BPCHAR", dialect=DIALECT).this,
             },
-            # all can ALTER to unparameterized `VARCHAR`
+            # all can ALTER to unparameterized version of `VARCHAR`
             exp.DataType.build("VARCHAR", dialect=DIALECT).this: {
                 exp.DataType.build("VARCHAR", dialect=DIALECT).this,
                 exp.DataType.build("CHAR", dialect=DIALECT).this,

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -32,13 +32,10 @@ class PostgresEngineAdapter(
     SCHEMA_DIFFER = SchemaDiffer(
         parameterized_type_defaults={
             # DECIMAL without precision is "up to 131072 digits before the decimal point; up to 16383 digits after the decimal point"
-            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {
-                0: (131072 + 16383, 16383),
-                1: (0,),
-            },
-            exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("TIME", dialect=DIALECT).this: {0: (6,)},
-            exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: {0: (6,)},
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(131072 + 16383, 16383), (0,)],
+            exp.DataType.build("CHAR", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("TIME", dialect=DIALECT).this: [(6,)],
+            exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: [(6,)],
         },
         types_with_unlimited_length={
             # all can ALTER to `TEXT`

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -49,9 +49,9 @@ class RedshiftEngineAdapter(
             exp.DataType.build("NCHAR", dialect=DIALECT).this: {0: (1,)},
             exp.DataType.build("NVARCHAR", dialect=DIALECT).this: {0: (256,)},
         },
-        types_with_max_parameter={
-            exp.DataType.build("CHAR", dialect=DIALECT).this,
-            exp.DataType.build("VARCHAR", dialect=DIALECT).this,
+        max_parameter_length={
+            exp.DataType.build("CHAR", dialect=DIALECT).this: 4096,
+            exp.DataType.build("VARCHAR", dialect=DIALECT).this: 65535,
         },
     )
 

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -20,6 +20,7 @@ from sqlmesh.core.engine_adapter.shared import (
     SourceQuery,
     set_catalog,
 )
+from sqlmesh.core.schema_diff import SchemaDiffer
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import SchemaName, TableName
@@ -39,6 +40,20 @@ class RedshiftEngineAdapter(
     # Redshift doesn't support comments for VIEWs WITH NO SCHEMA BINDING (which we always use)
     COMMENT_CREATION_VIEW = CommentCreationView.UNSUPPORTED
     SUPPORTS_REPLACE_TABLE = False
+    SCHEMA_DIFFER = SchemaDiffer(
+        parameterized_type_defaults={
+            exp.DataType.build("VARBYTE", dialect=DIALECT).this: {0: (64000,)},
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (18, 0), 1: (0,)},
+            exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("VARCHAR", dialect=DIALECT).this: {0: (256,)},
+            exp.DataType.build("NCHAR", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("NVARCHAR", dialect=DIALECT).this: {0: (256,)},
+        },
+        types_with_max_parameter={
+            exp.DataType.build("CHAR", dialect=DIALECT).this,
+            exp.DataType.build("VARCHAR", dialect=DIALECT).this,
+        },
+    )
 
     def _columns_query(self, table: exp.Table) -> exp.Select:
         sql = (

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -42,12 +42,12 @@ class RedshiftEngineAdapter(
     SUPPORTS_REPLACE_TABLE = False
     SCHEMA_DIFFER = SchemaDiffer(
         parameterized_type_defaults={
-            exp.DataType.build("VARBYTE", dialect=DIALECT).this: {0: (64000,)},
-            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (18, 0), 1: (0,)},
-            exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("VARCHAR", dialect=DIALECT).this: {0: (256,)},
-            exp.DataType.build("NCHAR", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("NVARCHAR", dialect=DIALECT).this: {0: (256,)},
+            exp.DataType.build("VARBYTE", dialect=DIALECT).this: [(64000,)],
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(18, 0), (0,)],
+            exp.DataType.build("CHAR", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("VARCHAR", dialect=DIALECT).this: [(256,)],
+            exp.DataType.build("NCHAR", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("NVARCHAR", dialect=DIALECT).this: [(256,)],
         },
         max_parameter_length={
             exp.DataType.build("CHAR", dialect=DIALECT).this: 4096,

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -45,17 +45,17 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
     CURRENT_CATALOG_EXPRESSION = exp.func("current_database")
     SCHEMA_DIFFER = SchemaDiffer(
         parameterized_type_defaults={
-            exp.DataType.build("BINARY", dialect=DIALECT).this: {0: (8388608,)},
-            exp.DataType.build("VARBINARY", dialect=DIALECT).this: {0: (8388608,)},
-            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (38, 0), 1: (0,)},
-            exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("NCHAR", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("VARCHAR", dialect=DIALECT).this: {0: (16777216,)},
-            exp.DataType.build("TIME", dialect=DIALECT).this: {0: (9,)},
-            exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: {0: (9,)},
-            exp.DataType.build("TIMESTAMP_LTZ", dialect=DIALECT).this: {0: (9,)},
-            exp.DataType.build("TIMESTAMP_NTZ", dialect=DIALECT).this: {0: (9,)},
-            exp.DataType.build("TIMESTAMP_TZ", dialect=DIALECT).this: {0: (9,)},
+            exp.DataType.build("BINARY", dialect=DIALECT).this: [(8388608,)],
+            exp.DataType.build("VARBINARY", dialect=DIALECT).this: [(8388608,)],
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(38, 0), (0,)],
+            exp.DataType.build("CHAR", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("NCHAR", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("VARCHAR", dialect=DIALECT).this: [(16777216,)],
+            exp.DataType.build("TIME", dialect=DIALECT).this: [(9,)],
+            exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: [(9,)],
+            exp.DataType.build("TIMESTAMP_LTZ", dialect=DIALECT).this: [(9,)],
+            exp.DataType.build("TIMESTAMP_NTZ", dialect=DIALECT).this: [(9,)],
+            exp.DataType.build("TIMESTAMP_TZ", dialect=DIALECT).this: [(9,)],
         },
     )
 

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -18,6 +18,7 @@ from sqlmesh.core.engine_adapter.shared import (
     SourceQuery,
     set_catalog,
 )
+from sqlmesh.core.schema_diff import SchemaDiffer
 from sqlmesh.utils import optional_import
 from sqlmesh.utils.errors import SQLMeshError
 
@@ -42,6 +43,21 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
     SUPPORTS_CLONING = True
     CATALOG_SUPPORT = CatalogSupport.FULL_SUPPORT
     CURRENT_CATALOG_EXPRESSION = exp.func("current_database")
+    SCHEMA_DIFFER = SchemaDiffer(
+        parameterized_type_defaults={
+            exp.DataType.build("BINARY", dialect=DIALECT).this: {0: (8388608,)},
+            exp.DataType.build("VARBINARY", dialect=DIALECT).this: {0: (8388608,)},
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (38, 0), 1: (0,)},
+            exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("NCHAR", dialect=DIALECT).this: {0: (1,)},
+            exp.DataType.build("VARCHAR", dialect=DIALECT).this: {0: (16777216,)},
+            exp.DataType.build("TIME", dialect=DIALECT).this: {0: (9,)},
+            exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: {0: (9,)},
+            exp.DataType.build("TIMESTAMP_LTZ", dialect=DIALECT).this: {0: (9,)},
+            exp.DataType.build("TIMESTAMP_NTZ", dialect=DIALECT).this: {0: (9,)},
+            exp.DataType.build("TIMESTAMP_TZ", dialect=DIALECT).this: {0: (9,)},
+        },
+    )
 
     @contextlib.contextmanager
     def session(self, properties: SessionProperties) -> t.Iterator[None]:

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -22,6 +22,7 @@ from sqlmesh.core.engine_adapter.shared import (
     SourceQuery,
     set_catalog,
 )
+from sqlmesh.core.schema_diff import SchemaDiffer
 from sqlmesh.utils import classproperty
 from sqlmesh.utils.errors import SQLMeshError
 
@@ -58,6 +59,12 @@ class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTableP
 
     WAP_PREFIX = "wap_"
     BRANCH_PREFIX = "branch_"
+    SCHEMA_DIFFER = SchemaDiffer(
+        parameterized_type_defaults={
+            exp.DataType.build("BINARY", dialect=DIALECT).this: {0: (100,)},
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (10, 0), 1: (0,)},
+        },
+    )
 
     @property
     def connection(self) -> SparkSessionConnection:

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -61,8 +61,8 @@ class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTableP
     BRANCH_PREFIX = "branch_"
     SCHEMA_DIFFER = SchemaDiffer(
         parameterized_type_defaults={
-            exp.DataType.build("BINARY", dialect=DIALECT).this: {0: (100,)},
-            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {0: (10, 0), 1: (0,)},
+            # default decimal precision varies across backends
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(), (0,)],
         },
     )
 

--- a/sqlmesh/core/engine_adapter/trino.py
+++ b/sqlmesh/core/engine_adapter/trino.py
@@ -56,16 +56,10 @@ class TrinoEngineAdapter(
     QUOTE_IDENTIFIERS_IN_VIEWS = False
     SCHEMA_DIFFER = SchemaDiffer(
         parameterized_type_defaults={
-            exp.DataType.build("DECIMAL", dialect=DIALECT).this: {1: (0,)},
-            exp.DataType.build("CHAR", dialect=DIALECT).this: {0: (1,)},
-            exp.DataType.build("TIME", dialect=DIALECT).this: {0: (3,)},
-            exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: {0: (3,)},
-        },
-        types_with_unlimited_length={
-            # parameterized `VARCHAR(n)` can ALTER to unparameterized `VARCHAR`
-            exp.DataType.build("VARCHAR", dialect=DIALECT).this: {
-                exp.DataType.build("VARCHAR", dialect=DIALECT).this
-            },
+            # default decimal precision varies across backends
+            exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(), (0,)],
+            exp.DataType.build("CHAR", dialect=DIALECT).this: [(1,)],
+            exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: [(3,)],
         },
     )
 

--- a/tests/core/test_schema_diff.py
+++ b/tests/core/test_schema_diff.py
@@ -812,7 +812,7 @@ def test_schema_diff_calculate_type_transitions():
             ],
             dict(
                 parameterized_type_defaults={
-                    exp.DataType.build("VARCHAR").this: {0: (1,)},
+                    exp.DataType.build("VARCHAR").this: [(1,)],
                 },
             ),
         ),
@@ -835,7 +835,7 @@ def test_schema_diff_calculate_type_transitions():
             ],
             dict(
                 parameterized_type_defaults={
-                    exp.DataType.build("VARCHAR").this: {0: (1,)},
+                    exp.DataType.build("VARCHAR").this: [(1,)],
                 },
                 support_positional_add=True,
             ),


### PR DESCRIPTION
Some data types can include user-specified precision parameters, such as decimal precision `DECIMAL(10,1)` or character length `VARCHAR(100)`. 

Currently, the SchemaDiffer outputs a DROP/ADD for all  precision changes, even though precision increases can be done with an ALTER. This PR makes the SchemaDiffer aware of precision such that it outputs ALTER statements when precision is increased.

Precision is implemented differently across engines and types:
- Some types have one parameter `VARCHAR(1)`, and others have two `DECIMAL(10,1)`.
- Sometimes a parameter is optional and has a default value (e.g., `VARCHAR` = `VARCHAR(256)`, `DECIMAL(10)` = `DECIMAL(10,0)`). The SchemaDiffer will automatically provide these default values where possible.
- Some engines/types allow explicitly making a type its maximum precision (e.g., `VARCHAR(max)`).  SchemaDiffer substitutes the corresponding numeric precision.
- Sometimes a parameter is optional and the default is "unlimited" precision (e.g., `VARCHAR` allows strings of any length up to system limits). SchemaDiffer will allow ALTERs from any explicit precision to an unlimited type.
- 
Default values for all engines and types are documented in [this Notion doc](https://www.notion.so/SchemaDiffer-type-docs-4464135715254cc597d638e4550c20dd?pvs=4).

## Complexities

Type aliases:
- Some engines provide multiple aliases for the same underlying type. For example, DuckDB has a single "unlimited" length character type and maps all of `VARCHAR`, `VARCHAR(1)`, `CHAR`, and others to that underlying type.
- In some engines, the aliases behave differently depending on whether a parameter is provided. For example, in Postgres `BPCHAR(1)` == `CHAR(1)` but `BPCHAR` != `CHAR`. 
- Therefore, direct comparison of parameter values only occurs WITHIN a SQLGlot `exp.DataType.Type`. If two type aliases are parsed to the same underlying SQLGlot type their parameters will be compared, if not SchemaDiffer will return DROP/ADD.