### PR TITLE
Fix!: Support for trailing comments in SQL model definitions

### DIFF
--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -347,7 +347,7 @@ class ExpressionRenderer(BaseExpressionRenderer):
                 **kwargs,
             )
             for e in expressions
-            if e
+            if e and not isinstance(e, exp.Semicolon)
         ]
 
 

--- a/sqlmesh/migrations/v0054_fix_trailing_comments.py
+++ b/sqlmesh/migrations/v0054_fix_trailing_comments.py
@@ -1,0 +1,5 @@
+"""Fix support for trailing comments in SQL model definitions."""
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    pass

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -5210,3 +5210,36 @@ def test_managed_kind_python():
             module_path=Path("."),
             path=Path("."),
         ).validate_definition()
+
+
+def test_trailing_comments():
+    expressions = d.parse(
+        """
+        MODEL (name db.table);
+
+        /* some comment A */
+
+        SELECT 1;
+        /* some comment B */
+        """
+    )
+    model = load_sql_based_model(expressions)
+    assert not model.render_pre_statements()
+    assert not model.render_post_statements()
+
+    expressions = d.parse(
+        """
+        MODEL (
+            name db.seed,
+            kind SEED (
+              path '../seeds/waiter_names.csv',
+              batch_size 100,
+            )
+        );
+
+        /* some comment A */
+        """
+    )
+    model = load_sql_based_model(expressions, path=Path("./examples/sushi/models/test_model.sql"))
+    assert not model.render_pre_statements()
+    assert not model.render_post_statements()


### PR DESCRIPTION
Before this fix, the renderer would return a `Semicolon` expression, resulting in an empty SQL string and subsequent failure when evaluating in the engine adapter.