### PR TITLE
Fix: pass dialect to debug terminal console

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1739,8 +1739,15 @@ class DatabricksMagicConsole(CaptureTerminalConsole):
 class DebuggerTerminalConsole(TerminalConsole):
     """A terminal console to use while debugging with no fluff, progress bars, etc."""
 
-    def __init__(self, console: t.Optional[RichConsole], *args: t.Any, **kwargs: t.Any) -> None:
+    def __init__(
+        self,
+        console: t.Optional[RichConsole],
+        *args: t.Any,
+        dialect: DialectType = None,
+        **kwargs: t.Any,
+    ) -> None:
         self.console: RichConsole = console or srich.console
+        self.dialect = dialect
 
     def _write(self, msg: t.Any, *args: t.Any, **kwargs: t.Any) -> None:
         self.console.log(msg, *args, **kwargs)


### PR DESCRIPTION
Missed this one in https://github.com/TobikoData/sqlmesh/commit/a2b4d9db9cf842dfcb9cf7aeb2a6e28182c2ca10.