### PR TITLE
Feat: helpful err msg if forward_only specified in incremental by partition

### DIFF
--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -488,6 +488,14 @@ class IncrementalByPartitionKind(_Incremental):
     forward_only: Literal[True] = True
     disable_restatement: SQLGlotBool = True
 
+    @field_validator("forward_only", mode="before")
+    def _forward_only_validator(cls, v: t.Union[bool, exp.Expression]) -> Literal[True]:
+        if v is not True:
+            raise ConfigError(
+                "Do not specify the `forward_only` configuration key - INCREMENTAL_BY_PARTITION models are always forward_only."
+            )
+        return v
+
     @property
     def metadata_hash_values(self) -> t.List[t.Optional[str]]:
         return [

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -4755,6 +4755,24 @@ def test_incremental_by_partition(sushi_context, assert_exp_eq):
         )
         load_sql_based_model(expressions)
 
+    with pytest.raises(
+        ConfigError,
+        match=r".*Do not specify the `forward_only` configuration key.*",
+    ):
+        expressions = d.parse(
+            """
+            MODEL (
+                name db.table,
+                kind INCREMENTAL_BY_PARTITION (
+                    forward_only true
+                ),
+            );
+
+            SELECT a, b
+            """
+        )
+        load_sql_based_model(expressions)
+
 
 @pytest.mark.parametrize(
     ["model_def", "path", "expected_name"],


### PR DESCRIPTION
`INCREMENTAL_BY_PARTITION` models are always `forward_only`. If a user specifies the forward_only key with true (or any other value), they currently receive a cryptic pydantic error. 

This PR adds a field validator that provides an error message telling the user not to specify the forward_only key.