### PR TITLE
fix: properly handle panda columns scd type 2

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1328,12 +1328,22 @@ class EngineAdapter:
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         truncate: bool = False,
     ) -> None:
-        source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
-            source_table, columns_to_types, target_table=target_table, batch_size=0
-        )
-        columns_to_types = columns_to_types or self.columns(target_table)
+        def remove_managed_columns(
+            cols_to_types: t.Dict[str, exp.DataType],
+        ) -> t.Dict[str, exp.DataType]:
+            return {
+                k: v for k, v in cols_to_types.items() if k not in {valid_from_name, valid_to_name}
+            }
+
         valid_from_name = valid_from_col.name
         valid_to_name = valid_to_col.name
+        unmanaged_columns_to_types = (
+            remove_managed_columns(columns_to_types) if columns_to_types else None
+        )
+        source_queries, unmanaged_columns_to_types = self._get_source_queries_and_columns_to_types(
+            source_table, unmanaged_columns_to_types, target_table=target_table, batch_size=0
+        )
+        columns_to_types = columns_to_types or self.columns(target_table)
         updated_at_name = updated_at_col.name if updated_at_col else None
         if (
             valid_from_name not in columns_to_types
@@ -1343,6 +1353,9 @@ class EngineAdapter:
             columns_to_types = self.columns(target_table)
         if not columns_to_types:
             raise SQLMeshError(f"Could not get columns_to_types. Does {target_table} exist?")
+        unmanaged_columns_to_types = unmanaged_columns_to_types or remove_managed_columns(
+            columns_to_types
+        )
         if not unique_key:
             raise SQLMeshError("unique_key must be provided for SCD Type 2")
         if check_columns and updated_at_col:
@@ -1361,13 +1374,9 @@ class EngineAdapter:
             raise SQLMeshError(
                 f"Column {updated_at_name} not found in {target_table}. Table must contain an `updated_at` timestamp for SCD Type 2"
             )
-
-        unmanaged_columns = [
-            col for col in columns_to_types if col not in {valid_from_name, valid_to_name}
-        ]
         time_data_type = columns_to_types[valid_from_name]
         select_source_columns: t.List[t.Union[str, exp.Alias]] = [
-            col for col in unmanaged_columns if col != updated_at_name
+            col for col in unmanaged_columns_to_types if col != updated_at_name
         ]
         table_columns = [exp.column(c, quoted=True) for c in columns_to_types]
         if updated_at_name:
@@ -1381,7 +1390,7 @@ class EngineAdapter:
         # If we want to change this, then we just need to check the expressions in unique_key and pull out the
         # column names and then remove them from the unmanaged_columns
         if check_columns and check_columns == exp.Star():
-            check_columns = [exp.column(col) for col in unmanaged_columns]
+            check_columns = [exp.column(col) for col in unmanaged_columns_to_types]
         execution_ts = to_time_column(execution_time, time_data_type)
         if updated_at_as_valid_from:
             if not updated_at_col:
@@ -1491,7 +1500,7 @@ class EngineAdapter:
                 prefixed_col.this.set("this", f"t_{prefixed_col.name}")
                 prefixed_columns_to_types.append(prefixed_col)
             prefixed_unmanaged_columns = []
-            for column in unmanaged_columns:
+            for column in unmanaged_columns_to_types:
                 prefixed_col = exp.column(column).copy()
                 prefixed_col.this.set("this", f"t_{prefixed_col.name}")
                 prefixed_unmanaged_columns.append(prefixed_col)
@@ -1563,7 +1572,10 @@ class EngineAdapter:
                             exp.column(col, table="latest").as_(prefixed_columns_to_types[i].this)
                             for i, col in enumerate(columns_to_types)
                         ),
-                        *(exp.column(col, table="source").as_(col) for col in unmanaged_columns),
+                        *(
+                            exp.column(col, table="source").as_(col)
+                            for col in unmanaged_columns_to_types
+                        ),
                     )
                     .from_("latest")
                     .join(
@@ -1587,7 +1599,7 @@ class EngineAdapter:
                             ),
                             *(
                                 exp.column(col, table="source").as_(col)
-                                for col in unmanaged_columns
+                                for col in unmanaged_columns_to_types
                             ),
                         )
                         .from_("latest")
@@ -1615,7 +1627,7 @@ class EngineAdapter:
                                 exp.column(prefixed_unmanaged_columns[i].this, table="joined"),
                                 exp.column(col, table="joined"),
                             ).as_(col)
