### PR TITLE
Chore: fix sushi waiters default_catalog capitalization

### DIFF
--- a/examples/sushi/models/items.py
+++ b/examples/sushi/models/items.py
@@ -94,4 +94,4 @@ def execute(
             .rename(columns={"index": "id"})
         )
 
-    return pd.concat(dfs)
+    return pd.concat(dfs).reset_index(drop=True)

--- a/examples/sushi/models/order_items.py
+++ b/examples/sushi/models/order_items.py
@@ -99,4 +99,4 @@ def execute(
                 .rename(columns={"index": "id"})
             )
 
-        yield pd.concat(dfs)
+        yield pd.concat(dfs).reset_index(drop=True)

--- a/examples/sushi/models/orders.py
+++ b/examples/sushi/models/orders.py
@@ -69,4 +69,4 @@ def execute(
             .rename(columns={"index": "id"})
         )
 
-    return pd.concat(dfs)
+    return pd.concat(dfs).reset_index(drop=True)

--- a/examples/sushi/models/raw_marketing.py
+++ b/examples/sushi/models/raw_marketing.py
@@ -67,5 +67,5 @@ def execute(
         errors="coerce",
         utc=True,
     )
-    df = df.drop(columns=["status_old", "updated_at_old"])
+    df = df.drop(columns=["status_old", "updated_at_old"]).reset_index(drop=True)
     return df


### PR DESCRIPTION
And address pandas warnings by resetting DF indexes in sushi python models

Context:
- Snowflake normalizes unquoted object names to uppercase, which can cause case mismatches with default_catalog due to sqlmesh's default normalization behavior. 
- SQLMesh addresses this by rewriting the default catalog name on the fly in snowflake `_to_sql()`. 
- Sushi's waiters.py model code manually extracts default_catalog name prior to the rewriting, so we must manually lowercase the default_catalog if the parent catalog name is an uppercase version of the default catalog name.