### PR TITLE
Feat: Support the strict mode when creating external models

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -702,12 +702,17 @@ def rollback(obj: Context) -> None:
 
 
 @cli.command("create_external_models")
+@click.option(
+    "--strict",
+    is_flag=True,
+    help="Raise an error if the external model is missing in the database",
+)
 @click.pass_obj
 @error_handler
 @cli_analytics
-def create_external_models(obj: Context) -> None:
+def create_external_models(obj: Context, **kwargs: t.Any) -> None:
     """Create a schema file containing external model schemas."""
-    obj.create_external_models()
+    obj.create_external_models(**kwargs)
 
 
 @cli.command("table_diff")

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1655,11 +1655,14 @@ class GenericContext(BaseContext, t.Generic[C]):
         self._new_state_sync().rollback()
 
     @python_api_analytics
-    def create_external_models(self) -> None:
+    def create_external_models(self, strict: bool = False) -> None:
         """Create a file to document the schema of external models.
 
         The external models file contains all columns and types of external models, allowing for more
         robust lineage, validation, and optimizations.
+
+        Args:
+            strict: If True, raise an error if the external model is missing in the database.
         """
         if not self._models:
             self.load(update_schemas=False)
@@ -1685,6 +1688,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 dialect=config.model_defaults.dialect,
                 gateway=self.gateway,
                 max_workers=self.concurrent_tasks,
+                strict=strict,
             )
 
     @python_api_analytics

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -558,11 +558,17 @@ class SQLMeshMagics(Magics):
         context.console.log_success("Migration complete")
 
     @magic_arguments()
+    @argument(
+        "--strict",
+        action="store_true",
+        help="Raise an error if the external model is missing in the database",
+    )
     @line_magic
     @pass_sqlmesh_context
     def create_external_models(self, context: Context, line: str) -> None:
         """Create a schema file containing external model schemas."""
-        context.create_external_models()
+        args = parse_argstring(self.create_external_models, line)
+        context.create_external_models(strict=args.strict)
 
     @magic_arguments()
     @argument(

--- a/tests/core/test_schema_loader.py
+++ b/tests/core/test_schema_loader.py
@@ -1,3 +1,4 @@
+import pytest
 import logging
 import typing as t
 from pathlib import Path
@@ -16,6 +17,7 @@ from sqlmesh.core.model.definition import ExternalModel
 from sqlmesh.core.schema_loader import create_external_models_file
 from sqlmesh.core.snapshot import SnapshotChangeCategory
 from sqlmesh.utils.yaml import YAML
+from sqlmesh.utils.errors import SQLMeshError
 
 
 def test_create_external_models(tmpdir, assert_exp_eq):
@@ -354,3 +356,13 @@ def test_missing_table(tmp_path: Path):
     with open(filename, "r", encoding="utf8") as fd:
         schema = YAML().load(fd)
     assert len(schema) == 0
+
+    with pytest.raises(SQLMeshError, match=r"""Unable to get schema for '"tbl_source"'.*"""):
+        create_external_models_file(
+            filename,
+            {"a": model},  # type: ignore
+            context.engine_adapter,
+            context.state_reader,
+            "",
+            strict=True,
+        )


### PR DESCRIPTION
The strict mode ensures that the process fails if a referenced external table is missing in the target database.

Before this update, SQLMesh would emit a warning but ignore the missing table otherwise.