### PR TITLE
Fix: Set the dbt invocation context before loading the profile

### DIFF
--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import typing as t
 from argparse import Namespace
@@ -263,7 +264,7 @@ class ManifestHelper:
         if DBT_VERSION >= (1, 8):
             from dbt_common.context import set_invocation_context  # type: ignore
 
-            set_invocation_context({})
+            set_invocation_context(os.environ)
 
         profile = self._load_profile()
         project = self._load_project(profile)

--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -260,6 +260,11 @@ class ManifestHelper:
         )
         flags.set_from_args(args, None)
 
+        if DBT_VERSION >= (1, 8):
+            from dbt_common.context import set_invocation_context  # type: ignore
+
+            set_invocation_context({})
+
         profile = self._load_profile()
         project = self._load_project(profile)
 
@@ -274,10 +279,8 @@ class ManifestHelper:
 
         if DBT_VERSION >= (1, 8):
             from dbt.mp_context import get_mp_context  # type: ignore
-            from dbt_common.context import set_invocation_context  # type: ignore
 
             register_adapter(runtime_config, get_mp_context())  # type: ignore
-            set_invocation_context({})
         else:
             register_adapter(runtime_config)  # type: ignore
 


### PR DESCRIPTION
Fixes the following exception:
```
...
File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/sqlmesh/dbt/manifest.py", line 295, in _load_profile
    return Profile.from_raw_profiles(
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt/config/profile.py", line 369, in from_raw_profiles
    return cls.from_raw_profile_info(
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt/config/profile.py", line 315, in from_raw_profile_info
    target_name, profile_data = cls.render_profile(
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt/config/profile.py", line 284, in render_profile
    profile_data = renderer.render_data(raw_profile_data)
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt/config/renderer.py", line 53, in render_data
    return deep_map_render(self.render_entry, data)
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt_common/utils/dict.py", line 129, in deep_map_render
    return _deep_map_render(func, value, ())
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt_common/utils/dict.py", line 94, in _deep_map_render
    ret = {k: _deep_map_render(func, v, (keypath + (str(k),))) for k, v in value.items()}
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt_common/utils/dict.py", line 94, in <dictcomp>
    ret = {k: _deep_map_render(func, v, (keypath + (str(k),))) for k, v in value.items()}
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt_common/utils/dict.py", line 96, in _deep_map_render
    ret = func(value, keypath)
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt/config/renderer.py", line 37, in render_entry
    return self.render_value(value, keypath)
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt/config/renderer.py", line 203, in render_value
    raise ex
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt/config/renderer.py", line 196, in render_value
    rendered = super().render_value(value, keypath)
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt/config/renderer.py", line 46, in render_value
    return get_rendered(value, self.context, native=True)
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt/clients/jinja.py", line 146, in get_rendered
    rendered = render_template(template, ctx, node)
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt_common/clients/jinja.py", line 539, in render_template
    return template.render(ctx)
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt_common/clients/jinja.py", line 228, in render
    return self.environment.handle_exception()
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/jinja2/environment.py", line 939, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt_common/clients/jinja.py", line 184, in quoted_native_concat
    head = list(islice(nodes, 2))
  File "<template>", line 1, in top-level template code
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/jinja2/sandbox.py", line 394, in call
    return __context.call(__obj, *args, **kwargs)
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt/context/secret.py", line 32, in env_var
    env = get_invocation_context().env
  File "/Users/sung/Desktop/git_repos/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/dbt_common/context.py", line 53, in get_invocation_context
    ctx = invocation_var.get()
LookupError: <ContextVar name='DBT_INVOCATION_CONTEXT_VAR' at 0x14ad2ed40>
```