### PR TITLE
Feat!: Support pre-post statements in python models at creation time

### DIFF
--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -329,7 +329,7 @@ class SqlMeshLoader(Loader):
         """
         models = self._load_sql_models(macros, jinja_macros, audits)
         models.update(self._load_external_models(gateway))
-        models.update(self._load_python_models(macros))
+        models.update(self._load_python_models(macros, jinja_macros))
 
         return models
 
@@ -392,7 +392,9 @@ class SqlMeshLoader(Loader):
 
         return models
 
-    def _load_python_models(self, macros: MacroRegistry) -> UniqueKeyDict[str, Model]:
+    def _load_python_models(
+        self, macros: MacroRegistry, jinja_macros: JinjaMacroRegistry
+    ) -> UniqueKeyDict[str, Model]:
         """Loads the python models into a Dict"""
         models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")
         registry = model_registry.registry()
@@ -421,6 +423,8 @@ class SqlMeshLoader(Loader):
                             path=path,
                             module_path=context_path,
                             defaults=config.model_defaults.dict(),
+                            macros=macros,
+                            jinja_macros=jinja_macros,
                             dialect=config.model_defaults.dialect,
                             time_column_format=config.time_column_format,
                             physical_schema_override=config.physical_schema_override,

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -416,9 +416,6 @@ class SqlMeshLoader(Loader):
                     new = registry.keys() - registered
                     registered |= new
                     for name in new:
-                        if macros:
-                            macro.set_registry(macros)
-
                         model = registry[name].model(
                             path=path,
                             module_path=context_path,

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -329,7 +329,7 @@ class SqlMeshLoader(Loader):
         """
         models = self._load_sql_models(macros, jinja_macros, audits)
         models.update(self._load_external_models(gateway))
-        models.update(self._load_python_models())
+        models.update(self._load_python_models(macros))
 
         return models
 
@@ -392,7 +392,7 @@ class SqlMeshLoader(Loader):
 
         return models
 
-    def _load_python_models(self) -> UniqueKeyDict[str, Model]:
+    def _load_python_models(self, macros: MacroRegistry) -> UniqueKeyDict[str, Model]:
         """Loads the python models into a Dict"""
         models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")
         registry = model_registry.registry()
@@ -414,6 +414,9 @@ class SqlMeshLoader(Loader):
                     new = registry.keys() - registered
                     registered |= new
                     for name in new:
+                        if macros:
+                            macro.set_registry(macros)
+
                         model = registry[name].model(
                             path=path,
                             module_path=context_path,

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -8,6 +8,8 @@ import inspect
 from sqlglot import exp
 from sqlglot.dialects.dialect import DialectType
 
+from sqlmesh.core.macros import MacroRegistry
+from sqlmesh.utils.jinja import JinjaMacroRegistry
 from sqlmesh.core import constants as c
 from sqlmesh.core.dialect import MacroFunc
 from sqlmesh.core.model.definition import (
@@ -75,6 +77,8 @@ class model(registry_decorator):
         module_path: Path,
         path: Path,
         defaults: t.Optional[t.Dict[str, t.Any]] = None,
+        macros: t.Optional[MacroRegistry] = None,
+        jinja_macros: t.Optional[JinjaMacroRegistry] = None,
         dialect: t.Optional[str] = None,
         time_column_format: str = c.DEFAULT_TIME_COLUMN_FORMAT,
         physical_schema_override: t.Optional[t.Dict[str, str]] = None,
@@ -132,5 +136,12 @@ class model(registry_decorator):
             )
 
         return create_python_model(
-            self.name, entrypoint, columns=self.columns, dialect=dialect, **common_kwargs
+            self.name,
+            entrypoint,
+            module_path=module_path,
+            macros=macros,
+            jinja_macros=jinja_macros,
+            columns=self.columns,
+            dialect=dialect,
+            **common_kwargs,
         )

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -11,7 +11,7 @@ from sqlglot.dialects.dialect import DialectType
 from sqlmesh.core.macros import MacroRegistry
 from sqlmesh.utils.jinja import JinjaMacroRegistry
 from sqlmesh.core import constants as c
-from sqlmesh.core.dialect import MacroFunc
+from sqlmesh.core.dialect import MacroFunc, parse_one
 from sqlmesh.core.model.definition import (
     Model,
     create_python_model,
@@ -127,7 +127,7 @@ class model(registry_decorator):
         for key in ("pre_statements", "post_statements"):
             statements = common_kwargs.get(key)
             if statements:
-                common_kwargs[key] = [exp.maybe_parse(s, dialect=dialect) for s in statements]
+                common_kwargs[key] = [parse_one(s, dialect=dialect) for s in statements]
 
         if self.is_sql:
             query = MacroFunc(this=exp.Anonymous(this=entrypoint))

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -127,7 +127,9 @@ class model(registry_decorator):
         for key in ("pre_statements", "post_statements"):
             statements = common_kwargs.get(key)
             if statements:
-                common_kwargs[key] = [parse_one(s, dialect=dialect) for s in statements]
+                common_kwargs[key] = [
+                    parse_one(s, dialect=dialect) if isinstance(s, str) else s for s in statements
+                ]
 
         if self.is_sql:
             query = MacroFunc(this=exp.Anonymous(this=entrypoint))

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -965,7 +965,7 @@ def test_python_model_jinja_pre_post_statements():
         ],
         post_statements=[
             "JINJA_STATEMENT_BEGIN;\nCREATE INDEX {{test_macro('idx')}} ON db.test_model(id);\nJINJA_END;",
-            "DROP TABLE x2;",
+            parse_one("DROP TABLE x2;"),
         ],
     )
     def model_with_statements(context, **kwargs):

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -49,7 +49,7 @@ from sqlmesh.core.node import IntervalUnit, _Node
 from sqlmesh.core.snapshot import Snapshot, SnapshotChangeCategory
 from sqlmesh.utils.date import TimeLike, to_datetime, to_ds, to_timestamp
 from sqlmesh.utils.errors import ConfigError, SQLMeshError
