### PR TITLE
Feat: Introduce metadata only flag for macro functions

### DIFF
--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -60,6 +60,7 @@ GATEWAY = "gateway"
 
 SQLMESH_MACRO = "__sqlmesh__macro__"
 SQLMESH_BUILTIN = "__sqlmesh__builtin__"
+SQLMESH_METADATA = "__sqlmesh__metadata__"
 
 
 BUILTIN = "builtin"

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -565,7 +565,8 @@ class macro(registry_decorator):
     def __call__(
         self, func: t.Callable[..., DECORATOR_RETURN_TYPE]
     ) -> t.Callable[..., DECORATOR_RETURN_TYPE]:
-        setattr(func, c.SQLMESH_METADATA, self.is_metadata)
+        if self.is_metadata:
+            setattr(func, c.SQLMESH_METADATA, self.is_metadata)
         wrapper = super().__call__(func)
 
         # This is used to identify macros at runtime to unwrap during serialization.

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -558,9 +558,14 @@ class macro(registry_decorator):
 
     registry_name = "macros"
 
+    def __init__(self, *args: t.Any, is_metadata: bool = False, **kwargs: t.Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.is_metadata = is_metadata
+
     def __call__(
         self, func: t.Callable[..., DECORATOR_RETURN_TYPE]
     ) -> t.Callable[..., DECORATOR_RETURN_TYPE]:
+        setattr(func, c.SQLMESH_METADATA, self.is_metadata)
         wrapper = super().__call__(func)
 
         # This is used to identify macros at runtime to unwrap during serialization.

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -992,10 +992,10 @@ class _SqlBasedModel(_Model):
         if isinstance(statement, d.MacroFunc):
             target_macro = macro.get_registry().get(statement.name)
             if target_macro:
-                return getattr(target_macro.func, c.SQLMESH_METADATA, False)
+                return target_macro.is_metadata
             target_macro = self.python_env.get(statement.name)
             if isinstance(target_macro, Executable):
-                return target_macro.is_metadata is True
+                return bool(target_macro.is_metadata)
         return False
 
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -962,9 +962,7 @@ class _SqlBasedModel(_Model):
 
         for statement in (*self.pre_statements, *self.post_statements):
             statement_exprs: t.List[exp.Expression] = []
-            if isinstance(statement, d.MacroDef):
-                statement_exprs = [statement]
-            else:
+            if not isinstance(statement, d.MacroDef):
                 rendered = self._statement_renderer(statement).render()
                 if self._is_metadata_statement(statement):
                     continue
@@ -988,7 +986,7 @@ class _SqlBasedModel(_Model):
 
     def _is_metadata_statement(self, statement: exp.Expression) -> bool:
         if isinstance(statement, d.MacroDef):
-            return False
+            return True
         if isinstance(statement, d.MacroFunc):
             target_macro = macro.get_registry().get(statement.name)
             if target_macro:

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -314,6 +314,7 @@ class Executable(PydanticModel):
     name: t.Optional[str] = None
     path: t.Optional[str] = None
     alias: t.Optional[str] = None
+    is_metadata: t.Optional[bool] = None
 
     @property
     def is_definition(self) -> bool:
@@ -360,6 +361,7 @@ def serialize_env(env: t.Dict[str, t.Any], path: Path) -> t.Dict[str, Executable
                     # Do `as_posix` to serialize windows path back to POSIX
                     path=t.cast(Path, file_path).relative_to(path.absolute()).as_posix(),
                     alias=k if name != k else None,
+                    is_metadata=getattr(v, c.SQLMESH_METADATA, None),
                 )
             else:
                 serialized[k] = Executable(

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -3,6 +3,7 @@ import typing as t
 import pytest
 from sqlglot import MappingSchema, ParseError, exp, parse_one
 
+from sqlmesh.core import constants as c
 from sqlmesh.core.dialect import StagedFilePath
 from sqlmesh.core.macros import SQL, MacroEvalError, MacroEvaluator, macro
 from sqlmesh.utils.errors import SQLMeshError
@@ -599,3 +600,19 @@ def test_macro_parameter_resolution(macro_evaluator):
     with pytest.raises(MacroEvalError) as e:
         macro_evaluator.evaluate(parse_one("@test_arg_resolution(1, 2, 3)"))
     assert str(e.value.__cause__) == "too many positional arguments"
+
+
+def test_macro_metadata_flag():
+    @macro()
+    def noop(evaluator) -> None:
+        return None
+
+    @macro(is_metadata=True)
+    def noop_metadata_only(evaluator) -> None:
+        return None
+
+    assert not hasattr(noop, c.SQLMESH_METADATA)
+    assert macro.get_registry()["noop"].is_metadata is False
+
+    assert getattr(noop_metadata_only, c.SQLMESH_METADATA) is True
+    assert macro.get_registry()["noop_metadata_only"].is_metadata is True

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -612,7 +612,7 @@ def test_macro_metadata_flag():
         return None
 
     assert not hasattr(noop, c.SQLMESH_METADATA)
-    assert macro.get_registry()["noop"].is_metadata is False
+    assert not macro.get_registry()["noop"].is_metadata
 
     assert getattr(noop_metadata_only, c.SQLMESH_METADATA) is True
     assert macro.get_registry()["noop_metadata_only"].is_metadata is True

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -5103,6 +5103,9 @@ def test_macro_func_metadata_hash():
     def noop(evaluator) -> None:
         return None
 
+    # Standardize the python_env of the below models
+    setattr(macro.get_registry()["noop"], c.SQLMESH_BUILTIN, True)
+
     expressions = d.parse(
         """
         MODEL (
@@ -5129,7 +5132,9 @@ def test_macro_func_metadata_hash():
         expressions, path=Path("./examples/sushi/models/test_model.sql")
     )
 
+    assert model.data_hash != new_model.data_hash
     assert model.metadata_hash(audits={}) == new_model.metadata_hash(audits={})
 
     setattr(macro.get_registry()["noop"], c.SQLMESH_METADATA, True)
+    assert model.data_hash == new_model.data_hash
     assert model.metadata_hash(audits={}) != new_model.metadata_hash(audits={})

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -174,7 +174,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
         "models_to_backfill": ['"test_model"'],
         "end_bounded": False,
         "ensure_finalized_snapshots": False,
-        "directly_modified_snapshots": [{"identifier": "349602315", "name": '"test_model"'}],
+        "directly_modified_snapshots": [{"identifier": "844700562", "name": '"test_model"'}],
         "indirectly_modified_snapshots": {},
         "removed_snapshots": [],
         "restatements": {'"test_model"': [to_timestamp("2024-01-01"), to_timestamp("2024-01-02")]},


### PR DESCRIPTION
This PR allows flagging macro functions in a SQL model's pre and post hooks to be included in the model's metadata hash instead of its data hash.