### PR TITLE
Fix: handle Paren in value or tuple validator

### DIFF
--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -156,6 +156,9 @@ class ModelMeta(_Node):
         def _normalize(value: t.Any) -> t.Any:
             return normalize_identifiers(value, dialect=dialect) if normalize else value
 
+        if isinstance(v, exp.Paren):
+            v = [v.unnest()]
+
         if isinstance(v, (exp.Tuple, exp.Array)):
             return [_normalize(e).name for e in v.expressions]
         if isinstance(v, exp.Expression):

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -939,7 +939,8 @@ def test_audits():
             audits (
                 audit_a,
                 audit_b(key='value')
-            )
+            ),
+            tags (foo)
         );
         SELECT 1, ds;
     """
@@ -950,6 +951,7 @@ def test_audits():
         ("audit_a", {}),
         ("audit_b", {"key": exp.Literal.string("value")}),
     ]
+    assert model.tags == ["foo"]
 
 
 def test_description(sushi_context):


### PR DESCRIPTION
Before:

```python
>>> ctx.get_model("name").tags
['']
```

After:

```python
>>> ctx.get_model("name").tags
['foo']
```