### PR TITLE
Fix: redshift leverages postgres adapter dispatch implementations for common functionality

### DIFF
--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -105,9 +105,9 @@ class BaseAdapter(abc.ABC):
             package_name, macro_name = val
             score = 0
             if package_name != package:
-                score += 3
-            if macro_name.startswith("default"):
                 score += 2
+            if macro_name.startswith("default"):
+                score += 3
             elif not macro_name.startswith(target_type):
                 score += 1
             return score

--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -110,9 +110,9 @@ class BaseAdapter(abc.ABC):
             return 1
 
         macros = [
-            MacroReference(package=package_name, name=macro_name)
-            for package_name, macros in self.jinja_macros.packages.items()
-            if (package_name == package) or (package == "dbt" and package_name.startswith("dbt_"))
+            MacroReference(package=macro_package, name=macro_name)
+            for macro_package, macros in self.jinja_macros.packages.items()
+            if (macro_package == package) or (package == "dbt" and macro_package.startswith("dbt_"))
             for macro_name in macros.keys()
             if macro_name.endswith(macro_suffix)
         ]

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -148,10 +148,9 @@ def test_adapter_dispatch(sushi_test_project: Project, runtime_renderer: t.Calla
     context = sushi_test_project.context
     renderer = runtime_renderer(context)
     assert renderer("{{ adapter.dispatch('current_engine', 'customers')() }}") == "duckdb"
-    assert renderer("{{ adapter.dispatch('current_engine')() }}") == "duckdb"
 
-    with pytest.raises(ConfigError, match=r"Macro 'missing_macro'.*was not found."):
-        renderer("{{ adapter.dispatch('missing_macro')() }}")
+    with pytest.raises(ConfigError, match=r"Macro 'current_engine'.*was not found."):
+        renderer("{{ adapter.dispatch('current_engine')() }}")
 
 
 def test_adapter_map_snapshot_tables(

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -148,9 +148,13 @@ def test_adapter_dispatch(sushi_test_project: Project, runtime_renderer: t.Calla
     context = sushi_test_project.context
     renderer = runtime_renderer(context)
     assert renderer("{{ adapter.dispatch('current_engine', 'customers')() }}") == "duckdb"
+    assert renderer("{{ adapter.dispatch('current_timestamp')() }}") == "now()"
+    assert renderer("{{ adapter.dispatch('current_timestamp', 'dbt')() }}") == "now()"
 
     with pytest.raises(ConfigError, match=r"Macro 'current_engine'.*was not found."):
         renderer("{{ adapter.dispatch('current_engine')() }}")
+    with pytest.raises(ConfigError, match=r"Macro 'current_timestamp'.*was not found."):
+        assert renderer("{{ adapter.dispatch('current_timestamp', 'customers')() }}")
 
 
 def test_adapter_map_snapshot_tables(

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -148,9 +148,10 @@ def test_adapter_dispatch(sushi_test_project: Project, runtime_renderer: t.Calla
     context = sushi_test_project.context
     renderer = runtime_renderer(context)
     assert renderer("{{ adapter.dispatch('current_engine', 'customers')() }}") == "duckdb"
+    assert renderer("{{ adapter.dispatch('current_engine')() }}") == "duckdb"
 
-    with pytest.raises(ConfigError, match=r"Macro 'current_engine'.*was not found."):
-        renderer("{{ adapter.dispatch('current_engine')() }}")
+    with pytest.raises(ConfigError, match=r"Macro 'missing_macro'.*was not found."):
+        renderer("{{ adapter.dispatch('missing_macro')() }}")
 
 
 def test_adapter_map_snapshot_tables(


### PR DESCRIPTION
The redshift dbt adapter depends on the postgres adapter. For adapter dispatch, this means that postgres dispatch macros are valid when a corresponding redshift macro does not exist.

Note: The databricks adapter also depends on the spark adapter, so this fix applies there too.