### PR TITLE
Feat: Managed models

### DIFF
--- a/docs/concepts/models/managed_models.md
+++ b/docs/concepts/models/managed_models.md
@@ -58,7 +58,7 @@ MODEL (
     target_lag = '2 minutes',
     data_retention_time_in_days = 2
   )
-)
+);
 
 SELECT
   event_date::DATE as event_date,

--- a/docs/concepts/models/managed_models.md
+++ b/docs/concepts/models/managed_models.md
@@ -26,7 +26,7 @@ Managed models follow the same lifecycle as other models:
 
 - Creating a Virtual Environment creates a pointer to the current model snapshot
 - Modifying the model causes a new snapshot to be created
-- Breaking upstream changes cause a new snapshot to be created
+- Any upstream changes cause a new snapshot to be created
 - The model can be deployed and rolled back via the usual pointer swap mechanism
 - Once the TTL expires, model snapshots are cleaned up
 

--- a/docs/concepts/models/managed_models.md
+++ b/docs/concepts/models/managed_models.md
@@ -1,0 +1,107 @@
+# Managed models
+Unlike normal tables where the user is responsible for managing the data within the table, some database engines have a concept of a table where the engine itself ensures that the data within the table is up to date. These tables are typically based on a query that reads from other tables within the database. Each time these other tables are updated, the database will ensure that the managed table reflects the changes without the user having to do anything special (such as issue a `REFRESH` command).
+
+Under the hood, each supported database engine achieves this in a slightly different way but most of them have background processes that run and automatically keep the tables up to date, within the parameters you define when you create the table.
+
+For supported engines, we expose this functionality through Managed models. This indicates to SQLMesh that the underlying database engine will ensure that the data remains up to date and all SQLMesh needs to do is maintain the schema.
+
+Due to this, managed models would typically be built off an [External Model](./external_models.md) rather than another SQLMesh model. Since SQLMesh already ensures that models it's tracking are kept up to date, the main benefit of managed models comes when they read from external tables that arent tracked by SQLMesh.
+
+## Difference from materialized views
+The difference between an Managed model and a materialized view is down to semantics and in some engines there is no difference.
+
+SQLMesh has support for [materialized views](./model_kinds#materialized-views) already. However, depending on the engine, these are subject to some limitations, such as:
+
+- A Materialized View query can only be derived from a single base table
+- The Materialized View is not automatically maintained by the engine. To refresh the data, a `REFRESH MATERIALIZED VIEW` or equivalent command must be issued
+
+Managed models are different in that:
+
+- The engine updates the table data automatically when a base table changes
+- When performing updates, the engine has a semantic understanding of the query and can decide if an incremental or full refresh should be applied
+- There is no need to issue manual `REFRESH` commands. The engine maintains the table transparently in a background process
+
+## Lifecycle in SQLMesh
+Managed models follow the same lifecycle as other models:
+
+- Creating a Virtual Environment creates a pointer to the current model snapshot
+- Modifying the model causes a new snapshot to be created
+- Breaking upstream changes cause a new snapshot to be created
+- The model can be deployed and rolled back via the usual pointer swap mechanism
+- Once the TTL expires, model snapshots are cleaned up
+
+However, there is usually extra vendor-imposed costs associated with Managed models. For example, Snowflake has [additional costs](https://docs.snowflake.com/en/user-guide/dynamic-tables-cost) for Dynamic Tables.
+
+Therefore, we try to not create managed tables unnecessarily. For example, in [forward-only plans](../plans.md#forward-only-change) we just create a normal table to preview the changes and only re-create the managed table on deployment to prod.
+
+## Supported Engines
+SQLMesh supports managed models in the following database engines:
+
+| Engine                                               | Implementatation                                                               |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------ |
+| [Snowflake](../../integrations/engines/snowflake.md) | [Dynamic Table](https://docs.snowflake.com/en/user-guide/dynamic-tables-intro) |
+
+To define a managed model, you can use the [`MANAGED`](./model_kinds.md#managed) model Kind.
+
+### Snowflake
+
+Managed Models are in Snowflake are implemented as [Dynamic Tables](https://docs.snowflake.com/en/user-guide/dynamic-tables-intro).
+
+Here is an example of a SQLMesh model that will result in a dynamic table being created:
+
+```sql linenums="1"
+MODEL (
+  name db.events,
+  kind MANAGED,
+  physical_properties (
+    warehouse = datalake,
+    target_lag = '2 minutes',
+    data_retention_time_in_days = 2
+  )
+)
+
+SELECT
+  event_date::DATE as event_date,
+  event_payload::TEXT as payload
+FROM raw_events
+```
+
+results in:
+
+```sql linenums="1"
+CREATE OR REPLACE DYNAMIC TABLE db.events
+  WAREHOUSE = "datalake",
+  TARGET_LAG = '2 minutes'
+  DATA_RETENTION_TIME_IN_DAYS = 2
+AS SELECT
+  event_date::DATE as event_date,
+  event_payload::TEXT as payload
+FROM raw_events
+```
+
+!!! info
+
+    Note that SQLMesh will not create intervals and run this model for each interval, so there is no need to add a WHERE clause with date filters like you would for a normal incremental model. How the data in this model is refreshed is completely up to Snowflake.
+
+#### Table properties
+
+Dynamic Tables have some properties that affect things like how often the data is refreshed by Snowflake, when the initial data is populated, how long data is retained for etc. The list of available properties is located in the [Snowflake documentation](https://docs.snowflake.com/sql-reference/sql/create-dynamic-table).
+
+In SQLMesh, these properties are set on the model definition.
+
+The following Dynamic Table properties are set on the model [`physical_properties`](../models/overview.md#physical_properties-previously-table_properties):
+
+| Snowflake Property              | Required | Notes
+| ------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| target_lag                      | Y        |                                                                                                                                         |
+| warehouse                       | N        | In Snowflake, this is a required property. However, if not specified, then SQLMesh will use the result of `select current_warehouse()`. |
+| refresh_mode                    | N        |                                                                                                                                         |
+| initialize                      | N        |                                                                                                                                         |
+| data_retention_time_in_days     | N        |                                                                                                                                         |
+| max_data_extension_time_in_days | N        |                                                                                                                                         |
+
+The following Dynamic Table properties can be set directly on the model:
+
+| Snowflake Property | Required   | Notes                                                                                                                                                                   |
+| ------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| cluster by         | N          | `clustered_by` is a [standard model property](../models/overview.md#clustered_by), so set `clustered_by` on the model to add a `CLUSTER BY` clause to the Dynamic Table |

--- a/docs/concepts/models/model_kinds.md
+++ b/docs/concepts/models/model_kinds.md
@@ -810,3 +810,21 @@ GROUP BY
 ## EXTERNAL
 
 The EXTERNAL model kind is used to specify [external models](./external_models.md) that store metadata about external tables. External models are special; they are not specified in .sql files like the other model kinds. They are optional but useful for propagating column and type information for external tables queried in your SQLMesh project.
+
+## MANAGED
+
+!!! warning
+
+    Managed models are still under development and the API / semantics may change as support for more engines is added
+
+The `MANAGED` model kind is used to create models where the underlying database engine manages the data lifecycle.
+
+These models dont get updated with new intervals or refreshed when `sqlmesh run` is called. Responsibility for keeping the *data* up to date falls on the engine.
+
+You can control how the engine creates the managed model by using the [`physical_properties`](../overview#physical_properties-previously-table_properties) to pass engine-specific parameters for adapter to use when issuing commands to the underlying database.
+
+Due to there being no standard, each vendor has a different implementation with different semantics and different configuration parameters. Therefore, `MANAGED` models are not as portable between database engines as other SQLMesh model types. In addition, due to their black-box nature, SQLMesh has limited visibility into the integrity and state of the model.
+
+We would recommend using standard SQLMesh model types in the first instance. However, if you do need to use Managed models, you still gain other SQLMesh benefits like the ability to use them in [virtual environments](../../concepts/overview#build-a-virtual-environment).
+
+See [Managed Models](./managed_models.md) for more information on which engines are supported and which properties are available.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - concepts/models/python_models.md
       - concepts/models/seed_models.md
       - concepts/models/external_models.md
+      - concepts/models/managed_models.md
     - Macros:
       - concepts/macros/overview.md
       - concepts/macros/macro_variables.md

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -441,7 +441,7 @@ class EngineAdapter:
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         **kwargs: t.Any,
     ) -> None:
-        """Create an managed table using a query.
+        """Create a managed table using a query.
 
         "Managed" means that once the table is created, the data is kept up to date by the underlying database engine and not SQLMesh.
 

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -493,6 +493,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
         table_properties: t.Optional[t.Dict[str, exp.Expression]] = None,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
+        table_kind: t.Optional[str] = None,
     ) -> t.Optional[exp.Properties]:
         properties: t.List[exp.Expression] = []
 

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -126,6 +126,7 @@ class HiveMetastoreTablePropertiesMixin(EngineAdapter):
         table_properties: t.Optional[t.Dict[str, exp.Expression]] = None,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
+        table_kind: t.Optional[str] = None,
     ) -> t.Optional[exp.Properties]:
         properties: t.List[exp.Expression] = []
 
@@ -235,6 +236,7 @@ class VarcharSizeWorkaroundMixin(EngineAdapter):
         replace: bool = False,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
+        table_kind: t.Optional[str] = None,
         **kwargs: t.Any,
     ) -> exp.Create:
         statement = super()._build_create_table_exp(
@@ -244,6 +246,7 @@ class VarcharSizeWorkaroundMixin(EngineAdapter):
             replace=replace,
             columns_to_types=columns_to_types,
             table_description=table_description,
+            table_kind=table_kind,
             **kwargs,
         )
 

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -90,6 +90,7 @@ class RedshiftEngineAdapter(
         replace: bool = False,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
+        table_kind: t.Optional[str] = None,
         **kwargs: t.Any,
     ) -> None:
         """

--- a/sqlmesh/core/engine_adapter/shared.py
+++ b/sqlmesh/core/engine_adapter/shared.py
@@ -27,6 +27,7 @@ class DataObjectType(str, Enum):
     TABLE = "table"
     VIEW = "view"
     MATERIALIZED_VIEW = "materialized_view"
+    MANAGED_TABLE = "managed_table"
 
     @property
     def is_unknown(self) -> bool:
@@ -44,6 +45,10 @@ class DataObjectType(str, Enum):
     def is_materialized_view(self) -> bool:
         return self == DataObjectType.MATERIALIZED_VIEW
 
+    @property
+    def is_managed_table(self) -> bool:
+        return self == DataObjectType.MANAGED_TABLE
+
     @classmethod
     def from_str(cls, s: str) -> DataObjectType:
         s = s.lower()
@@ -53,6 +58,8 @@ class DataObjectType(str, Enum):
             return DataObjectType.VIEW
         if s == "materialized_view":
             return DataObjectType.MATERIALIZED_VIEW
+        if s == "managed_table":
+            return DataObjectType.MANAGED_TABLE
         return DataObjectType.UNKNOWN
 
 

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -136,7 +136,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
         )
 
         self._create_table_from_source_queries(
-            quote_identifiers(target_table),
+            target_table,
             source_queries,
             columns_to_types,
             replace=self.SUPPORTS_REPLACE_TABLE,

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -419,6 +419,7 @@ class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTableP
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
+        table_kind: t.Optional[str] = None,
         **kwargs: t.Any,
     ) -> None:
         table_name = (

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -767,7 +767,7 @@ class SCDType2ByColumnKind(_SCDType2Kind):
 
 class ManagedKind(_ModelKind):
     name: Literal[ModelKindName.MANAGED] = ModelKindName.MANAGED
-    disable_restatement: SQLGlotBool = True
+    disable_restatement: t.Literal[True] = True
 
     @property
     def supports_python_models(self) -> bool:

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -115,6 +115,10 @@ class ModelKindMixin:
         return self.model_kind_name == ModelKindName.CUSTOM
 
     @property
+    def is_managed(self) -> bool:
+        return self.model_kind_name == ModelKindName.MANAGED
+
+    @property
     def is_symbolic(self) -> bool:
         """A symbolic model is one that doesn't execute at all."""
         return self.model_kind_name in (ModelKindName.EMBEDDED, ModelKindName.EXTERNAL)
@@ -136,7 +140,12 @@ class ModelKindMixin:
             ModelKindName.INCREMENTAL_BY_UNIQUE_KEY,
             ModelKindName.INCREMENTAL_BY_PARTITION,
             ModelKindName.SCD_TYPE_2,
+            ModelKindName.MANAGED,
         )
+
+    @property
+    def supports_python_models(self) -> bool:
+        return True
 
 
 class ModelKindName(str, ModelKindMixin, Enum):
@@ -157,6 +166,7 @@ class ModelKindName(str, ModelKindMixin, Enum):
     SEED = "SEED"
     EXTERNAL = "EXTERNAL"
     CUSTOM = "CUSTOM"
+    MANAGED = "MANAGED"
 
     @property
     def model_kind_name(self) -> t.Optional[ModelKindName]:
@@ -755,6 +765,15 @@ class SCDType2ByColumnKind(_SCDType2Kind):
         )
 
 
+class ManagedKind(_ModelKind):
+    name: Literal[ModelKindName.MANAGED] = ModelKindName.MANAGED
+    disable_restatement: SQLGlotBool = True
+
+    @property
+    def supports_python_models(self) -> bool:
+        return False
+
+
 class EmbeddedKind(_ModelKind):
     name: Literal[ModelKindName.EMBEDDED] = ModelKindName.EMBEDDED
 
@@ -839,6 +858,7 @@ ModelKind = Annotated[
         SCDType2ByTimeKind,
         SCDType2ByColumnKind,
         CustomKind,
+        ManagedKind,
     ],
     Field(discriminator="name"),
 ]
@@ -857,6 +877,7 @@ MODEL_KIND_NAME_TO_TYPE: t.Dict[str, t.Type[ModelKind]] = {
     ModelKindName.SCD_TYPE_2_BY_TIME: SCDType2ByTimeKind,
     ModelKindName.SCD_TYPE_2_BY_COLUMN: SCDType2ByColumnKind,
     ModelKindName.CUSTOM: CustomKind,
+    ModelKindName.MANAGED: ManagedKind,
 }
 
 

--- a/sqlmesh/utils/errors.py
+++ b/sqlmesh/utils/errors.py
@@ -103,6 +103,7 @@ class AuditError(SQLMeshError):
 
 
 class TestError(SQLMeshError):
+    __test__ = False  # prevent pytest trying to collect this as a test class
     pass
 
 

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -18,9 +18,11 @@ from sqlmesh.core.config import load_config_from_paths
 from sqlmesh.core.dialect import normalize_model_name
 import sqlmesh.core.dialect as d
 from sqlmesh.core.engine_adapter import SparkEngineAdapter, TrinoEngineAdapter
-from sqlmesh.core.model import load_sql_based_model
+from sqlmesh.core.model import Model, load_sql_based_model
 from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 from sqlmesh.core.model.definition import create_sql_model
+from sqlmesh.core.plan import Plan
+from sqlmesh.core.snapshot import Snapshot, SnapshotChangeCategory
 from sqlmesh.utils import random_id
 from sqlmesh.utils.date import now, to_date, to_ds, to_time_column, yesterday
 from sqlmesh.utils.pydantic import PydanticModel
@@ -35,6 +37,8 @@ TEST_SCHEMA = "test_schema"
 
 
 class TestContext:
+    __test__ = False  # prevent pytest trying to collect this as a test class
+
     def __init__(
         self,
         test_type: str,
@@ -423,12 +427,14 @@ class MetadataResults(PydanticModel):
     tables: t.List[str] = []
     views: t.List[str] = []
     materialized_views: t.List[str] = []
+    managed_tables: t.List[str] = []
 
     @classmethod
     def from_data_objects(cls, data_objects: t.List[DataObject]) -> MetadataResults:
         tables = []
         views = []
         materialized_views = []
+        managed_tables = []
         for obj in data_objects:
             if obj.type.is_table:
                 tables.append(obj.name)
@@ -436,13 +442,58 @@ class MetadataResults(PydanticModel):
                 views.append(obj.name)
             elif obj.type.is_materialized_view:
                 materialized_views.append(obj.name)
+            elif obj.type.is_managed_table:
+                managed_tables.append(obj.name)
             else:
                 raise ValueError(f"Unexpected object type: {obj.type}")
-        return MetadataResults(tables=tables, views=views, materialized_views=materialized_views)
+        return MetadataResults(
+            tables=tables,
+            views=views,
+            materialized_views=materialized_views,
+            managed_tables=managed_tables,
+        )
 
     @property
     def non_temp_tables(self) -> t.List[str]:
         return [x for x in self.tables if not x.startswith("__temp") and not x.startswith("temp")]
+
+
+class PlanResults(PydanticModel):
+    plan: Plan
+    ctx: TestContext
+    schema_metadata: MetadataResults
+    internal_schema_metadata: MetadataResults
+
+    @classmethod
+    def create(cls, plan: Plan, ctx: TestContext, schema_name: str):
+        schema_metadata = ctx.get_metadata_results(schema_name)
+        internal_schema_metadata = ctx.get_metadata_results(f"sqlmesh__{schema_name}")
+        return PlanResults(
+            plan=plan,
+            ctx=ctx,
+            schema_metadata=schema_metadata,
+            internal_schema_metadata=internal_schema_metadata,
+        )
+
+    def snapshot_for(self, model: Model) -> Snapshot:
+        return next((s for s in list(self.plan.snapshots.values()) if s.name == model.fqn))
+
+    def modified_snapshot_for(self, model: Model) -> Snapshot:
+        return next((s for s in list(self.plan.modified_snapshots.values()) if s.name == model.fqn))
+
+    def table_name_for(
+        self, snapshot_or_model: Snapshot | Model, is_deployable: bool = True
+    ) -> str:
+        snapshot = (
+            snapshot_or_model
+            if isinstance(snapshot_or_model, Snapshot)
+            else self.snapshot_for(snapshot_or_model)
+        )
+        table_name = snapshot.table_name(is_deployable)
+        return exp.to_table(table_name).this.sql(dialect=self.ctx.dialect)
+
+    def temp_table_name_for(self, snapshot: Snapshot) -> str:
+        return self.table_name_for(snapshot, is_deployable=False)
 
 
 @pytest.fixture(params=["df", "query", "pyspark"])
@@ -2242,3 +2293,199 @@ def test_batch_size_on_incremental_by_unique_key_model(
 
     finally:
         ctx.cleanup(context)
+
+
+def test_managed_model_upstream_forward_only(ctx: TestContext):
+    """
+    This scenario goes as follows:
+        - A managed model B is a downstream dependency of an incremental model A
+            (as a sidenote: this is an incorrect use of managed models, they should really only reference external models, but we dont prevent it specifically to be more user friendly)
+        - User plans a forward-only change against Model A in a virtual environment "dev"
+        - This causes a new non-deployable snapshot of Model B in "dev".
+        - In these situations, we create a normal table for Model B, not a managed table
+        - User modifies model B and applies a plan in "dev"
+            - This should also result in a normal table
+        - User decides they want to deploy so they run their plan against prod
+            - We need to ensure we ignore the normal table for Model B (it was just a dev preview) and create a new managed table for prod
+            - Upon apply to prod, Model B should be completely recreated as a managed table
+    """
+
+    if ctx.test_type != "query":
+        pytest.skip("This only needs to run once so we skip anything not query")
+
+    if not ctx.engine_adapter.SUPPORTS_MANAGED_MODELS:
+        pytest.skip("This test only runs for engines that support managed models")
+
+    def _run_plan(sqlmesh_context: Context, environment: str = None) -> PlanResults:
+        plan: Plan = sqlmesh_context.plan(auto_apply=True, no_prompts=True, environment=environment)
+        return PlanResults.create(plan, ctx, schema)
+
+    context = ctx.create_context()
+    schema = ctx.add_test_suffix(TEST_SCHEMA)
+
+    model_a = load_sql_based_model(
+        d.parse(  # type: ignore
+            f"""
+            MODEL (
+                name {schema}.upstream_model,
+                kind INCREMENTAL_BY_TIME_RANGE (
+                    time_column ts,
+                    forward_only True
+                ),
+            );
+
+            SELECT 1 as id, 'foo' as name, current_timestamp as ts;
+            """
+        )
+    )
+
+    model_b = load_sql_based_model(
+        d.parse(  # type: ignore
+            f"""
+            MODEL (
+                name {schema}.managed_model,
+                kind MANAGED,
+                physical_properties (
+                    target_lag = '5 minutes'
+                )
+            );
+
+            SELECT * from {schema}.upstream_model;
+            """
+        )
+    )
+
+    context.upsert_model(model_a)
+    context.upsert_model(model_b)
+
+    plan_1 = _run_plan(context)
+
+    assert plan_1.snapshot_for(model_a).change_category == SnapshotChangeCategory.BREAKING
+    assert plan_1.snapshot_for(model_b).change_category == SnapshotChangeCategory.BREAKING
+
+    # so far so good, model_a should exist as a normal table, model b should be a managed table and the prod views should exist
+    assert len(plan_1.schema_metadata.views) == 2
+    assert plan_1.snapshot_for(model_a).model.view_name in plan_1.schema_metadata.views
+    assert plan_1.snapshot_for(model_b).model.view_name in plan_1.schema_metadata.views
+
+    assert len(plan_1.internal_schema_metadata.tables) == 3
+    assert plan_1.table_name_for(model_a) in plan_1.internal_schema_metadata.tables
+    assert plan_1.temp_table_name_for(model_a) in plan_1.internal_schema_metadata.tables
+    assert (
+        plan_1.table_name_for(model_b) not in plan_1.internal_schema_metadata.tables
+    )  # because its a managed table
+    assert (
+        plan_1.temp_table_name_for(model_b) in plan_1.internal_schema_metadata.tables
+    )  # its __temp table is a normal table however
+
+    assert len(plan_1.internal_schema_metadata.managed_tables) == 1
+    assert plan_1.table_name_for(model_b) in plan_1.internal_schema_metadata.managed_tables
+    assert (
+        plan_1.temp_table_name_for(model_b) not in plan_1.internal_schema_metadata.managed_tables
+    )  # the __temp table should not be created as managed
+
+    # Let's modify model A with a breaking change and plan it against a dev environment. This should trigger a forward-only plan
+    new_model_a = load_sql_based_model(
+        d.parse(  # type: ignore
+            f"""
+            MODEL (
+                name {schema}.upstream_model,
+                kind INCREMENTAL_BY_TIME_RANGE (
+                    time_column ts,
+                    forward_only True
+                ),
+            );
+
+            SELECT 1 as id, 'foo' as name, 'bar' as extra, current_timestamp as ts;
+            """
+        )
+    )
+    context.upsert_model(new_model_a)
+
+    # apply plan to dev environment
+    plan_2 = _run_plan(context, "dev")
+
+    assert plan_2.plan.has_changes
+    assert len(plan_2.plan.modified_snapshots) == 2
+    assert plan_2.snapshot_for(new_model_a).change_category == SnapshotChangeCategory.FORWARD_ONLY
+    assert plan_2.snapshot_for(model_b).change_category == SnapshotChangeCategory.NON_BREAKING
+
+    # verify that the new snapshots were created correctly
+    # the forward-only change to model A should be in a new table separate from the one created in the first plan
+    # since model B depends on an upstream model with a forward-only change, it should also get recreated, but as a normal table, not a managed table
+    assert plan_2.table_name_for(model_a) == plan_1.table_name_for(
+        model_a
+    )  # no change in the main table because the dev preview changes go to the __temp table
+    assert plan_2.temp_table_name_for(model_a) != plan_1.temp_table_name_for(
+        model_a
+    )  # it creates a new __temp table to hold the dev preview
+    assert plan_2.temp_table_name_for(model_a) in plan_2.internal_schema_metadata.tables
+
+    assert plan_2.table_name_for(model_b) != plan_1.table_name_for(
+        model_b
+    )  # model b gets a new table
+    assert plan_2.temp_table_name_for(model_b) != plan_1.temp_table_name_for(
+        model_b
+    )  # model b gets a new __temp table as well
+    assert (
+        plan_2.table_name_for(model_b) in plan_2.internal_schema_metadata.tables
+    )  # the new table is a regular table, not a managed table, because it was triggered by a forward-only change
+    assert plan_2.table_name_for(model_b) not in plan_2.internal_schema_metadata.managed_tables
+    assert (
+        plan_2.temp_table_name_for(model_b) in plan_2.internal_schema_metadata.tables
+    )  # __temp tables are always regular tables for managed models
+
+    # modify model B, still in the dev environment
+    new_model_b = load_sql_based_model(
+        d.parse(  # type: ignore
+            f"""
+            MODEL (
+                name {schema}.managed_model,
+                kind MANAGED,
+                physical_properties (
+                    target_lag = '5 minutes'
+                )
+            );
+
+            SELECT *, 'modified' as extra_b from {schema}.upstream_model;
+            """
+        )
+    )
+    context.upsert_model(new_model_b)
+
+    plan_3 = _run_plan(context, "dev")
+
+    assert plan_3.plan.has_changes
+    assert len(plan_3.plan.modified_snapshots) == 1
+    assert (
+        plan_3.modified_snapshot_for(model_b).change_category == SnapshotChangeCategory.NON_BREAKING
+    )
+
+    # model A should be unchanged
+    # the new model B should be a normal table, not a managed table
+    assert plan_3.table_name_for(model_a) == plan_2.table_name_for(model_a)
+    assert plan_3.temp_table_name_for(model_a) == plan_2.temp_table_name_for(model_a)
+    assert plan_3.table_name_for(model_b) != plan_2.table_name_for(model_b)
+    assert plan_3.temp_table_name_for(model_b) != plan_2.table_name_for(model_b)
+
+    assert plan_3.table_name_for(model_b) in plan_3.internal_schema_metadata.tables
+    assert plan_3.temp_table_name_for(model_b) in plan_3.internal_schema_metadata.tables
+    assert (
+        plan_3.table_name_for(model_b) not in plan_3.internal_schema_metadata.managed_tables
+    )  # still not a managed table
+
+    # apply plan to prod
+    plan_4 = _run_plan(context)
+
+    assert plan_4.plan.has_changes
+    assert plan_4.snapshot_for(model_a).change_category == SnapshotChangeCategory.FORWARD_ONLY
+    assert plan_4.snapshot_for(model_b).change_category == SnapshotChangeCategory.NON_BREAKING
+
+    # verify the Model B table is a managed table in prod even though it was non-managed in the dev virtual env
+    assert plan_4.table_name_for(model_b) == plan_3.table_name_for(
+        model_b
+    )  # the model didnt change; the table should still have the same name
+    assert (
+        plan_4.table_name_for(model_b) not in plan_4.internal_schema_metadata.tables
+    )  # however, it should now be a managed table, not a normal table
+    assert plan_4.table_name_for(model_b) in plan_4.internal_schema_metadata.managed_tables


### PR DESCRIPTION
Initial implementation of Managed models. This defines the general semantics and contains an implementation for Snowflake, based on Dynamic Tables.

As a side effect, this PR also fixes [issue 1049](https://github.com/TobikoData/sqlmesh/issues/1049).

Follow-up PR's:
 - Support for other engines
 - Cleanup / compaction support, essentially the ability for something like `sqlmesh clean` to drop any objects that aren't referenced in a specific environment. The assumption up until now is that storage is cheap so keeping old snapshots around for a while isn't a problem. However, costs could add up quickly with managed models because users would be paying for models to be refreshed that aren't actually being referenced