### PR TITLE
Fix: Support unordered columns in test data generation query

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -503,24 +503,22 @@ class ModelTest(unittest.TestCase):
         if not all_columns or query.is_star:
             return query
 
-        query_columns = set(query.named_selects)
-        missing_columns = [col for col in all_columns if col not in query_columns]
-        if missing_columns:
-            if isinstance(query, exp.Union):
-                if isinstance(query.left, exp.Query):
-                    self._add_missing_columns(query.left, all_columns)
-                if isinstance(query.right, exp.Query):
-                    self._add_missing_columns(query.right, all_columns)
-            else:
-                selects = {select.alias: select for select in query.selects}
-                query.select(
-                    *[
-                        exp.null().as_(col) if col not in query_columns else selects[col]
-                        for col in all_columns
-                    ],
-                    append=False,
-                    copy=False,
-                )
+        if isinstance(query, exp.Union):
+            if isinstance(query.left, exp.Query):
+                self._add_missing_columns(query.left, all_columns)
+            if isinstance(query.right, exp.Query):
+                self._add_missing_columns(query.right, all_columns)
+        else:
+            query_columns = set(query.named_selects)
+            selects = {select.alias: select for select in query.selects}
+            query.select(
+                *[
+                    exp.null().as_(col) if col not in query_columns else selects[col]
+                    for col in all_columns
+                ],
+                append=False,
+                copy=False,
+            )
 
         return query
 

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -506,7 +506,21 @@ class ModelTest(unittest.TestCase):
         query_columns = set(query.named_selects)
         missing_columns = [col for col in all_columns if col not in query_columns]
         if missing_columns:
-            query.select(*[exp.null().as_(col) for col in missing_columns], copy=False)
+            if isinstance(query, exp.Union):
+                if isinstance(query.left, exp.Query):
+                    self._add_missing_columns(query.left, all_columns)
+                if isinstance(query.right, exp.Query):
+                    self._add_missing_columns(query.right, all_columns)
+            else:
+                selects = {select.alias: select for select in query.selects}
+                query.select(
+                    *[
+                        exp.null().as_(col) if col not in query_columns else selects[col]
+                        for col in all_columns
+                    ],
+                    append=False,
+                    copy=False,
+                )
 
         return query
 

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -1340,11 +1340,13 @@ test_example_full_model_alt:
   inputs:
     sqlmesh_example.incremental_model:
       query: |
-        SELECT 1 AS id, 1 AS item_id
+        SELECT 1 AS item_id, 1 AS id
         UNION ALL
-        SELECT 2 AS id, 1 AS item_id
+        SELECT 1 AS item_id, 2 AS id
         UNION ALL
         SELECT 3 AS id, 2 AS item_id
+        UNION ALL
+        SELECT 3 as item_id
   outputs:
     query:
       rows:
@@ -1352,9 +1354,40 @@ test_example_full_model_alt:
         num_orders: 2
       - item_id: 2
         num_orders: 1
+      - item_id: 3
+        num_orders: 0
                 """
             ),
             test_name="test_example_full_model_alt",
+            model=context.get_model("sqlmesh_example.full_model"),
+            context=context,
+        ).run()
+    )
+
+    _check_successful_or_raise(
+        _create_test(
+            body=load_yaml(
+                """
+test_example_full_model_partial:
+  model: sqlmesh_example.full_model
+  inputs:
+    sqlmesh_example.incremental_model:
+      query: |
+        SELECT 1 AS item_id, 1 AS id
+        UNION ALL
+        SELECT 2 AS item_id
+        UNION ALL
+        SELECT 3 AS id
+  outputs:
+    query:
+      partial: true
+      rows:
+      - item_id: 1
+      - item_id: 2
+      - item_id: null
+                """
+            ),
+            test_name="test_example_full_model_partial",
             model=context.get_model("sqlmesh_example.full_model"),
             context=context,
         ).run()

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -1344,9 +1344,11 @@ test_example_full_model_alt:
         UNION ALL
         SELECT 1 AS item_id, 2 AS id
         UNION ALL
-        SELECT 3 AS id, 2 AS item_id
+        SELECT 2 AS item_id, 3 AS id
         UNION ALL
-        SELECT 3 as item_id
+        SELECT 3 AS item_id, 4 AS id
+        UNION ALL
+        SELECT 4 AS item_id, null AS id
   outputs:
     query:
       rows:
@@ -1355,6 +1357,8 @@ test_example_full_model_alt:
       - item_id: 2
         num_orders: 1
       - item_id: 3
+        num_orders: 1
+      - item_id: 4
         num_orders: 0
                 """
             ),
@@ -1373,18 +1377,15 @@ test_example_full_model_partial:
   inputs:
     sqlmesh_example.incremental_model:
       query: |
-        SELECT 1 AS item_id, 1 AS id
+        SELECT 1 as id,
         UNION ALL
-        SELECT 2 AS item_id
-        UNION ALL
-        SELECT 3 AS id
+        SELECT 2 as id,
   outputs:
     query:
       partial: true
       rows:
-      - item_id: 1
-      - item_id: 2
       - item_id: null
+        num_orders: 2
                 """
             ),
             test_name="test_example_full_model_partial",


### PR DESCRIPTION
Currently, the order of columns in input data generated from a SQL query must be identical to the model definition. This update lifts that restriction, to allow to skip or declare columns in random order without issues. This is addressed by adapting the `_add_missing_columns` function, so that aside from filling with nulls the missing values, to maintain the correct order as well.