### PR TITLE
Feat: increase default type precision in redshift/mssql view workaround

### DIFF
--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -244,7 +244,7 @@ class VarcharSizeWorkaroundMixin(EngineAdapter):
                 parameter = self.SCHEMA_DIFFER.get_type_parameters(col_type)
                 type_default = types_with_max_default_param[col_type.this]
                 if parameter == type_default:
-                    col_type.set("expressions", [exp.DataTypeParam(this=exp.Var(this="max"))])
+                    col_type.set("expressions", [exp.DataTypeParam(this=exp.var("max"))])
 
         return columns_to_types
 

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -238,7 +238,10 @@ class VarcharSizeWorkaroundMixin(EngineAdapter):
             if k in self.SCHEMA_DIFFER.parameterized_type_defaults
         }
 
-        # if type supports "max" and has default length, convert to "max" length
+        # Redshift and MSSQL have a bug where CTAS statements have non-deterministic types. If a LIMIT
+        # is applied to a CTAS statement, VARCHAR (and possibly other) types sometimes revert to their
+        # default length of 256 (Redshift) or 1 (MSSQL). If we detect that a type has its default length
+        # and supports "max" length, we convert it to "max" length to prevent inadvertent data truncation.
         for col_name, col_type in columns_to_types.items():
             if col_type.this in types_with_max_default_param and col_type.expressions:
                 parameter = self.SCHEMA_DIFFER.get_type_parameters(col_type)

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -44,7 +44,7 @@ class PostgresEngineAdapter(
                 exp.DataType.build("CHAR", dialect=DIALECT).this,
                 exp.DataType.build("BPCHAR", dialect=DIALECT).this,
             },
