### PR TITLE
Fix: Builtin pattern matching audits operators

### DIFF
--- a/sqlmesh/core/audit/builtin.py
+++ b/sqlmesh/core/audit/builtin.py
@@ -341,7 +341,7 @@ WHERE @AND(
       @patterns,
       c -> NOT REGEXP_LIKE(@column, c)
     ),
-    (l, r) -> l OR r
+    (l, r) -> l AND r
   ),
   @condition,
 )
@@ -375,14 +375,15 @@ match_like_pattern_list = ModelAudit(
     query="""
 SELECT *
 FROM @this_model
-WHERE @condition AND (
+WHERE @AND(
   @REDUCE(
     @EACH(
       @patterns,
       c -> NOT @column LIKE c
     ),
-    (l, r) -> l OR r
-  )
+    (l, r) -> l AND r
+  ),
+  @condition,
 )
     """,
 )


### PR DESCRIPTION
Fix for the generated queries of the built-in pattern matching audits: `match_regex_pattern_list` and `match_like_pattern_list` by switching the operators in the query from `or` to `and`.