### PR TITLE
feat: Action bot - Support referencing branch instead of prod state when creating PR environment

### DIFF
--- a/sqlmesh/integrations/github/cicd/config.py
+++ b/sqlmesh/integrations/github/cicd/config.py
@@ -34,6 +34,7 @@ class GithubCICDBotConfig(BaseConfig):
     pr_include_unmodified: t.Optional[bool] = None
     run_on_deploy_to_prod: bool = True
     pr_environment_name: t.Optional[str] = None
+    pr_environment_ref_branch: t.Optional[str] = None
 
     @model_validator(mode="before")
     @model_validator_v1_args
@@ -43,6 +44,12 @@ class GithubCICDBotConfig(BaseConfig):
         if values.get("command_namespace") and not values.get("enable_deploy_command"):
             raise ValueError("enable_deploy_command must be set if command_namespace is set")
         return values
+
+    @property
+    def pr_environment_git_selector(self) -> t.Optional[str]:
+        if self.pr_environment_ref_branch:
+            return f"git:{self.pr_environment_ref_branch}+"
+        return None
 
     FIELDS_FOR_ANALYTICS: t.ClassVar[t.Set[str]] = {
         "invalidate_environment_after_deploy",

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -389,6 +389,10 @@ class GithubController:
     @property
     def pr_plan(self) -> Plan:
         if not self._pr_plan_builder:
+            if self.bot_config.pr_environment_git_selector:
+                logger.debug(
+                    f"Creating PR plan with git selector: {self.bot_config.pr_environment_git_selector}"
+                )
             self._pr_plan_builder = self._context.plan_builder(
                 environment=self.pr_environment_name,
                 skip_tests=True,
@@ -396,6 +400,9 @@ class GithubController:
                 start=self.bot_config.default_pr_start,
                 skip_backfill=self.bot_config.skip_pr_backfill,
                 include_unmodified=self.bot_config.pr_include_unmodified,
+                select_models=[self.bot_config.pr_environment_git_selector]
+                if self.bot_config.pr_environment_ref_branch
+                else None,
             )
         assert self._pr_plan_builder
         return self._pr_plan_builder.build()


### PR DESCRIPTION
Prior to this change we would always reference the prod state when checking for changes in a PR environment. In the case where a `sqlmesh run` has been triggered, therefore models are missing intervals, the bot will try to load those missing intervals in the PR environment. Although this doesn't cause any direct issues, it does result in a waste of resources as the PR environment starts loading data as the `sqlmesh run` is being executed.

This change allows users to reference a branch instead of prod environment and therefore this will invoke the selector and only include models that are changed. We can't do this by default since we don't know the branch is that represent production so it requires the user to provide the branch. 