### PR TITLE
Fix!: Ignore the warehouse property on non-dynamic tables

### DIFF
--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -183,7 +183,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin):
             table_properties = {k.upper(): v for k, v in table_properties.items()}
             # if we are creating a non-dynamic table; remove any properties that are only valid for dynamic tables
             if table_kind != self.MANAGED_TABLE_KIND:
-                for prop in {"TARGET_LAG", "REFRESH_MODE", "INITIALIZE"}:
+                for prop in {"WAREHOUSE", "TARGET_LAG", "REFRESH_MODE", "INITIALIZE"}:
                     table_properties.pop(prop, None)
 
             properties.extend(self._table_or_view_properties_to_expressions(table_properties))


### PR DESCRIPTION
In snowflake, when creating managed models, the `warehouse` property was missed from the list of physical properties to exclude when creating dev preview tables.

This change adds it to the list.

Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1721168591596139