### PR TITLE
Fix!: Send notifications for failing non-blocking audits from the builtin scheduler

### DIFF
--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -227,7 +227,7 @@ class Scheduler:
         )
 
         audit_error_to_raise: t.Optional[AuditError] = None
-        for audit_result in [result for result in audit_results if result.count]:
+        for audit_result in (result for result in audit_results if result.count):
             error = AuditError(
                 audit_name=audit_result.audit.name,
                 model=snapshot.model_or_none,

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -601,7 +601,7 @@ def test_audit_failure_notifications(
     assert notify_user_mock.call_count == 0
     assert notify_mock.call_count == 0
 
-    audit = audit.model_copy(update={"blocking": False})
+    audit = audit.copy(update={"blocking": False})
     evaluator_audit_mock.return_value = [
         AuditResult(audit=audit, model=waiter_names.model, count=1, skipped=False)
     ]
@@ -611,7 +611,7 @@ def test_audit_failure_notifications(
     notify_user_mock.reset_mock()
     notify_mock.reset_mock()
 
-    audit = audit.model_copy(update={"blocking": True})
+    audit = audit.copy(update={"blocking": True})
     evaluator_audit_mock.return_value = [
         AuditResult(audit=audit, model=waiter_names.model, count=1, skipped=False)
     ]

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -584,6 +584,8 @@ def test_audit_failure_notifications(
             DeployabilityIndex.all_deployable(),
             0,
         )
+        _, kwargs = evaluator_audit_mock.call_args_list[0]
+        assert not kwargs["raise_exception"]
 
     evaluator_audit_mock.return_value = [
         AuditResult(audit=audit, model=waiter_names.model, count=0, skipped=False)


### PR DESCRIPTION
Currently, the builtin-scheduler only sends notifications when the `SnapshotEvaluator` raises an `AuditError` exception, which only happens for failing, blocking audits.

This PR addresses two things. First, it delays when the `AuditError` is raised, so that all of the snapshot's audits execute first and second, it sends notifications for all audits that failed, blocking or non-blocking.