### PR TITLE
feat: support upstream/downstream git selector

### DIFF
--- a/sqlmesh/core/selector.py
+++ b/sqlmesh/core/selector.py
@@ -158,8 +158,9 @@ class Selector:
                     add_sub_results(
                         self._expand_model_tag(sub_selection[4:], models, models_by_tag)
                     )
-                elif sub_selection.startswith("git:"):
-                    add_sub_results(self._expand_git(sub_selection[4:], models))
+                elif sub_selection.startswith(("git:", "+git:")):
+                    sub_selection = sub_selection.replace("git:", "")
+                    add_sub_results(self._expand_git(sub_selection, models))
                 else:
                     add_sub_results(self._expand_model_name(sub_selection, models))
 

--- a/tests/core/test_selector.py
+++ b/tests/core/test_selector.py
@@ -392,6 +392,7 @@ def test_model_selection_normalized(mocker: MockerFixture, make_snapshot):
     [
         (["git:main"], {'"test_model_a"', '"test_model_c"'}),
         (["git:main & +*model_c"], {'"test_model_c"'}),
+        (["git:main+"], {'"test_model_a"', '"test_model_c"', '"test_model_d"'}),
     ],
 )
 def test_expand_git_selection(

--- a/tests/core/test_selector.py
+++ b/tests/core/test_selector.py
@@ -393,6 +393,8 @@ def test_model_selection_normalized(mocker: MockerFixture, make_snapshot):
         (["git:main"], {'"test_model_a"', '"test_model_c"'}),
         (["git:main & +*model_c"], {'"test_model_c"'}),
         (["git:main+"], {'"test_model_a"', '"test_model_c"', '"test_model_d"'}),
+        (["+git:main"], {'"test_model_a"', '"test_model_c"', '"test_model_b"'}),
+        (["+git:main+"], {'"test_model_a"', '"test_model_c"', '"test_model_b"', '"test_model_d"'}),
     ],
 )
 def test_expand_git_selection(
@@ -408,7 +410,11 @@ def test_expand_git_selection(
     model_b._path = Path("/path/to/test_model_b.sql")
     models[model_b.fqn] = model_b
 
-    model_c = SqlModel(name="test_model_c", query=d.parse_one("SELECT 3 AS c"))
+    model_c = SqlModel(
+        name="test_model_c",
+        query=d.parse_one("SELECT b AS c FROM test_model_b"),
+        depends_on={"test_model_b"},
+    )
     model_c._path = Path("/path/to/test_model_c.sql")
     models[model_c.fqn] = model_c
 


### PR DESCRIPTION
Prior to this change the git branch selector didn't support upstream/downstream selection (using `+`) so this PR adds that functionality. This is part of work to allow the Github Action CI/CD bot to be able to compare against git main instead of prod. Slack context for that change: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1720792390212429