### PR TITLE
Feat: make MacroEvaluator.columns_to_types more lenient

### DIFF
--- a/examples/sushi/macros/macros.py
+++ b/examples/sushi/macros/macros.py
@@ -7,3 +7,17 @@ from sqlmesh import macro
 @macro()
 def incremental_by_ds(evaluator, column: exp.Column):
     return between(evaluator, column, evaluator.locals["start_date"], evaluator.locals["end_date"])
+
+
+@macro()
+def assert_has_columns(evaluator, model, columns_to_types):
+    if evaluator.runtime_stage == "creating":
+        expected_schema = {
+            column_type.name: exp.maybe_parse(
+                column_type.text("expression"), into=exp.DataType, dialect=evaluator.dialect
+            )
+            for column_type in columns_to_types.expressions
+        }
+        assert expected_schema.items() <= evaluator.columns_to_types(model).items()
+
+    return None

--- a/examples/sushi/models/marketing.sql
+++ b/examples/sushi/models/marketing.sql
@@ -12,4 +12,15 @@ SELECT
   status::TEXT AS status,
   updated_at::TIMESTAMP AS updated_at
 FROM
-  sushi.raw_marketing
+  sushi.raw_marketing;
+
+@assert_has_columns(
+    sushi.marketing,
+    {
+        customer_id: 'int',
+        status: 'text',
+        updated_at: 'timestamp',
+        valid_from: 'timestamp',
+        valid_to: 'timestamp',
+    }
+)

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -405,7 +405,11 @@ class MacroEvaluator:
 
     def columns_to_types(self, model_name: TableName | exp.Column) -> t.Dict[str, exp.DataType]:
         """Returns the columns-to-types mapping corresponding to the specified model."""
-        if self._schema is None or self._schema.empty:
+
+        # We only return this dummy schema at load time, because if we don't actually know the
+        # target model's schema at creation/evaluation time, returning a dummy schema could lead
+        # to unintelligible errors when the query is executed
+        if (self._schema is None or self._schema.empty) and self.runtime_stage == "loading":
             self.columns_to_types_called = True
             return {"__schema_unavailable_at_load__": exp.DataType.build("unknown")}
 
@@ -414,9 +418,16 @@ class MacroEvaluator:
             default_catalog=self.default_catalog,
             dialect=self.dialect,
         )
-        columns_to_types = self._schema.find(
-            exp.to_table(normalized_model_name), ensure_data_types=True
+        model_name = exp.to_table(normalized_model_name)
+
+        columns_to_types = (
+            self._schema.find(model_name, ensure_data_types=True) if self._schema else None
         )
+        if columns_to_types is None:
+            snapshot = self.get_snapshot(model_name)
+            if snapshot and snapshot.node.is_model:
+                columns_to_types = snapshot.node.columns_to_types  # type: ignore
+
         if columns_to_types is None:
             raise SQLMeshError(f"Schema for model '{model_name}' can't be statically determined.")
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -26,6 +26,7 @@ from sqlmesh.core.config import (
 from sqlmesh.core.context import Context
 from sqlmesh.core.dialect import parse, schema_
 from sqlmesh.core.environment import Environment
+from sqlmesh.core.macros import macro
 from sqlmesh.core.model import load_sql_based_model, model
 from sqlmesh.core.model.kind import ModelKindName
 from sqlmesh.core.plan import BuiltInPlanEvaluator, PlanBuilder
@@ -812,3 +813,28 @@ def test_override_dialect_normalization_strategy():
 
     # The above change is applied globally so we revert it to avoid breaking other tests
     DuckDB.NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE
+
+
+def test_access_self_columns_to_types_in_macro(tmp_path: pathlib.Path):
+    create_temp_file(
+        tmp_path,
+        pathlib.Path(pathlib.Path("models"), "test.sql"),
+        "MODEL(name test); SELECT 1 AS c; @post_statement()",
+    )
+    create_temp_file(
+        tmp_path,
+        pathlib.Path(pathlib.Path("macros"), "post_statement.py"),
+        """
+from sqlglot import exp
+from sqlmesh.core.macros import macro
+
+@macro()
+def post_statement(evaluator):
+    if evaluator.runtime_stage != 'loading':
+        assert evaluator.columns_to_types("test") == {"c": exp.DataType.build("int")}
+    return None
+""",
+    )
+
+    context = Context(paths=tmp_path, config=Config())
+    context.plan(auto_apply=True, no_prompts=True)

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -26,7 +26,6 @@ from sqlmesh.core.config import (
 from sqlmesh.core.context import Context
 from sqlmesh.core.dialect import parse, schema_
 from sqlmesh.core.environment import Environment
-from sqlmesh.core.macros import macro
 from sqlmesh.core.model import load_sql_based_model, model
 from sqlmesh.core.model.kind import ModelKindName
 from sqlmesh.core.plan import BuiltInPlanEvaluator, PlanBuilder

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -552,7 +552,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
     assert len(output.outputs) == 3
     assert convert_all_html_output_to_text(output) == [
         "Models: 17",
-        "Macros: 5",
+        "Macros: 6",
         "Data warehouse connection succeeded",
     ]
     assert get_all_html_output(output) == [
@@ -582,7 +582,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
                     h(
                         "span",
                         {"style": f"{NEUTRAL_STYLE}; font-weight: bold"},
-                        "5",
+                        "6",
                         autoescape=False,
                     )
                 ),


### PR DESCRIPTION
This PR makes the `columns_to_types` method more lenient by leveraging any existing snapshots in the evaluator's context as a fallback to fetch the target model's schema.

The motivation can be found [here](https://tobiko-data.slack.com/archives/C044BRE5W4S/p1723568953070039?thread_ts=1723562831.081849&cid=C044BRE5W4S): one real-world example is executing `ALTER` statements for the physical table of a model after it's created, for which we need to know the model's schema. This is not possible today, because the model's own schema is not included in its `mapping_schema` -- it only includes its dependencies' schemas.

I also added a guard that protects from returning the dummy schema unless we're at the loading runtime stage, to avoid cryptic errors such as "Column `__schema_unavailable_at_load__` does not exist!" when queries are executed during table creation or model evaluation.