### PR TITLE
Chore: add persistent duckdb gateway to sushi and wursthall examples

### DIFF
--- a/examples/sushi/config.py
+++ b/examples/sushi/config.py
@@ -62,12 +62,6 @@ test_config = Config(
     model_defaults=model_defaults,
 )
 
-# A stateful DuckDB config.
-local_config = Config(
-    default_connection=DuckDBConnectionConfig(database=f"{DATA_DIR}/local.duckdb"),
-    model_defaults=model_defaults,
-)
-
 airflow_config = Config(
     default_scheduler=AirflowSchedulerConfig(),
     gateways=GatewayConfig(

--- a/examples/sushi/config.py
+++ b/examples/sushi/config.py
@@ -29,9 +29,17 @@ model_defaults = ModelDefaultsConfig(**defaults)
 model_defaults_iceberg = ModelDefaultsConfig(**defaults, storage_format="iceberg")
 
 
-# An in memory DuckDB config.
+# A DuckDB config, in-memory by default.
 config = Config(
-    default_connection=DuckDBConnectionConfig(),
+    gateways={
+        "duckdb": GatewayConfig(
+            connection=DuckDBConnectionConfig(),
+        ),
+        "duckdb_persistent": GatewayConfig(
+            connection=DuckDBConnectionConfig(database=f"{DATA_DIR}/duckdb.db"),
+        ),
+    },
+    default_gateway="duckdb",
     model_defaults=model_defaults,
 )
 

--- a/examples/wursthall/config.yaml
+++ b/examples/wursthall/config.yaml
@@ -3,6 +3,10 @@ gateways:
   duckdb:
     connection:
       type: duckdb
+  duckdb_persistent:
+    connection:
+      type: duckdb
+      database: duckdb.db
 
 model_defaults:
   dialect: 'duckdb'

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -47,7 +47,7 @@ def test_global_config(copy_to_temp_path: t.Callable):
 
 
 def test_named_config(copy_to_temp_path: t.Callable):
-    context = Context(paths=copy_to_temp_path("examples/sushi"), config="local_config")
+    context = Context(paths=copy_to_temp_path("examples/sushi"), config="test_config")
     assert len(context.config.gateways) == 1
 
 
@@ -85,7 +85,7 @@ def test_config_not_found(copy_to_temp_path: t.Callable):
         ConfigError,
         match=r".*config could not be found.*",
     ):
-        Context(paths="nonexistent/directory", config="local_config")
+        Context(paths="nonexistent/directory", config="config")
 
 
 def test_custom_macros(sushi_context):
@@ -594,14 +594,14 @@ def test_plan_default_end(sushi_context_pre_scheduling: Context):
 def test_plan_start_ahead_of_end(copy_to_temp_path):
     path = copy_to_temp_path("examples/sushi")
     with freezegun.freeze_time("2024-01-02 00:00:00"):
-        context = Context(paths=path, config="local_config")
+        context = Context(paths=path, gateway="duckdb_persistent")
         context.plan("prod", no_prompts=True, auto_apply=True)
         assert context.state_sync.max_interval_end_for_environment("prod") == to_timestamp(
             "2024-01-02"
         )
         context.close()
     with freezegun.freeze_time("2024-01-03 00:00:00"):
-        context = Context(paths=path, config="local_config")
+        context = Context(paths=path, gateway="duckdb_persistent")
         expression = d.parse(
             """
                 MODEL(


### PR DESCRIPTION
These changes allow wursthall to use a persistent duckdb database with the CLI `--gateway duckdb_persistent` option.

They also modify sushi so its persistent duckdb config is specified with the same `--gateway duckdb_persistent` option (rather than the current `--config local_config` option).