### PR TITLE
Fix: conditional statement parsing edge case

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -454,7 +454,13 @@ def _parse_if(self: Parser) -> t.Optional[exp.Expression]:
         else:
             self.raise_error("Expecting )")
 
-        return exp.Anonymous(this="IF", expressions=[cond, self._parse_statement()])
+        index = self._index
+        stmt = self._parse_statement()
+        if self._curr:
+            self._retreat(index)
+            stmt = self._parse_as_command(self._tokens[index])
+
+        return exp.Anonymous(this="IF", expressions=[cond, stmt])
 
 
 def _create_parser(parser_type: t.Type[exp.Expression], table_keys: t.List[str]) -> t.Callable:

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -606,3 +606,6 @@ def test_conditional_statement():
         q.sql("snowflake")
         == "@IF(TRUE, COPY INTO 's3://example/data.csv' FROM EXTRA.EXAMPLE.TABLE STORAGE_INTEGRATION = S3_INTEGRATION FILE_FORMAT = (TYPE=CSV COMPRESSION=NONE NULL_IF=('') FIELD_OPTIONALLY_ENCLOSED_BY='\"') HEADER = TRUE OVERWRITE = TRUE SINGLE = TRUE /* this is a comment */)"
     )
+
+    q = parse_one("@IF(cond, VACUUM ANALYZE);", read="postgres")
+    assert q.sql(dialect="postgres") == "@IF(cond, VACUUM ANALYZE)"


### PR DESCRIPTION
This PR aims to fix the following case:

```
>>> from sqlmesh.core.dialect import parse_one
>>> parse_one("@IF(cond, VACUUM ANALYZE)", dialect="postgres")
'@IF(cond, VACUUM ANALYZE' contains unsupported syntax. Falling back to parsing as a 'Command'.
Alias(
  this=MacroFunc(
    this=Anonymous(
      this=IF,
      expressions=[
        Column(
          this=Identifier(this=cond, quoted=False)),
        Command(this=VACUUM)])),
  alias=Identifier(this=ANALYZE, quoted=False))
```

The problem is that we're currently producing an `Alias` node as shown above, which happens because SQLGlot tokenizes both `VACUUM` and `ANALYZE` as `TokenType.COMMAND`, instead of producing a `STRING` for the latter.

This is a SQLMesh-related edge case, since SQLGlot doesn't generally expect a statement to show within a function, such as `@IF` in this case.