### PR TITLE
Fix: Drop the dev table clone if the schema migration fails

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -688,6 +688,9 @@ class SnapshotEvaluator:
                         snapshot, alter_expressions, allow_destructive_snapshots
                     )
                     self.adapter.alter_table(alter_expressions)
+                except Exception:
+                    self.adapter.drop_table(target_table_name)
+                    raise
                 finally:
                     self.adapter.drop_table(tmp_table_name)
             else:


### PR DESCRIPTION
This is a necessary cleanup step to make sure that next time the plan runs SQLMesh attempts to create and migrate the table again.

Fixes #2782