### PR TITLE
Fix: Make sure that views are not recreated unnecessarily in the face of concurrent plan application

### DIFF
--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -739,8 +739,12 @@ def test_plan_set_choice_is_reflected_in_missing_intervals(init_and_plan_context
 
 
 @freeze_time("2023-01-08 15:00:00")
-def test_non_breaking_change_after_forward_only_in_dev(init_and_plan_context: t.Callable):
+@pytest.mark.parametrize("has_view_binding", [False, True])
+def test_non_breaking_change_after_forward_only_in_dev(
+    init_and_plan_context: t.Callable, has_view_binding: bool
+):
     context, plan = init_and_plan_context("examples/sushi")
+    context.snapshot_evaluator.adapter.HAS_VIEW_BINDING = has_view_binding
     context.apply(plan)
 
     model = context.get_model("sushi.waiter_revenue_by_day")


### PR DESCRIPTION
This fix ensures that the snapshot view doesn't get recreated unnecessarily when concurrent plans evaluate the same snapshot.

Even though the recreation of a view is not a significant issue for most engines, it leads to negative consequences in Postgres due to the lack of support for late schema binding. As a result, the only way to replace a view in Postgres is through the `DROP CASCADE` statement, which drops all dependent views downstream. When the same view snapshot is evaluated concurrently in different plans, the environment views can be unintentionally dropped (and not recreated).