### PR TITLE
Feat: Add support for defaults in user audits

### DIFF
--- a/docs/concepts/audits.md
+++ b/docs/concepts/audits.md
@@ -75,6 +75,19 @@ Notice how `column` and `threshold` parameters have been set. These values will 
 
 Note that the same audit can be applied more than once to the a model using different sets of parameters.
 
+Generic audits can define default values as follows:
+```sql linenums="1"
+AUDIT (
+  name does_not_exceed_threshold,
+  defaults (
+    threshold = 10,
+    column = id
+  )
+);
+SELECT * FROM @this_model
+WHERE @column >= @threshold;
+```
+
 ### Naming
 We recommended avoiding SQL keywords when naming audit parameters. Quote any audit argument that is also a SQL keyword.
 

--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -7,7 +7,6 @@ from functools import cached_property
 from pathlib import Path
 
 from pydantic import Field
-from pydantic_core.core_schema import ValidationInfo
 from sqlglot import exp
 from sqlglot.optimizer.qualify_columns import quote_identifiers
 from sqlglot.optimizer.simplify import gen

--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -7,6 +7,7 @@ from functools import cached_property
 from pathlib import Path
 
 from pydantic import Field
+from pydantic_core.core_schema import ValidationInfo
 from sqlglot import exp
 from sqlglot.optimizer.qualify_columns import quote_identifiers
 from sqlglot.optimizer.simplify import gen
@@ -148,7 +149,7 @@ def audit_string_validator(cls: t.Type, v: t.Any) -> t.Optional[str]:
 
 
 @field_validator("defaults", mode="before", check_fields=False)
-def audit_map_validator(cls: t.Type, v: t.Any, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
+def audit_map_validator(cls: t.Type, v: t.Any, values: ValidationInfo) -> t.Dict[str, t.Any]:
     if isinstance(v, exp.Paren):
         return dict([_maybe_parse_arg_pair(v.unnest())])
     if isinstance(v, (exp.Tuple, exp.Array)):

--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -149,13 +149,13 @@ def audit_string_validator(cls: t.Type, v: t.Any) -> t.Optional[str]:
 
 
 @field_validator("defaults", mode="before", check_fields=False)
-def audit_map_validator(cls: t.Type, v: t.Any, values: ValidationInfo) -> t.Dict[str, t.Any]:
+def audit_map_validator(cls: t.Type, v: t.Any, values: t.Any) -> t.Dict[str, t.Any]:
     if isinstance(v, exp.Paren):
         return dict([_maybe_parse_arg_pair(v.unnest())])
     if isinstance(v, (exp.Tuple, exp.Array)):
         return dict(map(_maybe_parse_arg_pair, v.expressions))
     elif isinstance(v, dict):
-        dialect = values.data.get("dialect")
+        dialect = (values if isinstance(values, dict) else values.data).get("dialect")
         return {
             key: value
             if isinstance(value, exp.Expression)

--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -34,6 +34,7 @@ from sqlmesh.utils.metaprogramming import Executable
 from sqlmesh.utils.pydantic import (
     PydanticModel,
     field_validator,
+    get_dialect,
     model_validator,
     model_validator_v1_args,
 )
@@ -154,7 +155,7 @@ def audit_map_validator(cls: t.Type, v: t.Any, values: t.Any) -> t.Dict[str, t.A
     if isinstance(v, (exp.Tuple, exp.Array)):
         return dict(map(_maybe_parse_arg_pair, v.expressions))
     elif isinstance(v, dict):
-        dialect = (values if isinstance(values, dict) else values.data).get("dialect")
+        dialect = get_dialect(values)
         return {
             key: value
             if isinstance(value, exp.Expression)

--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -148,11 +148,19 @@ def audit_string_validator(cls: t.Type, v: t.Any) -> t.Optional[str]:
 
 
 @field_validator("defaults", mode="before", check_fields=False)
-def audit_map_validator(cls: t.Type, v: t.Any) -> t.Dict[str, t.Any]:
+def audit_map_validator(cls: t.Type, v: t.Any, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
+    if isinstance(v, exp.Paren):
+        return dict([_maybe_parse_arg_pair(v.unnest())])
     if isinstance(v, (exp.Tuple, exp.Array)):
         return dict(map(_maybe_parse_arg_pair, v.expressions))
     elif isinstance(v, dict):
-        return v
+        dialect = values.data.get("dialect")
+        return {
+            key: value
+            if isinstance(value, exp.Expression)
+            else d.parse_one(str(value), dialect=dialect)
+            for key, value in v.items()
+        }
     else:
         raise_config_error(
             "Defaults must be a tuple of exp.EQ or a dict", error_type=AuditConfigError

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -303,6 +303,49 @@ def test_load_multiple(assert_exp_eq):
     )
 
 
+def test_load_with_dictionary_defaults():
+    expressions = parse(
+        """
+        AUDIT (
+            name my_audit,
+            dialect spark,
+            defaults (
+                field1 = some_column,
+                field2 = 3
+            ),
+        );
+
+        SELECT 1
+    """
+    )
+
+    audit = load_audit(expressions, dialect="spark")
+    assert audit.defaults.keys() == {"field1", "field2"}
+    for value in audit.defaults.values():
+        assert isinstance(value, exp.Expression)
+
+
+def test_load_with_single_defaults():
+    # testing it also works with a single default with no trailing comma
+    expressions = parse(
+        """
+        AUDIT (
+            name my_audit,
+            defaults (
+                field1 = some_column
+            ),
+        );
+
+        SELECT 1
+    """
+    )
+
+    audit = load_audit(expressions, dialect="duckdb")
+    assert audit.defaults.keys() == {"field1"}
+    for value in audit.defaults.values():
+        assert isinstance(value, exp.Expression)
+
+
 def test_no_audit_statement():
     expressions = parse(
         """


### PR DESCRIPTION
I was writing an audit and I figured it would be nice to have defaults for the variables.
I tried it and it almost already works, except it was loading the values as strings instead of expressions.

The goal is to be able to define an audit with defaults like this:
audit (
    name generic_sums_add_up,
    defaults (
        percentage_absolute_difference_accepted=0.01,
    )
);

Since defaults has to be a dictionary of string to Expression, it seems to make sense to parse the string values into Expression.

defaults: t.Dict[str, exp.Expression]

I tried the code and it works, but there are some points I'm not sure about.
1. Is it possible to support not needing a trailing comma when there's only one key in the dictionary?
2. Is sqlglot.parse the right way to do it? How would we get the audit's configured dialect and the project's dialect to pass them in to parse?
3. Is it correct to take out the first element of what parse returns? I tried with a default value that was a list like (0.01, 0.02) and it kept the whole list so that seemed fine.

The formatting of the code is probably not right. I saw there's a make file but not sure how to run it is there a page on that you can point me to? Anything on standards for the codebase would also help.

I could also provide a draft for documentation (I know where the docs file is) and some tests (not sure where I'd put them).