### PR TITLE
Fix: BIGNUMERIC column can't be altered into FLOAT64 in BigQuery

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -65,9 +65,6 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
                 exp.DataType.build("FLOAT64", dialect=DIALECT),
                 exp.DataType.build("BIGNUMERIC", dialect=DIALECT),
             },
-            exp.DataType.build("BIGNUMERIC", dialect=DIALECT): {
-                exp.DataType.build("FLOAT64", dialect=DIALECT),
-            },
             exp.DataType.build("DATE", dialect=DIALECT): {
                 exp.DataType.build("DATETIME", dialect=DIALECT),
             },


### PR DESCRIPTION
```
CREATE TABLE iaroslav.bignumeric_testing (cola BIGNUMERIC);
ALTER TABLE iaroslav.bignumeric_testing ALTER COLUMN cola SET DATA TYPE FLOAT64;
```
Results in:
```
Provided Schema does not match Table <project id>:iaroslav.bignumeric_testing. Field cola has changed type from BIGNUMERIC to FLOAT
