### PR TITLE
Fix: normalization issue in table diff

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1325,7 +1325,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                         expr = ref.expression
 
                         def _quote_identifier(expr: exp.Expression) -> str:
-                            return f"'{expr.this.this}'" if expr.this.quoted else expr.this.this
+                            return f'"{expr.this.this}"' if expr.this.quoted else expr.this.this
 
                         on = (
                             [_quote_identifier(key) for key in expr.expressions]

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1326,8 +1326,6 @@ class GenericContext(BaseContext, t.Generic[C]):
 
                         if isinstance(expr, exp.Tuple):
                             on = [key.this.sql() for key in expr.expressions]
-                        elif isinstance(expr, exp.Paren):
-                            on = [expr.this.this.sql()]
                         else:
                             on = [expr.this.sql()]
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1327,6 +1327,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                         if isinstance(expr, exp.Tuple):
                             on = [key.this.sql() for key in expr.expressions]
                         else:
+                            # Handle a single Column or Paren expression
                             on = [expr.this.sql()]
 
         if not on:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1324,16 +1324,12 @@ class GenericContext(BaseContext, t.Generic[C]):
                     if ref.unique:
                         expr = ref.expression
 
-                        def _quote_identifier(expr: exp.Expression) -> str:
-                            return f'"{expr.this.this}"' if expr.this.quoted else expr.this.this
-
-                        on = (
-                            [_quote_identifier(key) for key in expr.expressions]
-                            if isinstance(expr, exp.Tuple)
-                            else [_quote_identifier(expr)]
-                            if isinstance(expr.this.this, str)
-                            else [_quote_identifier(expr.this)]
-                        )
+                        if isinstance(expr, exp.Tuple):
+                            on = [key.this.sql() for key in expr.expressions]
+                        elif isinstance(expr, exp.Paren):
+                            on = [expr.this.this.sql()]
+                        else:
+                            on = [expr.this.sql()]
 
         if not on:
             raise SQLMeshError(

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -161,8 +161,8 @@ class TableDiff:
         self.source_alias = source_alias
         self.target_alias = target_alias
 
-        join_condition = [exp.parse_identifier(key) for key in on]
-        if isinstance(join_condition, (list, tuple)):
+        if isinstance(on, (list, tuple)):
+            join_condition = [exp.parse_identifier(key) for key in on]
             s_table = exp.to_identifier("s", quoted=True)
             t_table = exp.to_identifier("t", quoted=True)
 
@@ -177,7 +177,7 @@ class TableDiff:
                 )
             )
         else:
-            self.on = join_condition
+            self.on = on
 
         normalize_identifiers(self.on, dialect=self.model_dialect or self.dialect)
 

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -138,7 +138,7 @@ class TableDiff:
         adapter: EngineAdapter,
         source: TableName,
         target: TableName,
-        on: t.List[str | exp.Identifier] | exp.Condition,
+        on: t.List[str] | exp.Condition,
         where: t.Optional[str | exp.Condition] = None,
         limit: int = 20,
         source_alias: t.Optional[str] = None,
@@ -161,7 +161,8 @@ class TableDiff:
         self.source_alias = source_alias
         self.target_alias = target_alias
 
-        if isinstance(on, (list, tuple)):
+        join_condition = [exp.parse_identifier(key) for key in on]
+        if isinstance(join_condition, (list, tuple)):
             s_table = exp.to_identifier("s", quoted=True)
             t_table = exp.to_identifier("t", quoted=True)
 
@@ -172,11 +173,11 @@ class TableDiff:
                         exp.column(c, s_table).is_(exp.null())
                         & exp.column(c, t_table).is_(exp.null())
                     )
-                    for c in on
+                    for c in join_condition
                 )
             )
         else:
-            self.on = on
+            self.on = join_condition
 
         normalize_identifiers(self.on, dialect=self.model_dialect or self.dialect)
 

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -138,12 +138,13 @@ class TableDiff:
         adapter: EngineAdapter,
         source: TableName,
         target: TableName,
-        on: t.List[str] | exp.Condition,
+        on: t.List[str | exp.Identifier] | exp.Condition,
         where: t.Optional[str | exp.Condition] = None,
         limit: int = 20,
         source_alias: t.Optional[str] = None,
         target_alias: t.Optional[str] = None,
         model_name: t.Optional[str] = None,
