### PR TITLE
Fix: build table diff sqlglot expressions properly

### DIFF
--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -256,10 +256,10 @@ class TableDiff:
                 exp.select(
                     *s_selects.values(),
                     *t_selects.values(),
-                    exp.func("IF", exp.or_(*(c.not_().is_(exp.Null()) for c in s_index)), 1, 0).as_(
+                    exp.func("IF", exp.or_(*(c.is_(exp.Null()).not_() for c in s_index)), 1, 0).as_(
                         "s_exists"
                     ),
-                    exp.func("IF", exp.or_(*(c.not_().is_(exp.Null()) for c in t_index)), 1, 0).as_(
+                    exp.func("IF", exp.or_(*(c.is_(exp.Null()).not_() for c in t_index)), 1, 0).as_(
                         "t_exists"
                     ),
                     exp.func(
@@ -268,8 +268,8 @@ class TableDiff:
                             *(
                                 exp.and_(
                                     exp.column(c, "s").eq(exp.column(c, "t")),
-                                    exp.column(c, "s").not_().is_(exp.Null()),
-                                    exp.column(c, "t").not_().is_(exp.Null()),
+                                    exp.column(c, "s").is_(exp.Null()).not_(),
+                                    exp.column(c, "t").is_(exp.Null()).not_(),
                                 )
                                 for c in index_cols
                             ),


### PR DESCRIPTION
Fixes #2821

Didn't add any tests for this because it's a relatively small change and it matches what we do [elsewhere](https://github.com/TobikoData/sqlmesh/blob/9087309155b1eae7641dc9359a35b4632fb143ec/sqlmesh/core/engine_adapter/base.py#L1350-L1351) in the codebase:

```python
>>> from sqlglot import exp
>>>
>>> exp.column("c").not_().is_(exp.Null()).sql()
'NOT c IS NULL'
>>> exp.column("c").not_().is_(exp.Null()).sql("tsql")
'NOT c <> 0 IS NULL'
>>>
>>> exp.column("c").is_(exp.Null()).not_().sql()
'NOT c IS NULL'
>>> exp.column("c").is_(exp.Null()).not_().sql("tsql")
'NOT c IS NULL'
```