### PR TITLE
Fix: add gateway name to model cache identifier

### DIFF
--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -542,7 +542,7 @@ class SqlMeshLoader(Loader):
                     # default catalog), and it is retained in cached model's fully
                     # qualified name
                     self._loader._context.default_catalog or "",
-                    # gateway can change at runtime, and it is retained in a cached
+                    # gateway is configurable, and it is retained in a cached
                     # model's python environment if the @gateway macro variable is
                     # used in the model
                     self._loader._context.gateway

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -538,9 +538,14 @@ class SqlMeshLoader(Loader):
                 [
                     str(max(m for m in mtimes if m is not None)),
                     self._loader._context.config.fingerprint,
-                    # We need to check default catalog since the provided config could not change but the
-                    # gateway we are using could change, therefore potentially changing the default catalog
-                    # which would then invalidate the cached model definition.
+                    # default catalog can change outside sqlmesh (e.g., DB user's
+                    # default catalog), and it is retained in cached model's fully
+                    # qualified name
                     self._loader._context.default_catalog or "",
+                    # gateway can change at runtime, and it is retained in a cached
+                    # model's python environment if the @gateway macro variable is
+                    # used in the model
+                    self._loader._context.gateway
+                    or self._loader._context.config.default_gateway_name,
                 ]
             )

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -704,7 +704,7 @@ def test_default_catalog_connections(copy_to_temp_path: t.Callable):
         "sqlmesh.core.engine_adapter.base.EngineAdapter.default_catalog",
         PropertyMock(return_value=None),
     ):
-        context = Context(paths="examples/sushi")
+        context = Context(paths=copy_to_temp_path("examples/sushi"))
         assert context.default_catalog is None
 
     # Verify that providing a catalog gets set as default catalog


### PR DESCRIPTION
Model definitions are cached by the SQLMesh loader. Currently, the cached model ID consists of the latest time any project files were modified, a fingerprint of the context config object, and the context's default catalog. 

If a model uses the `@gateway` macro variable, its value will be stored in the model's python environment and included in the cache. If the project is run with a different gateway, a cache hit can occur with the wrong gateway value being rendered into the model.

This PR fixes this by adding the gateway name to the model cache ID. 

Implications:
- All project models will have a cache miss when the gateway changes. The miss will be unnecessary for all models that do not use the `@gateway` macro variable.
- An alternative approach is to leave the cache ID as-is, and after cache read check whether the gateway has changed and the `@gateway` macro variable is used. That approach will result in unnecessary cache hits when the gateway has changed and is used in the model.