### PR TITLE
Fix: Dry run for self-referencing model queries when creating a temp table during cloning

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -661,7 +661,12 @@ class SnapshotEvaluator:
                 logger.info(f"Cloning table '{source_table_name}' into '{target_table_name}'")
 
                 evaluation_strategy.create(
-                    snapshot, tmp_table_name, False, is_snapshot_deployable, **create_render_kwargs
+                    snapshot,
+                    tmp_table_name,
+                    False,
+                    is_snapshot_deployable,
+                    table_mapping={snapshot.name: tmp_table_name},
+                    **create_render_kwargs,
                 )
                 try:
                     self.adapter.clone_table(target_table_name, snapshot.table_name(), replace=True)


### PR DESCRIPTION
When cloning a table for forward-only snapshots we first create a temporary table which serves as a source for the updated schema. 

As part of this step we also run the CTAS query from this snapshot as a dry run to validate it. 

The issue arises when the model query is self-referencing in which case we don't resolve the table mapping for it correctly, referencing a physical table which doesn't exist yet.