### PR TITLE
Feat: Add support for dbt sources external location defined in meta

### DIFF
--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -211,12 +211,6 @@ def generate_source(sources: t.Dict[str, t.Any], api: Api) -> t.Callable:
         if relation_info is None:
             logger.debug("Could not resolve source package='%s' name='%s'", package, name)
             return None
-        external_location = relation_info["source_meta"].get("external_location", None)
-        if external_location:
-            relation_info["external"] = external_location.replace(
-                "{name}", relation_info.identifier
-            )
-
         return _relation_info_to_relation(relation_info, api.Relation, api.quote_policy)
 
     return source

--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -211,6 +211,11 @@ def generate_source(sources: t.Dict[str, t.Any], api: Api) -> t.Callable:
         if relation_info is None:
             logger.debug("Could not resolve source package='%s' name='%s'", package, name)
             return None
+        external_location = relation_info["source_meta"].get("external_location", None)
+        if external_location:
+            relation_info["external"] = external_location.replace(
+                "{name}", relation_info.identifier
+            )
 
         return _relation_info_to_relation(relation_info, api.Relation, api.quote_policy)
 

--- a/sqlmesh/dbt/source.py
+++ b/sqlmesh/dbt/source.py
@@ -44,6 +44,7 @@ class SourceConfig(GeneralConfig):
     loaded_at_field: t.Optional[str] = None
     quoting: t.Dict[str, t.Optional[bool]] = {}
     external: t.Optional[t.Dict[str, t.Any]] = {}
+    source_meta: t.Optional[t.Dict[str, t.Any]] = {}
     columns: t.Dict[str, ColumnConfig] = {}
 
     _canonical_name: t.Optional[str] = None
@@ -93,5 +94,7 @@ class SourceConfig(GeneralConfig):
                 "identifier": self.table_name,
                 "type": RelationType.External.value,
                 "quote_policy": AttributeDict(self.quoting),
+                "external": self.external,
+                "source_meta": self.source_meta,
             }
         )

--- a/sqlmesh/dbt/source.py
+++ b/sqlmesh/dbt/source.py
@@ -87,6 +87,15 @@ class SourceConfig(GeneralConfig):
 
     @property
     def relation_info(self) -> AttributeDict:
+        external_location = (
+            self.source_meta.get("external_location", None) if self.source_meta else None
+        )
+        external = (
+            {"external": external_location.replace("{name}", self.table_name)}
+            if external_location
+            else {}
+        )
+
         return AttributeDict(
             {
                 "database": self.database,
@@ -94,7 +103,6 @@ class SourceConfig(GeneralConfig):
                 "identifier": self.table_name,
                 "type": RelationType.External.value,
                 "quote_policy": AttributeDict(self.quoting),
-                "external": self.external,
-                "source_meta": self.source_meta,
+                **external,
             }
         )

--- a/sqlmesh/dbt/source.py
+++ b/sqlmesh/dbt/source.py
@@ -87,14 +87,12 @@ class SourceConfig(GeneralConfig):
 
     @property
     def relation_info(self) -> AttributeDict:
+        extras = {}
         external_location = (
             self.source_meta.get("external_location", None) if self.source_meta else None
         )
-        external = (
-            {"external": external_location.replace("{name}", self.table_name)}
-            if external_location
-            else {}
-        )
+        if external_location:
+            extras["external"] = external_location.replace("{name}", self.table_name)
 
         return AttributeDict(
             {
@@ -103,6 +101,6 @@ class SourceConfig(GeneralConfig):
                 "identifier": self.table_name,
                 "type": RelationType.External.value,
                 "quote_policy": AttributeDict(self.quoting),
-                **external,
+                **extras,
             }
         )

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -340,9 +340,11 @@ def test_variables(assert_exp_eq, sushi_test_project):
 def test_source_config(sushi_test_project: Project):
     source_configs = sushi_test_project.packages["sushi"].sources
     assert set(source_configs) == {
-        "streaming.items",
         "streaming.orders",
+        "parquet_file.items",
         "streaming.order_items",
+        "streaming.items",
+        "parquet_file.orders",
     }
 
     expected_config = {
@@ -357,6 +359,11 @@ def test_source_config(sushi_test_project: Project):
     assert (
         source_configs["streaming.order_items"].canonical_name(sushi_test_project.context)
         == "raw.order_items"
+    )
+
+    assert (
+        source_configs["parquet_file.orders"].canonical_name(sushi_test_project.context)
+        == "read_parquet('path/to/external/orders.parquet')"
     )
 
 

--- a/tests/fixtures/dbt/sushi_test/models/schema.yml
+++ b/tests/fixtures/dbt/sushi_test/models/schema.yml
@@ -23,3 +23,10 @@ sources:
       - name: items
       - name: orders
       - name: order_items
+
+  - name: parquet_file
+    meta:
+      external_location: "read_parquet('path/to/external/{name}.parquet')"
+    tables:
+      - name: items
+      - name: orders


### PR DESCRIPTION
An update to the dbt adapter to resolve sources' tables from an external location when specified in the source metadata, rather than using schema and table names, fixes: #2988 

