### PR TITLE
WIP: Support for reusable SQL Macros

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -705,6 +705,7 @@ def parse(
     default_dialect: t.Optional[str] = None,
     match_dialect: bool = True,
     into: t.Optional[exp.IntoType] = None,
+    tokens: t.Optional[t.List[Token]] = None,
 ) -> t.List[exp.Expression]:
     """Parse a sql string.
 
@@ -721,7 +722,7 @@ def parse(
     match = match_dialect and DIALECT_PATTERN.search(sql[:MAX_MODEL_DEFINITION_SIZE])
     dialect = Dialect.get_or_raise(match.group(2) if match else default_dialect)
 
-    tokens = dialect.tokenizer.tokenize(sql)
+    tokens = tokens or dialect.tokenizer.tokenize(sql)
     chunks: t.List[t.Tuple[t.List[Token], ChunkType]] = [([], ChunkType.SQL)]
     total = len(tokens)
 

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -180,9 +180,7 @@ class MacroEvaluator:
     def send(
         self, name: str, *args: t.Any, **kwargs: t.Any
     ) -> t.Union[None, exp.Expression, t.List[exp.Expression]]:
-        func = self.macros.get(normalize_macro_name(name)) or self.macros.get(
-            normalize_macro_name("@" + name)
-        )
+        func = self.macros.get(normalize_macro_name(name))
 
         if not callable(func):
             raise SQLMeshError(f"Macro '{name}' does not exist.")
@@ -1096,7 +1094,7 @@ def var(
 
 def normalize_macro_name(name: str) -> str:
     """Prefix macro name with @ and upcase"""
-    return f"@{name.upper()}"
+    return name.upper() if name.startswith("@") else f"@{name.upper()}"
 
 
 for m in macro.get_registry().values():

--- a/sqlmesh/utils/jinja.py
+++ b/sqlmesh/utils/jinja.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from enum import Enum
 
 from jinja2 import Environment, Template, nodes
-from sqlglot import Dialect, Expression, Parser, TokenType
+from sqlglot import Dialect, Expression, Parser, TokenType, Token
 
 from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
@@ -55,7 +55,9 @@ class MacroReturnVal(Exception):
 
 
 class MacroExtractor(Parser):
-    def extract(self, jinja: str, dialect: str = "") -> t.Dict[str, MacroInfo]:
+    def extract(
+        self, jinja: str, dialect: str = "", tokens: t.Optional[t.List[Token]] = None
+    ) -> t.Dict[str, MacroInfo]:
         """Extract a dictionary of macro definitions from a jinja string.
 
         Args:
@@ -67,7 +69,7 @@ class MacroExtractor(Parser):
         """
         self.reset()
         self.sql = jinja
-        self._tokens = Dialect.get_or_raise(dialect).tokenizer.tokenize(jinja)
+        self._tokens = tokens or Dialect.get_or_raise(dialect).tokenizer.tokenize(jinja)
         self._index = -1
         self._advance()
 


### PR DESCRIPTION
This is a WIP that introduces support for reusable user-defined SQL macros, fixes: #2505 

These will be declared within the .sql files in the `macros/` directory using the [SQLMesh syntax](https://sqlmesh.readthedocs.io/en/latest/concepts/macros/sqlmesh_macros/#macro-functions):

```sql
@DEF(pythag, (x, y) -> sqrt(pow(x, 2) + pow(y, 2)));
```

Additionally, this enhancement will allow for nesting between macro functions defined in different files.