### PR TITLE
Chore: bump sqlglot to v25.3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=25.3.2",
+        "sqlglot[rs]~=25.3.3",
     ],
     extras_require={
         "bigquery": [

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=25.3.0",
+        "sqlglot[rs]~=25.3.2",
     ],
     extras_require={
         "bigquery": [


### PR DESCRIPTION
Bumping to get a few of the latest patches in, see https://github.com/tobymao/sqlglot/commits/main/