### PR TITLE
Fix: Check for null or duplicate primary keys when running table_diff

### DIFF
--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -109,6 +109,15 @@ The `COMMON ROWS sample data differences` section displays the row whose `item_i
 
 The `PROD ONLY sample rows` section shows the one row that is present in `PROD` but not in `DEV`.
 
+If we add the `--check-grain` option, the grain is also validated. If rows contain null or duplicate grains, a warning is displayed to the user.
+
+```bash linenums="1"
+$ sqlmesh table_diff prod:dev2 sqlmesh_example.incremental_model --check-grain
+
+Grain should have unique and not-null audits for accurate results.
+
+```
+
 ## Diffing tables or views
 
 Compare specific tables or views with the SQLMesh CLI interface by using the command `sqlmesh table_diff [source table]:[target table]`.

--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -109,10 +109,10 @@ The `COMMON ROWS sample data differences` section displays the row whose `item_i
 
 The `PROD ONLY sample rows` section shows the one row that is present in `PROD` but not in `DEV`.
 
-If we add the `--check-grain` option, the grain is also validated. If rows contain null or duplicate grains, a warning is displayed to the user.
+If we add the `--skip-grain-check` option, the grain is not validated. By default without this flag, a warning is displayed to the user if rows contain null or duplicate grains.
 
 ```bash linenums="1"
-$ sqlmesh table_diff prod:dev2 sqlmesh_example.incremental_model --check-grain
+$ sqlmesh table_diff prod:dev2 sqlmesh_example.incremental_model
 
 Grain should have unique and not-null audits for accurate results.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -417,6 +417,8 @@ Options:
   --limit INTEGER         The limit of the sample dataframe.
   --show-sample           Show a sample of the rows that differ. With many
                           columns, the output can be very wide.
+  --check-grain           Display a warning if rows contain null or duplicate 
+                          grains.
   -d, --decimals INTEGER  The number of decimal places to keep when comparing
                           floating point columns. Default: 3
   --help                  Show this message and exit.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -417,8 +417,8 @@ Options:
   --limit INTEGER         The limit of the sample dataframe.
   --show-sample           Show a sample of the rows that differ. With many
                           columns, the output can be very wide.
-  --check-grain           Display a warning if rows contain null or duplicate 
-                          grains.
+  --skip-grain-check      Disable the check for a primary key (grain) that 
+                          is missing or is not unique.
   -d, --decimals INTEGER  The number of decimal places to keep when comparing
                           floating point columns. Default: 3
   --help                  Show this message and exit.

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -267,7 +267,7 @@ Create a schema file containing external model schemas.
 #### table_diff
 ```
 %table_diff [--on [ON ...]] [--model MODEL] [--where WHERE]
-                  [--limit LIMIT] [--show-sample] [--check-grain]
+                  [--limit LIMIT] [--show-sample] [--skip-grain-check]
                   SOURCE:TARGET
 
 Show the diff between two tables.
@@ -278,15 +278,15 @@ positional arguments:
   SOURCE:TARGET    Source and target in `SOURCE:TARGET` format
 
 options:
-  --on <[ON ...]>  The column to join on. Can be specified multiple times. The
-                   model grain will be used if not specified.
-  --model MODEL    The model to diff against when source and target are
-                   environments and not tables.
-  --where WHERE    An optional where statement to filter results.
-  --limit LIMIT    The limit of the sample dataframe.
-  --show-sample    Show a sample of the rows that differ. With many columns,
-                   the output can be very wide.  
-  --check-grain    Display a warning if rows contain null or duplicate grains.
+  --on <[ON ...]>     The column to join on. Can be specified multiple times. The
+                      model grain will be used if not specified.
+  --model MODEL       The model to diff against when source and target are
+                      environments and not tables.
+  --where WHERE       An optional where statement to filter results.
+  --limit LIMIT       The limit of the sample dataframe.
+  --show-sample       Show a sample of the rows that differ. With many columns,
+                      the output can be very wide.  
+  --skip-grain-check  Disable the check for a primary key (grain) that is missing or is not unique.
 ```
 
 #### model

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -267,7 +267,7 @@ Create a schema file containing external model schemas.
 #### table_diff
 ```
 %table_diff [--on [ON ...]] [--model MODEL] [--where WHERE]
-                  [--limit LIMIT] [--show-sample]
+                  [--limit LIMIT] [--show-sample] [--check-grain]
                   SOURCE:TARGET
 
 Show the diff between two tables.
@@ -285,7 +285,8 @@ options:
   --where WHERE    An optional where statement to filter results.
   --limit LIMIT    The limit of the sample dataframe.
   --show-sample    Show a sample of the rows that differ. With many columns,
