### PR TITLE
Feat: Allow the janitor to be run on-demand

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,6 +30,7 @@ Commands:
   info                    Print information about a SQLMesh project.
   init                    Create a new SQLMesh repository.
   invalidate              Invalidate the target environment, forcing its...
+  janitor                 Run the janitor task on-demand.
   migrate                 Migrate SQLMesh to the current running version.
   plan                    Apply local changes to the target environment.
   prompt                  Uses LLM to generate a SQL query from a prompt.
@@ -227,6 +228,21 @@ Options:
               janitor process. This option requires a connection to the data
               warehouse.
   --help      Show this message and exit.
+```
+
+## janitor
+
+```
+Usage: sqlmesh janitor [OPTIONS]
+
+  Run the janitor task on-demand.
+
+  The janitor cleans up old environments and expired snapshots.
+
+Options:
+  --ignore-ttl  Cleanup snapshots that are not referenced in any environment,
+                regardless of when they're set to expire
+  --help        Show this message and exit.
 ```
 
 ## migrate

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,7 +30,7 @@ Commands:
   info                    Print information about a SQLMesh project.
   init                    Create a new SQLMesh repository.
   invalidate              Invalidate the target environment, forcing its...
-  janitor                 Run the janitor task on-demand.
+  janitor                 Run the janitor process on-demand.
   migrate                 Migrate SQLMesh to the current running version.
   plan                    Apply local changes to the target environment.
   prompt                  Uses LLM to generate a SQL query from a prompt.
@@ -235,7 +235,7 @@ Options:
 ```
 Usage: sqlmesh janitor [OPTIONS]
 
-  Run the janitor task on-demand.
+  Run the janitor process on-demand.
 
   The janitor cleans up old environments and expired snapshots.
 

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -329,6 +329,16 @@ positional arguments:
   environment  The environment to invalidate.
 ```
 
+#### janitor
+```
+%janitor
+
+Run the janitor process to clean up old environments and expired snapshots.
+
+options:
+  --ignore-ttl Cleanup snapshots that are not referenced in any environment, regardless of when they're set to expire
+```
+
 #### create_test
 ```
 %create_test --query QUERY [QUERY ...] [--overwrite]

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -439,6 +439,24 @@ def invalidate(ctx: click.Context, environment: str, **kwargs: t.Any) -> None:
     context.invalidate_environment(environment, **kwargs)
 
 
