### PR TITLE
Fix: Use correct attribute to fetch the dialect from a dbt target

### DIFF
--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -326,9 +326,7 @@ def create_builtin_globals(
     jinja_globals = jinja_globals.copy()
 
     target: t.Optional[AttributeDict] = jinja_globals.get("target", None)
-    project_dialect = jinja_globals.pop("dialect", None) or (
-        target.get("dialect") if target else None
-    )
+    project_dialect = jinja_globals.pop("dialect", None) or (target.get("type") if target else None)
     api = Api(project_dialect)
 
     builtin_globals["api"] = api


### PR DESCRIPTION
Previously we were using an incorrect attribute name.