### PR TITLE
Feat: Support enabling audits in model defaults

### DIFF
--- a/docs/concepts/audits.md
+++ b/docs/concepts/audits.md
@@ -88,6 +88,15 @@ SELECT * FROM @this_model
 WHERE @column >= @threshold;
 ```
 
+Alternatively, you can apply specific audits globally by including them in the model defaults configuration:
+
+```sql linenums="1"
+model_defaults:
+  audits: 
+    - assert_positive_order_ids
+    - does_not_exceed_threshold(column := id, threshold := 1000)
+```
+
 ### Naming
 We recommended avoiding SQL keywords when naming audit parameters. Quote any audit argument that is also a SQL keyword.
 

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -61,7 +61,7 @@ You create audits by writing SQL queries that should return 0 rows. For example,
 
 Audits are flexible &mdash; they can be tied to a specific model's contents, or you can use [macros](./macros/overview.md) to create audits that are usable by multiple models. SQLMesh also includes pre-made audits for common use cases, such as detecting NULL or duplicated values.
 
-You specify which audits should run for a model by including them in the model's metadata properties.
+You specify which audits should run for a model by including them in the model's metadata properties. To apply them globally across your project, include them in the model defaults configuration.
 
 SQLMesh automatically runs audits when you apply a `plan` to an environment, or you can run them on demand with the [`audit` command](../reference/cli.md#audit).
 

--- a/docs/reference/model_configuration.md
+++ b/docs/reference/model_configuration.md
@@ -51,6 +51,7 @@ The SQLMesh project-level `model_defaults` key supports the following options, d
 - storage_format
 - session_properties (on per key basis)
 - on_destructive_change (described [below](#incremental-models))
+- audits (described [here](../concepts/audits.md#generic-audits))
 
 
 ### Model Naming

--- a/sqlmesh/core/config/model.py
+++ b/sqlmesh/core/config/model.py
@@ -69,7 +69,6 @@ class ModelDefaultsConfig(BaseConfig):
                 kwargs[arg.left.name.lower()] = arg.right
             return func.lower(), kwargs
 
-        breakpoint()
         if isinstance(v, list):
             return [extract(parse(audit)[0]) for audit in v]
 

--- a/sqlmesh/core/config/model.py
+++ b/sqlmesh/core/config/model.py
@@ -30,6 +30,7 @@ class ModelDefaultsConfig(BaseConfig):
         storage_format: The storage format used to store the physical table, only applicable in certain engines.
             (eg. 'parquet')
         on_destructive_change: What should happen when a forward-only model requires a destructive schema change.
+        audits: The audits to be applied globally to all models in the project.
     """
 
     kind: t.Optional[ModelKind] = None

--- a/sqlmesh/core/config/model.py
+++ b/sqlmesh/core/config/model.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-from sqlmesh.core.dialect import parse, extract_audit
+from sqlmesh.core.dialect import parse_one, extract_audit
 from sqlmesh.core.config.base import BaseConfig
 from sqlmesh.core.model.kind import (
     ModelKind,
@@ -48,6 +48,6 @@ class ModelDefaultsConfig(BaseConfig):
     @field_validator("audits", mode="before")
     def _audits_validator(cls, v: t.Any) -> t.Any:
         if isinstance(v, list):
-            return [extract_audit(parse(audit)[0]) for audit in v]
+            return [extract_audit(parse_one(audit)) for audit in v]
 
         return v

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1907,6 +1907,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                     audits=audits,
                     cache=fingerprint_cache,
                     ttl=ttl,
+                    config=self.config_for_node(node),
                 )
                 snapshots[snapshot.name] = snapshot
             return snapshots

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -464,7 +464,7 @@ class _Model(ModelMeta, frozen=True):
     def referenced_audits(
         self,
         audits: t.Dict[str, ModelAudit],
-        config_audits: t.Optional[t.List[AuditReference]] = None,
+        default_audits: t.Optional[t.List[AuditReference]] = None,
     ) -> t.List[ModelAudit]:
         """Returns audits referenced in this model.
 
@@ -475,7 +475,7 @@ class _Model(ModelMeta, frozen=True):
 
         referenced_audits = []
 
-        combined_audits = self.audits + config_audits if config_audits else self.audits
+        combined_audits = self.audits + default_audits if default_audits else self.audits
         for audit_name, _ in combined_audits:
             if audit_name in self.inline_audits:
                 referenced_audits.append(self.inline_audits[audit_name])

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -25,7 +25,7 @@ from sqlmesh.core import dialect as d
 from sqlmesh.core.macros import MacroRegistry, MacroStrTemplate, macro
 from sqlmesh.core.model.common import expression_validator
 from sqlmesh.core.model.kind import ModelKindName, SeedKind, ModelKind, FullKind, create_model_kind
-from sqlmesh.core.model.meta import ModelMeta
+from sqlmesh.core.model.meta import ModelMeta, AuditReference
 from sqlmesh.core.model.seed import CsvSeedReader, Seed, create_seed
 from sqlmesh.core.renderer import ExpressionRenderer, QueryRenderer
 from sqlmesh.utils import columns_to_types_all_known, str_to_bool, UniqueKeyDict
@@ -461,7 +461,11 @@ class _Model(ModelMeta, frozen=True):
             )
         return query
 
-    def referenced_audits(self, audits: t.Dict[str, ModelAudit]) -> t.List[ModelAudit]:
+    def referenced_audits(
+        self,
+        audits: t.Dict[str, ModelAudit],
+        config_audits: t.Optional[t.List[AuditReference]] = None,
+    ) -> t.List[ModelAudit]:
         """Returns audits referenced in this model.
 
         Args:
@@ -471,7 +475,8 @@ class _Model(ModelMeta, frozen=True):
 
         referenced_audits = []
 
-        for audit_name, _ in self.audits:
+        combined_audits = self.audits + config_audits if config_audits else self.audits
+        for audit_name, _ in combined_audits:
             if audit_name in self.inline_audits:
                 referenced_audits.append(self.inline_audits[audit_name])
             elif audit_name in audits:

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -464,7 +464,7 @@ class _Model(ModelMeta, frozen=True):
     def referenced_audits(
         self,
         audits: t.Dict[str, ModelAudit],
-        default_audits: t.Optional[t.List[AuditReference]] = None,
+        default_audits: t.List[AuditReference] = [],
     ) -> t.List[ModelAudit]:
         """Returns audits referenced in this model.
 
@@ -475,8 +475,7 @@ class _Model(ModelMeta, frozen=True):
 
         referenced_audits = []
 
-        combined_audits = self.audits + default_audits if default_audits else self.audits
-        for audit_name, _ in combined_audits:
+        for audit_name, _ in self.audits + default_audits:
             if audit_name in self.inline_audits:
                 referenced_audits.append(self.inline_audits[audit_name])
             elif audit_name in audits:

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -636,10 +636,10 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         """
         created_ts = now_timestamp()
         kwargs = {}
-        config_audits = config.model_defaults.audits if config else []
+        default_audits = config.model_defaults.audits if config else []
         if node.is_model:
             kwargs["audits"] = tuple(
-                t.cast(_Model, node).referenced_audits(audits or {}, config_audits)
+                t.cast(_Model, node).referenced_audits(audits or {}, default_audits)
             )
 
         return cls(

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -636,7 +636,9 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         """
         created_ts = now_timestamp()
         kwargs = {}
-        default_audits = config.model_defaults.audits if config else []
+        default_audits = (
+            config.model_defaults.audits if (config and config.model_defaults.audits) else []
+        )
         if node.is_model:
             kwargs["audits"] = tuple(
                 t.cast(_Model, node).referenced_audits(audits or {}, default_audits)

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -46,6 +46,7 @@ else:
 if t.TYPE_CHECKING:
     from sqlglot.dialects.dialect import DialectType
     from sqlmesh.core.environment import EnvironmentNamingInfo
+    from sqlmesh.core.config import Config
 
 Interval = t.Tuple[int, int]
 Intervals = t.List[Interval]
@@ -617,6 +618,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         version: t.Optional[str] = None,
         audits: t.Optional[t.Dict[str, ModelAudit]] = None,
         cache: t.Optional[t.Dict[str, SnapshotFingerprint]] = None,
+        config: t.Optional[Config] = None,
     ) -> Snapshot:
         """Creates a new snapshot for a node.
 
@@ -634,8 +636,11 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         """
         created_ts = now_timestamp()
         kwargs = {}
+        config_audits = config.model_defaults.audits if config else []
         if node.is_model:
-            kwargs["audits"] = tuple(t.cast(_Model, node).referenced_audits(audits or {}))
+            kwargs["audits"] = tuple(
+                t.cast(_Model, node).referenced_audits(audits or {}, config_audits)
+            )
 
         return cls(
             name=node.fqn,

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -15,6 +15,7 @@ from sqlmesh.cli.example_project import init_example_project
 
 from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
+from sqlmesh.core.audit import ModelAudit
 from sqlmesh.core.config import (
     Config,
     NameInferenceConfig,
@@ -967,6 +968,39 @@ def test_audits():
         ("audit_b", {"key": exp.Literal.string("value")}),
     ]
     assert model.tags == ["foo"]
+
+
+def test_enable_audits_from_model_defaults():
+    expressions = d.parse(
+        """
+        MODEL (
+            name db.audit_model,
+        );
+        SELECT 1 as id;
+
+        AUDIT (
+    name assert_positive_order_ids,
+    );
+    SELECT *
+    FROM @this_model
+    WHERE
+    id < 0;
+    """
+    )
+
+    model = load_sql_based_model(expressions, path=Path("./examples/sushi/models/test_model.sql"))
+    assert len(model.audits) == 0
+    assert len(model.inline_audits) == 1
+
+    config = Config(
+        model_defaults=ModelDefaultsConfig(dialect="duckdb", audits=["assert_positive_order_ids"])
+    )
+    assert config.model_defaults.audits[0] == ("assert_positive_order_ids", {})
+
+    snapshot = Snapshot.from_node(model, nodes={}, config=config)
+    assert len(snapshot.audits) == 1
+    assert type(snapshot.audits[0]) == ModelAudit
+    assert snapshot.audits[0].query.sql() == "SELECT * FROM @this_model WHERE id < 0"
 
 
 def test_description(sushi_context):


### PR DESCRIPTION
This update enables audits in model defaults and to be applied globally. The syntax for each respective audit is similar to the model definition, but is used in the YAML file:

```yaml
model_defaults:
    audits: 
        - assert_positive_order_ids
        - does_not_exceed_threshold(column := id, threshold := 1000)
```

fixes: #2567 