### PR TITLE
Docs: lazy load images

### DIFF
--- a/docs/guides/observer.md
+++ b/docs/guides/observer.md
@@ -70,7 +70,7 @@ SQLMesh Observer is part of the `sqlmesh-enterprise` Python library and is insta
 
 Installation requires a license key provided by Tobiko Data. You include the license key in the `pip` install command executed from the command line. It is quite long, so we recommend placing it in a file that the installation command reads. In this example, we have stored the key in a `txt` file:
 
-![SQLMesh Enterprise key stored in txt file](./observer/observer_key-file.png)
+![SQLMesh Enterprise key stored in txt file](./observer/observer_key-file.png){ loading=lazy }
 
 Run the installation command and read the key file with the following command. The key is passed to the `--extra-index-url` argument, either directly by pasting the key into the command or by reading the key from file with an embedded `cat` command. You should replace `<path to key file>` with the path to your key file:
 
@@ -100,11 +100,11 @@ sqlmesh observe
 
 After starting up, SQLMesh Observer is served at `http://127.0.0.1:8000` by default:
 
-![SQLMesh Observer startup on CLI](./observer/observer_cli.png)
+![SQLMesh Observer startup on CLI](./observer/observer_cli.png){ loading=lazy }
 
 Navigate to the URL by clicking the link in your terminal (if supported) or copy-pasting it into your web browser:
 
-![SQLMesh Observer dashboard interface](./observer/observer_dashboard.png)
+![SQLMesh Observer dashboard interface](./observer/observer_dashboard.png){ loading=lazy }
 
 ## Interface
 
@@ -120,7 +120,7 @@ The "Dashboard" page is displayed when Observer starts - it consists of the foll
 4. Interactive chart of historical audit failure counts in the bottom left
 5. Interactive chart of historical `run` failures in the bottom right
 
-![SQLMesh Observer dashboard](./observer/observer_dashboard-components.png)
+![SQLMesh Observer dashboard](./observer/observer_dashboard-components.png){ loading=lazy }
 
 ### Charts
 
@@ -128,44 +128,44 @@ Observer presents historical information via charts and tables. Most charts repr
 
 In a chart's top left corner is the `Time` selector, which sets the range of the x-axis. For example, the first chart displays 1 week of data, from November 27 through December 4. The second chart displays the same data but includes 3 months of historical data beginning on September 4:
 
-![SQLMesh Observer chart x-axis time selector](./observer/observer_chart-time-selector.png)
+![SQLMesh Observer chart x-axis time selector](./observer/observer_chart-time-selector.png){ loading=lazy }
 
 In a chart's top right corner is the `Scale` selector, which toggles between a linear and log y-axis scale. A log scale may be helpful for comparing highly variable data series over time. This example displays the data from the second chart in the previous figure with a log y-axis scale:
 
-![SQLMesh Observer chart y-axis scale selector](./observer/observer_chart-scale-selector.png)
+![SQLMesh Observer chart y-axis scale selector](./observer/observer_chart-scale-selector.png){ loading=lazy }
 
 Charts also display the data underlying a specific data point when the mouse hovers over it:
 
