### PR TITLE
Fix: Avoid type coercion when converting pandas dataframes to agate tables in the dbt adapter

### DIFF
--- a/sqlmesh/dbt/util.py
+++ b/sqlmesh/dbt/util.py
@@ -13,9 +13,9 @@ def _get_dbt_version() -> t.Tuple[int, int]:
 DBT_VERSION = _get_dbt_version()
 
 if DBT_VERSION < (1, 8):
-    from dbt.clients.agate_helper import table_from_data, empty_table, as_matrix  # type: ignore  # noqa: F401
+    from dbt.clients.agate_helper import table_from_data_flat, empty_table, as_matrix  # type: ignore  # noqa: F401
 else:
-    from dbt_common.clients.agate_helper import table_from_data, empty_table, as_matrix  # type: ignore  # noqa: F401
+    from dbt_common.clients.agate_helper import table_from_data_flat, empty_table, as_matrix  # type: ignore  # noqa: F401
 
 
 def pandas_to_agate(df: pd.DataFrame) -> agate.Table:
@@ -23,4 +23,4 @@ def pandas_to_agate(df: pd.DataFrame) -> agate.Table:
     Converts a Pandas DataFrame to an Agate Table
     """
 
-    return table_from_data(df.to_dict(orient="records"), df.columns.tolist())
+    return table_from_data_flat(df.to_dict(orient="records"), df.columns.tolist())

--- a/tests/dbt/test_util.py
+++ b/tests/dbt/test_util.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import pandas as pd
+from sqlmesh.dbt.util import pandas_to_agate
+
+
+def test_pandas_to_agate_type_coercion():
+    df = pd.DataFrame({"data": ["_2024_01_01", "_2024_01_02", "_2024_01_03"]})
+    agate_rows = pandas_to_agate(df).rows
+
+    values = [v[0] for v in agate_rows.values()]
+    assert values == ["_2024_01_01", "_2024_01_02", "_2024_01_03"]


### PR DESCRIPTION
The previous method was coercing string values into more specific types which was messing up dynamic queries in dbt models for some users.