### PR TITLE
Feat: add support for native SQLMesh SQL macros

### DIFF
--- a/examples/sushi/macros/utils.sql
+++ b/examples/sushi/macros/utils.sql
@@ -1,0 +1,9 @@
+@DEF(
+    add2,
+    (x, y) -> x + y
+);
+
+@DEF(
+    add3,
+    (x, y, z) -> x + y + z
+);

--- a/examples/sushi/models/top_waiters.sql
+++ b/examples/sushi/models/top_waiters.sql
@@ -11,6 +11,8 @@ MODEL (
 WITH test_macros AS (
   SELECT
     @ADD_ONE(1) AS lit_two,
+    @ADD2(1, 2) AS lit_three,
+    @ADD3(1, 2, 3) AS lit_six,
     @MULTIPLY(revenue, 2.0) AS sql_exp,
     @SQL_LITERAL(revenue::text, 'x', 'y', a, "b") AS sql_lit,
   FROM sushi.waiter_revenue_by_day

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -708,6 +708,7 @@ def parse(
     default_dialect: t.Optional[str] = None,
     match_dialect: bool = True,
     into: t.Optional[exp.IntoType] = None,
+    tokens: t.Optional[t.List[Token]] = None,
 ) -> t.List[exp.Expression]:
     """Parse a sql string.
 
@@ -717,6 +718,9 @@ def parse(
     Args:
         sql: The sql based definition.
         default_dialect: The dialect to use if the model does not specify one.
+        match_dialect: Whether to search `sql` for a `dialect <name>` pattern.
+        into: The target expression to be returned.
+        tokens: An existing list of tokens. If this is provided, `sql` won't be tokenized.
 
     Returns:
         A list of the parsed expressions: [Model, *Statements, Query, *Statements]
@@ -724,7 +728,7 @@ def parse(
     match = match_dialect and DIALECT_PATTERN.search(sql[:MAX_MODEL_DEFINITION_SIZE])
     dialect = Dialect.get_or_raise(match.group(2) if match else default_dialect)
 
-    tokens = dialect.tokenizer.tokenize(sql)
+    tokens = tokens or dialect.tokenizer.tokenize(sql)
     chunks: t.List[t.Tuple[t.List[Token], ChunkType]] = [([], ChunkType.SQL)]
     total = len(tokens)
 

--- a/sqlmesh/utils/jinja.py
+++ b/sqlmesh/utils/jinja.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from enum import Enum
 
 from jinja2 import Environment, Template, nodes
-from sqlglot import Dialect, Expression, Parser, TokenType
+from sqlglot import Dialect, Expression, Parser, TokenType, Token
 
 from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
@@ -55,7 +55,9 @@ class MacroReturnVal(Exception):
 
 
 class MacroExtractor(Parser):
-    def extract(self, jinja: str, dialect: str = "") -> t.Dict[str, MacroInfo]:
+    def extract(
+        self, jinja: str, dialect: str = "", tokens: t.Optional[t.List[Token]] = None
+    ) -> t.Dict[str, MacroInfo]:
         """Extract a dictionary of macro definitions from a jinja string.
 
         Args:
@@ -67,7 +69,7 @@ class MacroExtractor(Parser):
         """
         self.reset()
         self.sql = jinja
-        self._tokens = Dialect.get_or_raise(dialect).tokenizer.tokenize(jinja)
+        self._tokens = tokens or Dialect.get_or_raise(dialect).tokenizer.tokenize(jinja)
         self._index = -1
         self._advance()
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1340,6 +1340,8 @@ def test_render_query(assert_exp_eq, sushi_context):
         WITH "test_macros" AS (
           SELECT
             2 AS "lit_two",
+            3 AS "lit_three",
+            6 AS "lit_six",
             "waiter_revenue_by_day"."revenue" * 2.0 AS "sql_exp",
             CAST("waiter_revenue_by_day"."revenue" AS TEXT) AS "sql_lit"
           FROM "memory"."sushi"."waiter_revenue_by_day" AS "waiter_revenue_by_day"

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -552,7 +552,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
     assert len(output.outputs) == 3
     assert convert_all_html_output_to_text(output) == [
         "Models: 17",
-        "Macros: 5",
+        "Macros: 7",
         "Data warehouse connection succeeded",
     ]
     assert get_all_html_output(output) == [
@@ -582,7 +582,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
                     h(
                         "span",
                         {"style": f"{NEUTRAL_STYLE}; font-weight: bold"},
-                        "5",
+                        "7",
                         autoescape=False,
                     )
                 ),


### PR DESCRIPTION
This is a hacky and somewhat incomplete (*) solution, but I tried a few others and they all had issues related to serialization. So I'm mostly opening this PR to begin a discussion and if needed I can refactor, perhaps with the help of @Themiscodes.

Regarding the serialization issues, take the following example as an alternative approach (loader.py):

```python
for definition in macro_definitions:
    _, fn = _norm_var_arg_lambda(MacroEvaluator(dialect=dialect), definition.expression)
    macro(definition.name)(lambda evaluator, *args: fn(evaluator, *args)
```

At serialization time, `normalize_source` would produce a payload for the lambda that looks like `"lambda ...: ... fn ..."` and when we actually try to evaluate this, `fn` would be an undefined reference. Other [approaches](https://github.com/TobikoData/sqlmesh/compare/main...themis/reusable_macros) had similar issues. Maybe we could explore other options, i.e. avoid converting a SQL definition into a python function that simulates a macro?

(*) kwargs are not supported for these macros, because `exp.Lambda` only accepts positional arguments.

Fixes https://github.com/TobikoData/sqlmesh/issues/2505