### PR TITLE
Fix!: Regression in Snowflake Python models using Snowpark DataFrame's

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,8 @@ setup(
             # https://github.com/dbt-labs/dbt-snowflake/blob/main/dev-requirements.txt#L12
             "cryptography~=42.0.4",
             "snowflake-connector-python[pandas,secure-local-storage]",
+            # as at 2024-08-05, snowflake-snowpark-python is only available up to Python 3.11
+            "snowflake-snowpark-python; python_version<'3.12'",
         ],
         "trino": [
             "trino",

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -371,7 +371,7 @@ def test_missing_intervals_end_bounded_with_ignore_cron(make_snapshot):
 
 
 def test_missing_intervals_past_end_date_with_lookback(make_snapshot):
-    snapshot: Snapshot = make_snapshot(
+    snapshot: Snapshot = make_snapshot(  # type: ignore
         SqlModel(
             name="test_model",
             kind=IncrementalByTimeRangeKind(time_column=TimeColumn(column="ds"), lookback=2),


### PR DESCRIPTION
Prior to this change, attempting to create a Python model on Snowflake utilising a Snowpark DataFrame would produce the following error:

```
snowflake.connector.errors.ProgrammingError: SQL compilation error:  Object found is of type 'VIEW', not specified type 'TABLE'.
```

This is because for Snowpark, the DataFrame is made available via `CREATE TEMPORARY VIEW` but the cleanup logic in the Snowflake engine adapter assumed a Table (because Pandas DataFrames use Tables) and tried to issue `DROP TABLE` instead of `DROP VIEW`.

Now the cleanup logic will issue `DROP VIEW` if a Snowpark DataFrame is in use.

In order to add a test for this, I had to re-introduce a dependency on `snowflake-snowpark-python` (first introduced in #2666 and then removed in #2761)

Since Snowpark doesnt work on Python 3.12, I also added some guards to only install it on Python < 3.12 and also skip the test if Snowpark is not available