### PR TITLE
Fix!: Snowflake adapter

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -2055,13 +2055,15 @@ class EngineAdapter:
         """
         raise NotImplementedError()
 
-    def _get_temp_table(self, table: TableName, table_only: bool = False) -> exp.Table:
+    def _get_temp_table(
+        self, table: TableName, table_only: bool = False, quoted: bool = True
+    ) -> exp.Table:
         """
         Returns the name of the temp table that should be used for the given table name.
         """
         table = t.cast(exp.Table, exp.to_table(table).copy())
         table.set(
-            "this", exp.to_identifier(f"__temp_{table.name}_{random_id(short=True)}", quoted=True)
+            "this", exp.to_identifier(f"__temp_{table.name}_{random_id(short=True)}", quoted=quoted)
         )
 
         if table_only:

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -292,10 +292,6 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
 
         schema = to_schema(schema_name)
         catalog_name = schema.catalog or self.get_current_catalog()
-        if catalog_name:
-            catalog_name = normalize_identifiers(catalog_name, dialect=self.dialect).sql(
-                dialect=self.dialect
-            )
 
         query = (
             exp.select(

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -200,7 +200,9 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
         batch_size: int,
         target_table: TableName,
     ) -> t.List[SourceQuery]:
-        temp_table = self._get_temp_table(target_table or "pandas")
+        temp_table = self._get_temp_table(
+            target_table or "pandas", quoted=False
+        )  # write_pandas() re-quotes everything without checking if its already quoted
 
         def query_factory() -> Query:
             if snowpark and isinstance(df, snowpark.dataframe.DataFrame):
@@ -211,10 +213,10 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
                 # Workaround for https://github.com/snowflakedb/snowflake-connector-python/issues/1034
                 # The above issue has already been fixed upstream, but we keep the following
                 # line anyway in order to support a wider range of Snowflake versions.
-                schema = f'"{temp_table.db}"'
+                schema = temp_table.db
                 if temp_table.catalog:
-                    schema = f'"{temp_table.catalog}".{schema}'
-                self.cursor.execute(f"USE SCHEMA {schema}")
+                    schema = f"{temp_table.catalog}.{schema}"
+                self.set_current_schema(schema)
 
                 # See: https://stackoverflow.com/a/75627721
                 for column, kind in columns_to_types.items():
@@ -240,7 +242,11 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
                     df,
                     temp_table.name,
                     schema=temp_table.db or None,
-                    database=temp_table.catalog or None,
+                    database=normalize_identifiers(temp_table.catalog, dialect=self.dialect).sql(
+                        dialect=self.dialect
+                    )
+                    if temp_table.catalog
+                    else None,
                     chunk_size=self.DEFAULT_BATCH_SIZE,
                     overwrite=True,
                     table_type="temp",  # if you dont have this, it will convert the table we created above into a normal table and it wont get dropped when the session ends
@@ -252,7 +258,13 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
 
             return exp.select(*self._casted_columns(columns_to_types)).from_(temp_table)
 
-        return [SourceQuery(query_factory=query_factory)]
+        # the cleanup_func technically isnt needed because the temp table gets dropped when the session ends
+        # but boy does it make our multi-adapter integration tests easier to write
+        return [
+            SourceQuery(
+                query_factory=query_factory, cleanup_func=lambda: self.drop_table(temp_table)
+            )
+        ]
 
     def _fetch_native_df(
         self, query: t.Union[exp.Expression, str], quote_identifiers: bool = False
@@ -280,6 +292,11 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
 
         schema = to_schema(schema_name)
         catalog_name = schema.catalog or self.get_current_catalog()
+        if catalog_name:
+            catalog_name = normalize_identifiers(catalog_name, dialect=self.dialect).sql(
+                dialect=self.dialect
+            )
+
         query = (
             exp.select(
                 exp.column("TABLE_CATALOG").as_("catalog"),
@@ -308,6 +325,8 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
             )
             .from_(exp.table_("TABLES", db="INFORMATION_SCHEMA", catalog=catalog_name))
             .where(exp.column("TABLE_SCHEMA").eq(schema.db))
+            # Snowflake seems to have delayed internal metadata updates and will sometimes return duplicates
+            .distinct()
         )
         if object_names:
             query = query.where(exp.column("TABLE_NAME").isin(*object_names))
@@ -326,7 +345,39 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
         ]
 
     def set_current_catalog(self, catalog: str) -> None:
-        self.execute(exp.Use(this=exp.to_identifier(catalog)))
+        self.execute(exp.Use(this=normalize_identifiers(catalog, dialect=self.dialect)))
+
+    def set_current_schema(self, schema: str) -> None:
+        self.execute(exp.Use(kind="SCHEMA", this=to_schema(schema)))
+
+    def _to_sql(self, expression: exp.Expression, quote: bool = True, **kwargs: t.Any) -> str:
+        # note: important to use self._default_catalog instead of the self.default_catalog property
+        # otherwise we get RecursionError: maximum recursion depth exceeded
+        # because it calls get_current_catalog(), which executes a query, which needs the default catalog, which calls get_current_catalog()... etc
+        if self._default_catalog:
+
+            def unquote_and_lower(identifier: str) -> str:
+                return exp.to_identifier(identifier).name.lower()
+
+            default_catalog_unquoted = unquote_and_lower(self._default_catalog)
+            default_catalog_normalized = normalize_identifiers(
+                self._default_catalog, dialect=self.dialect
+            )
+
+            def catalog_rewriter(node: exp.Expression) -> exp.Expression:
+                if isinstance(node, exp.Table):
+                    if node.catalog:
+                        # only replace the catalog on the model with the target catalog if the two are functionally equivalent
+                        if unquote_and_lower(node.catalog) == default_catalog_unquoted:
+                            node.set("catalog", default_catalog_normalized)
+                return node
+
+            # Rewrite whatever default catalog is present on the query to be compatible with what the user supplied in the
+            # Snowflake connection config. This is because the catalog present on the model gets normalized and quoted to match
+            # the source dialect, which isnt always compatible with Snowflake
+            expression = expression.transform(catalog_rewriter)
+
+        return super()._to_sql(expression=expression, quote=quote, **kwargs)
 
     def _build_create_comment_column_exp(
         self, table: exp.Table, column_name: str, column_comment: str, table_kind: str = "TABLE"

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -357,7 +357,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
         if self._default_catalog:
 
             def unquote_and_lower(identifier: str) -> str:
-                return exp.to_identifier(identifier).name.lower()
+                return exp.parse_identifier(identifier).name.lower()
 
             default_catalog_unquoted = unquote_and_lower(self._default_catalog)
             default_catalog_normalized = normalize_identifiers(

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -351,7 +351,11 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
         # otherwise we get RecursionError: maximum recursion depth exceeded
         # because it calls get_current_catalog(), which executes a query, which needs the default catalog, which calls get_current_catalog()... etc
         if self._default_catalog:
-
+            # the purpose of this function is to identify instances where the default catalog is being used
+            # (so that we can replace it with the actual catalog as specified in the gateway)
+            #
+            # we can't do a direct string comparison because the catalog value on the model
+            # gets changed when it's normalized as part of generating `model.fqn`
             def unquote_and_lower(identifier: str) -> str:
                 return exp.parse_identifier(identifier).name.lower()
 

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -341,7 +341,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
         ]
 
     def set_current_catalog(self, catalog: str) -> None:
-        self.execute(exp.Use(this=normalize_identifiers(catalog, dialect=self.dialect)))
+        self.execute(exp.Use(this=exp.to_identifier(catalog)))
 
     def set_current_schema(self, schema: str) -> None:
         self.execute(exp.Use(kind="SCHEMA", this=to_schema(schema)))
@@ -370,6 +370,9 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
                         # only replace the catalog on the model with the target catalog if the two are functionally equivalent
                         if unquote_and_lower(node.catalog) == default_catalog_unquoted:
                             node.set("catalog", default_catalog_normalized)
+                elif isinstance(node, exp.Use) and isinstance(node.this, exp.Identifier):
+                    if unquote_and_lower(node.this.output_name) == default_catalog_unquoted:
+                        node.set("this", default_catalog_normalized)
                 return node
 
             # Rewrite whatever default catalog is present on the query to be compatible with what the user supplied in the

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -382,7 +382,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
     def _build_create_comment_column_exp(
         self, table: exp.Table, column_name: str, column_comment: str, table_kind: str = "TABLE"
     ) -> exp.Comment | str:
-        table_sql = table.sql(dialect=self.dialect, identify=True)
+        table_sql = self._to_sql(table)  # so that catalog replacement happens
         column_sql = exp.column(column_name).sql(dialect=self.dialect, identify=True)
 
         truncated_comment = self._truncate_column_comment(column_comment)

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -249,7 +249,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
                     else None,
                     chunk_size=self.DEFAULT_BATCH_SIZE,
                     overwrite=True,
-                    table_type="temp",  # if you dont have this, it will convert the table we created above into a normal table and it wont get dropped when the session ends
+                    table_type="temp",
                 )
             else:
                 raise SQLMeshError(

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -284,9 +284,7 @@ class SparkEngineAdapter(GetCurrentCatalogFromFunctionMixin, HiveMetastoreTableP
         return self.spark.createDataFrame(df, **kwargs)  # type: ignore
 
     def _get_temp_table(
-        self,
-        table: TableName,
-        table_only: bool = False,
+        self, table: TableName, table_only: bool = False, quoted: bool = True
     ) -> exp.Table:
         """
         Returns the name of the temp table that should be used for the given table name.

