### PR TITLE
Fix: include external models in mapping of context.table

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1552,7 +1552,7 @@ def to_table_mapping(
     return {
         snapshot.name: snapshot.table_name(deployability_index.is_representative(snapshot))
         for snapshot in snapshots
-        if snapshot.version and not snapshot.is_symbolic and snapshot.is_model
+        if snapshot.version and not snapshot.is_embedded and snapshot.is_model
     }
 
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -739,6 +739,11 @@ def test_load_external_models(copy_to_temp_path):
     # from external_models/prod.yaml, should not show unless --gateway=prod
     assert "prod_raw.model1" not in external_model_names
 
+    # get physical table names of external models using table
+    assert context.table("raw.model1") == "memory.raw.model1"
+    assert context.table("raw.demographics") == "memory.raw.demographics"
+    assert context.table("raw.model2") == "memory.raw.model2"
+
 
 def test_load_gateway_specific_external_models(copy_to_temp_path):
     path = copy_to_temp_path("examples/sushi")

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -181,7 +181,7 @@ def test_adapter_map_snapshot_tables(
     snapshot_mock = mocker.Mock()
     snapshot_mock.name = '"memory"."test_db"."test_model"'
     snapshot_mock.version = "1"
-    snapshot_mock.is_symbolic = False
+    snapshot_mock.is_embedded = False
     snapshot_mock.table_name.return_value = '"memory"."sqlmesh"."test_db__test_model"'
     snapshot_mock.snapshot_id = SnapshotId(
         name='"memory"."test_db"."test_model"', identifier="12345"


### PR DESCRIPTION
This addresses an issue with external models not found in Python models using Context.table(...), by relaxing the condition of the `to_table_mapping` function to include external models when detecting table names.