### PR TITLE
Feat: add support for audit formatting in sqlmesh format

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -26,7 +26,7 @@ Commands:
   diff                    Show the diff between the local state and the...
   evaluate                Evaluate a model and return a dataframe with a...
   fetchdf                 Run a SQL query and display the results.
-  format                  Format all SQL models.
+  format                  Format all SQL models and audits.
   info                    Print information about a SQLMesh project.
   init                    Create a new SQLMesh repository.
   invalidate              Invalidate the target environment, forcing its...
@@ -166,7 +166,7 @@ Options:
 ```
 Usage: sqlmesh format [OPTIONS]
 
-  Format all SQL models.
+  Format all SQL models and audits.
 
 Options:
   -t, --transpile TEXT        Transpile project models to the specified

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -27,7 +27,7 @@ Runs all audits.
 Read more about [auditing](../concepts/audits.md).
 
 ## format
-Formats all SQL model files in place.
+Formats all SQL model and audit files in place.
 
 ## diff
 Shows the diff between the local model and a model in an environment.

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -259,7 +259,7 @@ def evaluate(
 @error_handler
 @cli_analytics
 def format(ctx: click.Context, **kwargs: t.Any) -> None:
-    """Format all SQL models."""
+    """Format all SQL models and audits."""
     ctx.obj.format(**{k: v for k, v in kwargs.items() if v is not None})
 
 

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -804,7 +804,7 @@ def extend_sqlglot() -> None:
         if MacroFunc not in generator.TRANSFORMS:
             generator.TRANSFORMS.update(
                 {
-                    Audit: lambda self, e: _sqlmesh_ddl_sql(self, e, "Audit"),
+                    Audit: lambda self, e: _sqlmesh_ddl_sql(self, e, "AUDIT"),
                     DColonCast: lambda self, e: f"{self.sql(e, 'this')}::{self.sql(e, 'to')}",
                     Jinja: lambda self, e: e.name,
                     JinjaQuery: lambda self, e: f"{JINJA_QUERY_BEGIN};\n{e.name}\n{JINJA_END};",

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -724,7 +724,7 @@ class SQLMeshMagics(Magics):
     @line_magic
     @pass_sqlmesh_context
     def format(self, context: Context, line: str) -> None:
-        """Format all SQL models."""
+        """Format all SQL models and audits."""
         args = parse_argstring(self.format, line)
         context.format(**{k: v for k, v in vars(args).items() if v is not None})
 

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -670,7 +670,7 @@ def test_text_diff():
 
 @@ -1,5 +1,5 @@
 
- Audit (
+ AUDIT (
 -  name my_audit,
 +  name my_audit_2,
    dialect spark,

--- a/tests/core/test_format.py
+++ b/tests/core/test_format.py
@@ -30,7 +30,7 @@ def test_format_files(tmp_path: pathlib.Path):
     f4 = create_temp_file(
         tmp_path,
         pathlib.Path(models_dir, "model_3.sql"),
-        "MODEL(name audit.model); SELECT 3 AS item_id; AUDIT(name inline_audit); SELECT  * FROM @this_model WHERE  item_id < 0;",
+        "MODEL(name audit.model, audits (inline_audit)); SELECT 3 AS item_id; AUDIT(name inline_audit); SELECT  * FROM @this_model WHERE  item_id < 0;",
     )
 
     config = Config()
@@ -73,12 +73,12 @@ def test_format_files(tmp_path: pathlib.Path):
     upd3 = f3.read_text(encoding="utf-8")
     assert (
         upd3
-        == "Audit (\n  name assert_positive_id,\n  dialect 'bigquery'\n);\n\nSELECT\n  *\nFROM @this_model\nWHERE\n  `CaseSensitive_item_id` < 0"
+        == "AUDIT (\n  name assert_positive_id,\n  dialect 'bigquery'\n);\n\nSELECT\n  *\nFROM @this_model\nWHERE\n  `CaseSensitive_item_id` < 0"
     )
 
     # Ensure inline audit is formatted within model definition
     upd4 = f4.read_text(encoding="utf-8")
     assert (
         upd4
-        == "MODEL (\n  name audit.model\n);\n\nSELECT\n  3 AS item_id;\n\nAudit (\n  name inline_audit\n);\n\nSELECT\n  *\nFROM @this_model\nWHERE\n  item_id < 0"
+        == "MODEL (\n  name audit.model,\n  audits (\n    inline_audit\n  )\n);\n\nSELECT\n  3 AS item_id;\n\nAUDIT (\n  name inline_audit\n);\n\nSELECT\n  *\nFROM @this_model\nWHERE\n  item_id < 0"
     )


### PR DESCRIPTION
This feature enhances the `sqlmesh format` functionality to include audits and format them as well, in a style consistent with models, fixes: #2889 