--- a/tests/core/engine_adapter/test_snowflake.py
+++ b/tests/core/engine_adapter/test_snowflake.py
@@ -280,6 +280,7 @@ def test_ctas_skips_dynamic_table_properties(make_mocked_engine_adapter: t.Calla
         'CREATE TABLE IF NOT EXISTS "test_table" AS SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (SELECT "a", "b" FROM "source_table") AS "_subquery"'
     ]
 
+
 def test_set_current_catalog(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(SnowflakeEngineAdapter)
     adapter._default_catalog = "foo"
@@ -347,6 +348,10 @@ def test_set_current_schema(make_mocked_engine_adapter: t.Callable):
 
     adapter.set_current_schema('"foo"')
     adapter.set_current_schema('foo."foo"')
+
+    # in this example, the catalog of '"foo"' is normalized in duckdb.
+    # even though it's quoted, it should get replaced with "FOO"
+    # because it matches the default catalog
     adapter.set_current_schema('"foo"."fOo"')
 
     assert to_sql_calls(adapter) == [

--- a/tests/core/engine_adapter/test_snowflake.py
+++ b/tests/core/engine_adapter/test_snowflake.py
@@ -5,8 +5,11 @@ import pytest
 from pytest_mock.plugin import MockerFixture
 from sqlglot import exp, parse_one
 
+import sqlmesh.core.dialect as d
 from sqlmesh.core.dialect import normalize_model_name
+from sqlmesh.core.model import load_sql_based_model
 from sqlmesh.core.engine_adapter import SnowflakeEngineAdapter
+from sqlmesh.core.model.definition import SqlModel
 from sqlmesh.utils.errors import SQLMeshError
 from tests.core.engine_adapter import to_sql_calls
 
@@ -274,5 +277,80 @@ def test_ctas_skips_dynamic_table_properties(make_mocked_engine_adapter: t.Calla
     )
 
     assert to_sql_calls(adapter) == [
-        'CREATE TABLE IF NOT EXISTS "test_table" AS SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (SELECT "a", "b" FROM "source_table") AS "_subquery"',
+        'CREATE TABLE IF NOT EXISTS "test_table" AS SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (SELECT "a", "b" FROM "source_table") AS "_subquery"'
+    ]
+
+def test_set_current_catalog(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(SnowflakeEngineAdapter)
+    adapter._default_catalog = "foo"
+
+    adapter.set_current_catalog("foo")
+    adapter.set_current_catalog("FOO")
+    adapter.set_current_catalog("fOo")
+    adapter.set_current_catalog("bar")
+    adapter.set_current_catalog("BAR")
+
+    model_a: SqlModel = t.cast(
+        SqlModel,
+        load_sql_based_model(
+            d.parse(
+                """
+        MODEL (
+            name external.test.table,
+            kind full,
+            dialect bigquery
+        );
+
+        SELECT 1;
+    """
+            )
+        ),
+    )
+
+    model_b: SqlModel = t.cast(
+        SqlModel,
+        load_sql_based_model(
+            d.parse(
+                """
+        MODEL (
+            name "exTERnal".test.table,
+            kind full,
+            dialect bigquery
+        );
+
+        SELECT 1;
+    """
+            )
+        ),
+    )
+
+    assert model_a.catalog == "external"
+    assert model_b.catalog == "exTERnal"
+
+    adapter.set_current_catalog(model_a.catalog)
+    adapter.set_current_catalog(model_b.catalog)
+
+    assert to_sql_calls(adapter) == [
+        'USE "FOO"',
+        'USE "FOO"',
+        'USE "FOO"',
+        'USE "bar"',
+        'USE "BAR"',
+        'USE "external"',
+        'USE "exTERnal"',
+    ]
+
+
+def test_set_current_schema(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(SnowflakeEngineAdapter)
+    adapter._default_catalog = "foo"
+
+    adapter.set_current_schema('"foo"')
+    adapter.set_current_schema('foo."foo"')
+    adapter.set_current_schema('"foo"."fOo"')
+
+    assert to_sql_calls(adapter) == [
+        'USE SCHEMA "foo"',
+        'USE SCHEMA "FOO"."foo"',
+        'USE SCHEMA "FOO"."fOo"',
     ]


### PR DESCRIPTION
This fixes the Snowflake adapter so that the integration tests pass again (and `sushi` example compatibility is restored).

The main issue was the catalog from the Snowflake gateway config not being respected. This change modifies every query `Expression` before it gets converted to SQL to replace the default catalog references (which are almost always wrong in a multi-dialect project because they contain the catalog normalized against the source dialect, not Snowflake) with whatever the user supplied in the Gateway config.

There are also some other issues around how the `write_pandas()` function from the Snowflake python lib handles things as well as recent changes to normalizing environment names that broke the `SushiDataValidator` in the `test_sushi` integration test.

Note that the integration tests are still not being run as part of the build; that will be a future PR