### PR TITLE
Chore!: Set interval end per model in plan

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1130,31 +1130,15 @@ class GenericContext(BaseContext, t.Generic[C]):
 
         # If no end date is specified, use the max interval end from prod
         # to prevent unintended evaluation of the entire DAG.
+        default_end: t.Optional[int] = None
+        max_interval_end_per_model: t.Optional[t.Dict[str, int]] = None
         if not run:
-            if backfill_models is not None:
-                # Only consider selected models for the default end value.
-                models_for_default_end = backfill_models.copy()
-                for name in backfill_models:
-                    if name not in snapshots:
-                        continue
-                    snapshot = snapshots[name]
-                    snapshot_id = snapshot.snapshot_id
-                    if (
-                        snapshot_id in context_diff.added
-                        and snapshot_id in context_diff.new_snapshots
-                    ):
-                        # If the selected model is a newly added model, then we should narrow down the intervals
-                        # that should be considered for the default plan end value by including its parents.
-                        models_for_default_end |= {s.name for s in snapshot.parents}
-                default_end = self.state_sync.greatest_common_interval_end(
-                    c.PROD,
-                    models_for_default_end,
-                    ensure_finalized_snapshots=self.config.plan.use_finalized_state,
-                )
-            else:
-                default_end = self.state_sync.max_interval_end_for_environment(
-                    c.PROD, ensure_finalized_snapshots=self.config.plan.use_finalized_state
-                )
+            max_interval_end_per_model = self.state_sync.max_interval_end_per_model(
+                c.PROD,
+                ensure_finalized_snapshots=self.config.plan.use_finalized_state,
+            )
+            if max_interval_end_per_model:
+                default_end = max(max_interval_end_per_model.values())
         else:
             default_end = None
 
@@ -1190,6 +1174,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             end_bounded=not run,
             ensure_finalized_snapshots=self.config.plan.use_finalized_state,
             engine_schema_differ=self.engine_adapter.SCHEMA_DIFFER,
+            interval_end_per_model=max_interval_end_per_model,
             console=self.console,
         )
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1133,8 +1133,20 @@ class GenericContext(BaseContext, t.Generic[C]):
         default_end: t.Optional[int] = None
         max_interval_end_per_model: t.Optional[t.Dict[str, int]] = None
         if not run:
+            models_for_interval_end: t.Optional[t.Set[str]] = None
+            if backfill_models is not None:
+                models_for_interval_end = set()
+                models_stack = list(backfill_models)
+                while models_stack:
+                    next_model = models_stack.pop()
+                    if next_model not in snapshots:
+                        continue
+                    models_for_interval_end.add(next_model)
+                    models_stack.extend([s.name for s in snapshots[next_model].parents])
+
             max_interval_end_per_model = self.state_sync.max_interval_end_per_model(
                 c.PROD,
+                models=models_for_interval_end,
                 ensure_finalized_snapshots=self.config.plan.use_finalized_state,
             )
             if max_interval_end_per_model:

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -69,6 +69,7 @@ class PlanBuilder:
             environment state, or to use whatever snapshots are in the current environment state even if
             the environment is not finalized.
         engine_schema_differ: Schema differ from the context engine adapter.
+        interval_end_per_model: The mapping from model FQNs to target end dates.
     """
 
     def __init__(
@@ -98,6 +99,7 @@ class PlanBuilder:
         enable_preview: bool = False,
         end_bounded: bool = False,
         ensure_finalized_snapshots: bool = False,
+        interval_end_per_model: t.Optional[t.Dict[str, int]] = None,
         console: t.Optional[Console] = None,
     ):
         self._context_diff = context_diff
@@ -111,6 +113,7 @@ class PlanBuilder:
         self._enable_preview = enable_preview
         self._end_bounded = end_bounded
         self._ensure_finalized_snapshots = ensure_finalized_snapshots
+        self._interval_end_per_model = interval_end_per_model
         self._environment_ttl = environment_ttl
         self._categorizer_config = categorizer_config or CategorizerConfig()
         self._auto_categorization_enabled = auto_categorization_enabled
@@ -272,6 +275,7 @@ class PlanBuilder:
             ignored=ignored,
             deployability_index=deployability_index,
             restatements=restatements,
+            interval_end_per_model=self._interval_end_per_model,
             models_to_backfill=models_to_backfill,
             effective_from=self._effective_from,
             execution_time=self._execution_time,

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -53,6 +53,7 @@ class Plan(PydanticModel, frozen=True):
 
     deployability_index: DeployabilityIndex
     restatements: t.Dict[SnapshotId, Interval]
+    interval_end_per_model: t.Optional[t.Dict[str, int]]
 
     models_to_backfill: t.Optional[t.Set[str]] = None
     effective_from: t.Optional[TimeLike] = None
@@ -162,6 +163,7 @@ class Plan(PydanticModel, frozen=True):
                 execution_time=self.execution_time,
                 restatements=self.restatements,
                 deployability_index=self.deployability_index,
+                interval_end_per_model=self.interval_end_per_model,
                 end_bounded=self.end_bounded,
             ).items()
             if snapshot.is_model and missing

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -173,6 +173,7 @@ class BuiltInPlanEvaluator(PlanEvaluator):
             deployability_index=deployability_index,
             circuit_breaker=circuit_breaker,
             end_bounded=plan.end_bounded,
+            interval_end_per_model=plan.interval_end_per_model,
         )
         if not is_run_successful:
             raise SQLMeshError("Plan application failed.")
@@ -402,6 +403,7 @@ class StateBasedAirflowPlanEvaluator(BaseAirflowPlanEvaluator):
                 for change_source, snapshots in plan.indirectly_modified.items()
             },
             removed_snapshots=list(plan.context_diff.removed_snapshots),
+            interval_end_per_model=plan.interval_end_per_model,
             execution_time=plan.execution_time,
             allow_destructive_snapshots=plan.allow_destructive_models,
         )
@@ -480,6 +482,7 @@ class AirflowPlanEvaluator(StateBasedAirflowPlanEvaluator):
                 for change_source, snapshots in plan.indirectly_modified.items()
             },
             removed_snapshots=list(plan.context_diff.removed_snapshots),
+            interval_end_per_model=plan.interval_end_per_model,
             execution_time=plan.execution_time,
             allow_destructive_snapshots=plan.allow_destructive_models,
         )

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -155,6 +155,7 @@ class Scheduler:
         execution_time: t.Optional[TimeLike] = None,
         deployability_index: t.Optional[DeployabilityIndex] = None,
         restatements: t.Optional[t.Dict[SnapshotId, SnapshotInterval]] = None,
+        interval_end_per_model: t.Optional[t.Dict[str, int]] = None,
         ignore_cron: bool = False,
         end_bounded: bool = False,
         selected_snapshots: t.Optional[t.Set[str]] = None,
@@ -175,6 +176,7 @@ class Scheduler:
             execution_time: The date/time time reference to use for execution time. Defaults to now.
             deployability_index: Determines snapshots that are deployable in the context of this evaluation.
             restatements: A set of snapshot names being restated.
+            interval_end_per_model: The mapping from model FQNs to target end dates.
             ignore_cron: Whether to ignore the node's cron schedule.
             end_bounded: If set to true, the returned intervals will be bounded by the target end date, disregarding lookback,
                 allow_partials, and other attributes that could cause the intervals to exceed the target end date.
@@ -196,6 +198,7 @@ class Scheduler:
             deployability_index=deployability_index,
             execution_time=execution_time or now(),
             restatements=restatements,
+            interval_end_per_model=interval_end_per_model,
             ignore_cron=ignore_cron,
             end_bounded=end_bounded,
             signal_factory=self.signal_factory,
@@ -283,6 +286,7 @@ class Scheduler:
         end: t.Optional[TimeLike] = None,
         execution_time: t.Optional[TimeLike] = None,
         restatements: t.Optional[t.Dict[SnapshotId, SnapshotInterval]] = None,
+        interval_end_per_model: t.Optional[t.Dict[str, int]] = None,
         ignore_cron: bool = False,
         end_bounded: bool = False,
         selected_snapshots: t.Optional[t.Set[str]] = None,
@@ -299,6 +303,7 @@ class Scheduler:
             end: The end of the run. Defaults to now.
             execution_time: The date/time time reference to use for execution time. Defaults to now.
             restatements: A dict of snapshots to restate and their intervals.
+            interval_end_per_model: The mapping from model FQNs to target end dates.
             ignore_cron: Whether to ignore the node's cron schedule.
             end_bounded: If set to true, the evaluated intervals will be bounded by the target end date, disregarding lookback,
                 allow_partials, and other attributes that could cause the intervals to exceed the target end date.
@@ -334,6 +339,7 @@ class Scheduler:
             execution_time,
             deployability_index=deployability_index,
             restatements=restatements,
+            interval_end_per_model=interval_end_per_model,
             ignore_cron=ignore_cron,
             end_bounded=end_bounded,
             selected_snapshots=selected_snapshots,
@@ -472,6 +478,7 @@ def compute_interval_params(
     deployability_index: t.Optional[DeployabilityIndex] = None,
     execution_time: t.Optional[TimeLike] = None,
     restatements: t.Optional[t.Dict[SnapshotId, SnapshotInterval]] = None,
+    interval_end_per_model: t.Optional[t.Dict[str, int]] = None,
     ignore_cron: bool = False,
     end_bounded: bool = False,
     signal_factory: t.Optional[SignalFactory] = None,
@@ -494,6 +501,7 @@ def compute_interval_params(
         deployability_index: Determines snapshots that are deployable in the context of this evaluation.
         execution_time: The date/time time reference to use for execution time.
         restatements: A dict of snapshot names being restated and their intervals.
+        interval_end_per_model: The mapping from model FQNs to target end dates.
         ignore_cron: Whether to ignore the node's cron schedule.
         end_bounded: If set to true, the returned intervals will be bounded by the target end date, disregarding lookback,
             allow_partials, and other attributes that could cause the intervals to exceed the target end date.
@@ -510,6 +518,7 @@ def compute_interval_params(
         execution_time=execution_time,
         restatements=restatements,
         deployability_index=deployability_index,
+        interval_end_per_model=interval_end_per_model,
         ignore_cron=ignore_cron,
         end_bounded=end_bounded,
     ).items():

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -140,34 +140,20 @@ class StateReader(abc.ABC):
         """
 
     @abc.abstractmethod
