### PR TITLE
Feat: support skipping columns from being matched in table diff

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -410,18 +410,20 @@ Usage: sqlmesh table_diff [OPTIONS] SOURCE:TARGET [MODEL]
   Show the diff between two tables.
 
 Options:
-  -o, --on TEXT           The column to join on. Can be specified multiple
-                          times. The model grain will be used if not
-                          specified.
-  --where TEXT            An optional where statement to filter results.
-  --limit INTEGER         The limit of the sample dataframe.
-  --show-sample           Show a sample of the rows that differ. With many
-                          columns, the output can be very wide.
-  --skip-grain-check      Disable the check for a primary key (grain) that 
-                          is missing or is not unique.
-  -d, --decimals INTEGER  The number of decimal places to keep when comparing
-                          floating point columns. Default: 3
-  --help                  Show this message and exit.
+  -o, --on TEXT            The column to join on. Can be specified multiple
+                           times. The model grain will be used if not
+                           specified.
+  -s, --skip-columns TEXT  The column(s) to skip when comparing the source and
+                           target table.
+  --where TEXT             An optional where statement to filter results.
+  --limit INTEGER          The limit of the sample dataframe.
+  --show-sample            Show a sample of the rows that differ. With many
+                           columns, the output can be very wide.
+  -d, --decimals INTEGER   The number of decimal places to keep when comparing
+                           floating point columns. Default: 3
+  --skip-grain-check       Disable the check for a primary key (grain) that is
+                           missing or is not unique.
+  --help                   Show this message and exit.
 ```
 
 ## table_name

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -266,27 +266,34 @@ Create a schema file containing external model schemas.
 
 #### table_diff
 ```
-%table_diff [--on [ON ...]] [--model MODEL] [--where WHERE]
-                  [--limit LIMIT] [--show-sample] [--skip-grain-check]
-                  SOURCE:TARGET
+%table_diff [--on [ON ...]] [--skip-columns [SKIP_COLUMNS ...]]
+                [--model MODEL] [--where WHERE] [--limit LIMIT]
+                [--show-sample] [--decimals DECIMALS] [--skip-grain-check]
+                SOURCE:TARGET
 
 Show the diff between two tables.
 
 Can either be two tables or two environments and a model.
 
 positional arguments:
-  SOURCE:TARGET    Source and target in `SOURCE:TARGET` format
+  SOURCE:TARGET         Source and target in `SOURCE:TARGET` format
 
 options:
-  --on <[ON ...]>     The column to join on. Can be specified multiple times. The
-                      model grain will be used if not specified.
-  --model MODEL       The model to diff against when source and target are
-                      environments and not tables.
-  --where WHERE       An optional where statement to filter results.
-  --limit LIMIT       The limit of the sample dataframe.
-  --show-sample       Show a sample of the rows that differ. With many columns,
-                      the output can be very wide.  
-  --skip-grain-check  Disable the check for a primary key (grain) that is missing or is not unique.
+  --on <[ON ...]>       The column to join on. Can be specified multiple
+                        times. The model grain will be used if not specified.
+  --skip-columns <[SKIP_COLUMNS ...]>
+                        The column(s) to skip when comparing the source and
+                        target table.
+  --model MODEL         The model to diff against when source and target are
+                        environments and not tables.
+  --where WHERE         An optional where statement to filter results.
+  --limit LIMIT         The limit of the sample dataframe.
+  --show-sample         Show a sample of the rows that differ. With many
+                        columns, the output can be very wide.
+  --decimals DECIMALS   The number of decimal places to keep when comparing
+                        floating point columns. Default: 3
+  --skip-grain-check    Disable the check for a primary key (grain) that is
+                        missing or is not unique.
 ```
 
 #### model

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -721,6 +721,13 @@ def create_external_models(obj: Context) -> None:
     help="The column to join on. Can be specified multiple times. The model grain will be used if not specified.",
 )
 @click.option(
+    "-s",
+    "--skip-columns",
+    type=str,
+    multiple=True,
+    help="The column(s) to skip when comparing the source and target table.",
+)
+@click.option(
     "--where",
     type=str,
     help="An optional where statement to filter results.",

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1272,6 +1272,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         source: str,
         target: str,
         on: t.List[str] | exp.Condition | None = None,
+        skip_columns: t.List[str] | None = None,
         model_or_snapshot: t.Optional[ModelOrSnapshot] = None,
         where: t.Optional[str | exp.Condition] = None,
         limit: int = 20,
@@ -1287,6 +1288,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             target: The target environment or table.
             on: The join condition, table aliases must be "s" and "t" for source and target.
                 If omitted, the table's grain will be used.
+            skip_columns: The columns to skip when computing the table diff.
             model_or_snapshot: The model or snapshot to use when environments are passed in.
             where: An optional where statement to filter results.
             limit: The limit of the sample dataframe.
@@ -1340,6 +1342,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             source=source,
             target=target,
             on=on,
+            skip_columns=skip_columns,
             where=where,
             source_alias=source_alias,
             target_alias=target_alias,

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -244,9 +244,7 @@ class TableDiff:
             s_index = list(dict.fromkeys(s_index))
             t_index = list(dict.fromkeys(t_index))
 
-            matched_columns = {
-                c: t for c, t in source_schema.items() if t == target_schema.get(c)
-            }
+            matched_columns = {c: t for c, t in source_schema.items() if t == target_schema.get(c)}
 
             def _column_expr(name: str, table: str) -> exp.Expression:
                 if matched_columns[name].this in exp.DataType.FLOAT_TYPES:

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -578,6 +578,12 @@ class SQLMeshMagics(Magics):
         help="The column to join on. Can be specified multiple times. The model grain will be used if not specified.",
     )
     @argument(
+        "--skip-columns",
+        type=str,
+        nargs="*",
+        help="The column(s) to skip when comparing the source and target table.",
+    )
+    @argument(
         "--model",
         type=str,
         help="The model to diff against when source and target are environments and not tables.",
@@ -622,6 +628,7 @@ class SQLMeshMagics(Magics):
             source=source,
             target=target,
             on=args.on,
+            skip_columns=args.skip_columns,
             model_or_snapshot=args.model,
             where=args.where,
             limit=args.limit,

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -230,6 +230,7 @@ def test_generated_sql(sushi_context_fixed_date: Context, mocker: MockerFixture)
             {
                 "key": [1, 2, 3],
                 "value": [1.0, 4.2, 4.1],
+                "ignored": [1, 2, 3],
             }
         ),
     )
@@ -240,6 +241,7 @@ def test_generated_sql(sushi_context_fixed_date: Context, mocker: MockerFixture)
             {
                 "key": [1, 2, 6],
                 "value": [1.0, 3.0, -2.2],
+                "ignored": [1, 2, 3],
             }
         ),
     )
@@ -255,6 +257,7 @@ def test_generated_sql(sushi_context_fixed_date: Context, mocker: MockerFixture)
         source="table_diff_source",
         target="table_diff_target",
         on=["key"],
+        skip_columns=["ignored"],
     )
 
     spy_execute.assert_any_call(query_sql)


### PR DESCRIPTION
Sometimes we can't compare certain columns using the equality (`=`) operator. For example, in BigQuery we can't compare arrays, i.e. `SELECT [1, 2, 3] = [1, 2, 3]` is invalid. Such SQL is generated [here](https://github.com/TobikoData/sqlmesh/blob/main/sqlmesh/core/table_diff.py#L243), resulting in a crash when the query is executed.

This PR adds a flag that can be used to skip certain columns from being matched, so users can selectively discard array columns from the table diffing process.