### PR TITLE
Fix: Ignore local changes when restating

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1089,7 +1089,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             environment or c.PROD,
             snapshots=snapshots,
             create_from=create_from,
-            force_no_diff=(restate_models is not None and not expanded_restate_models)
+            force_no_diff=restate_models is not None
             or (backfill_models is not None and not backfill_models),
             ensure_finalized_snapshots=self.config.plan.use_finalized_state,
         )
@@ -1896,10 +1896,7 @@ class GenericContext(BaseContext, t.Generic[C]):
     ) -> ContextDiff:
         environment = Environment.sanitize_name(environment)
         if force_no_diff:
-            return ContextDiff.create_no_diff(
-                self.state_reader.get_environment(environment.lower())
-                or EnvironmentNamingInfo(name=environment)
-            )
+            return ContextDiff.create_no_diff(environment, self.state_reader)
 
         return ContextDiff.create(
             environment,

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -703,16 +703,12 @@ def test_restate_models(sushi_context_pre_scheduling: Context):
     assert plan.requires_backfill
 
     plan = sushi_context_pre_scheduling.plan(restate_models=["unknown_model"], no_prompts=True)
-    assert plan.snapshots == {}
-    assert plan.missing_intervals == []
     assert not plan.has_changes
-    assert not plan.requires_backfill
+    assert not plan.restatements
 
     plan = sushi_context_pre_scheduling.plan(restate_models=["tag:unknown_tag"], no_prompts=True)
-    assert plan.snapshots == {}
-    assert plan.missing_intervals == []
     assert not plan.has_changes
-    assert not plan.requires_backfill
+    assert not plan.restatements
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Before this change the `sqlmesh plan` command with the `--restate-model` argument(s) would fail if the state of the target environment is different from the local state.

This is really annoying to users since it essentially requires their local code repo to always be in sync with the target environment which may sometimes be outside of their control. This can happen when, for example, prod hasn't caught up with the main branch yet.

This update ensures that the local changes are ignored instead if a plan contains restatements.