### PR TITLE
fix: make lookback conditional on missing intervals closes #2985

### DIFF
--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -287,10 +287,14 @@ def make_inclusive(start: TimeLike, end: TimeLike) -> Interval:
 
 
 def make_inclusive_end(end: TimeLike) -> datetime:
-    end_dt = to_datetime(end)
-    if is_date(end):
-        end_dt = end_dt + timedelta(days=1)
-    return end_dt - timedelta(microseconds=1)
+    return make_exclusive(end) - timedelta(microseconds=1)
+
+
+def make_exclusive(time: TimeLike) -> datetime:
+    dt = to_datetime(time)
+    if is_date(time):
+        dt = dt + timedelta(days=1)
+    return dt
 
 
 def validate_date_range(


### PR DESCRIPTION
refactor of how lookback works. the current implementation has some weird interactions with cron that makes non standard crons and lookback always backfill no matter what.

this refactors missing_intervals to only check for lookback when there are any missing intervals to begin with, otherwise we don't bother with lookback.