### PR TITLE
fix: issue with stringify pydantic models with sets

### DIFF
--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -249,7 +249,7 @@ class PydanticModel(pydantic.BaseModel):
         for k, info in self.all_field_infos().items():
             v = getattr(self, k)
 
-            if v != info.default:
+            if type(v) != type(info.default) or v != info.default:
                 args.append(f"{k}: {v}")
 
         return f"{self.__class__.__name__}<{', '.join(args)}>"

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -210,10 +210,15 @@ def test_diff(sushi_context: Context, mocker: MockerFixture):
     plan_evaluator = BuiltInPlanEvaluator(
         sushi_context.state_sync, sushi_context.snapshot_evaluator, sushi_context.default_catalog
     )
+
     plan = PlanBuilder(
         context_diff=sushi_context._context_diff("prod"),
         engine_schema_differ=sushi_context.engine_adapter.SCHEMA_DIFFER,
     ).build()
+
+    # stringify used to trigger an unhashable exception due to
+    # https://github.com/pydantic/pydantic/issues/8016
+    assert str(plan) != ""
 
     promotion_result = plan_evaluator._promote(plan)
     plan_evaluator._update_views(plan, promotion_result)


### PR DESCRIPTION
pydantic models with nested sets of other pydantic models cannot be called with .dict(). we call dict() on equality checks in order to recursively check equality. this is trigger on stringify because we check that each field is not equal to the default value. this commit bypasses that check so we don't trigger the dict() calls.

related github issue https://github.com/pydantic/pydantic/issues/8016