### PR TITLE
feat: automatically load signals from the `signals/` subfolder

### DIFF
--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -141,7 +141,6 @@ class BuiltInSchedulerConfig(_EngineAdapterStateSyncSchedulerConfig, BaseConfig)
             backfill_concurrent_tasks=context.concurrent_tasks,
             console=context.console,
             notification_target_manager=context.notification_target_manager,
-            signal_factory=context._signal_factory,
         )
 
     def get_default_catalog(self, context: GenericContext) -> t.Optional[str]:

--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -47,6 +47,7 @@ MATERIALIZATIONS = "materializations"
 METRICS = "metrics"
 MODELS = "models"
 SEEDS = "seeds"
+SIGNALS = "signals"
 TESTS = "tests"
 
 EXTERNAL_MODELS_YAML = "external_models.yaml"

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -80,7 +80,7 @@ from sqlmesh.core.notification_target import (
 )
 from sqlmesh.core.plan import Plan, PlanBuilder
 from sqlmesh.core.reference import ReferenceGraph
-from sqlmesh.core.scheduler import Scheduler, SignalFactory
+from sqlmesh.core.scheduler import Scheduler
 from sqlmesh.core.schema_loader import create_external_models_file
 from sqlmesh.core.selector import Selector
 from sqlmesh.core.snapshot import (
@@ -308,7 +308,6 @@ class GenericContext(BaseContext, t.Generic[C]):
         load: bool = True,
         console: t.Optional[Console] = None,
         users: t.Optional[t.List[User]] = None,
-        signal_factory: t.Optional[SignalFactory] = None,
     ):
         self.configs = (
             config if isinstance(config, dict) else load_configs(config, self.CONFIG_TYPE, paths)
@@ -355,7 +354,6 @@ class GenericContext(BaseContext, t.Generic[C]):
         )
 
         self._snapshot_evaluator: t.Optional[SnapshotEvaluator] = None
-        self._signal_factory = signal_factory
 
         self._provided_state_sync: t.Optional[StateSync] = state_sync
         self._state_sync: t.Optional[StateSync] = None
@@ -476,7 +474,6 @@ class GenericContext(BaseContext, t.Generic[C]):
             max_workers=self.concurrent_tasks,
             console=self.console,
             notification_target_manager=self.notification_target_manager,
-            signal_factory=self._signal_factory,
         )
 
     @property

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -102,7 +102,7 @@ def signal_factory(f: SignalFactory) -> None:
     global _registered_signal_factory
 
     if _registered_signal_factory is not None:
-        raise RuntimeError("only one function may be decorated with @signal_factory")
+        raise SQLMeshError("Only one function may be decorated with @signal_factory")
 
     _registered_signal_factory = f
 

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -486,7 +486,7 @@ def compute_interval_params(
         ignore_cron=ignore_cron,
         end_bounded=end_bounded,
     ).items():
-        if signal_factory:
+        if signal_factory and snapshot.is_model:
             for signal in snapshot.model.render_signals(
                 start=start, end=end, execution_time=execution_time
             ):

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -626,7 +626,7 @@ def test_signal_factory(mocker: MockerFixture, make_snapshot):
     from sqlmesh.core.scheduler import signal_factory, Batch, Signal
 
     class AlwaysReadySignal(Signal):
-        def check_intervals(self, batch: Batch) -> bool | Batch:
+        def check_intervals(self, batch: Batch):
             return True
 
     signal_factory_invoked = 0


### PR DESCRIPTION
This is a follow-up to https://github.com/TobikoData/sqlmesh/pull/2822 to allow loading a `signal_factory` from the sqlmesh project structure instead of having to specify it to the `Context`. This allows using built-in signals without any extra configuration in `config.py` or similar.