### PR TITLE
Fix: Set the default model start when initializing a new project

### DIFF
--- a/sqlmesh/cli/example_project.py
+++ b/sqlmesh/cli/example_project.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import click
 from sqlglot import Dialect
+from sqlmesh.utils.date import yesterday_ds
 
 
 class ProjectTemplate(Enum):
@@ -25,6 +26,7 @@ default_gateway: local
 
 model_defaults:
   dialect: {dialect}
+  start: {yesterday_ds()}
 """,
         ProjectTemplate.AIRFLOW: f"""gateways:
   local:
@@ -42,6 +44,7 @@ default_scheduler:
 
 model_defaults:
   dialect: {dialect}
+  start: {yesterday_ds()}
 """,
         ProjectTemplate.DBT: """from pathlib import Path
 


### PR DESCRIPTION
Setting the default start date in the config at project generation time. Otherwise the model start will be a relative value set to "1 day ago".