### PR TITLE
Fix: take the default_gateway into account when loading external models

### DIFF
--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -123,7 +123,9 @@ class Loader(abc.ABC):
         self._config_mtimes = {path: max(mtimes) for path, mtimes in config_mtimes.items()}
 
         macros, jinja_macros = self._load_scripts()
-        models = self._load_models(macros, jinja_macros, context.gateway)
+        models = self._load_models(
+            macros, jinja_macros, context.gateway or context.config.default_gateway
+        )
 
         for model in models.values():
             self._add_model_to_dag(model)


### PR DESCRIPTION
Currently, the external model loading code expects that, if you want to load models relating to a specific gateway, you supply the `--gateway` flag when invoking the SQLMesh CLI.

However, some users override the default gateway in the config instead via setting the `SQLMESH__DEFAULT_GATEWAY` environment variable.

This change uses the config setting as a fallback when loading external models if the `--gateway` option is not supplied