+        model_dialect: t.Optional[str] = None,
         decimals: int = 3,
     ):
         self.adapter = adapter
@@ -153,6 +154,7 @@ class TableDiff:
         self.where = exp.condition(where, dialect=self.dialect) if where else None
         self.limit = limit
         self.model_name = model_name
+        self.model_dialect = model_dialect
         self.decimals = decimals
 
         # Support environment aliases for diff output improvement in certain cases
@@ -176,7 +178,7 @@ class TableDiff:
         else:
             self.on = on
 
-        normalize_identifiers(self.on, dialect=self.dialect)
+        normalize_identifiers(self.on, dialect=self.model_dialect or self.dialect)
 
         self._source_schema: t.Optional[t.Dict[str, exp.DataType]] = None
         self._target_schema: t.Optional[t.Dict[str, exp.DataType]] = None
@@ -321,7 +323,7 @@ class TableDiff:
                 .as_("row_full_match"),
             ).from_(query.subquery("stats"))
 
-            query = quote_identifiers(query, dialect=self.dialect)
+            query = quote_identifiers(query, dialect=self.model_dialect or self.dialect)
             temp_table = exp.table_("diff", db="sqlmesh_temp", quoted=True)
 
             with self.adapter.temp_table(query, name=temp_table) as table:

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -142,10 +142,10 @@ def test_data_diff_decimals(sushi_context_fixed_date):
 def test_grain_check(sushi_context_fixed_date):
     expressions = d.parse(
         """
-        MODEL (name memory.sushi.grain_items, kind full, grain(key_1, key_2));
+        MODEL (name memory.sushi.grain_items, kind full, grain("key_1", KEY_2));
         SELECT
-            key_1,
-            key_2,
+            key_1 as "key_1",
+            KEY_2,
             value,
         FROM
             (VALUES
@@ -156,10 +156,10 @@ def test_grain_check(sushi_context_fixed_date):
                 (1, 2, 2),
                 (4, NULL, 3),
                 (2, 3, 2),
-            ) AS t (key_1,key_2, value)
+            ) AS t (key_1,KEY_2, value)
     """
     )
-    model_s = load_sql_based_model(expressions)
+    model_s = load_sql_based_model(expressions, dialect="snowflake")
     sushi_context_fixed_date.upsert_model(model_s)
     sushi_context_fixed_date.plan(
         "source_dev",
@@ -170,14 +170,14 @@ def test_grain_check(sushi_context_fixed_date):
         end="2023-01-31",
     )
 
-    model = sushi_context_fixed_date.models['"memory"."sushi"."grain_items"']
+    model = sushi_context_fixed_date.models['"MEMORY"."SUSHI"."GRAIN_ITEMS"']
 
     modified_model = model.dict()
     modified_model["query"] = (
         exp.select("*")
         .from_(model.query.subquery())
         .union(
-            "SELECT key_1, key_2, value FROM (VALUES (1, 6, 1),(1, 5, 3),(NULL, 2, 3),) AS t (key_1, key_2, value)"
+            'SELECT key_1 as "key_1", KEY_2, value FROM (VALUES (1, 6, 1),(1, 5, 3),(NULL, 2, 3),) AS t (key_1, KEY_2, value)'
         )
     )
 
@@ -200,8 +200,8 @@ def test_grain_check(sushi_context_fixed_date):
     diff = sushi_context_fixed_date.table_diff(
         source="source_dev",
         target="target_dev",
-        on=["key_1", "key_2"],
-        model_or_snapshot="sushi.grain_items",
+        on=["key_1", "KEY_2"],
+        model_or_snapshot="SUSHI.GRAIN_ITEMS",
         skip_grain_check=False,
     )
 

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -200,7 +200,7 @@ def test_grain_check(sushi_context_fixed_date):
     diff = sushi_context_fixed_date.table_diff(
         source="source_dev",
         target="target_dev",
-        on=["key_1", "KEY_2"],
+        on=["'key_1'", "key_2"],
         model_or_snapshot="SUSHI.GRAIN_ITEMS",
         skip_grain_check=False,
     )


### PR DESCRIPTION
This addresses an issue encountered when running table diff, fixes: #2869 
The proposed fix is to use the project dialect for normalization instead of the gateway dialect and also account for quoted names. `test_table_diff` has been adapted to test for both quoted and unquoted identifiers in snowflake.