-from sqlmesh.utils.jinja import JinjaMacroRegistry, MacroInfo
+from sqlmesh.utils.jinja import JinjaMacroRegistry, MacroInfo, MacroExtractor
 from sqlmesh.utils.metaprogramming import Executable
 
 
@@ -945,6 +945,66 @@ def test_seed_with_special_characters_in_column(tmp_path, assert_exp_eq):
         'CAST("col!@#$" AS TEXT) AS "col!@#$" '
         """FROM (VALUES (123, 'foo')) AS t("col.", "col!@#$")""",
     )
+
+
+def test_python_model_jinja_pre_post_statements():
+    macros = """
+    {% macro test_macro(v) %}{{ v }}{% endmacro %}
+    {% macro extra_macro(v) %}{{ v + 1 }}{% endmacro %}
+    """
+
+    jinja_macros = JinjaMacroRegistry()
+    jinja_macros.add_macros(MacroExtractor().extract(macros))
+
+    @model(
+        "db.test_model",
+        kind="full",
+        columns={"id": "string", "name": "string"},
+        pre_statements=[
+            "JINJA_STATEMENT_BEGIN;\n{% set table_name = 'x' %}\nCREATE OR REPLACE TABLE {{table_name}}{{ 1 + 1 }};\nJINJA_END;"
+        ],
+        post_statements=[
+            "JINJA_STATEMENT_BEGIN;\nCREATE INDEX {{test_macro('idx')}} ON db.test_model(id);\nJINJA_END;",
+            "DROP TABLE x2;",
+        ],
+    )
+    def model_with_statements(context, **kwargs):
+        return pd.DataFrame(
+            [
+                {
+                    "id": context.var("1"),
+                    "name": context.var("var"),
+                }
+            ]
+        )
+
+    python_model = model.get_registry()["db.test_model"].model(
+        module_path=Path("."), path=Path("."), dialect="duckdb", jinja_macros=jinja_macros
+    )
+
+    assert len(jinja_macros.root_macros) == 2
+    assert len(python_model.jinja_macros.root_macros) == 1
+    assert "test_macro" in python_model.jinja_macros.root_macros
+    assert "extra_macro" not in python_model.jinja_macros.root_macros
+
+    expected_pre = [
+        d.jinja_statement(
+            "{% set table_name = 'x' %}\nCREATE OR REPLACE TABLE {{table_name}}{{ 1 + 1 }};"
+        ),
+    ]
+    assert python_model.pre_statements == expected_pre
+    assert python_model.render_pre_statements()[0].sql() == 'CREATE OR REPLACE TABLE "x2"'
+
+    expected_post = [
+        d.jinja_statement("CREATE INDEX {{test_macro('idx')}} ON db.test_model(id);"),
+        *d.parse("DROP TABLE x2;"),
+    ]
+    assert python_model.post_statements == expected_post
+    assert (
+        python_model.render_post_statements()[0].sql()
+        == 'CREATE INDEX "idx" ON "db"."test_model"("id" NULLS LAST)'
+    )
+    assert python_model.render_post_statements()[1].sql() == 'DROP TABLE "x2"'
 
 
 def test_audits():

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -552,7 +552,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
     assert len(output.outputs) == 3
     assert convert_all_html_output_to_text(output) == [
         "Models: 17",
-        "Macros: 5",
+        "Macros: 0",
         "Data warehouse connection succeeded",
     ]
     assert get_all_html_output(output) == [
@@ -582,7 +582,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
                     h(
                         "span",
                         {"style": f"{NEUTRAL_STYLE}; font-weight: bold"},
-                        "5",
+                        "0",
                         autoescape=False,
                     )
                 ),

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -552,7 +552,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
     assert len(output.outputs) == 3
     assert convert_all_html_output_to_text(output) == [
         "Models: 17",
-        "Macros: 0",
+        "Macros: 5",
         "Data warehouse connection succeeded",
     ]
     assert get_all_html_output(output) == [
@@ -582,7 +582,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
                     h(
                         "span",
                         {"style": f"{NEUTRAL_STYLE}; font-weight: bold"},
-                        "0",
+                        "5",
                         autoescape=False,
                     )
                 ),


### PR DESCRIPTION
This update introduces the ability to enable pre- and post-statements in python models that can be executed during the table creation phase, fixes: #2866 

The SqlBased model renderers has been moved to the `_Model` class, so that the logic can be reused by python models. Also to support macro calls in the pre- and post-statements, the python environment is updated with the referenced macros (similarly to sql models).