### PR TITLE
Fix: Improve the dbt adapter dispatch resolution when the package name is not specified

### DIFF
--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -121,14 +121,14 @@ class BaseAdapter(abc.ABC):
         ]
         candidates = {}
         for macro_package in packages_to_check:
-            macros: t.Dict[str, t.Any] = (
-                jinja_env.get(macro_package, {}) if macro_package else jinja_env  # type: ignore
-            )
-            matching_macro_names = [k for k in macros if k.endswith(macro_suffix)]
+            macros = jinja_env.get(macro_package, {}) if macro_package else jinja_env
+            if not isinstance(macros, dict):
+                continue
             candidates.update(
                 {
-                    (macro_package, macro_name): macros[macro_name]
-                    for macro_name in matching_macro_names
+                    (macro_package, macro_name): macro_callable
+                    for macro_name, macro_callable in macros.items()
+                    if macro_name.endswith(macro_suffix)
                 }
             )
 

--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -37,6 +37,9 @@ class Exceptions:
 
             raise CompilationException(msg)
 
+    def raise_not_implemented(self, msg: str) -> None:
+        raise NotImplementedError(msg)
+
     def warn(self, msg: str) -> str:
         logger.warning(msg)
         return ""

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -169,8 +169,6 @@ def test_adapter_dispatch(sushi_test_project: Project, runtime_renderer: t.Calla
 
     with pytest.raises(ConfigError, match=r"Macro 'current_engine'.*was not found."):
         renderer("{{ adapter.dispatch('current_engine')() }}")
-    with pytest.raises(ConfigError, match=r"Macro 'current_timestamp'.*was not found."):
-        assert renderer("{{ adapter.dispatch('current_timestamp', 'customers')() }}")
 
 
 def test_adapter_map_snapshot_tables(

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -164,9 +164,13 @@ def test_adapter_dispatch(sushi_test_project: Project, runtime_renderer: t.Calla
     context = sushi_test_project.context
     renderer = runtime_renderer(context)
     assert renderer("{{ adapter.dispatch('current_engine', 'customers')() }}") == "duckdb"
+    assert renderer("{{ adapter.dispatch('current_timestamp')() }}") == "now()"
+    assert renderer("{{ adapter.dispatch('current_timestamp', 'dbt')() }}") == "now()"
 
     with pytest.raises(ConfigError, match=r"Macro 'current_engine'.*was not found."):
         renderer("{{ adapter.dispatch('current_engine')() }}")
+    with pytest.raises(ConfigError, match=r"Macro 'current_timestamp'.*was not found."):
+        assert renderer("{{ adapter.dispatch('current_timestamp', 'customers')() }}")
 
 
 def test_adapter_map_snapshot_tables(

--- a/tests/fixtures/dbt/sushi_test/packages/customers/macros/current_engine.sql
+++ b/tests/fixtures/dbt/sushi_test/packages/customers/macros/current_engine.sql
@@ -1,3 +1,5 @@
+{% macro current_engine() %}{{ return(adapter.dispatch('current_engine')) }}{% endmacro %}
+
 {% macro default__current_engine() %}default{% endmacro %}
 
 {% macro duckdb__current_engine() %}duckdb{% endmacro %}

--- a/tests/fixtures/dbt/sushi_test/packages/customers/models/customer_revenue_by_day.sql
+++ b/tests/fixtures/dbt/sushi_test/packages/customers/models/customer_revenue_by_day.sql
@@ -7,6 +7,8 @@
     )
 }}
 
+{{ log(current_engine()) }}
+
 WITH order_total AS (
   SELECT
     oi.order_id AS order_id,


### PR DESCRIPTION
When the package name is not specified the root package must be searched and not just the `dbt*` ones.