-                   the output can be very wide.
+                   the output can be very wide.  
+  --check-grain    Display a warning if rows contain null or duplicate grains.
 ```
 
 #### model

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -743,6 +743,11 @@ def create_external_models(obj: Context) -> None:
     default=3,
     help="The number of decimal places to keep when comparing floating point columns. Default: 3",
 )
+@click.option(
+    "--check-grain",
+    is_flag=True,
+    help="An optional check if a primary key (grain) is missing or is not unique.",
+)
 @click.pass_obj
 @error_handler
 @cli_analytics

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -744,9 +744,9 @@ def create_external_models(obj: Context) -> None:
     help="The number of decimal places to keep when comparing floating point columns. Default: 3",
 )
 @click.option(
-    "--check-grain",
+    "--skip-grain-check",
     is_flag=True,
-    help="An optional check if a primary key (grain) is missing or is not unique.",
+    help="Disable the check for a primary key (grain) that is missing or is not unique.",
 )
 @click.pass_obj
 @error_handler

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -255,7 +255,7 @@ class Console(abc.ABC):
 
     @abc.abstractmethod
     def show_row_diff(
-        self, row_diff: RowDiff, show_sample: bool = True, check_grain: bool = True
+        self, row_diff: RowDiff, show_sample: bool = True, skip_grain_check: bool = False
     ) -> None:
         """Show table summary diff."""
 
@@ -1068,7 +1068,7 @@ class TerminalConsole(Console):
         self.console.print(tree)
 
     def show_row_diff(
-        self, row_diff: RowDiff, show_sample: bool = True, check_grain: bool = True
+        self, row_diff: RowDiff, show_sample: bool = True, skip_grain_check: bool = False
     ) -> None:
         source_name = row_diff.source
         if row_diff.source_alias:
@@ -1078,7 +1078,7 @@ class TerminalConsole(Console):
             target_name = row_diff.target_alias.upper()
 
         if row_diff.stats["null_grain_count"] > 0 or (
-            check_grain
+            not skip_grain_check
             and (
                 row_diff.stats["distinct_count_s"] != row_diff.stats["s_count"]
                 or row_diff.stats["distinct_count_t"] != row_diff.stats["t_count"]
@@ -2048,7 +2048,7 @@ class DebuggerTerminalConsole(TerminalConsole):
         self._write(schema_diff)
 
     def show_row_diff(
-        self, row_diff: RowDiff, show_sample: bool = True, check_grain: bool = True
+        self, row_diff: RowDiff, show_sample: bool = True, skip_grain_check: bool = False
     ) -> None:
         self._write(row_diff)
 

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -254,7 +254,9 @@ class Console(abc.ABC):
         """Show table schema diff."""
 
     @abc.abstractmethod
-    def show_row_diff(self, row_diff: RowDiff, show_sample: bool = True) -> None:
+    def show_row_diff(
+        self, row_diff: RowDiff, show_sample: bool = True, check_grain: bool = False
+    ) -> None:
         """Show table summary diff."""
 
     def _limit_model_names(self, tree: Tree, verbose: bool = False) -> Tree:
@@ -1065,13 +1067,23 @@ class TerminalConsole(Console):
 
         self.console.print(tree)
 
-    def show_row_diff(self, row_diff: RowDiff, show_sample: bool = True) -> None:
+    def show_row_diff(
+        self, row_diff: RowDiff, show_sample: bool = True, check_grain: bool = False
+    ) -> None:
         source_name = row_diff.source
         if row_diff.source_alias:
             source_name = row_diff.source_alias.upper()
         target_name = row_diff.target
         if row_diff.target_alias:
             target_name = row_diff.target_alias.upper()
+
+        if check_grain and (
+            row_diff.stats["null_grain_count"] > 0
+            or row_diff.stats["join_count"] != row_diff.stats["distinct_grain_count"]
+        ):
+            self.console.print(
+                "[b][red]Grain should have unique and not-null audits for accurate results.[/red][/b]"
+            )
 
         tree = Tree("[b]Row Counts:[/b]")
         if row_diff.full_match_count:
@@ -2032,7 +2044,9 @@ class DebuggerTerminalConsole(TerminalConsole):
     def show_schema_diff(self, schema_diff: SchemaDiff) -> None:
         self._write(schema_diff)
 
-    def show_row_diff(self, row_diff: RowDiff, show_sample: bool = True) -> None:
+    def show_row_diff(
+        self, row_diff: RowDiff, show_sample: bool = True, check_grain: bool = False
+    ) -> None:
         self._write(row_diff)
 
 

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -982,14 +982,17 @@ class TerminalConsole(Console):
         ):
             plan_builder.apply()
 
-    def _check_grain_uniqueness(self, stats: t.Dict[str, float], check_grain: bool = False)-> bool:
-
+    def _check_grain_uniqueness(self, stats: t.Dict[str, float], check_grain: bool = False) -> bool:
         if stats["null_grain_count"] > 0:
             return True
-        
+
         if check_grain:
             join_count = stats["join_count"]
-            return all(count != join_count for key, count in stats.items() if key.startswith('distinct_count_'))
+            return all(
+                count != join_count
+                for key, count in stats.items()
+                if key.startswith("distinct_count_")
+            )
 
         return False
 
@@ -1087,7 +1090,7 @@ class TerminalConsole(Console):
         target_name = row_diff.target
         if row_diff.target_alias:
             target_name = row_diff.target_alias.upper()
-        
+
         if self._check_grain_uniqueness(row_diff.stats, check_grain):
             self.console.print(
                 "[b][red]\nGrain should have unique and not-null audits for accurate results.[/red][/b]"

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1275,7 +1275,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         show: bool = True,
         show_sample: bool = True,
         decimals: int = 3,
-        check_grain: bool = True,
+        skip_grain_check: bool = False,
     ) -> TableDiff:
         """Show a diff between two tables.
 
@@ -1290,7 +1290,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             show: Show the table diff output in the console.
             show_sample: Show the sample dataframe in the console. Requires show=True.
             decimals: The number of decimal places to keep when comparing floating point columns.
-            check_grain: Display a warning if rows contain null or duplicate grains.
+            skip_grain_check: Skip check for rows that contain null or duplicate grains.
 
         Returns:
             The TableDiff object containing schema and summary differences.
@@ -1340,9 +1340,9 @@ class GenericContext(BaseContext, t.Generic[C]):
         if show:
             self.console.show_schema_diff(table_diff.schema_diff())
             self.console.show_row_diff(
-                table_diff.row_diff(check_grain=check_grain),
+                table_diff.row_diff(skip_grain_check=skip_grain_check),
                 show_sample=show_sample,
-                check_grain=check_grain,
+                skip_grain_check=skip_grain_check,
             )
         return table_diff
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1275,6 +1275,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         show: bool = True,
         show_sample: bool = True,
         decimals: int = 3,
+        check_grain: bool = False,
     ) -> TableDiff:
         """Show a diff between two tables.
 
@@ -1337,7 +1338,11 @@ class GenericContext(BaseContext, t.Generic[C]):
         )
         if show:
             self.console.show_schema_diff(table_diff.schema_diff())
-            self.console.show_row_diff(table_diff.row_diff(), show_sample=show_sample)
+            self.console.show_row_diff(
+                table_diff.row_diff(check_grain=check_grain),
+                show_sample=show_sample,
+                check_grain=check_grain,
+            )
         return table_diff
 
     @python_api_analytics

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1275,7 +1275,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         show: bool = True,
         show_sample: bool = True,
         decimals: int = 3,
-        check_grain: bool = False,
+        check_grain: bool = True,
     ) -> TableDiff:
         """Show a diff between two tables.
 
@@ -1290,6 +1290,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             show: Show the table diff output in the console.
             show_sample: Show the sample dataframe in the console. Requires show=True.
             decimals: The number of decimal places to keep when comparing floating point columns.
+            check_grain: Display a warning if rows contain null or duplicate grains.
 
         Returns:
             The TableDiff object containing schema and summary differences.

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -277,7 +277,7 @@ class TableDiff:
                         1,
                         0,
                     ).as_("row_joined"),
-                     exp.func(
+                    exp.func(
                         "IF",
                         exp.or_(
                             *(
@@ -323,7 +323,6 @@ class TableDiff:
             temp_table = exp.table_("diff", db="sqlmesh_temp", quoted=True)
 
             with self.adapter.temp_table(query, name=temp_table) as table:
-
                 summary_sums = [
                     exp.func("SUM", "s_exists").as_("s_count"),
                     exp.func("SUM", "t_exists").as_("t_count"),
@@ -335,14 +334,22 @@ class TableDiff:
 
                 if check_grain:
                     distincts = [
-                        *(exp.func("COUNT", exp.func("DISTINCT", f"s__{c}")).as_("distinct_count_s") for c in index_cols),
-                        *(exp.func("COUNT", exp.func("DISTINCT", f"t__{c}")).as_("distinct_count_t") for c in index_cols),
+                        *(
+                            exp.func("COUNT", exp.func("DISTINCT", f"s__{c}")).as_(
+                                "distinct_count_s"
+                            )
+                            for c in index_cols
+                        ),
+                        *(
+                            exp.func("COUNT", exp.func("DISTINCT", f"t__{c}")).as_(
+                                "distinct_count_t"
+                            )
+                            for c in index_cols
+                        ),
                     ]
                     summary_sums.extend(distincts)
 
-                summary_query = exp.select(
-                    *summary_sums
-                ).from_(table)
+                summary_query = exp.select(*summary_sums).from_(table)
 
                 stats_df = self.adapter.fetchdf(summary_query, quote_identifiers=True)
                 stats_df["s_only_count"] = stats_df["s_count"] - stats_df["join_count"]

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -333,14 +333,12 @@ class TableDiff:
                 ]
 
                 if check_grain:
+                    s_grains = ", ".join((f"s__{c}" for c in index_cols))
+                    t_grains = ", ".join((f"t__{c}" for c in index_cols))
                     summary_sums.extend(
                         [
-                            parse_one(
-                                f"COUNT(DISTINCT({", ".join((f"s__{c}" for c in index_cols))}))"
-                            ).as_("distinct_count_s"),
-                            parse_one(
-                                f"COUNT(DISTINCT({", ".join((f"t__{c}" for c in index_cols))}))"
-                            ).as_("distinct_count_t"),
+                            parse_one(f"COUNT(DISTINCT({s_grains}))").as_("distinct_count_s"),
+                            parse_one(f"COUNT(DISTINCT({t_grains}))").as_("distinct_count_t"),
                         ]
                     )
 

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -205,7 +205,7 @@ class TableDiff:
             model_name=self.model_name,
         )
 
-    def row_diff(self, check_grain: bool = True) -> RowDiff:
+    def row_diff(self, skip_grain_check: bool = False) -> RowDiff:
         if self._row_diff is None:
             s_selects = {c: exp.column(c, "s").as_(f"s__{c}") for c in self.source_schema}
             t_selects = {c: exp.column(c, "t").as_(f"t__{c}") for c in self.target_schema}
@@ -332,7 +332,7 @@ class TableDiff:
                     *(exp.func("SUM", name(c)).as_(c.alias) for c in comparisons),
                 ]
 
-                if check_grain:
+                if not skip_grain_check:
                     s_grains = ", ".join((f"s__{c}" for c in index_cols))
                     t_grains = ", ".join((f"t__{c}" for c in index_cols))
                     summary_sums.extend(

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -604,6 +604,11 @@ class SQLMeshMagics(Magics):
         default=3,
         help="The number of decimal places to keep when comparing floating point columns. Default: 3",
     )
+    @argument(
+        "--check-grain",
+        action="store_true",
+        help="An optional check if a primary key (grain) is missing or is not unique.",
+    )
     @line_magic
     @pass_sqlmesh_context
     def table_diff(self, context: Context, line: str) -> None:
@@ -622,6 +627,7 @@ class SQLMeshMagics(Magics):
             limit=args.limit,
             show_sample=args.show_sample,
             decimals=args.decimals,
+            check_grain=args.check_grain,
         )
 
     @magic_arguments()

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -605,9 +605,9 @@ class SQLMeshMagics(Magics):
         help="The number of decimal places to keep when comparing floating point columns. Default: 3",
     )
     @argument(
-        "--check-grain",
+        "--skip-grain-check",
         action="store_true",
-        help="An optional check if a primary key (grain) is missing or is not unique.",
+        help="Disable the check for a primary key (grain) that is missing or is not unique.",
     )
     @line_magic
     @pass_sqlmesh_context
@@ -627,7 +627,7 @@ class SQLMeshMagics(Magics):
             limit=args.limit,
             show_sample=args.show_sample,
             decimals=args.decimals,
-            check_grain=args.check_grain,
+            skip_grain_check=args.skip_grain_check,
         )
 
     @magic_arguments()

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -201,7 +201,7 @@ def test_grain_check(sushi_context_fixed_date):
         target="target_dev",
         on=["key_1", "key_2"],
         model_or_snapshot="sushi.grain_items",
-        check_grain=True,
+        skip_grain_check=False,
     )
 
     row_diff = diff.row_diff()


### PR DESCRIPTION
This adds a check for the uniqueness of the primary key (grain) or whether it contains null values and accordingly shows a warning to the user, fixes: #2810 

By default, this behavior is turned off due to the overhead of the additional query, but it can be enabled with the `check_grain` flag.

```
sqlmesh table_diff prod:dev sqlmesh_example.full_model --show-sample --check-grain

Grain should have unique and not-null audits for accurate results.

Row Counts:
└──  FULL MATCH: 3 rows (100.0%)

COMMON ROWS column comparison stats:
            pct_match
num_orders      100.0

COMMON ROWS sample data differences:
  All joined rows match
```