### PR TITLE
Fix!: enable loading of Snowflake models that use staged file paths

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -101,8 +101,10 @@ class MetricAgg(exp.AggFunc):
         return self.this.name
 
 
-class StagedFilePath(exp.Table):
+class StagedFilePath(exp.Expression):
     """Represents paths to "staged files" in Snowflake."""
+
+    arg_types = exp.Table.arg_types.copy()
 
 
 def _parse_statement(self: Parser) -> t.Optional[exp.Expression]:
@@ -409,7 +411,7 @@ def _parse_types(
 # See: https://docs.snowflake.com/en/user-guide/querying-stage
 def _parse_table_parts(
     self: Parser, schema: bool = False, is_db_reference: bool = False
-) -> exp.Table:
+) -> exp.Table | StagedFilePath:
     index = self._index
     table = self.__parse_table_parts(schema=schema, is_db_reference=is_db_reference)  # type: ignore
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -5371,3 +5371,16 @@ def test_trailing_comments():
     model = load_sql_based_model(expressions, path=Path("./examples/sushi/models/test_model.sql"))
     assert not model.render_pre_statements()
     assert not model.render_post_statements()
+
+
+def test_staged_file_path():
+    expressions = d.parse(
+        """
+        MODEL (name test, dialect snowflake);
+
+        SELECT * FROM @a.b/c/d.csv(FILE_FORMAT => 'b.ff')
+        """
+    )
+    model = load_sql_based_model(expressions)
+    query = model.render_query()
+    assert query.sql(dialect="snowflake") == "SELECT * FROM @a.b/c/d.csv (FILE_FORMAT => 'b.ff')"


### PR DESCRIPTION
Right now, Snowflake models that contain queries like:

```sql
SELECT ... FROM @mystage2/data1.json.gz
```

or

```sql
SELECT ... FROM @path.to/some/serialized_dag.csv(FILE_FORMAT => 'foo.bar')
```

can't be loaded by SQLMesh, because:

1. Staged file paths are [subclasses](https://github.com/TobikoData/sqlmesh/blob/ad7edce4f825fc677179b464efd861d617890e8a/sqlmesh/core/dialect.py#L104) of `Table`, meaning that [they're picked up as dependencies](https://github.com/TobikoData/sqlmesh/blob/ad7edce4f825fc677179b464efd861d617890e8a/sqlmesh/core/dialect.py#L995-L1000) (`depends_on`) in models
2. This [line](https://github.com/TobikoData/sqlmesh/blob/ad7edce4f825fc677179b464efd861d617890e8a/sqlmesh/core/model/definition.py#L552) is reached and we fail to parse the staged file path syntax because there's no dialect specified, and only the Snowflake dialect can parse that syntax (there's at least another [place](https://github.com/TobikoData/sqlmesh/blob/ad7edce4f825fc677179b464efd861d617890e8a/sqlmesh/core/renderer.py#L478) where the same thing happens later in the control flow)

For (2), one alternative could be to try and move the parsing logic for staged file paths to the base parser, but that's problematic for two reasons:

a. We'd need to also move Snowflake's override of `_parse_table_parts` to the base parser in SQLGlot, introducing more complexity only to address a SQLMesh-specific problem
b. We could open ourselves to more failures caused by the clash between SQLMesh's macro `@...` syntax and the staged file path syntax. We've already come across various edge cases for Snowflake, and so applying that logic to all dialects could result in unexpected breakages

This PR takes the approach of not treating staged file path references as dependencies altogether, thus we shouldn't hit the problematic line that leads to the parse error. I believe this means users won't be able to specify schemas for these refs as they can for external models, but it _should_ still be possible to list out the columns to types explicitly, either in the projections or using the `columns` property?

Happy to pivot into a different solution if there are other ideas.