### PR TITLE
Fix: Converting boolean columns from CSV files

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1242,7 +1242,9 @@ class SeedModel(_SqlBasedModel):
             for column in date_columns:
                 df[column] = df[column].dt.date
 
-            df[bool_columns] = df[bool_columns].map(lambda i: str_to_bool(str(i)))
+            for column in bool_columns:
+                df[column] = df[column].apply(lambda i: str_to_bool(str(i)))
+
             df.loc[:, string_columns] = df[string_columns].mask(
                 cond=lambda x: x.notna(),  # type: ignore
                 other=df[string_columns].astype(str),  # type: ignore

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1242,7 +1242,7 @@ class SeedModel(_SqlBasedModel):
             for column in date_columns:
                 df[column] = df[column].dt.date
 
-            df[bool_columns] = df[bool_columns].apply(lambda i: str_to_bool(str(i)))
+            df[bool_columns] = df[bool_columns].applymap(lambda i: str_to_bool(str(i)))
             df.loc[:, string_columns] = df[string_columns].mask(
                 cond=lambda x: x.notna(),  # type: ignore
                 other=df[string_columns].astype(str),  # type: ignore

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1242,7 +1242,7 @@ class SeedModel(_SqlBasedModel):
             for column in date_columns:
                 df[column] = df[column].dt.date
 
-            df[bool_columns] = df[bool_columns].applymap(lambda i: str_to_bool(str(i)))
+            df[bool_columns] = df[bool_columns].map(lambda i: str_to_bool(str(i)))
             df.loc[:, string_columns] = df[string_columns].mask(
                 cond=lambda x: x.notna(),  # type: ignore
                 other=df[string_columns].astype(str),  # type: ignore

--- a/tests/core/test_seed.py
+++ b/tests/core/test_seed.py
@@ -6,10 +6,10 @@ from sqlmesh.core.model.seed import CsvSettings, Seed
 
 
 def test_read():
-    content = """key,value,ds
-1,one,2022-01-01
-2,two,2022-01-02
-3,three,2022-01-03
+    content = """key,value,ds,bool
+1,one,2022-01-01,true
+2,two,2022-01-02,false
+3,three,2022-01-03,true
 """
     seed = Seed(content=content)
     # Since we provide "snowflake" as the dialect, all identifiers are expected to
@@ -20,13 +20,14 @@ def test_read():
         "KEY": exp.DataType.build("bigint"),
         "VALUE": exp.DataType.build("text"),
         "DS": exp.DataType.build("text"),
+        "BOOL": exp.DataType.build("boolean"),
     }
-
     expected_df = pd.DataFrame(
         data={
             "KEY": [1, 2, 3],
             "VALUE": ["one", "two", "three"],
             "DS": ["2022-01-01", "2022-01-02", "2022-01-03"],
+            "BOOL": [True, False, True],
         }
     )
     dfs = seed_reader.read(batch_size=2)


### PR DESCRIPTION
This update fixes an issue when reading from `csv` files that contain booleans doesn't convert individual elements of the column