### PR TITLE
Feat: Add support for variable identifiers in test files

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1506,6 +1506,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                         path / c.TESTS,
                         patterns=match_patterns,
                         ignore_patterns=config.ignore_patterns,
+                        variables=config.variables
                     )
                 )
 

--- a/sqlmesh/core/test/__init__.py
+++ b/sqlmesh/core/test/__init__.py
@@ -111,9 +111,9 @@ def run_model_tests(
         path = pathlib.Path(filename)
 
         if test_name:
-            loaded_tests.append(load_model_test_file(path)[test_name])
+            loaded_tests.append(load_model_test_file(path, config.variables)[test_name])
         else:
-            loaded_tests.extend(load_model_test_file(path).values())
+            loaded_tests.extend(load_model_test_file(path, config.variables).values())
 
     if patterns:
         loaded_tests = filter_tests_by_patterns(loaded_tests, patterns)

--- a/sqlmesh/core/test/discovery.py
+++ b/sqlmesh/core/test/discovery.py
@@ -32,7 +32,10 @@ def replace_placeholder_identifiers(file_contents: str, variables: dict[str, str
     for m in re.finditer(r"@{(.*)}", file_contents):
         thing_to_replace = file_contents[m.span()[0]:m.span()[1]]
         thing_to_replace_with = variables.get(m.group(1))
-        replaced_file_contents = re.sub(thing_to_replace, thing_to_replace_with, replaced_file_contents)
+        if thing_to_replace_with:
+            replaced_file_contents = re.sub(thing_to_replace, thing_to_replace_with, replaced_file_contents)
+        else:
+            raise ValueError(f"Could not find value for {thing_to_replace}")
     return replaced_file_contents
 
 

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -247,6 +247,7 @@ class SQLMeshMagics(Magics):
                 get_all_model_tests(
                     path / c.TESTS,
                     ignore_patterns=config.ignore_patterns,
+                    variables=config.variables,
                 )
             )
 


### PR DESCRIPTION
A small change to replace identifier placeholders in test files with values from the variables in the given context configuration before executing the test.
e.g.
```
MODEL(
  name @{gold}.schema.goldmodel
);

select
  id::int,
  name::varchar
from @{silver}.schema.silvermodel
```

Can be tested like:
```
good_test:
  model: '@{gold}.schema.goldmodel'
  inputs:
    '@{silver}.schema.silvermodel':
      rows:
        - id: 1
  outputs:
    query:
      rows:
        - id: 1
 ```