### PR TITLE
Chore: Add Missing ConnectionConfigs to core.config init

### DIFF
--- a/sqlmesh/core/config/__init__.py
+++ b/sqlmesh/core/config/__init__.py
@@ -4,6 +4,7 @@ from sqlmesh.core.config.categorizer import (
 )
 from sqlmesh.core.config.common import EnvironmentSuffixTarget as EnvironmentSuffixTarget
 from sqlmesh.core.config.connection import (
+    BaseDuckDBConnectionConfig as BaseDuckDBConnectionConfig,
     BigQueryConnectionConfig as BigQueryConnectionConfig,
     ConnectionConfig as ConnectionConfig,
     DatabricksConnectionConfig as DatabricksConnectionConfig,
@@ -16,6 +17,7 @@ from sqlmesh.core.config.connection import (
     RedshiftConnectionConfig as RedshiftConnectionConfig,
     SnowflakeConnectionConfig as SnowflakeConnectionConfig,
     SparkConnectionConfig as SparkConnectionConfig,
+    TrinoConnectionConfig as TrinoConnectionConfig,
     parse_connection_config as parse_connection_config,
 )
 from sqlmesh.core.config.gateway import GatewayConfig as GatewayConfig


### PR DESCRIPTION
This commit adds two missing ConnectionConfig subclasses to the sqlmesh.core.config __init__.py file:
- BaseDuckDBConnectionConfig
- TrinoConnectionConfig

This allows for easier referencing of the above, and is consistent with the manner in which other ConnectionConfig subclasses are imported.