### PR TITLE
fix:plan apply end should not succeed if previous steps fail

### DIFF
--- a/sqlmesh/schedulers/airflow/dag_generator.py
+++ b/sqlmesh/schedulers/airflow/dag_generator.py
@@ -263,7 +263,7 @@ class SnapshotDagGenerator:
                 task_id="on_plan_apply_end",
                 python_callable=on_plan_apply_end,
                 op_kwargs={"plan_id": plan_dag_spec.environment.plan_id},
-                trigger_rule="all_done",
+                trigger_rule="all_success",
             )
             finalize_task >> on_plan_apply_end_task
 


### PR DESCRIPTION
### Issue
In our environment we discovered an issue using sqlmesh together with the airflow integration.

If `sqlmesh plan` or the `sqlmesh_cicd` command are being executed a broken model will fail. But the Airflow DAG state in which the plan gets applied overall will be in status `success`. I believe this is because the second to last task in these dags is only checking if upstream tasks have finished by checking `all_done`. Instead it should verify if upstream_tasks have actually succeeded by `all_success`.  Because the DAG is executed remotely and succeeds, the `sqlmesh plan` command executed in a github action step also succeeds indicating that the model got applied successfully, which is not the case.

Hence I suggest to set the DAG to fail and let the CLI command know about this and report the failure. So that the developer can take action and fix the issue.

Ideally we can even print the error reason in the github logs, but I am not sure how to achieve that.

I am also not sure, if the change has any other side affects that I am not aware of. Feedback in that regard would be amazing.


### Reproduce
Add this model to sqlmesh 

```MODEL (
  cron '5 5 * * *',
  start '2024-01-01',
  description 'broken model',
  name foo.bar,
  kind INCREMENTAL_BY_PARTITION,
  partitioned_by measured_at_month
);

SELECT
  FORMAT_DATETIME('%Y %B', '2024-01-01') AS measured_at_month, /* test column */
  1 AS bar, /* test column */
  'foo' AS foo /* test column */
```
and run `sqlmesh plan` with the airflow integration. 