### PR TITLE
Fix: control python model loading with enabled flag

### DIFF
--- a/examples/sushi/models/disabled.py
+++ b/examples/sushi/models/disabled.py
@@ -1,0 +1,15 @@
+import typing as t
+from sqlmesh import ExecutionContext, model
+
+@model(
+  "sushi.disabled_py",
+  columns={
+    "id": "int",
+  },
+  enabled=False
+)
+def execute(
+  context: ExecutionContext,
+  **kwargs: t.Any,
+):
+  pass

--- a/examples/sushi/models/disabled.py
+++ b/examples/sushi/models/disabled.py
@@ -1,15 +1,16 @@
 import typing as t
 from sqlmesh import ExecutionContext, model
 
+
 @model(
-  "sushi.disabled_py",
-  columns={
-    "id": "int",
-  },
-  enabled=False
+    "sushi.disabled_py",
+    columns={
+        "id": "int",
+    },
+    enabled=False,
 )
 def execute(
-  context: ExecutionContext,
-  **kwargs: t.Any,
-):
-  pass
+    context: ExecutionContext,
+    **kwargs: t.Any,
+) -> None:
+    return None

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -378,7 +378,8 @@ class SqlMeshLoader(Loader):
                             variables=variables,
                             infer_names=config.model_naming.infer_names,
                         )
-                        models[model.fqn] = model
+                        if model.enabled:
+                            models[model.fqn] = model
             finally:
                 model_registry._dialect = None
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -774,6 +774,9 @@ def test_disabled_model(copy_to_temp_path):
     assert (path[0] / "models" / "disabled.sql").exists()
     assert not context.get_model("sushi.disabled")
 
+    assert (path[0] / "models" / "disabled.py").exists()
+    assert not context.get_model("sushi.disabled_py")
+
 
 def test_get_model_mixed_dialects(copy_to_temp_path):
     path = copy_to_temp_path("examples/sushi")

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1589,7 +1589,7 @@ CONST = "bar"
 def test_python_model(assert_exp_eq) -> None:
     from functools import reduce
 
-    @model(name="my_model", kind="full", columns={'"COL"': "int"})
+    @model(name="my_model", kind="full", columns={'"COL"': "int"}, enabled=True)
     def my_model(context, **kwargs):
         context.table("foo")
         context.table(model_name=CONST + ".baz")
@@ -1603,6 +1603,7 @@ def test_python_model(assert_exp_eq) -> None:
         dialect="duckdb",
     )
 
+    assert m.enabled
     assert m.dialect == "duckdb"
     assert m.depends_on == {'"foo"', '"bar"."baz"'}
     assert m.columns_to_types == {"col": exp.DataType.build("int")}


### PR DESCRIPTION
This fix ensures that models are not loaded when the 'enabled' flag in a Python model is false, mirroring the behaviour of sql models.