-                            for i, col in enumerate(unmanaged_columns)
+                            for i, col in enumerate(unmanaged_columns_to_types)
                         ),
                         valid_from_case_stmt,
                         valid_to_case_stmt,
@@ -1638,7 +1650,7 @@ class EngineAdapter:
                 .with_(
                     "inserted_rows",
                     exp.select(
-                        *unmanaged_columns,
+                        *unmanaged_columns_to_types,
                         insert_valid_from_start.as_(valid_from_col.this),  # type: ignore
                         to_time_column(exp.null(), time_data_type).as_(valid_to_col.this),
                     )

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -1398,12 +1398,10 @@ WITH "source" AS (
       CAST("name" AS VARCHAR) AS "name",
       CAST("price" AS DOUBLE) AS "price",
       CAST("test_updated_at" AS TIMESTAMPTZ) AS "test_updated_at",
-      CAST("test_valid_from" AS TIMESTAMPTZ) AS "test_valid_from",
-      CAST("test_valid_to" AS TIMESTAMPTZ) AS "test_valid_to"
     FROM (VALUES
       (1, 4, 'muffins', 4.0, '2020-01-01 10:00:00'),
       (2, 5, 'chips', 5.0, '2020-01-02 15:00:00'),
-      (3, 6, 'soda', 6.0, '2020-01-03 12:00:00')) AS "t"("id1", "id2", "name", "price", "test_updated_at", "test_valid_from", "test_valid_to")
+      (3, 6, 'soda', 6.0, '2020-01-03 12:00:00')) AS "t"("id1", "id2", "name", "price", "test_updated_at")
   ) AS "raw_source"
 ), "static" AS (
   SELECT

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -1466,7 +1466,7 @@ def test_scd_type_2_by_column(ctx: TestContext):
         valid_to_col=exp.column("valid_to", quoted=True),
         execution_time="2023-01-01",
         execution_time_as_valid_from=False,
-        columns_to_types=input_schema,
+        columns_to_types=ctx.columns_to_types,
     )
     results = ctx.get_metadata_results()
     assert len(results.views) == 0
@@ -1535,7 +1535,7 @@ def test_scd_type_2_by_column(ctx: TestContext):
         valid_to_col=exp.column("valid_to", quoted=True),
         execution_time="2023-01-05",
         execution_time_as_valid_from=False,
-        columns_to_types=input_schema,
+        columns_to_types=ctx.columns_to_types,
     )
     results = ctx.get_metadata_results()
     assert len(results.views) == 0

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -3533,6 +3533,40 @@ def test_scd_type_2_by_column_overrides():
     assert scd_type_2_model.kind == _model_kind_validator(None, model_kind_dict, {})
 
 
+def test_scd_type_2_python_model() -> None:
+    @model(
+        "test_scd_type_2_python_model",
+        kind=dict(
+            name=ModelKindName.SCD_TYPE_2_BY_TIME,
+            unique_key="a",
+            updated_at_name="b",
+            updated_at_as_valid_from=True,
+        ),
+        columns={"a": "string", "b": "string"},
+    )
+    def scd_type_2_model(context, **kwargs):
+        return pd.DataFrame(
+            [
+                {
+                    "a": "val1",
+                    "b": "2024-01-01",
+                }
+            ]
+        )
+
+    python_model = model.get_registry()["test_scd_type_2_python_model"].model(
+        module_path=Path("."),
+        path=Path("."),
+    )
+
+    assert python_model.columns_to_types == {
+        "a": exp.DataType.build("string"),
+        "b": exp.DataType.build("string"),
+        "valid_from": exp.DataType.build("TIMESTAMP"),
+        "valid_to": exp.DataType.build("TIMESTAMP"),
+    }
+
+
 @pytest.mark.parametrize(
     "input_columns,expected_columns",
     [


### PR DESCRIPTION
Prior to this change when converting a pandas dataframe to SQL we would use the full columns to types, which included managed columns `valid_from` and `valid_to`, when selecting from the values created from the dataframe. There is actually a test that exposes this bug that I didn't catch: https://github.com/TobikoData/sqlmesh/blob/f9d5880429465149d9b613b606a436259803e571/tests/core/engine_adapter/test_base.py#L1395-L1407

Now we remove the managed columns from converting the dataframe. Also updated the integration test to properly reflect how the method gets called (before it was being called with unmanaged columns instead of all columns which is why the test passed). 