### PR TITLE
Chore!: Ensure databricks-connect is actually installed before running Databricks tests

### DIFF
--- a/.circleci/install-prerequisites.sh
+++ b/.circleci/install-prerequisites.sh
@@ -14,13 +14,9 @@ ENGINE="$1"
 
 COMMON_DEPENDENCIES="libpq-dev netcat-traditional"
 ENGINE_DEPENDENCIES=""
-PIP_DEPENDENCIES=""
 
 if [ "$ENGINE" == "spark" ]; then
     ENGINE_DEPENDENCIES="default-jdk"
-elif [ "$ENGINE" == "databricks" ]; then
-    # databricks-connect version needs to match the target cluster version that the tests are being run against
-    PIP_DEPENDENCIES="databricks-connect==15.3.*"
 fi
 
 ALL_DEPENDENCIES="$COMMON_DEPENDENCIES $ENGINE_DEPENDENCIES"
@@ -28,10 +24,5 @@ ALL_DEPENDENCIES="$COMMON_DEPENDENCIES $ENGINE_DEPENDENCIES"
 echo "Installing OS-level dependencies: $ALL_DEPENDENCIES"
 
 sudo apt-get -y update && sudo apt-get -y install $ALL_DEPENDENCIES
-
-if [ "$PIP_DEPENDENCIES" != "" ]; then
-    echo "Installing extra pip dependencies"
-    pip install "$PIP_DEPENDENCIES"
-fi
 
 echo "All done"

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,8 @@ snowflake-test: guard-SNOWFLAKE_ACCOUNT guard-SNOWFLAKE_WAREHOUSE guard-SNOWFLAK
 bigquery-test: guard-BIGQUERY_KEYFILE engine-bigquery-install
 	pytest -n auto -x -m "bigquery" --junitxml=test-results/junit-bigquery.xml
 
-databricks-test: guard-DATABRICKS_CATALOG guard-DATABRICKS_SERVER_HOSTNAME guard-DATABRICKS_HTTP_PATH guard-DATABRICKS_ACCESS_TOKEN engine-databricks-install
+databricks-test: guard-DATABRICKS_CATALOG guard-DATABRICKS_SERVER_HOSTNAME guard-DATABRICKS_HTTP_PATH guard-DATABRICKS_ACCESS_TOKEN guard-DATABRICKS_CONNECT_VERSION engine-databricks-install
+	pip install 'databricks-connect==${DATABRICKS_CONNECT_VERSION}'
 	pytest -n auto -x -m "databricks" --junitxml=test-results/junit-databricks.xml
 
 redshift-test: guard-REDSHIFT_HOST guard-REDSHIFT_USER guard-REDSHIFT_PASSWORD guard-REDSHIFT_DATABASE engine-redshift-install

--- a/tests/core/engine_adapter/config.yaml
+++ b/tests/core/engine_adapter/config.yaml
@@ -49,6 +49,7 @@ gateways:
       type: spark
       config:
         spark.remote: sc://localhost
+      concurrent_tasks: 1
     state_connection:
       type: duckdb
   inttest_mssql:
@@ -95,6 +96,7 @@ gateways:
       server_hostname: {{ env_var('DATABRICKS_SERVER_HOSTNAME') }}
       http_path: {{ env_var('DATABRICKS_HTTP_PATH') }}
       access_token: {{ env_var('DATABRICKS_ACCESS_TOKEN') }}
+      concurrent_tasks: 1
     state_connection:
       type: duckdb
 


### PR DESCRIPTION
`databricks-connect` needs to be installed after the main python dependencies but before tests are run (if it's installed before the main python dependencies then I get a bunch of ImportError's)

this PR modifies its installation to be part of `make databricks-test` and adds an extra requirement for a `DATABRICKS_CONNECT_VERSION` environment variable to be present to allow the user to set the correct version for their cluster