### PR TITLE
Fix: prevent race conditions in concurrent cross process postgres pla…

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -99,6 +99,7 @@ class EngineAdapter:
     SUPPORTS_REPLACE_TABLE = True
     DEFAULT_CATALOG_TYPE = DIALECT
     QUOTE_IDENTIFIERS_IN_VIEWS = True
+    REQUIRE_APPLICATION_LOCK = False
 
     def __init__(
         self,
@@ -1886,6 +1887,12 @@ class EngineAdapter:
     def _is_session_active(self) -> bool:
         """Indicates whether or not a session is active."""
         return False
+
+    def _acquire_application_lock(self, lock_id: t.Optional[int] = None) -> None:
+        """Acquire a cross-process application-specific lock, blocking if needed."""
+
+    def _release_application_lock(self, lock_id: t.Optional[int] = None) -> None:
+        """Release the cross-process application-specific lock."""
 
     def execute(
         self,


### PR DESCRIPTION
…n applications

As discussed with @izeigerman , currently if two or more plans are being applied simultaneously, even to different environments --  the `DROP ... CASCADE;` required by the pg adapter can cause an invalid state for the concurrent plans. This can result in plan failures and even worst, this can result in a promoted environment missing views while the state sync says it exists. We have also seen similar with missing physical snapshot views which we currently attribute to some `CASCADE` race condition between different sqlmesh users operating on the same pg database simultaneously.

To prioritize correctness, for postgres _only_, we will acquire an application lock. This lock only lives for the duration of the active session. While active, other plan/apply flows proceeding into `apply` lifecycle will ensure exclusivity. If the lock is applied, we will wait for the running PlanEvaluator `_evaluate` to complete.


Failure to address this results in users needing to delete the `sqlmesh` state schema and rebuild from scratch or to meticulously and carefully manually manipulate it to recover. I postulate that users using postgres would strongly prefer correctness over many concurrent users applying plans simultaneously. We can re-visit and optimize this later if there are better solutions to the larger `CASCADE` problem wrt multiple processes. 