-    def max_interval_end_for_environment(
-        self, environment: str, ensure_finalized_snapshots: bool = False
-    ) -> t.Optional[int]:
-        """Returns the max interval end for the given environment.
+    def max_interval_end_per_model(
+        self,
+        environment: str,
+        ensure_finalized_snapshots: bool = False,
+    ) -> t.Optional[t.Dict[str, int]]:
+        """Returns the max interval end per model for the given environment.
 
         Args:
-            environment: The environment.
+            environment: The target environment.
             ensure_finalized_snapshots: Whether to use snapshots from the latest finalized environment state,
                 or to use whatever snapshots are in the current environment state even if the environment is not finalized.
 
         Returns:
-            A timestamp or None if no interval or environment exists.
-        """
-
-    @abc.abstractmethod
-    def greatest_common_interval_end(
-        self, environment: str, models: t.Set[str], ensure_finalized_snapshots: bool = False
-    ) -> t.Optional[int]:
-        """Returns the greatest common interval end for given models in the target environment.
-
-        Args:
-            environment: The environment.
-            models: The model FQNs to select intervals from.
-            ensure_finalized_snapshots: Whether to use snapshots from the latest finalized environment state,
-                or to use whatever snapshots are in the current environment state even if the environment is not finalized.
-
-        Returns:
-            A timestamp or None if no interval or environment exists.
+            A dictionary of model FQNs to their respective interval ends in milliseconds since epoch.
         """
 
     @abc.abstractmethod

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -145,7 +145,7 @@ class StateReader(abc.ABC):
         environment: str,
         models: t.Optional[t.Set[str]] = None,
         ensure_finalized_snapshots: bool = False,
-    ) -> t.Optional[t.Dict[str, int]]:
+    ) -> t.Dict[str, int]:
         """Returns the max interval end per model for the given environment.
 
         Args:

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -143,12 +143,14 @@ class StateReader(abc.ABC):
     def max_interval_end_per_model(
         self,
         environment: str,
+        models: t.Optional[t.Set[str]] = None,
         ensure_finalized_snapshots: bool = False,
     ) -> t.Optional[t.Dict[str, int]]:
         """Returns the max interval end per model for the given environment.
 
         Args:
             environment: The target environment.
+            models: The models to get the max interval end for. If None, all models are considered.
             ensure_finalized_snapshots: Whether to use snapshots from the latest finalized environment state,
                 or to use whatever snapshots are in the current environment state even if the environment is not finalized.
 

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -999,10 +999,10 @@ class EngineAdapterStateSync(StateSync):
         environment: str,
         models: t.Optional[t.Set[str]] = None,
         ensure_finalized_snapshots: bool = False,
-    ) -> t.Optional[t.Dict[str, int]]:
+    ) -> t.Dict[str, int]:
         env = self._get_environment(environment)
         if not env:
-            return None
+            return {}
 
         snapshots = (
             env.snapshots if not ensure_finalized_snapshots else env.finalized_or_current_snapshots

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -997,6 +997,7 @@ class EngineAdapterStateSync(StateSync):
     def max_interval_end_per_model(
         self,
         environment: str,
+        models: t.Optional[t.Set[str]] = None,
         ensure_finalized_snapshots: bool = False,
     ) -> t.Optional[t.Dict[str, int]]:
         env = self._get_environment(environment)
@@ -1006,6 +1007,11 @@ class EngineAdapterStateSync(StateSync):
         snapshots = (
             env.snapshots if not ensure_finalized_snapshots else env.finalized_or_current_snapshots
         )
+        if models is not None:
+            snapshots = [s for s in snapshots if s.name in models]
+
+        if not snapshots:
+            return {}
 
         table_alias = "intervals"
         name_col = exp.column("name", table=table_alias)

--- a/sqlmesh/schedulers/airflow/api.py
+++ b/sqlmesh/schedulers/airflow/api.py
@@ -75,9 +75,11 @@ def get_environments() -> Response:
 @check_authentication
 def max_interval_end_per_model(name: str) -> Response:
     with util.scoped_state_sync() as state_sync:
+        models = json.loads(request.args["models"]) if "models" in request.args else None
         ensure_finalized_snapshots = "ensure_finalized_snapshots" in request.args
         interval_end_per_model = state_sync.max_interval_end_per_model(
             name,
+            set(models) if models is not None else None,
             ensure_finalized_snapshots=ensure_finalized_snapshots,
         )
         response = common.IntervalEndResponse(

--- a/sqlmesh/schedulers/airflow/api.py
+++ b/sqlmesh/schedulers/airflow/api.py
@@ -70,20 +70,22 @@ def get_environments() -> Response:
     return _success(common.EnvironmentsResponse(environments=environments))
 
 
-@sqlmesh_api_v1.route("/environments/<name>/max_interval_end_per_model")
+@sqlmesh_api_v1.route("/environments/<name>/max_interval_end_per_model", methods=["POST"])
 @csrf.exempt
 @check_authentication
 def max_interval_end_per_model(name: str) -> Response:
+    max_interval_end_per_model_request = common.MaxIntervalEndPerModelRequest.parse_obj(
+        request.json or {}
+    )
+    models = max_interval_end_per_model_request.models
     with util.scoped_state_sync() as state_sync:
-        models = json.loads(request.args["models"]) if "models" in request.args else None
-        ensure_finalized_snapshots = "ensure_finalized_snapshots" in request.args
         interval_end_per_model = state_sync.max_interval_end_per_model(
             name,
             set(models) if models is not None else None,
-            ensure_finalized_snapshots=ensure_finalized_snapshots,
+            ensure_finalized_snapshots=max_interval_end_per_model_request.ensure_finalized_snapshots,
         )
         response = common.IntervalEndResponse(
-            environment=name, max_interval_end_per_model=interval_end_per_model
+            environment=name, interval_end_per_model=interval_end_per_model
         )
         return _success(response)
 
@@ -101,14 +103,14 @@ def invalidate_environment(name: str) -> Response:
     return _success(common.InvalidateEnvironmentResponse(name=name))
 
 
-@sqlmesh_api_v1.route("/snapshots")
+@sqlmesh_api_v1.route("/snapshots/search", methods=["POST"])
 @csrf.exempt
 @check_authentication
 def get_snapshots() -> Response:
+    snapshots_request = common.SnapshotsRequest.parse_obj(request.json or {})
+    snapshot_ids = snapshots_request.snapshot_ids
     with util.scoped_state_sync() as state_sync:
-        snapshot_ids = _snapshot_ids_from_request()
-
-        if "check_existence" in request.args:
+        if snapshots_request.check_existence:
             existing_snapshot_ids = (
                 state_sync.snapshots_exist(snapshot_ids) if snapshot_ids is not None else set()
             )

--- a/sqlmesh/schedulers/airflow/api.py
+++ b/sqlmesh/schedulers/airflow/api.py
@@ -70,30 +70,19 @@ def get_environments() -> Response:
     return _success(common.EnvironmentsResponse(environments=environments))
 
 
-@sqlmesh_api_v1.route("/environments/<name>/max_interval_end")
+@sqlmesh_api_v1.route("/environments/<name>/max_interval_end_per_model")
 @csrf.exempt
 @check_authentication
-def get_max_interval_end(name: str) -> Response:
+def max_interval_end_per_model(name: str) -> Response:
     with util.scoped_state_sync() as state_sync:
         ensure_finalized_snapshots = "ensure_finalized_snapshots" in request.args
-        max_interval_end = state_sync.max_interval_end_for_environment(
-            name, ensure_finalized_snapshots=ensure_finalized_snapshots
+        interval_end_per_model = state_sync.max_interval_end_per_model(
+            name,
+            ensure_finalized_snapshots=ensure_finalized_snapshots,
         )
-        response = common.IntervalEndResponse(environment=name, max_interval_end=max_interval_end)
-        return _success(response)
-
-
-@sqlmesh_api_v1.route("/environments/<name>/greatest_common_interval_end")
-@csrf.exempt
-@check_authentication
-def get_greatest_common_interval_end(name: str) -> Response:
-    with util.scoped_state_sync() as state_sync:
-        models = json.loads(request.args["models"]) if "models" in request.args else []
-        ensure_finalized_snapshots = "ensure_finalized_snapshots" in request.args
-        max_interval_end = state_sync.greatest_common_interval_end(
-            name, set(models), ensure_finalized_snapshots=ensure_finalized_snapshots
+        response = common.IntervalEndResponse(
+            environment=name, max_interval_end_per_model=interval_end_per_model
         )
-        response = common.IntervalEndResponse(environment=name, max_interval_end=max_interval_end)
         return _success(response)
 
 

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -263,7 +263,7 @@ class AirflowClient(BaseAirflowClient):
         environment: str,
         models: t.Optional[t.Collection[str]],
         ensure_finalized_snapshots: bool,
-    ) -> t.Optional[t.Dict[str, int]]:
+    ) -> t.Dict[str, int]:
         max_interval_end_per_model_request = common.MaxIntervalEndPerModelRequest(
             models=models, ensure_finalized_snapshots=ensure_finalized_snapshots
         )

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -1,5 +1,4 @@
 import abc
-import json
 import time
 import typing as t
 import uuid
@@ -15,7 +14,6 @@ from sqlmesh.core.snapshot.definition import Interval
 from sqlmesh.core.state_sync import Versions
 from sqlmesh.core.user import User
 from sqlmesh.schedulers.airflow import common, NO_DEFAULT_CATALOG
-from sqlmesh.utils import unique
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.errors import (
     ApiServerError,
@@ -23,14 +21,13 @@ from sqlmesh.utils.errors import (
     SQLMeshError,
     raise_for_status,
 )
-from sqlmesh.utils.pydantic import PydanticModel
 
 DAG_RUN_PATH_TEMPLATE = "api/v1/dags/{}/dagRuns"
 
 
 PLANS_PATH = f"{common.SQLMESH_API_BASE_PATH}/plans"
 ENVIRONMENTS_PATH = f"{common.SQLMESH_API_BASE_PATH}/environments"
-SNAPSHOTS_PATH = f"{common.SQLMESH_API_BASE_PATH}/snapshots"
+SNAPSHOTS_PATH = f"{common.SQLMESH_API_BASE_PATH}/snapshots/search"
 SEEDS_PATH = f"{common.SQLMESH_API_BASE_PATH}/seeds"
 INTERVALS_PATH = f"{common.SQLMESH_API_BASE_PATH}/intervals"
 MODELS_PATH = f"{common.SQLMESH_API_BASE_PATH}/models"
@@ -179,11 +176,9 @@ class AirflowClient(BaseAirflowClient):
         session: requests.Session,
         airflow_url: str,
         console: t.Optional[Console] = None,
-        snapshot_ids_batch_size: t.Optional[int] = None,
     ):
         super().__init__(airflow_url, console)
         self._session = session
-        self._snapshot_ids_batch_size = snapshot_ids_batch_size
 
     def apply_plan(
         self,
@@ -232,42 +227,17 @@ class AirflowClient(BaseAirflowClient):
             interval_end_per_model=interval_end_per_model,
             execution_time=execution_time,
         )
-
-        response = self._session.post(
-            urljoin(self._airflow_url, PLANS_PATH),
-            data=request.json(),
-            headers={"Content-Type": "application/json"},
-        )
-        raise_for_status(response)
+        self._post(PLANS_PATH, request.json())
 
     def get_snapshots(self, snapshot_ids: t.Optional[t.List[SnapshotId]]) -> t.List[Snapshot]:
-        output = []
-
-        if snapshot_ids is not None:
-            for ids_batch in _list_to_json(
-                unique(snapshot_ids), batch_size=self._snapshot_ids_batch_size
-            ):
-                output.extend(
-                    common.SnapshotsResponse.parse_obj(
-                        self._get(SNAPSHOTS_PATH, ids=ids_batch)
-                    ).snapshots
-                )
-            return output
-
-        return common.SnapshotsResponse.parse_obj(self._get(SNAPSHOTS_PATH)).snapshots
+        snapshots_request = common.SnapshotsRequest(snapshot_ids=snapshot_ids)
+        response = self._post(SNAPSHOTS_PATH, snapshots_request.json())
+        return common.SnapshotsResponse.parse_obj(response).snapshots
 
     def snapshots_exist(self, snapshot_ids: t.List[SnapshotId]) -> t.Set[SnapshotId]:
-        output = set()
-        for ids_batch in _list_to_json(
-            unique(snapshot_ids), batch_size=self._snapshot_ids_batch_size
-        ):
-            output |= set(
-                common.SnapshotIdsResponse.parse_obj(
-                    self._get(SNAPSHOTS_PATH, "check_existence", ids=ids_batch)
-                ).snapshot_ids
-            )
-
-        return output
+        snapshots_request = common.SnapshotsRequest(snapshot_ids=snapshot_ids, check_existence=True)
+        response = self._post(SNAPSHOTS_PATH, snapshots_request.json())
+        return set(common.SnapshotIdsResponse.parse_obj(response).snapshot_ids)
 
     def nodes_exist(self, names: t.Iterable[str], exclude_external: bool = False) -> t.Set[str]:
         flags = ["exclude_external"] if exclude_external else []
@@ -294,15 +264,12 @@ class AirflowClient(BaseAirflowClient):
         models: t.Optional[t.Collection[str]],
         ensure_finalized_snapshots: bool,
     ) -> t.Optional[t.Dict[str, int]]:
-        flags = ["ensure_finalized_snapshots"] if ensure_finalized_snapshots else []
-        params = {}
-        if models is not None:
-            params["models"] = _json_query_param(list(models))
-
-        response = self._get(
+        max_interval_end_per_model_request = common.MaxIntervalEndPerModelRequest(
+            models=models, ensure_finalized_snapshots=ensure_finalized_snapshots
+        )
+        response = self._post(
             f"{ENVIRONMENTS_PATH}/{environment}/max_interval_end_per_model",
-            *flags,
-            **params,
+            max_interval_end_per_model_request.json(),
         )
         return common.IntervalEndResponse.parse_obj(response).interval_end_per_model
 
@@ -349,26 +316,22 @@ class AirflowClient(BaseAirflowClient):
         return self._get(f"api/v1/dags/{dag_id}")
 
     def _get(self, path: str, *flags: str, **params: str) -> t.Dict[str, t.Any]:
+        response = self._session.get(self._url(path, *flags, **params))
+        raise_for_status(response)
+        return response.json()
+
+    def _post(self, path: str, data: str, *flags: str, **params: str) -> t.Dict[str, t.Any]:
+        response = self._session.post(
+            self._url(path, *flags, **params),
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        raise_for_status(response)
+        return response.json()
+
+    def _url(self, path: str, *flags: str, **params: str) -> str:
         all_params = [*flags, *([urlencode(params)] if params else [])]
         query_string = "&".join(all_params)
         if query_string:
             path = f"{path}?{query_string}"
-        response = self._session.get(urljoin(self._airflow_url, path))
-        raise_for_status(response)
-        return response.json()
-
-
-T = t.TypeVar("T", bound=PydanticModel)
-
-
-def _list_to_json(models: t.Collection[T], batch_size: t.Optional[int] = None) -> t.List[str]:
-    serialized = [m.dict() for m in models]
-    if batch_size is not None:
-        batches = [serialized[i : i + batch_size] for i in range(0, len(serialized), batch_size)]
-    else:
-        batches = [serialized]
-    return [_json_query_param(batch) for batch in batches]
-
-
-def _json_query_param(value: t.Any) -> str:
-    return json.dumps(value, separators=(",", ":"))
+        return urljoin(self._airflow_url, path)

--- a/sqlmesh/schedulers/airflow/client.py
+++ b/sqlmesh/schedulers/airflow/client.py
@@ -291,13 +291,18 @@ class AirflowClient(BaseAirflowClient):
     def max_interval_end_per_model(
         self,
         environment: str,
+        models: t.Optional[t.Collection[str]],
         ensure_finalized_snapshots: bool,
     ) -> t.Optional[t.Dict[str, int]]:
         flags = ["ensure_finalized_snapshots"] if ensure_finalized_snapshots else []
+        params = {}
+        if models is not None:
+            params["models"] = _json_query_param(list(models))
 
         response = self._get(
             f"{ENVIRONMENTS_PATH}/{environment}/max_interval_end_per_model",
             *flags,
+            **params,
         )
         return common.IntervalEndResponse.parse_obj(response).interval_end_per_model
 

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -56,6 +56,7 @@ class PlanApplicationRequest(PydanticModel):
     directly_modified_snapshots: t.List[SnapshotId]
     indirectly_modified_snapshots: t.Dict[str, t.List[SnapshotId]]
     removed_snapshots: t.List[SnapshotId]
+    interval_end_per_model: t.Optional[t.Dict[str, int]] = None
     execution_time: t.Optional[TimeLike] = None
 
     def is_selected_for_backfill(self, model_fqn: str) -> bool:
@@ -121,7 +122,7 @@ class InvalidateEnvironmentResponse(PydanticModel):
 
 class IntervalEndResponse(PydanticModel):
     environment: str
-    max_interval_end: t.Optional[int] = None
+    interval_end_per_model: t.Optional[t.Dict[str, int]] = None
 
 
 def dag_id_for_snapshot_info(info: SnapshotInfoLike) -> str:

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -132,7 +132,7 @@ class MaxIntervalEndPerModelRequest(PydanticModel):
 
 class IntervalEndResponse(PydanticModel):
     environment: str
-    interval_end_per_model: t.Optional[t.Dict[str, int]] = None
+    interval_end_per_model: t.Dict[str, int]
 
 
 def dag_id_for_snapshot_info(info: SnapshotInfoLike) -> str:

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -100,6 +100,11 @@ class EnvironmentsResponse(PydanticModel):
     environments: t.List[Environment]
 
 
+class SnapshotsRequest(PydanticModel):
+    snapshot_ids: t.Optional[t.List[SnapshotId]] = None
+    check_existence: bool = False
+
+
 class SnapshotsResponse(PydanticModel):
     snapshots: t.List[Snapshot]
 
@@ -118,6 +123,11 @@ class ExistingModelsResponse(PydanticModel):
 
 class InvalidateEnvironmentResponse(PydanticModel):
     name: str
+
+
+class MaxIntervalEndPerModelRequest(PydanticModel):
+    models: t.Optional[t.List[str]] = None
+    ensure_finalized_snapshots: bool = False
 
 
 class IntervalEndResponse(PydanticModel):

--- a/sqlmesh/schedulers/airflow/plan.py
+++ b/sqlmesh/schedulers/airflow/plan.py
@@ -133,6 +133,7 @@ def create_plan_dag_spec(
             execution_time=request.execution_time or now(),
             deployability_index=deployability_index_for_evaluation,
             restatements=restatements,
+            interval_end_per_model=request.interval_end_per_model,
             end_bounded=request.end_bounded,
             signal_factory=None,
         )

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -72,7 +72,7 @@ class HttpStateSync(StateSync):
         environment: str,
         models: t.Optional[t.Set[str]] = None,
         ensure_finalized_snapshots: bool = False,
-    ) -> t.Optional[t.Dict[str, int]]:
+    ) -> t.Dict[str, int]:
         """Returns the max interval end per model for the given environment.
 
         Args:

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -70,12 +70,14 @@ class HttpStateSync(StateSync):
     def max_interval_end_per_model(
         self,
         environment: str,
+        models: t.Optional[t.Set[str]] = None,
         ensure_finalized_snapshots: bool = False,
     ) -> t.Optional[t.Dict[str, int]]:
         """Returns the max interval end per model for the given environment.
 
         Args:
             environment: The target environment.
+            models: The models to get the max interval end for. If None, all models are considered.
             ensure_finalized_snapshots: Whether to use snapshots from the latest finalized environment state,
                 or to use whatever snapshots are in the current environment state even if the environment is not finalized.
 
@@ -83,7 +85,7 @@ class HttpStateSync(StateSync):
             A dictionary of model FQNs to their respective interval ends in milliseconds since epoch.
         """
         return self._client.max_interval_end_per_model(
-            environment, ensure_finalized_snapshots=ensure_finalized_snapshots
+            environment, models=models, ensure_finalized_snapshots=ensure_finalized_snapshots
         )
 
     def get_snapshots(

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -67,39 +67,23 @@ class HttpStateSync(StateSync):
         """
         return self._client.get_environments()
 
-    def max_interval_end_for_environment(
-        self, environment: str, ensure_finalized_snapshots: bool = False
-    ) -> t.Optional[int]:
-        """Returns the max interval end for the given environment.
+    def max_interval_end_per_model(
+        self,
+        environment: str,
+        ensure_finalized_snapshots: bool = False,
+    ) -> t.Optional[t.Dict[str, int]]:
+        """Returns the max interval end per model for the given environment.
 
         Args:
-            environment: The environment.
+            environment: The target environment.
             ensure_finalized_snapshots: Whether to use snapshots from the latest finalized environment state,
                 or to use whatever snapshots are in the current environment state even if the environment is not finalized.
 
         Returns:
-            A timestamp or None if no interval or environment exists.
+            A dictionary of model FQNs to their respective interval ends in milliseconds since epoch.
         """
-        return self._client.max_interval_end_for_environment(
-            environment, ensure_finalized_snapshots
-        )
-
-    def greatest_common_interval_end(
-        self, environment: str, models: t.Set[str], ensure_finalized_snapshots: bool = False
-    ) -> t.Optional[int]:
-        """Returns the greatest common interval end for given models in the target environment.
-
-        Args:
-            environment: The environment.
-            models: The model FQNs to select intervals from.
-            ensure_finalized_snapshots: Whether to use snapshots from the latest finalized environment state,
-                or to use whatever snapshots are in the current environment state even if the environment is not finalized.
-
-        Returns:
-            A timestamp or None if no interval or environment exists.
-        """
-        return self._client.greatest_common_interval_end(
-            environment, models, ensure_finalized_snapshots
+        return self._client.max_interval_end_per_model(
+            environment, ensure_finalized_snapshots=ensure_finalized_snapshots
         )
 
     def get_snapshots(

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -596,8 +596,9 @@ def test_plan_start_ahead_of_end(copy_to_temp_path):
     with freezegun.freeze_time("2024-01-02 00:00:00"):
         context = Context(paths=path, gateway="duckdb_persistent")
         context.plan("prod", no_prompts=True, auto_apply=True)
-        assert context.state_sync.max_interval_end_for_environment("prod") == to_timestamp(
-            "2024-01-02"
+        assert all(
+            i == to_timestamp("2024-01-02")
+            for i in context.state_sync.max_interval_end_per_model("prod").values()
         )
         context.close()
     with freezegun.freeze_time("2024-01-03 00:00:00"):
@@ -619,8 +620,9 @@ def test_plan_start_ahead_of_end(copy_to_temp_path):
         # Since the new start is ahead of the latest end loaded for prod, the table is deployed as empty
         # This isn't considered a gap since prod has not loaded these intervals yet
         # As a results the max interval end is unchanged and the table is empty
-        assert context.state_sync.max_interval_end_for_environment("prod") == to_timestamp(
-            "2024-01-02"
+        assert all(
+            i == to_timestamp("2024-01-02")
+            for i in context.state_sync.max_interval_end_per_model("prod").values()
         )
         assert context.engine_adapter.fetchone("SELECT COUNT(*) FROM sushi.hourly")[0] == 0
         context.close()

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -503,7 +503,7 @@ def test_hourly_model_with_lookback_no_backfill_in_dev(init_and_plan_context: t.
 
 
 @freeze_time("2023-01-08 00:00:00")
-def test_parent_cron_before_child(init_and_plan_context: t.Callable):
+def test_parent_cron_after_child(init_and_plan_context: t.Callable):
     context, plan = init_and_plan_context("examples/sushi")
 
     model = context.get_model("sushi.waiter_revenue_by_day")
@@ -517,6 +517,11 @@ def test_parent_cron_before_child(init_and_plan_context: t.Callable):
 
     plan = context.plan("prod", no_prompts=True, skip_tests=True)
     context.apply(plan)
+
+    waiter_revenue_by_day_snapshot = context.get_snapshot(model.name, raise_if_missing=True)
+    assert waiter_revenue_by_day_snapshot.intervals == [
+        (to_timestamp("2023-01-01"), to_timestamp("2023-01-07"))
+    ]
 
     top_waiters_model = context.get_model("sushi.top_waiters")
     top_waiters_model = add_projection_to_model(t.cast(SqlModel, top_waiters_model), literal=True)

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -548,6 +548,51 @@ def test_parent_cron_after_child(init_and_plan_context: t.Callable):
         ]
 
 
+@freeze_time("2023-01-08 00:00:00")
+def test_cron_not_aligned_with_day_boundary(init_and_plan_context: t.Callable):
+    context, plan = init_and_plan_context("examples/sushi")
+
+    model = context.get_model("sushi.waiter_revenue_by_day")
+    model = SqlModel.parse_obj(
+        {
+            **model.dict(),
+            "cron": "0 12 * * *",
+        }
+    )
+    context.upsert_model(model)
+
+    plan = context.plan("prod", no_prompts=True, skip_tests=True)
+    context.apply(plan)
+
+    waiter_revenue_by_day_snapshot = context.get_snapshot(model.name, raise_if_missing=True)
+    assert waiter_revenue_by_day_snapshot.intervals == [
+        (to_timestamp("2023-01-01"), to_timestamp("2023-01-07"))
+    ]
+
+    model = add_projection_to_model(t.cast(SqlModel, model), literal=True)
+    context.upsert_model(model)
+
+    waiter_revenue_by_day_snapshot = context.get_snapshot(
+        "sushi.waiter_revenue_by_day", raise_if_missing=True
+    )
+
+    with freeze_time("2023-01-08 00:10:00"):  # Past model's cron.
+        plan = context.plan("dev", select_models=[model.name], no_prompts=True, skip_tests=True)
+        assert plan.missing_intervals == [
+            SnapshotIntervals(
+                snapshot_id=waiter_revenue_by_day_snapshot.snapshot_id,
+                intervals=[
+                    (to_timestamp("2023-01-01"), to_timestamp("2023-01-02")),
+                    (to_timestamp("2023-01-02"), to_timestamp("2023-01-03")),
+                    (to_timestamp("2023-01-03"), to_timestamp("2023-01-04")),
+                    (to_timestamp("2023-01-04"), to_timestamp("2023-01-05")),
+                    (to_timestamp("2023-01-05"), to_timestamp("2023-01-06")),
+                    (to_timestamp("2023-01-06"), to_timestamp("2023-01-07")),
+                ],
+            ),
+        ]
+
+
 @freeze_time("2023-01-08 15:00:00")
 def test_forward_only_parent_created_in_dev_child_created_in_prod(
     init_and_plan_context: t.Callable,

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -663,6 +663,7 @@ def test_missing_intervals_lookback(make_snapshot, mocker: MockerFixture):
         restatements={},
         end_bounded=False,
         ensure_finalized_snapshots=False,
+        interval_end_per_model=None,
     )
 
     assert not plan.missing_intervals

--- a/tests/core/test_plan_evaluator.py
+++ b/tests/core/test_plan_evaluator.py
@@ -109,6 +109,7 @@ def test_airflow_evaluator(sushi_plan: Plan, mocker: MockerFixture):
         indirectly_modified_snapshots={},
         removed_snapshots=[],
         execution_time=None,
+        interval_end_per_model=None,
     )
 
     airflow_client_mock.wait_for_dag_run_completion.assert_called_once()

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -2034,8 +2034,8 @@ def test_max_interval_end_per_model(
 
     environment_name = "test_max_interval_end_for_environment"
 
-    assert state_sync.max_interval_end_per_model(environment_name) is None
-    assert state_sync.max_interval_end_per_model(environment_name, {snapshot_a.name}) is None
+    assert state_sync.max_interval_end_per_model(environment_name) == {}
+    assert state_sync.max_interval_end_per_model(environment_name, {snapshot_a.name}) == {}
 
     state_sync.promote(
         Environment(
@@ -2103,8 +2103,8 @@ def test_max_interval_end_per_model_ensure_finalized_snapshots(
 
     environment_name = "test_max_interval_end_for_environment"
 
-    assert state_sync.max_interval_end_per_model(environment_name) is None
-    assert state_sync.max_interval_end_per_model(environment_name, {snapshot_a.name}) is None
+    assert state_sync.max_interval_end_per_model(environment_name) == {}
+    assert state_sync.max_interval_end_per_model(environment_name, {snapshot_a.name}) == {}
 
     state_sync.promote(
         Environment(

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -2003,7 +2003,7 @@ def test_cleanup_expired_views(
     ]
 
 
-def test_max_interval_end_for_environment(
+def test_max_interval_end_per_model(
     state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
 ) -> None:
     snapshot_a = make_snapshot(
@@ -2028,11 +2028,13 @@ def test_max_interval_end_for_environment(
 
     state_sync.add_interval(snapshot_a, "2023-01-01", "2023-01-01")
     state_sync.add_interval(snapshot_a, "2023-01-02", "2023-01-02")
+    state_sync.add_interval(snapshot_a, "2023-01-03", "2023-01-03")
     state_sync.add_interval(snapshot_b, "2023-01-01", "2023-01-01")
+    state_sync.add_interval(snapshot_b, "2023-01-02", "2023-01-02")
 
     environment_name = "test_max_interval_end_for_environment"
 
-    assert state_sync.max_interval_end_for_environment(environment_name) is None
+    assert state_sync.max_interval_end_per_model(environment_name) is None
 
     state_sync.promote(
         Environment(
@@ -2045,12 +2047,13 @@ def test_max_interval_end_for_environment(
         )
     )
 
-    assert state_sync.max_interval_end_for_environment(environment_name) == to_timestamp(
-        "2023-01-03"
-    )
+    assert state_sync.max_interval_end_per_model(environment_name) == {
+        snapshot_a.name: to_timestamp("2023-01-04"),
+        snapshot_b.name: to_timestamp("2023-01-03"),
+    }
 
 
-def test_max_interval_end_for_environment_ensure_finalized_snapshots(
+def test_max_interval_end_per_model_ensure_finalized_snapshots(
     state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
 ) -> None:
     snapshot_a = make_snapshot(
@@ -2075,16 +2078,13 @@ def test_max_interval_end_for_environment_ensure_finalized_snapshots(
 
     state_sync.add_interval(snapshot_a, "2023-01-01", "2023-01-01")
     state_sync.add_interval(snapshot_a, "2023-01-02", "2023-01-02")
+    state_sync.add_interval(snapshot_a, "2023-01-03", "2023-01-03")
     state_sync.add_interval(snapshot_b, "2023-01-01", "2023-01-01")
+    state_sync.add_interval(snapshot_b, "2023-01-02", "2023-01-02")
 
     environment_name = "test_max_interval_end_for_environment"
 
-    assert (
-        state_sync.max_interval_end_for_environment(
-            environment_name, ensure_finalized_snapshots=True
-        )
-        is None
-    )
+    assert state_sync.max_interval_end_per_model(environment_name) is None
 
     state_sync.promote(
         Environment(
@@ -2097,133 +2097,9 @@ def test_max_interval_end_for_environment_ensure_finalized_snapshots(
         )
     )
 
-    assert state_sync.max_interval_end_for_environment(
+    assert state_sync.max_interval_end_per_model(
         environment_name, ensure_finalized_snapshots=True
-    ) == to_timestamp("2023-01-02")
-
-
-def test_greatest_common_interval_end(
-    state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
-) -> None:
-    snapshot_a = make_snapshot(
-        SqlModel(
-            name="a",
-            cron="@daily",
-            query=parse_one("select 1, ds"),
-        ),
-    )
-    snapshot_a.categorize_as(SnapshotChangeCategory.BREAKING)
-
-    snapshot_b = make_snapshot(
-        SqlModel(
-            name="b",
-            cron="@daily",
-            query=parse_one("select 2, ds"),
-        ),
-    )
-    snapshot_b.categorize_as(SnapshotChangeCategory.BREAKING)
-
-    state_sync.push_snapshots([snapshot_a, snapshot_b])
-
-    state_sync.add_interval(snapshot_a, "2023-01-01", "2023-01-01")
-    state_sync.add_interval(snapshot_a, "2023-01-02", "2023-01-02")
-    state_sync.add_interval(snapshot_a, "2023-01-03", "2023-01-03")
-    state_sync.add_interval(snapshot_b, "2023-01-01", "2023-01-01")
-    state_sync.add_interval(snapshot_b, "2023-01-02", "2023-01-02")
-
-    environment_name = "test_max_interval_end_for_environment"
-
-    assert state_sync.greatest_common_interval_end(environment_name, {snapshot_a.name}) is None
-
-    state_sync.promote(
-        Environment(
-            name=environment_name,
-            snapshots=[snapshot_a.table_info, snapshot_b.table_info],
-            start_at="2023-01-01",
-            end_at="2023-01-03",
-            plan_id="test_plan_id",
-            previous_finalized_snapshots=[snapshot_b.table_info],
-        )
-    )
-
-    assert state_sync.greatest_common_interval_end(
-        environment_name, {snapshot_a.name}
-    ) == to_timestamp("2023-01-04")
-
-    assert state_sync.greatest_common_interval_end(
-        environment_name, {snapshot_b.name}
-    ) == to_timestamp("2023-01-03")
-
-    assert state_sync.greatest_common_interval_end(
-        environment_name, {snapshot_a.name, snapshot_b.name}
-    ) == to_timestamp("2023-01-03")
-
-    assert state_sync.greatest_common_interval_end(environment_name, {"missing"}) == to_timestamp(
-        "2023-01-03"
-    )
-    assert state_sync.greatest_common_interval_end(environment_name, set()) is None
-
-
-def test_greatest_common_interval_end_ensure_finalized_snapshots(
-    state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
-) -> None:
-    snapshot_a = make_snapshot(
-        SqlModel(
-            name="a",
-            cron="@daily",
-            query=parse_one("select 1, ds"),
-        ),
-    )
-    snapshot_a.categorize_as(SnapshotChangeCategory.BREAKING)
-
-    snapshot_b = make_snapshot(
-        SqlModel(
-            name="b",
-            cron="@daily",
-            query=parse_one("select 2, ds"),
-        ),
-    )
-    snapshot_b.categorize_as(SnapshotChangeCategory.BREAKING)
-
-    state_sync.push_snapshots([snapshot_a, snapshot_b])
-
-    state_sync.add_interval(snapshot_a, "2023-01-01", "2023-01-01")
-    state_sync.add_interval(snapshot_a, "2023-01-02", "2023-01-02")
-    state_sync.add_interval(snapshot_a, "2023-01-03", "2023-01-03")
-    state_sync.add_interval(snapshot_b, "2023-01-01", "2023-01-01")
-    state_sync.add_interval(snapshot_b, "2023-01-02", "2023-01-02")
-
-    environment_name = "test_max_interval_end_for_environment"
-
-    assert state_sync.greatest_common_interval_end(environment_name, {snapshot_a.name}) is None
-
-    state_sync.promote(
-        Environment(
-            name=environment_name,
-            snapshots=[snapshot_a.table_info, snapshot_b.table_info],
-            start_at="2023-01-01",
-            end_at="2023-01-03",
-            plan_id="test_plan_id",
-            previous_finalized_snapshots=[snapshot_b.table_info],
-        )
-    )
-
-    assert state_sync.greatest_common_interval_end(
-        environment_name, {snapshot_a.name}, ensure_finalized_snapshots=True
-    ) == to_timestamp("2023-01-03")
-
-    assert state_sync.greatest_common_interval_end(
-        environment_name, {snapshot_b.name}, ensure_finalized_snapshots=True
-    ) == to_timestamp("2023-01-03")
-
-    assert state_sync.greatest_common_interval_end(
-        environment_name, {snapshot_a.name, snapshot_b.name}, ensure_finalized_snapshots=True
-    ) == to_timestamp("2023-01-03")
-
-    assert state_sync.greatest_common_interval_end(
-        environment_name, {"missing"}, ensure_finalized_snapshots=True
-    ) == to_timestamp("2023-01-03")
-    assert state_sync.greatest_common_interval_end(environment_name, set()) is None
+    ) == {snapshot_b.name: to_timestamp("2023-01-03")}
 
 
 def test_get_snapshots(mocker):

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -2035,6 +2035,7 @@ def test_max_interval_end_per_model(
     environment_name = "test_max_interval_end_for_environment"
 
     assert state_sync.max_interval_end_per_model(environment_name) is None
+    assert state_sync.max_interval_end_per_model(environment_name, {snapshot_a.name}) is None
 
     state_sync.promote(
         Environment(
@@ -2047,10 +2048,28 @@ def test_max_interval_end_per_model(
         )
     )
 
+    assert state_sync.max_interval_end_per_model(environment_name, {snapshot_a.name}) == {
+        snapshot_a.name: to_timestamp("2023-01-04")
+    }
+
+    assert state_sync.max_interval_end_per_model(environment_name, {snapshot_b.name}) == {
+        snapshot_b.name: to_timestamp("2023-01-03")
+    }
+
+    assert state_sync.max_interval_end_per_model(
+        environment_name, {snapshot_a.name, snapshot_b.name}
+    ) == {
+        snapshot_a.name: to_timestamp("2023-01-04"),
+        snapshot_b.name: to_timestamp("2023-01-03"),
+    }
+
     assert state_sync.max_interval_end_per_model(environment_name) == {
         snapshot_a.name: to_timestamp("2023-01-04"),
         snapshot_b.name: to_timestamp("2023-01-03"),
     }
+
+    assert state_sync.max_interval_end_per_model(environment_name, {"missing"}) == {}
+    assert state_sync.max_interval_end_per_model(environment_name, set()) == {}
 
 
 def test_max_interval_end_per_model_ensure_finalized_snapshots(
@@ -2085,6 +2104,7 @@ def test_max_interval_end_per_model_ensure_finalized_snapshots(
     environment_name = "test_max_interval_end_for_environment"
 
     assert state_sync.max_interval_end_per_model(environment_name) is None
+    assert state_sync.max_interval_end_per_model(environment_name, {snapshot_a.name}) is None
 
     state_sync.promote(
         Environment(
@@ -2097,9 +2117,32 @@ def test_max_interval_end_per_model_ensure_finalized_snapshots(
         )
     )
 
+    assert (
+        state_sync.max_interval_end_per_model(
+            environment_name, {snapshot_a.name}, ensure_finalized_snapshots=True
+        )
+        == {}
+    )
+
+    assert state_sync.max_interval_end_per_model(
+        environment_name, {snapshot_b.name}, ensure_finalized_snapshots=True
+    ) == {snapshot_b.name: to_timestamp("2023-01-03")}
+
+    assert state_sync.max_interval_end_per_model(
+        environment_name, {snapshot_a.name, snapshot_b.name}, ensure_finalized_snapshots=True
+    ) == {snapshot_b.name: to_timestamp("2023-01-03")}
+
     assert state_sync.max_interval_end_per_model(
         environment_name, ensure_finalized_snapshots=True
     ) == {snapshot_b.name: to_timestamp("2023-01-03")}
+
+    assert (
+        state_sync.max_interval_end_per_model(
+            environment_name, {"missing"}, ensure_finalized_snapshots=True
+        )
+        == {}
+    )
+    assert state_sync.max_interval_end_per_model(environment_name, set()) == {}
 
 
 def test_get_snapshots(mocker):

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -1,6 +1,4 @@
 import json
-from unittest.mock import call
-from urllib.parse import urlencode
 
 import pytest
 import requests
@@ -11,9 +9,9 @@ from sqlmesh.core.config import EnvironmentSuffixTarget
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.model import IncrementalByTimeRangeKind, SqlModel
 from sqlmesh.core.node import NodeType
-from sqlmesh.core.snapshot import Snapshot, SnapshotChangeCategory, SnapshotId
+from sqlmesh.core.snapshot import Snapshot, SnapshotChangeCategory
 from sqlmesh.schedulers.airflow import common
-from sqlmesh.schedulers.airflow.client import AirflowClient, _list_to_json
+from sqlmesh.schedulers.airflow.client import AirflowClient
 from sqlmesh.utils.date import to_timestamp
 
 pytestmark = pytest.mark.airflow
@@ -183,17 +181,13 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
     common.PlanApplicationRequest.parse_raw(data["data"])
 
 
-def snapshot_url(snapshot_ids, key="ids") -> str:
-    return urlencode({key: _list_to_json(snapshot_ids)[0]})
-
-
 def test_get_snapshots(mocker: MockerFixture, snapshot: Snapshot):
     snapshots = common.SnapshotsResponse(snapshots=[snapshot])
 
     get_snapshots_response_mock = mocker.Mock()
     get_snapshots_response_mock.status_code = 200
     get_snapshots_response_mock.json.return_value = snapshots.dict()
-    get_snapshots_mock = mocker.patch("requests.Session.get")
+    get_snapshots_mock = mocker.patch("requests.Session.post")
     get_snapshots_mock.return_value = get_snapshots_response_mock
 
     client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
@@ -201,44 +195,13 @@ def test_get_snapshots(mocker: MockerFixture, snapshot: Snapshot):
 
     assert result == [snapshot]
 
-    get_snapshots_mock.assert_called_once_with(
-        f"http://localhost:8080/sqlmesh/api/v1/snapshots?{snapshot_url([snapshot.snapshot_id])}"
-    )
-
-
-def test_get_snapshots_batching(mocker: MockerFixture, snapshot: Snapshot):
-    snapshots = common.SnapshotsResponse(snapshots=[snapshot])
-
-    get_snapshots_response_mock = mocker.Mock()
-    get_snapshots_response_mock.status_code = 200
-    get_snapshots_response_mock.json.return_value = snapshots.dict()
-    get_snapshots_mock = mocker.patch("requests.Session.get")
-    get_snapshots_mock.return_value = get_snapshots_response_mock
-
-    snapshot_ids_batch_size = 40
-    first_batch_ids = [
-        SnapshotId(name=snapshot.name, identifier=str(i)) for i in range(snapshot_ids_batch_size)
-    ]
-
-    client = AirflowClient(
-        airflow_url=common.AIRFLOW_LOCAL_URL,
-        session=requests.Session(),
-        snapshot_ids_batch_size=snapshot_ids_batch_size,
-    )
-    result = client.get_snapshots([*first_batch_ids, snapshot.snapshot_id])
-
-    assert result == [snapshot] * 2
-
-    get_snapshots_mock.assert_has_calls(
-        [
-            call(f"http://localhost:8080/sqlmesh/api/v1/snapshots?{snapshot_url(first_batch_ids)}"),
-            call().json(),
-            call(
-                f"http://localhost:8080/sqlmesh/api/v1/snapshots?{snapshot_url([snapshot.snapshot_id])}"
-            ),
-            call().json(),
-        ]
-    )
+    args, data = get_snapshots_mock.call_args_list[0]
+    assert args[0] == "http://localhost:8080/sqlmesh/api/v1/snapshots/search"
+    assert data["headers"] == {"Content-Type": "application/json"}
+    assert json.loads(data["data"]) == {
+        "snapshot_ids": [snapshot.snapshot_id.dict()],
+        "check_existence": False,
+    }
 
 
 def test_snapshots_exist(mocker: MockerFixture, snapshot: Snapshot):
@@ -247,7 +210,7 @@ def test_snapshots_exist(mocker: MockerFixture, snapshot: Snapshot):
     snapshots_exist_response_mock = mocker.Mock()
     snapshots_exist_response_mock.status_code = 200
     snapshots_exist_response_mock.json.return_value = snapshot_ids.dict()
-    snapshots_exist_mock = mocker.patch("requests.Session.get")
+    snapshots_exist_mock = mocker.patch("requests.Session.post")
     snapshots_exist_mock.return_value = snapshots_exist_response_mock
 
     client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
@@ -255,46 +218,13 @@ def test_snapshots_exist(mocker: MockerFixture, snapshot: Snapshot):
 
     assert result == {snapshot.snapshot_id}
 
-    snapshots_exist_mock.assert_called_once_with(
-        f"http://localhost:8080/sqlmesh/api/v1/snapshots?check_existence&{snapshot_url([snapshot.snapshot_id])}"
-    )
-
-
-def test_snapshots_exist_batching(mocker: MockerFixture, snapshot: Snapshot):
-    snapshot_ids = common.SnapshotIdsResponse(snapshot_ids=[snapshot.snapshot_id])
-
-    snapshots_exist_response_mock = mocker.Mock()
-    snapshots_exist_response_mock.status_code = 200
-    snapshots_exist_response_mock.json.return_value = snapshot_ids.dict()
-    snapshots_exist_mock = mocker.patch("requests.Session.get")
-    snapshots_exist_mock.return_value = snapshots_exist_response_mock
-
-    snapshot_ids_batch_size = 40
-    first_batch_ids = [
-        SnapshotId(name=snapshot.name, identifier=str(i)) for i in range(snapshot_ids_batch_size)
-    ]
-
-    client = AirflowClient(
-        airflow_url=common.AIRFLOW_LOCAL_URL,
-        session=requests.Session(),
-        snapshot_ids_batch_size=snapshot_ids_batch_size,
-    )
-    result = client.snapshots_exist([*first_batch_ids, snapshot.snapshot_id])
-
-    assert result == {snapshot.snapshot_id}
-
-    snapshots_exist_mock.assert_has_calls(
-        [
-            call(
-                f"http://localhost:8080/sqlmesh/api/v1/snapshots?check_existence&{snapshot_url(first_batch_ids)}"
-            ),
-            call().json(),
-            call(
-                f"http://localhost:8080/sqlmesh/api/v1/snapshots?check_existence&{snapshot_url([snapshot.snapshot_id])}"
-            ),
-            call().json(),
-        ]
-    )
+    args, data = snapshots_exist_mock.call_args_list[0]
+    assert args[0] == "http://localhost:8080/sqlmesh/api/v1/snapshots/search"
+    assert data["headers"] == {"Content-Type": "application/json"}
+    assert json.loads(data["data"]) == {
+        "snapshot_ids": [snapshot.snapshot_id.dict()],
+        "check_existence": True,
+    }
 
 
 def test_models_exist(mocker: MockerFixture, snapshot: Snapshot):
@@ -384,7 +314,7 @@ def test_max_interval_end_per_model(
     max_interval_end_response_mock = mocker.Mock()
     max_interval_end_response_mock.status_code = 200
     max_interval_end_response_mock.json.return_value = response.dict()
-    max_interval_end_mock = mocker.patch("requests.Session.get")
+    max_interval_end_mock = mocker.patch("requests.Session.post")
     max_interval_end_mock.return_value = max_interval_end_response_mock
 
     client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
@@ -394,10 +324,16 @@ def test_max_interval_end_per_model(
 
     assert result == response.interval_end_per_model
 
-    flags = "ensure_finalized_snapshots&" if ensure_finalized_snapshots else ""
-    max_interval_end_mock.assert_called_once_with(
-        f"http://localhost:8080/sqlmesh/api/v1/environments/test_environment/max_interval_end_per_model?{flags}models=%5B%22a.b.c%22%5D"
+    args, data = max_interval_end_mock.call_args_list[0]
+    assert (
+        args[0]
+        == "http://localhost:8080/sqlmesh/api/v1/environments/test_environment/max_interval_end_per_model"
     )
+    assert data["headers"] == {"Content-Type": "application/json"}
+    assert json.loads(data["data"]) == {
+        "models": ["a.b.c"],
+        "ensure_finalized_snapshots": ensure_finalized_snapshots,
+    }
 
 
 def test_max_interval_end_per_model_no_models(mocker: MockerFixture, snapshot: Snapshot):
@@ -409,7 +345,7 @@ def test_max_interval_end_per_model_no_models(mocker: MockerFixture, snapshot: S
     max_interval_end_response_mock = mocker.Mock()
     max_interval_end_response_mock.status_code = 200
     max_interval_end_response_mock.json.return_value = response.dict()
-    max_interval_end_mock = mocker.patch("requests.Session.get")
+    max_interval_end_mock = mocker.patch("requests.Session.post")
     max_interval_end_mock.return_value = max_interval_end_response_mock
 
     client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
@@ -417,9 +353,15 @@ def test_max_interval_end_per_model_no_models(mocker: MockerFixture, snapshot: S
 
     assert result == response.interval_end_per_model
 
-    max_interval_end_mock.assert_called_once_with(
-        "http://localhost:8080/sqlmesh/api/v1/environments/test_environment/max_interval_end_per_model"
+    args, data = max_interval_end_mock.call_args_list[0]
+    assert (
+        args[0]
+        == "http://localhost:8080/sqlmesh/api/v1/environments/test_environment/max_interval_end_per_model"
     )
+    assert data["headers"] == {"Content-Type": "application/json"}
+    assert json.loads(data["data"]) == {
+        "ensure_finalized_snapshots": False,
+    }
 
 
 def test_get_dag_run_state(mocker: MockerFixture):

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -373,11 +373,12 @@ def test_get_environments(mocker: MockerFixture, snapshot: Snapshot):
 
 
 @pytest.mark.parametrize("ensure_finalized_snapshots", [True, False])
-def test_max_interval_end_for_environment(
+def test_max_interval_end_per_model(
     mocker: MockerFixture, snapshot: Snapshot, ensure_finalized_snapshots: bool
 ):
     response = common.IntervalEndResponse(
-        environment="test_environment", max_interval_end=to_timestamp("2023-01-01")
+        environment="test_environment",
+        interval_end_per_model={"model_name": to_timestamp("2023-01-01")},
     )
 
     max_interval_end_response_mock = mocker.Mock()
@@ -387,40 +388,13 @@ def test_max_interval_end_for_environment(
     max_interval_end_mock.return_value = max_interval_end_response_mock
 
     client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
-    result = client.max_interval_end_for_environment("test_environment", ensure_finalized_snapshots)
+    result = client.max_interval_end_per_model("test_environment", ensure_finalized_snapshots)
 
-    assert result == response.max_interval_end
+    assert result == response.interval_end_per_model
 
     flags = "?ensure_finalized_snapshots" if ensure_finalized_snapshots else ""
     max_interval_end_mock.assert_called_once_with(
-        f"http://localhost:8080/sqlmesh/api/v1/environments/test_environment/max_interval_end{flags}"
-    )
-
-
-@pytest.mark.parametrize("ensure_finalized_snapshots", [True, False])
-def test_greatest_common_interval_end(
-    mocker: MockerFixture, snapshot: Snapshot, ensure_finalized_snapshots: bool
-):
-    response = common.IntervalEndResponse(
-        environment="test_environment", max_interval_end=to_timestamp("2023-01-01")
-    )
-
-    max_interval_end_response_mock = mocker.Mock()
-    max_interval_end_response_mock.status_code = 200
-    max_interval_end_response_mock.json.return_value = response.dict()
-    max_interval_end_mock = mocker.patch("requests.Session.get")
-    max_interval_end_mock.return_value = max_interval_end_response_mock
-
-    client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
-    result = client.greatest_common_interval_end(
-        "test_environment", {"a.b.c"}, ensure_finalized_snapshots
-    )
-
-    assert result == response.max_interval_end
-
-    flags = "ensure_finalized_snapshots&" if ensure_finalized_snapshots else ""
-    max_interval_end_mock.assert_called_once_with(
-        f"http://localhost:8080/sqlmesh/api/v1/environments/test_environment/greatest_common_interval_end?{flags}models=%5B%22a.b.c%22%5D"
+        f"http://localhost:8080/sqlmesh/api/v1/environments/test_environment/max_interval_end_per_model{flags}"
     )
 
 

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -123,6 +123,7 @@ def test_create_plan_dag_spec(
         directly_modified_snapshots=[the_snapshot.snapshot_id],
         indirectly_modified_snapshots={},
         removed_snapshots=[],
+        interval_end_per_model=None,
     )
 
     deleted_snapshot = SnapshotTableInfo(
@@ -257,6 +258,7 @@ def test_restatement(
         directly_modified_snapshots=[],
         indirectly_modified_snapshots={},
         removed_snapshots=[],
+        interval_end_per_model=None,
     )
     old_environment = Environment(
         name=environment_name,
@@ -369,6 +371,7 @@ def test_select_models_for_backfill(mocker: MockerFixture, random_name, make_sna
         directly_modified_snapshots=[snapshot_a.snapshot_id, snapshot_b.snapshot_id],
         indirectly_modified_snapshots={},
         removed_snapshots=[],
+        interval_end_per_model=None,
     )
 
     state_sync_mock = mocker.Mock()
@@ -445,6 +448,7 @@ def test_create_plan_dag_spec_duplicated_snapshot(
         directly_modified_snapshots=[],
         indirectly_modified_snapshots={},
         removed_snapshots=[],
+        interval_end_per_model=None,
     )
 
     dag_run_mock = mocker.Mock()
@@ -498,6 +502,7 @@ def test_create_plan_dag_spec_unbounded_end(
         directly_modified_snapshots=[],
         indirectly_modified_snapshots={},
         removed_snapshots=[],
+        interval_end_per_model=None,
     )
 
     state_sync_mock = mocker.Mock()


### PR DESCRIPTION
Previously we were using one end date per plan for all models that are part of the plan. This approach has proven problematic because, at times, SQLMesh derived incorrect missing intervals for some models when making changes in dev, especially when the cron expression didn't align with day / hour boundaries.

This update ensures that each individual model receives its own end date value, ensuring that SQLMesh correctly backfills changes up to what is already available in the target environment.