-            # all can ALTER to unparameterized `VARCHAR`
+            # all can ALTER to unparameterized version of `VARCHAR`
             exp.DataType.build("VARCHAR", dialect=DIALECT).this: {
                 exp.DataType.build("VARCHAR", dialect=DIALECT).this,
                 exp.DataType.build("CHAR", dialect=DIALECT).this,

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -44,7 +44,7 @@ class PostgresEngineAdapter(
                 exp.DataType.build("CHAR", dialect=DIALECT).this,
                 exp.DataType.build("BPCHAR", dialect=DIALECT).this,
             },
-            # all can ALTER to unparameterized version of `VARCHAR`
+            # all can ALTER to unparameterized `VARCHAR`
             exp.DataType.build("VARCHAR", dialect=DIALECT).this: {
                 exp.DataType.build("VARCHAR", dialect=DIALECT).this,
                 exp.DataType.build("CHAR", dialect=DIALECT).this,

--- a/sqlmesh/core/schema_diff.py
+++ b/sqlmesh/core/schema_diff.py
@@ -372,8 +372,8 @@ class SchemaDiffer(PydanticModel):
         if current_type.this == new_type.this and not current_type.is_type(
             *exp.DataType.NESTED_TYPES
         ):
-            current_params = self._get_type_parameters(current_type)
-            new_params = self._get_type_parameters(new_type)
+            current_params = self.get_type_parameters(current_type)
+            new_params = self.get_type_parameters(new_type)
 
             if len(current_params) != len(new_params):
                 return False
@@ -381,7 +381,7 @@ class SchemaDiffer(PydanticModel):
             return all(new >= current for current, new in zip(current_params, new_params))
         return False
 
-    def _get_type_parameters(self, type: exp.DataType) -> t.List[t.Union[int, float]]:
+    def get_type_parameters(self, type: exp.DataType) -> t.List[t.Union[int, float]]:
         def _str_to_number(string: str, allows_max_param: bool) -> t.Union[int, float]:
             try:
                 return int(string)

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -116,6 +116,11 @@ def test_varchar_workaround_to_max(make_mocked_engine_adapter: t.Callable, mocke
         return_value=True,
     )
 
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.mssql.MSSQLEngineAdapter.columns",
+        return_value=columns,
+    )
+
     adapter.ctas(
         table_name="test_schema.test_table",
         query_or_df=parse_one(

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -77,6 +77,26 @@ def test_columns(make_mocked_engine_adapter: t.Callable):
     )
 
 
+def test_varchar_workaround_to_max(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+    adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
+
+    columns_to_max = adapter._default_precision_to_max(
+        {
+            "varchar": exp.DataType.build("VARCHAR", dialect=adapter.dialect),
+            "varchar2": exp.DataType.build("VARCHAR(2)", dialect=adapter.dialect),
+            "nvarchar": exp.DataType.build("NVARCHAR", dialect=adapter.dialect),
+            "nvarchar2": exp.DataType.build("NVARCHAR(2)", dialect=adapter.dialect),
+        }
+    )
+
+    assert columns_to_max == {
+        "varchar": exp.DataType.build("VARCHAR(max)", dialect=adapter.dialect),
+        "varchar2": exp.DataType.build("VARCHAR(2)", dialect=adapter.dialect),
+        "nvarchar": exp.DataType.build("NVARCHAR(max)", dialect=adapter.dialect),
+        "nvarchar2": exp.DataType.build("NVARCHAR(2)", dialect=adapter.dialect),
+    }
+
+
 def test_table_exists(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
     adapter.cursor.fetchone.return_value = (1,)

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -82,17 +82,29 @@ def test_varchar_workaround_to_max(make_mocked_engine_adapter: t.Callable, mocke
 
     columns_to_max = adapter._default_precision_to_max(
         {
+            "binary1": exp.DataType.build("BINARY(1)", dialect=adapter.dialect),
+            "varbinary": exp.DataType.build("VARBINARY", dialect=adapter.dialect),
+            "varbinary1": exp.DataType.build("VARBINARY(1)", dialect=adapter.dialect),
+            "varbinary2": exp.DataType.build("VARBINARY(2)", dialect=adapter.dialect),
             "varchar": exp.DataType.build("VARCHAR", dialect=adapter.dialect),
+            "varchar1": exp.DataType.build("VARCHAR(1)", dialect=adapter.dialect),
             "varchar2": exp.DataType.build("VARCHAR(2)", dialect=adapter.dialect),
             "nvarchar": exp.DataType.build("NVARCHAR", dialect=adapter.dialect),
+            "nvarchar1": exp.DataType.build("NVARCHAR(1)", dialect=adapter.dialect),
             "nvarchar2": exp.DataType.build("NVARCHAR(2)", dialect=adapter.dialect),
         }
     )
 
     assert columns_to_max == {
-        "varchar": exp.DataType.build("VARCHAR(max)", dialect=adapter.dialect),
+        "binary1": exp.DataType.build("BINARY(1)", dialect=adapter.dialect),
+        "varbinary": exp.DataType.build("VARBINARY", dialect=adapter.dialect),
+        "varbinary1": exp.DataType.build("VARBINARY(max)", dialect=adapter.dialect),
+        "varbinary2": exp.DataType.build("VARBINARY(2)", dialect=adapter.dialect),
+        "varchar": exp.DataType.build("VARCHAR", dialect=adapter.dialect),
+        "varchar1": exp.DataType.build("VARCHAR(max)", dialect=adapter.dialect),
         "varchar2": exp.DataType.build("VARCHAR(2)", dialect=adapter.dialect),
-        "nvarchar": exp.DataType.build("NVARCHAR(max)", dialect=adapter.dialect),
+        "nvarchar": exp.DataType.build("NVARCHAR", dialect=adapter.dialect),
+        "nvarchar1": exp.DataType.build("NVARCHAR(max)", dialect=adapter.dialect),
         "nvarchar2": exp.DataType.build("NVARCHAR(2)", dialect=adapter.dialect),
     }
 

--- a/tests/core/engine_adapter/test_redshift.py
+++ b/tests/core/engine_adapter/test_redshift.py
@@ -34,17 +34,23 @@ def test_varchar_size_workaround(make_mocked_engine_adapter: t.Callable, mocker:
 
     columns_to_max = adapter._default_precision_to_max(
         {
+            "nchar1": exp.DataType.build("NCHAR(1)", dialect=adapter.dialect),
             "char": exp.DataType.build("CHAR", dialect=adapter.dialect),
+            "char1": exp.DataType.build("CHAR(1)", dialect=adapter.dialect),
             "char2": exp.DataType.build("CHAR(2)", dialect=adapter.dialect),
             "varchar": exp.DataType.build("VARCHAR", dialect=adapter.dialect),
+            "varchar256": exp.DataType.build("VARCHAR(256)", dialect=adapter.dialect),
             "varchar2": exp.DataType.build("VARCHAR(2)", dialect=adapter.dialect),
         }
     )
 
     assert columns_to_max == {
-        "char": exp.DataType.build("CHAR(max)", dialect=adapter.dialect),
+        "nchar1": exp.DataType.build("NCHAR(1)", dialect=adapter.dialect),
+        "char": exp.DataType.build("CHAR", dialect=adapter.dialect),
+        "char1": exp.DataType.build("CHAR(max)", dialect=adapter.dialect),
         "char2": exp.DataType.build("CHAR(2)", dialect=adapter.dialect),
-        "varchar": exp.DataType.build("VARCHAR(max)", dialect=adapter.dialect),
+        "varchar": exp.DataType.build("VARCHAR", dialect=adapter.dialect),
+        "varchar256": exp.DataType.build("VARCHAR(max)", dialect=adapter.dialect),
         "varchar2": exp.DataType.build("VARCHAR(2)", dialect=adapter.dialect),
     }
 

--- a/tests/core/engine_adapter/test_redshift.py
+++ b/tests/core/engine_adapter/test_redshift.py
@@ -60,6 +60,11 @@ def test_varchar_size_workaround(make_mocked_engine_adapter: t.Callable, mocker:
         return_value=True,
     )
 
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.redshift.RedshiftEngineAdapter.columns",
+        return_value=columns,
+    )
+
     adapter.ctas(
         table_name="test_schema.test_table",
         query_or_df=parse_one(

--- a/tests/core/engine_adapter/test_redshift.py
+++ b/tests/core/engine_adapter/test_redshift.py
@@ -32,20 +32,16 @@ def test_columns(adapter: t.Callable):
 def test_varchar_size_workaround(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(RedshiftEngineAdapter)
 
-    columns_to_max = adapter._default_precision_to_max(
-        {
-            "nchar1": exp.DataType.build("NCHAR(1)", dialect=adapter.dialect),
-            "char": exp.DataType.build("CHAR", dialect=adapter.dialect),
-            "char1": exp.DataType.build("CHAR(1)", dialect=adapter.dialect),
-            "char2": exp.DataType.build("CHAR(2)", dialect=adapter.dialect),
-            "varchar": exp.DataType.build("VARCHAR", dialect=adapter.dialect),
-            "varchar256": exp.DataType.build("VARCHAR(256)", dialect=adapter.dialect),
-            "varchar2": exp.DataType.build("VARCHAR(2)", dialect=adapter.dialect),
-        }
-    )
+    columns = {
+        "char": exp.DataType.build("CHAR", dialect=adapter.dialect),
+        "char1": exp.DataType.build("CHAR(1)", dialect=adapter.dialect),
+        "char2": exp.DataType.build("CHAR(2)", dialect=adapter.dialect),
+        "varchar": exp.DataType.build("VARCHAR", dialect=adapter.dialect),
+        "varchar256": exp.DataType.build("VARCHAR(256)", dialect=adapter.dialect),
+        "varchar2": exp.DataType.build("VARCHAR(2)", dialect=adapter.dialect),
+    }
 
-    assert columns_to_max == {
-        "nchar1": exp.DataType.build("NCHAR(1)", dialect=adapter.dialect),
+    assert adapter._default_precision_to_max(columns) == {
         "char": exp.DataType.build("CHAR", dialect=adapter.dialect),
         "char1": exp.DataType.build("CHAR(max)", dialect=adapter.dialect),
         "char2": exp.DataType.build("CHAR(2)", dialect=adapter.dialect),
@@ -53,6 +49,30 @@ def test_varchar_size_workaround(make_mocked_engine_adapter: t.Callable, mocker:
         "varchar256": exp.DataType.build("VARCHAR(max)", dialect=adapter.dialect),
         "varchar2": exp.DataType.build("VARCHAR(2)", dialect=adapter.dialect),
     }
+
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.base.random_id",
+        return_value="test_random_id",
+    )
+
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.redshift.RedshiftEngineAdapter.table_exists",
+        return_value=True,
+    )
+
+    adapter.ctas(
+        table_name="test_schema.test_table",
+        query_or_df=parse_one(
+            "SELECT char, char1 + 1 AS char1, char2 AS char2, varchar, varchar256, varchar2 FROM (SELECT * FROM table WHERE FALSE LIMIT 0) WHERE d > 0 AND FALSE LIMIT 0"
+        ),
+        exists=False,
+    )
+
+    assert to_sql_calls(adapter) == [
+        'CREATE VIEW "__temp_ctas_test_random_id" AS SELECT "char", "char1" + 1 AS "char1", "char2" AS "char2", "varchar", "varchar256", "varchar2" FROM (SELECT * FROM "table")',
+        'DROP VIEW IF EXISTS "__temp_ctas_test_random_id" CASCADE',
+        'CREATE TABLE "test_schema"."test_table" ("char" CHAR, "char1" CHAR(max), "char2" CHAR(2), "varchar" VARCHAR, "varchar256" VARCHAR(max), "varchar2" VARCHAR(2))',
+    ]
 
 
 def test_create_table_from_query_exists_no_if_not_exists(

--- a/tests/core/engine_adapter/test_redshift.py
+++ b/tests/core/engine_adapter/test_redshift.py
@@ -29,6 +29,26 @@ def test_columns(adapter: t.Callable):
     assert resp == {"col": exp.DataType.build("INT")}
 
 
+def test_varchar_size_workaround(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+    adapter = make_mocked_engine_adapter(RedshiftEngineAdapter)
+
+    columns_to_max = adapter._default_precision_to_max(
+        {
+            "char": exp.DataType.build("CHAR", dialect=adapter.dialect),
+            "char2": exp.DataType.build("CHAR(2)", dialect=adapter.dialect),
+            "varchar": exp.DataType.build("VARCHAR", dialect=adapter.dialect),
+            "varchar2": exp.DataType.build("VARCHAR(2)", dialect=adapter.dialect),
+        }
+    )
+
+    assert columns_to_max == {
+        "char": exp.DataType.build("CHAR(max)", dialect=adapter.dialect),
+        "char2": exp.DataType.build("CHAR(2)", dialect=adapter.dialect),
+        "varchar": exp.DataType.build("VARCHAR(max)", dialect=adapter.dialect),
+        "varchar2": exp.DataType.build("VARCHAR(2)", dialect=adapter.dialect),
+    }
+
+
 def test_create_table_from_query_exists_no_if_not_exists(
     adapter: t.Callable, mocker: MockerFixture
 ):


### PR DESCRIPTION
Redshift and MSSQL use the `VarcharSizeWorkaroundMixin` to infer the size of a varchar or other "max" column when it cannot be resolved from model code.

Data may be truncated if it is inferred to the default length (256 in Redshift, 1 in MSSQL) and that was not intended by the user, so this PR increases the length to "max" if a column with the default length is detected. 