### PR TITLE
Fix: ensure Context.close doesn't unnecessarily create a state sync db

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -11,7 +11,7 @@ For more information regarding what a context can do, see `sqlmesh.core.context.
 Creating and applying a plan against the staging environment.
 ```python
 from sqlmesh.core.context import Context
-context = Context(path="example", config="local_config")
+context = Context(paths="example", config="local_config")
 plan = context.plan("staging")
 context.apply(plan)
 ```
@@ -19,14 +19,14 @@ context.apply(plan)
 Running audits on your data.
 ```python
 from sqlmesh.core.context import Context
-context = Context(path="example", config="local_config")
+context = Context(paths="example", config="local_config")
 context.audit("yesterday", "now")
 ```
 
 Running tests on your models.
 ```python
 from sqlmesh.core.context import Context
-context = Context(path="example")
+context = Context(paths="example")
 context.test()
 ```
 """
@@ -1721,7 +1721,8 @@ class GenericContext(BaseContext, t.Generic[C]):
     def close(self) -> None:
         """Releases all resources allocated by this context."""
         self.snapshot_evaluator.close()
-        self.state_sync.close()
+        if self._state_sync:
+            self._state_sync.close()
 
     def _run(
         self,

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1720,7 +1720,8 @@ class GenericContext(BaseContext, t.Generic[C]):
 
     def close(self) -> None:
         """Releases all resources allocated by this context."""
-        self.snapshot_evaluator.close()
+        if self._snapshot_evaluator:
+            self._snapshot_evaluator.close()
         if self._state_sync:
             self._state_sync.close()
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -9,6 +9,7 @@ from freezegun import freeze_time
 
 from sqlmesh.cli.example_project import init_example_project
 from sqlmesh.cli.main import cli
+from sqlmesh.core.context import Context
 
 FREEZE_TIME = "2023-01-01 00:00:00"
 
@@ -642,3 +643,20 @@ def test_table_name(runner, tmp_path):
         )
     assert result.exit_code == 0
     assert result.output.startswith("db.sqlmesh__sqlmesh_example.sqlmesh_example__full_model__")
+
+
+def test_info_on_new_project_does_not_create_state_sync(runner, tmp_path):
+    create_example_project(tmp_path)
+
+    # Invoke the info command
+    result = runner.invoke(cli, ["--log-file-dir", tmp_path, "--paths", tmp_path, "info"])
+    assert result.exit_code == 0
+
+    context = Context(paths=tmp_path)
+
+    # Confirm that the state sync tables haven't been created
+    assert not context.engine_adapter.table_exists("sqlmesh._snapshots")
+    assert not context.engine_adapter.table_exists("sqlmesh._environments")
+    assert not context.engine_adapter.table_exists("sqlmesh._intervals")
+    assert not context.engine_adapter.table_exists("sqlmesh._plan_dags")
+    assert not context.engine_adapter.table_exists("sqlmesh._versions")


### PR DESCRIPTION
@treysp noticed that `sqlmesh info` triggers all migrations in a fresh project (e.g. `sqlmesh init duckdb`), which is weird. This happens because the CLI calls `close()` on the instantiated context and in turn that results in doing `self.state_sync` within that method, which creates a new state sync and populates it. We only need to do that if `_state_sync` actually exists.