-![SQLMesh Observer chart mouse hover](./observer/observer_chart-hover.png)
+![SQLMesh Observer chart mouse hover](./observer/observer_chart-hover.png){ loading=lazy }
 
 Many charts display purple `Plan` markers, which provide contextual information about when changes to the project occurred. Clicking on the marker will open a page containing [more information about the plan](#plan-applications).
 
 Some Observer tables include a button that toggles a chart of the measures in the table:
 
-![SQLMesh Observer table chart toggle](./observer/observer_table-chart-toggle.png)
+![SQLMesh Observer table chart toggle](./observer/observer_table-chart-toggle.png){ loading=lazy }
 
 
 ### Environments
 
 Access the `Environments` landing page via the navigation links in the dashboard's top left. It displays a table listing each SQLMesh environment, the date it was created, the date it was last updated, and the date it expires (after which the SQLMesh janitor will delete it). The `prod` environment is always present and has no expiration date.
 
-![SQLMesh Observer environment landing page](./observer/observer_environments-landing.png)
+![SQLMesh Observer environment landing page](./observer/observer_environments-landing.png){ loading=lazy }
 
 Clicking an environment's name in the table open's the environment's information page. The page begins with historical charts of run time, audit failures, and evaluation failures:
 
-![SQLMesh Observer environment information page](./observer/observer_environments-info-1.png)
+![SQLMesh Observer environment information page](./observer/observer_environments-info-1.png){ loading=lazy }
 
 The page continues with lists of recent audit failures, evaluation failure, and model evaluations:
 
-![SQLMesh Observer environment information: recent occurrences](./observer/observer_environments-info-2.png)
+![SQLMesh Observer environment information: recent occurrences](./observer/observer_environments-info-2.png){ loading=lazy }
 
 The page finishes with a list of models that differ from those currently in the `prod` environment, a list of the audits that have historically failed most frequently, a list of the models that have historically failed most frequently, and a list of the models with the longest run times:
 
-![SQLMesh Observer environment information: historical outliers](./observer/observer_environments-info-3.png)
+![SQLMesh Observer environment information: historical outliers](./observer/observer_environments-info-3.png){ loading=lazy }
 
 Each model differing from the `prod` environment may be expanded to view the text diff between the two. The models are listed separately based on whether the plan directly or indirectly modified them, and breaking changes are indicated with an orange "Breaking" label:
 
-![SQLMesh Observer environment information: model text diff](./observer/observer_environments-info-prod-diff.png)
+![SQLMesh Observer environment information: model text diff](./observer/observer_environments-info-prod-diff.png){ loading=lazy }
 
 ### Plan Applications
 
@@ -180,15 +180,15 @@ Access the `Plan Applications` landing page via the navigation links in the dash
 - The start and end dates of the time interval covered by the plan
 - The start and end times of the plan application
 
-![SQLMesh Observer plans list](./observer/observer_plans-list.png)
+![SQLMesh Observer plans list](./observer/observer_plans-list.png){ loading=lazy }
 
 Clicking a Plan ID opens its information page, which lists the information included in the landing page table and links to models added or modified by the plan:
 
-![SQLMesh Observer plan information page](./observer/observer_plans-information.png)
+![SQLMesh Observer plan information page](./observer/observer_plans-information.png){ loading=lazy }
 
 Modified models can be expanded to display a text diff of the change:
 
-![SQLMesh Observer plan text diff](./observer/observer_plans-text-diff.png)
+![SQLMesh Observer plan text diff](./observer/observer_plans-text-diff.png){ loading=lazy }
 
 ### Models
 
@@ -196,19 +196,19 @@ A model can change over time, so its information is associated with a specific S
 
 The model information page begins with historical charts of model run time, audit failures, and evaluation failures:
 
-![SQLMesh Observer model charts](./observer/observer_model-information-1.png)
+![SQLMesh Observer model charts](./observer/observer_model-information-1.png){ loading=lazy }
 
 It continues with details about the model, including its metadata (e.g., model dialect and kind), model text, and list of previous model versions and text diffs:
 
-![SQLMesh Observer model details](./observer/observer_model-information-2.png)
+![SQLMesh Observer model details](./observer/observer_model-information-2.png){ loading=lazy }
 
 Next, the Loaded Intervals section displays the time intervals that have been loaded and are currently present in the model's physical table, and the Recent Model Evaluations section lists the time interval each evaluation processed and the evaluation's start and end times:
 
-![SQLMesh Observer model time intervals](./observer/observer_model-information-3.png)
+![SQLMesh Observer model time intervals](./observer/observer_model-information-3.png){ loading=lazy }
 
 The model information page concludes with a list of most frequent audits the model has failed, the most frequent time intervals that failed, and the largest historical model run times:
 
-![SQLMesh Observer historical outliers](./observer/observer_model-information-4.png)
+![SQLMesh Observer historical outliers](./observer/observer_model-information-4.png){ loading=lazy }
 
 ## Custom measures
 

--- a/docs/guides/ui.md
+++ b/docs/guides/ui.md
@@ -42,11 +42,11 @@ sqlmesh ui
 
 After starting up, the SQLMesh web UI is served at `http://127.0.0.1:8000` by default:
 
-![SQLMesh web UI startup on CLI](./ui/ui-quickstart_cli.png)
+![SQLMesh web UI startup on CLI](./ui/ui-quickstart_cli.png){ loading=lazy }
 
 Navigate to the URL by clicking the link in your terminal (if supported) or copy-pasting it into your web browser:
 
-![SQLMesh web UI startup in browser](./ui/ui-quickstart_ui-startup.png)
+![SQLMesh web UI startup in browser](./ui/ui-quickstart_ui-startup.png){ loading=lazy }
 
 ## Modules
 
@@ -71,7 +71,7 @@ The `editor` module will appear by default if the UI is started without specifyi
 4. Inspector provides settings and information based on recent actions and the currently active pane. (Note: inspector pane is collapsed by default. Expand it by clicking the hamburger button at the top of the collapsed pane - see previous image.)
 5. Details displays column-level lineage for models open in the editor and results of queries. (Note: details pane is collapsed by default. It will automatically expand upon opening a model in the editor or running a query.)
 
-![SQLMesh browser UI panes](./ui/ui-quickstart_ui-startup-panes.png)
+![SQLMesh browser UI panes](./ui/ui-quickstart_ui-startup-panes.png){ loading=lazy }
 
 It also contains nine buttons:
 
@@ -85,7 +85,7 @@ It also contains nine buttons:
 8. Format SQL query reformats a SQL query using SQLGlot's pretty layout.
 9. Change SQL dialect specifies the SQL dialect of the current tab for custom SQL queries. It does not affect the SQL dialect for the project.
 
-![SQLMesh browser UI buttons](./ui/ui-guide_ui-startup-buttons.png)
+![SQLMesh browser UI buttons](./ui/ui-guide_ui-startup-buttons.png){ loading=lazy }
 
 And it contains four status indicators:
 
@@ -94,7 +94,7 @@ And it contains four status indicators:
 3. Change indicator displays a summary of the changes in the project files relative to the most recently run SQLMesh plan in the selected environment.
 4. Error indicator displays the count of errors in the project.
 
-![SQLMesh web UI status indicators](./ui/ui-quickstart_ui-startup-status.png)
+![SQLMesh web UI status indicators](./ui/ui-quickstart_ui-startup-status.png){ loading=lazy }
 
 #### Edit models
 
@@ -102,11 +102,11 @@ Open a model in a new tab by clicking its file name in the left-hand project dir
 
 The tab will show the model definition, and the details pane at the bottom will display the model in the project's table and column lineage.
 
-![Incremental model open in editor](./ui/ui-quickstart_incremental-model.png)
+![Incremental model open in editor](./ui/ui-quickstart_incremental-model.png){ loading=lazy }
 
 The lineage display will update as model modifications are saved. For example, you might modify the incremental SQL model by adding a new column to the query. Press `Cmd + S` (`Ctrl + S` on Windows) to save the modified model file and display the updated lineage:
 
-![Incremental model modified in editor](./ui/ui-quickstart_incremental-model-modified.png)
+![Incremental model modified in editor](./ui/ui-quickstart_incremental-model-modified.png){ loading=lazy }
 
 The `Changes` indicator in the top right now shows blue and orange circles that reflect our model update.
 
@@ -116,11 +116,11 @@ Run SQL queries by executing them from custom SQL editor tabs.
 
 For example, we might add a SQL query `select * from sqlmesh_example.incremental_model` to the Custom SQL 1 tab. To run the query, first click the hamburger icon to open the explorer pane:
 
-![Querying `dev` incremental model with SQL query in editor](./ui/ui-guide_fetchdf-prod-query.png)
+![Querying `dev` incremental model with SQL query in editor](./ui/ui-guide_fetchdf-prod-query.png){ loading=lazy }
 
 Then click the `Run Query` button in the bottom right to execute the query:
 
-![Results from querying dev incremental model with SQL query in editor](./ui/ui-guide_fetchdf-prod.png)
+![Results from querying dev incremental model with SQL query in editor](./ui/ui-guide_fetchdf-prod.png){ loading=lazy }
 
 The results appear in an interactive table in the details pane below the editor.
 
@@ -143,7 +143,7 @@ When you open the plan module, it contains multiple pieces of information about 
 - The `Changes` section shows that SQLMesh detected three models added relative to the current empty environment.
 - The `Backfills` section shows that backfills will occur for all three of the added models.
 
-![Plan module - new project](./ui/ui-quickstart_run-plan.png)
+![Plan module - new project](./ui/ui-quickstart_run-plan.png){ loading=lazy }
 
 SQLMesh will apply the plan and initiate backfill when you click the blue button labeled `Apply Changes And Backfill`.
 
@@ -155,7 +155,7 @@ The `Snapshot Tables Created` indicates that [snapshots](../concepts/architectur
 
 The `Backfilled` section shows progress indicators for the backfill operations. The first progress indicator shows the total number of tasks and completion percentage for the entire backfill operation. The remaining progress bars show completion percentage and run time for each model (very fast in this simple example).
 
-![Plan module - plan applied](./ui/ui-quickstart_apply-plan.png)
+![Plan module - plan applied](./ui/ui-quickstart_apply-plan.png){ loading=lazy }
 
 #### New environment
 
@@ -163,21 +163,21 @@ To create a new environment, open the environment menu by clicking the drop-down
 
 To create an environment named "dev," type `dev` into the Environment field and click the blue `Add` button.
 
-![Open environment menu](./ui/ui-quickstart_create-dev.png)
+![Open environment menu](./ui/ui-quickstart_create-dev.png){ loading=lazy }
 
 The drop-down now shows that the SQLMesh UI is working in the `dev` environment:
 
-![Working in dev environment](./ui/ui-quickstart_plan-dev.png)
+![Working in dev environment](./ui/ui-quickstart_plan-dev.png){ loading=lazy }
 
 To populate the environment with views of the production environment, click the green `Plan` button to open the plan module:
 
-![Run plan on dev pane](./ui/ui-quickstart_run-plan-dev.png)
+![Run plan on dev pane](./ui/ui-quickstart_run-plan-dev.png){ loading=lazy }
 
 The output section does not list any added/modified models or backfills because `dev` is being created from the existing `prod` environment without modification.
 
 Clicking the blue `Apply Virtual Update` button applies the new plan:
 
-![Run plan on dev pane output](./ui/ui-quickstart_run-plan-dev-output.png)
+![Run plan on dev pane output](./ui/ui-quickstart_run-plan-dev-output.png){ loading=lazy }
 
 
 #### Existing environment
@@ -186,13 +186,13 @@ If you modify the project files, you will want to apply the changes to an existi
 
 The plan module will summarize the changes when you open it:
 
-![Plan pane after opening plan module with modified model](./ui/ui-quickstart_run-plan-dev-modified.png)
+![Plan pane after opening plan module with modified model](./ui/ui-quickstart_run-plan-dev-modified.png){ loading=lazy }
 
 The `Changes` section detects that `incremental_model` was directly modified and that `full_model` was indirectly modified because it selects from the incremental model.
 
 Click the blue `Apply Changes And Backfill` button to apply the plan and execute the backfill:
 
-![Plan after applying updated plan with modified model](./ui/ui-quickstart_apply-plan-dev-modified.png)
+![Plan after applying updated plan with modified model](./ui/ui-quickstart_apply-plan-dev-modified.png){ loading=lazy }
 
 ### Docs module
 
@@ -202,11 +202,11 @@ A list of all models is displayed in the left-hand pane. You can filter models b
 
 When you choose a model, its query, lineage, and attributes are displayed. This example shows information from the [quickstart project](../quick_start.md) incremental model:
 
-![Docs with incremental model selected](./ui/ui-guide_docs.png)
+![Docs with incremental model selected](./ui/ui-guide_docs.png){ loading=lazy }
 
 By default, the model definition source code is displayed. If you toggle to `Compiled Query`, it will display an example of the model query rendered with macro values substituted:
 
-![Docs with compiled incremental model query](./ui/ui-guide_docs-compiled-query.png)
+![Docs with compiled incremental model query](./ui/ui-guide_docs-compiled-query.png){ loading=lazy }
 
 ### Lineage module
 
@@ -214,15 +214,15 @@ The lineage module displays a graphical representation of the project's table an
 
 Click a model in the left-hand pane to view its lineage. By default, only the model's upstream parents and downstream children are displayed:
 
-![Lineage module](./ui/ui-guide_lineage.png)
+![Lineage module](./ui/ui-guide_lineage.png){ loading=lazy }
 
 You may include all a project's models by clicking `All` in the Show drop-down on the upper right. In this example, two additional models appear:
 
-![Lineage module - all models](./ui/ui-guide_lineage-all.png)
+![Lineage module - all models](./ui/ui-guide_lineage-all.png){ loading=lazy }
 
 Click `Connected` in the Show drop-down menu to highlight edges between upstream parents and downstream children in blue. This may be helpful when when a project contains many models:
 
-![Lineage module - all models, connected edges](./ui/ui-guide_lineage-all-connected.png)
+![Lineage module - all models, connected edges](./ui/ui-guide_lineage-all-connected.png){ loading=lazy }
 
 ## Modes
 
@@ -248,31 +248,31 @@ To use this workflow, first open a terminal in VSCode and navigate to your proje
 
 <b>1.</b> Start the browser UI in `plan` mode with the command `sqlmesh ui --mode plan`:
 
-![VSCode - start the UI](./ui/ui-guide_vscode-start-ui.png)
+![VSCode - start the UI](./ui/ui-guide_vscode-start-ui.png){ loading=lazy }
 
 <br></br>
 <b>2.</b> In VSCode, type the shortcut `cmd+shift+p` to open the search menu:
 
-![VSCode - open search menu](./ui/ui-guide_vscode-open-search.png)
+![VSCode - open search menu](./ui/ui-guide_vscode-open-search.png){ loading=lazy }
 
 <br></br>
 <b>3.</b> Type `simple browser` into the search menu and click the entry `Simple browser: Show`:
 
-![VSCode - open simple browser](./ui/ui-guide_vscode-start-browser.png)
+![VSCode - open simple browser](./ui/ui-guide_vscode-start-browser.png){ loading=lazy }
 
 <br></br>
 <b>4.</b> Copy the web address printed by the command output (`http://127.0.0.1:8000` by default), paste it into the menu, and click enter:
 
-![VSCode - navigate to UI](./ui/ui-guide_vscode-browser-url.png)
+![VSCode - navigate to UI](./ui/ui-guide_vscode-browser-url.png){ loading=lazy }
 
 <br></br>
 <b>5.</b> The UI will now appear in a VSCode tab:
 
-![VSCode - UI in browser tab](./ui/ui-guide_vscode-browser-ui.png)
+![VSCode - UI in browser tab](./ui/ui-guide_vscode-browser-ui.png){ loading=lazy }
 
 <br></br>
 <b>6.</b> Split the VSCode window to open a code editor alongside the UI. As you update models, the UI plan and lineage interfaces will update to reflect the changes in real time:
 
-![VSCode - update model plan](./ui/ui-guide_vscode-update-plan.png)
+![VSCode - update model plan](./ui/ui-guide_vscode-update-plan.png){ loading=lazy }
 
-![VSCode - update model lineage](./ui/ui-guide_vscode-update-lineage.png)
+![VSCode - update model lineage](./ui/ui-guide_vscode-update-lineage.png){ loading=lazy }

--- a/docs/quickstart/notebook.md
+++ b/docs/quickstart/notebook.md
@@ -38,13 +38,13 @@ If using a python virtual environment, ensure it's activated first by running th
 
 Import the SQLMesh library to load the notebook magic commands:
 
-![Cell importing the SQLMesh library](./notebook/nb-quickstart_import.png)
+![Cell importing the SQLMesh library](./notebook/nb-quickstart_import.png){ loading=lazy }
 
 Next, create a SQLMesh scaffold with the `%init` notebook magic, specifying a default SQL dialect for your models. The dialect should correspond to the dialect most of your models are written in; it can be overridden for specific models in the model's `MODEL` specification. All SQL dialects [supported by the SQLGlot library](https://github.com/tobymao/sqlglot/blob/main/sqlglot/dialects/dialect.py) are allowed.
 
 In this example, we specify the `duckdb` dialect:
 
-![Notebook output after project initiation](./notebook/nb-quickstart_init.png)
+![Notebook output after project initiation](./notebook/nb-quickstart_init.png){ loading=lazy }
 
 If the scaffold is successfully created, it will return `SQLMesh project scaffold created`.
 
@@ -126,7 +126,7 @@ Finally, the scaffold will include data for the example project to use.
 
 Inform SQLMesh of the project location by setting a context with the `%context` notebook magic. If the context is set successfully, it will return a message including the repository or list of repositories:
 
-![Notebook output after setting SQLMesh context](./notebook/nb-quickstart_context.png)
+![Notebook output after setting SQLMesh context](./notebook/nb-quickstart_context.png){ loading=lazy }
 
 You can specify multiple directories in one call to `%context` if your SQLMesh project has [multiple repositories](../guides/multi_repo.md).
 
@@ -240,7 +240,7 @@ The `seed_model` date range begins on the same day the plan was made because `SE
 
 Click the green button labeled `Apply - Backfill Tables` to apply the plan and initiate backfill. The following output will be displayed:
 
-![Notebook output after plan application](./notebook/nb-quickstart_apply-plan.png)
+![Notebook output after plan application](./notebook/nb-quickstart_apply-plan.png){ loading=lazy }
 
 The first output block shows the completion percentage and run time for each model (very fast in this simple example). The following line shows that the `prod` environment now points to the tables created during model execution.
 
@@ -252,15 +252,15 @@ Now that we have have populated the `prod` environment, let's modify one of the 
 
 We can modify the incremental SQL model using the `%model` *line* notebook magic (note the single `%`) and the model name:
 
-![%model line magic for sqlmesh_example.incremental_model](./notebook/nb-quickstart_model-line.png)
+![%model line magic for sqlmesh_example.incremental_model](./notebook/nb-quickstart_model-line.png){ loading=lazy }
 
 After we execute the cell, the contents will be replaced by the `%%model` *cell* notebook magic (note the double `%%`) and the model contents, along with a rendered version of the model SQL query. SQLMesh has automatically added explicit column aliases to the query (e.g., `id AS id`):
 
-![%%model cell magic for sqlmesh_example.incremental_model](./notebook/nb-quickstart_model-cell.png)
+![%%model cell magic for sqlmesh_example.incremental_model](./notebook/nb-quickstart_model-cell.png){ loading=lazy }
 
 We modify the incremental SQL model by adding a new column to the query. When we execute the cell it will write the updated model contents to the file and update the rendered version of the query:
 
-![%%model cell magic for updated sqlmesh_example.incremental_model](./notebook/nb-quickstart_model-cell-updated.png)
+![%%model cell magic for updated sqlmesh_example.incremental_model](./notebook/nb-quickstart_model-cell-updated.png){ loading=lazy }
 
 ## 4. Work with a development environment
 
@@ -269,7 +269,7 @@ Now that you've modified a model, it's time to create a development environment 
 
 Run `%plan dev` to create a development environment called `dev`. The following output will be displayed:
 
-![Notebook output after dev plan creation](./notebook/nb-quickstart_plan-dev.png)
+![Notebook output after dev plan creation](./notebook/nb-quickstart_plan-dev.png){ loading=lazy }
 
 The first block of output notes that `%plan` successfully executed the project's test `tests/test_full_model.yaml` with duckdb.
 
@@ -283,7 +283,7 @@ The `Models needing backfill` section shows that only the directly modified `inc
 
 Click the green button to perform the backfill:
 
-![Notebook output after dev plan application](./notebook/nb-quickstart_apply-plan-dev.png)
+![Notebook output after dev plan application](./notebook/nb-quickstart_apply-plan-dev.png){ loading=lazy }
 
 The output shows that SQLMesh created a new model version in `dev`. The last line of the output shows that SQLMesh applied the change to `sqlmesh_example__dev.incremental_model`. In the model schema, the suffix "`__dev`" indicates that it is in the `dev` environment.
 
@@ -294,7 +294,7 @@ You can now view this change by querying data from `incremental_model` with the 
 
 Note that the environment name `__dev` is appended to the schema namespace `sqlmesh_example` in the query:
 
-![Notebook output after executing %%fetchdf on `dev` incremental_model](./notebook/nb-quickstart_fetchdf-dev.png)
+![Notebook output after executing %%fetchdf on `dev` incremental_model](./notebook/nb-quickstart_fetchdf-dev.png){ loading=lazy }
 
 You can see that `new_column` was added to the dataset.
 
@@ -302,25 +302,25 @@ The production table was not modified; you can validate this by querying the pro
 
 Note that nothing has been appended to the schema namespace `sqlmesh_example` because `prod` is the default environment:
 
-![Notebook output after executing %%fetchdf on prod incremental_model before model update applied](./notebook/nb-quickstart_fetchdf-prod.png)
+![Notebook output after executing %%fetchdf on prod incremental_model before model update applied](./notebook/nb-quickstart_fetchdf-prod.png){ loading=lazy }
 
 The production table does not have `new_column` because the changes to `dev` have not yet been applied to `prod`.
 
 ## 5. Update the prod environment
 Now that we've tested the changes in dev, it's time to move them to production. Run `%plan` to plan and apply your changes to the `prod` environment:
 
-![Notebook output after executing %plan on prod](./notebook/nb-quickstart_apply-plan-prod-modified.png)
+![Notebook output after executing %plan on prod](./notebook/nb-quickstart_apply-plan-prod-modified.png){ loading=lazy }
 
 Click the green `Apply - Virtual Update` button to apply the plan and execute the backfill:
 
-![Notebook output after executing applying virtual update on prod](./notebook/nb-quickstart_apply-plan-prod-modified-update.png)
+![Notebook output after executing applying virtual update on prod](./notebook/nb-quickstart_apply-plan-prod-modified-update.png){ loading=lazy }
 
 Note that a backfill was not necessary and only a Virtual Update occurred.
 
 ### 5.2 Validate updates in prod
 Double-check that the data updated in `prod` by running `%%fetchdf` with the SQL query `select * from sqlmesh_example.incremental_model`:
 
-![Notebook output after executing %%fetchdf on prod incremental_model after model update applied](./notebook/nb-quickstart_fetchdf-prod-modified.png)
+![Notebook output after executing %%fetchdf on prod incremental_model after model update applied](./notebook/nb-quickstart_fetchdf-prod-modified.png){ loading=lazy }
 
 `new_column` is now present in the `prod` incremental model.
 

--- a/docs/quickstart/ui.md
+++ b/docs/quickstart/ui.md
@@ -148,11 +148,11 @@ sqlmesh ui
 
 After starting up, the SQLMesh web UI is served at `http://127.0.0.1:8000` by default:
 
-![SQLMesh web UI startup on CLI](./ui/ui-quickstart_cli.png)
+![SQLMesh web UI startup on CLI](./ui/ui-quickstart_cli.png){ loading=lazy }
 
 Navigate to the URL by clicking the link in your terminal (if supported) or copy-pasting it into your web browser:
 
-![SQLMesh web UI startup in browser](./ui/ui-quickstart_ui-startup.png)
+![SQLMesh web UI startup in browser](./ui/ui-quickstart_ui-startup.png){ loading=lazy }
 
 The SQLMesh UI default view contains five panes:
 
@@ -162,7 +162,7 @@ The SQLMesh UI default view contains five panes:
 4. Inspector provides settings and information based on recent actions and the currently active pane. (Note: inspector pane is collapsed by default. Expand it by clicking the hamburger button at the top of the collapsed pane - see previous image.)
 5. Details displays column-level lineage for models open in the editor and results of queries. (Note: details pane is collapsed by default. It will automatically expand upon opening a model in the editor or running a query.)
 
-![SQLMesh web UI panes](./ui/ui-quickstart_ui-startup-panes.png)
+![SQLMesh web UI panes](./ui/ui-quickstart_ui-startup-panes.png){ loading=lazy }
 
 It also contains nine buttons:
 
@@ -176,7 +176,7 @@ It also contains nine buttons:
 8. Format SQL query reformats a SQL query using SQLGlot's pretty layout.
 9. Change SQL dialect specifies the SQL dialect of the current tab for custom SQL queries. It does not affect the SQL dialect for the project.
 
-![SQLMesh web UI buttons](./ui/ui-quickstart_ui-startup-buttons.png)
+![SQLMesh web UI buttons](./ui/ui-quickstart_ui-startup-buttons.png){ loading=lazy }
 
 The default view contains four status indicators:
 
@@ -185,7 +185,7 @@ The default view contains four status indicators:
 3. Change indicator displays a summary of the changes in the project files relative to the most recently run SQLMesh plan in the selected environment.
 4. Error indicator displays the count of errors in the project.
 
-![SQLMesh web UI status indicators](./ui/ui-quickstart_ui-startup-status.png)
+![SQLMesh web UI status indicators](./ui/ui-quickstart_ui-startup-status.png){ loading=lazy }
 
 ## 3. Plan and apply environments
 ### 3.1 Create a prod environment
@@ -288,7 +288,7 @@ The pane contains multiple pieces of information about the plan:
     GROUP BY item_id
     ```
 
-![Run plan pane](./ui/ui-quickstart_run-plan.png)
+![Run plan pane](./ui/ui-quickstart_run-plan.png){ loading=lazy }
 
 Click the blue button labeled `Apply Changes And Backfill` to apply the plan and initiate backfill.
 
@@ -301,7 +301,7 @@ The `Snapshot Tables Created` indicates that [snapshots](../concepts/architectur
 
 The `Backfilled` section shows progress indicators for the backfill operations. The first progress indicator shows the total number of tasks and completion percentage for the entire backfill operation. The remaining progress bars show completion percentage and run time for each model (very fast in this simple example).
 
-![Apply plan pane](./ui/ui-quickstart_apply-plan.png)
+![Apply plan pane](./ui/ui-quickstart_apply-plan.png){ loading=lazy }
 
 Click the `Go Back` button to close the pane.
 
@@ -312,21 +312,21 @@ Now that you've created the production environment, it's time to create a develo
 
 Open the environment menu by clicking the button labeled `prod \/` next to the green `Plan` button on the top right. Type `dev` into the Environment field and click the blue `Add` button.
 
-![Open environment menu](./ui/ui-quickstart_create-dev.png)
+![Open environment menu](./ui/ui-quickstart_create-dev.png){ loading=lazy }
 
 The button now shows that the SQLMesh UI is working in the `dev` environment:
 
-![Working in dev environment](./ui/ui-quickstart_plan-dev.png)
+![Working in dev environment](./ui/ui-quickstart_plan-dev.png){ loading=lazy }
 
 Click the green `Plan` button, and a new pane will open:
 
-![Run plan on dev pane](./ui/ui-quickstart_run-plan-dev.png)
+![Run plan on dev pane](./ui/ui-quickstart_run-plan-dev.png){ loading=lazy }
 
 The output section does not list any added/modified models or backfills because `dev` is being created from the existing `prod` environment without modification. Because the project has not been modified, no new computations need to run and a virtual update occurs.
 
 Click the blue `Apply Virtual Update` button to apply the new plan:
 
-![Run plan on dev pane output](./ui/ui-quickstart_run-plan-dev-output.png)
+![Run plan on dev pane output](./ui/ui-quickstart_run-plan-dev-output.png){ loading=lazy }
 
 The output confirms that the tests, virtual update, snapshot table creation, and environment promotion steps have completed. Click the `Go Back` button to close the pane.
 
@@ -339,68 +339,68 @@ To modify the incremental SQL model, open it in the editor by clicking on it in 
 
 The `Details` pane at the bottom displays the project's table and column lineage.
 
-![Incremental model open in editor](./ui/ui-quickstart_incremental-model.png)
+![Incremental model open in editor](./ui/ui-quickstart_incremental-model.png){ loading=lazy }
 
 Modify the incremental SQL model by adding a new column to the query. Press `Cmd + S` (`Ctrl + S` on Windows) to save the modified model file and display the updated lineage:
 
-![Incremental model modified in editor](./ui/ui-quickstart_incremental-model-modified.png)
+![Incremental model modified in editor](./ui/ui-quickstart_incremental-model-modified.png){ loading=lazy }
 
 
 ## 4. Plan and apply updates
 Preview the impact of the change by clicking the green `Plan` button in the top right.
 
-![Plan pane after running plan with modified incremental model](./ui/ui-quickstart_run-plan-dev-modified.png)
+![Plan pane after running plan with modified incremental model](./ui/ui-quickstart_run-plan-dev-modified.png){ loading=lazy }
 
 The `Changes` section detects that we directly modified `incremental_model` and that `full_model` was indirectly modified because it selects from the incremental model. SQLMesh understood that the change was additive (added a column not used by `full_model`) and was automatically classified as a non-breaking change.
 
 The `Backfill` section shows that only `incremental_model` requires backfill. Click the blue `Apply Changes And Backfill` button to apply the plan and execute the backfill:
 
-![Plan after applying updated plan with modified incremental model](./ui/ui-quickstart_apply-plan-dev-modified.png)
+![Plan after applying updated plan with modified incremental model](./ui/ui-quickstart_apply-plan-dev-modified.png){ loading=lazy }
 
 SQLMesh applies the change to `sqlmesh_example.incremental_model` and backfills the model. The `Backfilled` section shows that the backfill completed successfully.
 
 ### 4.1 Validate updates in dev
 You can now view this change by querying data from `incremental_model`. Add the SQL query `select * from sqlmesh_example__dev.incremental_model` to the Custom SQL 1 tab in the editor:
 
-![Querying `dev` incremental model with SQL query in editor](./ui/ui-quickstart_fetchdf-dev.png)
+![Querying `dev` incremental model with SQL query in editor](./ui/ui-quickstart_fetchdf-dev.png){ loading=lazy }
 
 Note that the environment name `__dev` is appended to the schema namespace `sqlmesh_example` in the query: `select * from sqlmesh_example__dev.incremental_model`.
 
 Click the `Run Query` button in the bottom right to execute the query:
 
-![Results from querying dev incremental model with SQL query in editor](./ui/ui-quickstart_fetchdf-dev-results.png)
+![Results from querying dev incremental model with SQL query in editor](./ui/ui-quickstart_fetchdf-dev-results.png){ loading=lazy }
 
 You can see that `new_column` was added to the dataset. The production table was not modified; you can validate this by modifying the query so it selects from the production table with `select * from sqlmesh_example.incremental_model`.
 
 Note that nothing has been appended to the schema namespace `sqlmesh_example` because `prod` is the default environment.
 
-![Results from querying `prod` incremental model with SQL query in editor](./ui/ui-quickstart_fetchdf-prod.png)
+![Results from querying `prod` incremental model with SQL query in editor](./ui/ui-quickstart_fetchdf-prod.png){ loading=lazy }
 
 The production table does not have `new_column` because the changes to `dev` have not yet been applied to `prod`.
 
 ### 4.2 Apply updates to prod
 Now that we've tested the changes in dev, it's time to move them to prod. Open the environment menu in top right and select the `prod` environment:
 
-![`prod` environment selected in environment menu](./ui/ui-quickstart_plan-prod-modified.png)
+![`prod` environment selected in environment menu](./ui/ui-quickstart_plan-prod-modified.png){ loading=lazy }
 
 Click the green `Plan` button to open the run plan interface:
 
-![`prod` environment plan pane](./ui/ui-quickstart_plan-prod-modified-pane.png)
+![`prod` environment plan pane](./ui/ui-quickstart_plan-prod-modified-pane.png){ loading=lazy }
 
 Click the blue `Apply Virtual Update` button, and a warning screen will appear:
 
-![`prod` environment modification warning](./ui/ui-quickstart_plan-prod-modified-warning.png)
+![`prod` environment modification warning](./ui/ui-quickstart_plan-prod-modified-warning.png){ loading=lazy }
 
 Click the `Yes, Run prod` button to proceed with applying the plan:
 
-![`prod` environment after applying plan](./ui/ui-quickstart_apply-plan-prod-modified.png)
+![`prod` environment after applying plan](./ui/ui-quickstart_apply-plan-prod-modified.png){ loading=lazy }
 
 Note that a backfill was not necessary and only a Virtual Update occurred - the computations have already occurred when backfilling the model in `dev`. Click the `Go Back` button to close the pane.
 
 ### 4.3. Validate updates in prod
 Double-check that the data updated in `prod` by re-running the SQL query from the editor. Click the `Run Query` button to execute the query:
 
-![Results from querying updated `prod` incremental model with SQL query in editor](./ui/ui-quickstart_fetchdf-prod-modified.png)
+![Results from querying updated `prod` incremental model with SQL query in editor](./ui/ui-quickstart_fetchdf-prod-modified.png){ loading=lazy }
 
 `new_column` is now present in the `prod` incremental model.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,8 @@ markdown_extensions:
       alternate_style: true
   - admonition
   - pymdownx.details
+  - attr_list
+  - md_in_html
 extra_css:
   - stylesheets/extra.css
 copyright: Tobiko Data Inc.


### PR DESCRIPTION
This PR adds lazy image loading to the docs pages containing many images (annoyingly, it cannot be set as default so must be appended to every image inline).