+@cli.command("janitor")
+@click.option(
+    "--ignore-ttl",
+    is_flag=True,
+    help="Cleanup snapshots that are not referenced in any environment, regardless of when they're set to expire",
+)
+@click.pass_context
+@error_handler
+@cli_analytics
+def janitor(ctx: click.Context, ignore_ttl: bool, **kwargs: t.Any) -> None:
+    """
+    Run the janitor task on-demand.
+
+    The janitor cleans up old environments and expired snapshots.
+    """
+    ctx.obj.run_janitor(ignore_ttl, **kwargs)
+
+
 @cli.command("dag")
 @click.argument("file", required=True)
 @click.option(

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -450,7 +450,7 @@ def invalidate(ctx: click.Context, environment: str, **kwargs: t.Any) -> None:
 @cli_analytics
 def janitor(ctx: click.Context, ignore_ttl: bool, **kwargs: t.Any) -> None:
     """
-    Run the janitor task on-demand.
+    Run the janitor process on-demand.
 
     The janitor cleans up old environments and expired snapshots.
     """

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -463,9 +463,15 @@ class TerminalConsole(Console):
     def start_cleanup(self, ignore_ttl: bool) -> bool:
         if ignore_ttl:
             self._print(
-                "Are you sure you want to delete all orphaned snapshots regardless of their environment?"
+                "Are you sure you want to delete all snapshots that are not referenced in any environment?"
             )
-            if not self._confirm("This may affect other users. Proceed?"):
+            self._print(
+                "Note that this may cause a race condition if there are any concurrently running plans."
+            )
+            self._print(
+                "It may also confuse users who were expecting to be able to rollback changes in their development environments."
+            )
+            if not self._confirm("Proceed?"):
                 self.log_error("Cleanup aborted")
                 return False
         return True

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -287,11 +287,17 @@ class StateSync(StateReader, abc.ABC):
         """
 
     @abc.abstractmethod
-    def delete_expired_snapshots(self) -> t.List[SnapshotTableCleanupTask]:
+    def delete_expired_snapshots(
+        self, ignore_ttl: bool = False
+    ) -> t.List[SnapshotTableCleanupTask]:
         """Removes expired snapshots.
 
         Expired snapshots are snapshots that have exceeded their time-to-live
         and are no longer in use within an environment.
+
+        Args:
+            ignore_ttl: Ignore the TTL on the snapshot when considering it expired. This has the effect of deleting
+                all snapshots that are not referenced in any environment
 
         Returns:
             The list of table cleanup tasks.

--- a/sqlmesh/core/state_sync/cache.py
+++ b/sqlmesh/core/state_sync/cache.py
@@ -116,9 +116,11 @@ class CachingStateSync(DelegatingStateSync):
             self.snapshot_cache.pop(s.snapshot_id, None)
         self.state_sync.delete_snapshots(snapshot_ids)
 
-    def delete_expired_snapshots(self) -> t.List[SnapshotTableCleanupTask]:
+    def delete_expired_snapshots(
+        self, ignore_ttl: bool = False
+    ) -> t.List[SnapshotTableCleanupTask]:
         self.snapshot_cache.clear()
-        return self.state_sync.delete_expired_snapshots()
+        return self.state_sync.delete_expired_snapshots(ignore_ttl=ignore_ttl)
 
     def _add_snapshot_intervals(self, snapshot_intervals: SnapshotIntervals) -> None:
         self.snapshot_cache.pop(snapshot_intervals.snapshot_id, None)

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -741,6 +741,19 @@ class SQLMeshMagics(Magics):
         context.invalidate_environment(args.environment)
 
     @magic_arguments()
+    @argument(
+        "--ignore-ttl",
+        action="store_true",
+        help="Cleanup snapshots that are not referenced in any environment, regardless of when they're set to expire",
+    )
+    @line_magic
+    @pass_sqlmesh_context
+    def janitor(self, context: Context, line: str) -> None:
+        """Run the janitor process to clean up old environments and expired snapshots."""
+        args = parse_argstring(self.janitor, line)
+        context.run_janitor(ignore_ttl=args.ignore_ttl)
+
+    @magic_arguments()
     @argument("model", type=str)
     @argument(
         "--query",

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -176,7 +176,9 @@ class HttpStateSync(StateSync):
         """
         raise NotImplementedError("Deleting snapshots is not supported by the Airflow state sync.")
 
-    def delete_expired_snapshots(self) -> t.List[SnapshotTableCleanupTask]:
+    def delete_expired_snapshots(
+        self, ignore_ttl: bool = False
+    ) -> t.List[SnapshotTableCleanupTask]:
         """Removes expired snapshots.
 
         Expired snapshots are snapshots that have exceeded their time-to-live

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -420,6 +420,27 @@ def test_invalidate(
     ]
 
 
+@pytest.mark.slow
+def test_janitor(
+    notebook, loaded_sushi_context, convert_all_html_output_to_text, get_all_html_output
+):
+    with capture_output():
+        notebook.run_line_magic(
+            magic_name="plan", line="dev --include-unmodified --no-prompts --auto-apply"
+        )
+        notebook.run_line_magic(magic_name="invalidate", line="dev")
+
+    with capture_output() as output:
+        notebook.run_line_magic(magic_name="janitor", line="")
+
+    assert not output.stdout
+    assert not output.stderr
+    assert convert_all_html_output_to_text(output) == [
+        "Deleted object memory.sushi__dev",
+        "Cleanup complete.",
+    ]
+
+
 def test_dag(tmp_path_factory, notebook, sushi_context):
     temp_dir = tmp_path_factory.mktemp("dag")
     dag_file = temp_dir / "dag.html"


### PR DESCRIPTION
This exposes the janitor task to the CLI so that users may run it on-demand and not as part of `sqlmesh run`.

To trigger the janitor, just run `sqlmesh janitor` and it calls the janitor task in the exact same way that `sqlmesh run` would have.

The main benefit is being able to decouple the janitor process and the missing intervals process so they dont interfere with each other.

I've noticed that they can interfere with each other when there are many large tables to drop, particularly on systems like Trino / Iceberg where a `DROP TABLE` statement blocks until all the files have been removed from S3. This causes the main run to be blocked until the janitor is complete, which is undesirable when you want it to refresh data ASAP.

I also added an option `--ignore-ttl` to ignore the snapshot TTL when identifying snapshots to remove. Iterating heavily on a SQLMesh project leaves lots of unused tables lying around. If you want to clean them up now - you're stuck. You have no way to do it without either waiting for the TTL to expire or manually modifying the state database to adjust the TTL to be in the past.

This option gives you a way to do it. I understand there is some concern around race conditions, so it throws up a warning and requires the user to manually indicate they want to proceed before continuing. The idea isn't to use it all the time, just when it makes sense to perform an early cleanup.