### PR TITLE
Fix: Use the default dialect when constructing a table mapping key in the dbt adapter

### DIFF
--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -6,6 +6,7 @@ import typing as t
 
 import pandas as pd
 from sqlglot import exp, parse_one
+from sqlglot.optimizer.qualify_columns import quote_identifiers
 
 from sqlmesh.core.dialect import normalize_and_quote, normalize_model_name
 from sqlmesh.core.engine_adapter import EngineAdapter
@@ -353,7 +354,9 @@ class RuntimeAdapter(BaseAdapter):
         return identifier if identifier else None
 
     def _map_table_name(self, table: exp.Table) -> exp.Table:
-        name = table.sql(dialect=self.project_dialect)
+        # Use the default dialect since this is the dialect used to normalize and quote keys in the
+        # mapping table.
+        name = quote_identifiers(table, dialect=self.project_dialect).sql()
         physical_table_name = self.table_mapping.get(name)
         if not physical_table_name:
             return table

--- a/tests/dbt/conftest.py
+++ b/tests/dbt/conftest.py
@@ -17,7 +17,7 @@ def sushi_test_project(sushi_test_dbt_context: Context) -> Project:
 @pytest.fixture()
 def runtime_renderer() -> t.Callable:
     def create_renderer(context: DbtContext, **kwargs: t.Any) -> t.Callable:
-        environment = context.jinja_macros.build_environment(**context.jinja_globals, **kwargs)
+        environment = context.jinja_macros.build_environment(**{**context.jinja_globals, **kwargs})
 
         def render(value: str) -> str:
             return environment.from_string(value).render()


### PR DESCRIPTION
The keys in the mapping have been serialized using the default dialect so the same dialect should be used for lookup.