### PR TITLE
Feat: pass session parameters for Snowflake

### DIFF
--- a/docs/integrations/engines/snowflake.md
+++ b/docs/integrations/engines/snowflake.md
@@ -24,6 +24,7 @@ pip install "sqlmesh[snowflake]"
 | `private_key`            | The optional private key to use for authentication. Key can be Base64-encoded DER format (representing the key bytes), a plain-text PEM format, or bytes (Python config only). | string |    N     |
 | `private_key_path`       | The optional path to the private key to use for authentication. This would be used instead of `private_key`.                                                                   | string |    N     |
 | `private_key_passphrase` | The optional passphrase to use to decrypt `private_key` (if in PEM format) or `private_key_path`. Keys can be created without encryption so only provide this if needed.       | string |    N     |
+| `session_parameters`     | The optional session parameters to set for the connection.                                                                                                                     | dict   |    N     |
 
 
 #### Lowercase object names

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -333,6 +333,7 @@ class SnowflakeConnectionConfig(ConnectionConfig):
         private_key_passphrase: The optional passphrase to use to decrypt `private_key` or `private_key_path`. Keys can be created without encryption so only provide this if needed.
         register_comments: Whether or not to register model comments with the SQL engine.
         pre_ping: Whether or not to pre-ping the connection before starting a new transaction to ensure it is still alive.
+        session_parameters: The optional session parameters to set for the connection.
     """
 
     account: str
@@ -352,6 +353,8 @@ class SnowflakeConnectionConfig(ConnectionConfig):
     concurrent_tasks: int = 4
     register_comments: bool = True
     pre_ping: bool = False
+
+    session_parameters: t.Optional[dict] = None
 
     type_: Literal["snowflake"] = Field(alias="type", default="snowflake")
 
@@ -471,6 +474,7 @@ class SnowflakeConnectionConfig(ConnectionConfig):
             "authenticator",
             "token",
             "private_key",
+            "session_parameters",
         }
 
     @property

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -183,6 +183,17 @@ def test_snowflake(make_config, snowflake_key_passphrase_bytes, snowflake_oauth_
             authenticator="oauth",
         )
 
+    # Can pass in session parameters
+    config = make_config(
+        type="snowflake",
+        account="test",
+        user="test",
+        password="test",
+        authenticator="externalbrowser",
+        session_parameters={"query_tag": "test", "timezone": "UTC"},
+    )
+    assert isinstance(config, SnowflakeConnectionConfig)
+
 
 @pytest.mark.parametrize(
     "key_path_fixture, key_pem_fixture, key_b64_fixture, key_bytes_fixture, key_passphrase",


### PR DESCRIPTION
This PR is to implement the features in this issue:
https://github.com/TobikoData/sqlmesh/issues/2829

Looking at the code it didn't seem like much was missing.
Tried it with this in my config:
            session_parameters:
              timezone: UTC
              query_tag: state_test_tag

Not sure how to test it, but I checked in my query history that the queries are getting tagged.
<img width="193" alt="image" src="https://github.com/user-attachments/assets/14e09e5e-faec-4de8-af0e-c529c3b4e077">

From what I understand of the code this should get passed straight through to the connector.
https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect
This would add support for all session parameters supported by Snowflake.
https://docs.snowflake.com/en/sql-reference/parameters

I see here it passes everything defined in the connection kwarg keys.
https://github.com/TobikoData/sqlmesh/blob/7c1ed838295a898da759e59379cdc361b687a22c/sqlmesh/core/config/connection.py#L90
Then that gets passed to Snowflake's connector function and it takes in session_parameters.

I put in a basic test with the others would that be enough?