### PR TITLE
Feat: Improve table diff sample output in CLI

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1132,8 +1132,8 @@ class TerminalConsole(Console):
                     else:
                         keys.append(col)
 
-                assert len(list(environments.keys())) == 2
-                source_env, target_env = list(environments.keys())
+                assert len(environments) == 2
+                source_env, target_env = environments
 
                 column_styles = {
                     source_env: self.TABLE_DIFF_SOURCE_BLUE,
@@ -1142,16 +1142,20 @@ class TerminalConsole(Console):
 
                 for column in columns:
                     # Create a table with the joined keys and comparison columns
-                    column_table = sample[
-                        keys + [source_env + "__" + column, target_env + "__" + column]
-                    ]
+                    source_column = source_env + "__" + column
+                    target_column = target_env + "__" + column
+                    column_table = sample[keys + [source_column, target_column]]
 
                     # Filter to keep the rows where the values differ
                     column_table = column_table[
-                        column_table[source_env + "__" + column]
-                        != column_table[target_env + "__" + column]
+                        column_table[source_column] != column_table[target_column]
                     ]
-                    column_table.columns = column_table.columns.str.split("__").str[0]
+                    column_table = column_table.rename(
+                        columns={
+                            source_column: source_env,
+                            target_column: target_env,
+                        }
+                    )
 
                     table = Table(show_header=True)
                     for column_name in column_table.columns:

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1036,7 +1036,7 @@ class TerminalConsole(Console):
         if schema_diff.target_alias:
             target_name = schema_diff.target_alias.upper()
 
-        first_line = f"\n[b]Schema Diff Between '[yellow]{source_name}[/yellow]' and '[green]{target_name}[/green]'"
+        first_line = f"\n[b]Schema Diff Between '[#0248ff]{source_name}[/#0248ff]' and '[green]{target_name}[/green]'"
         if schema_diff.model_name:
             first_line = (
                 first_line + f" environments for model '[blue]{schema_diff.model_name}[/blue]'"
@@ -1130,7 +1130,7 @@ class TerminalConsole(Console):
                         keys.append(col)
 
                 column_styles = {
-                    environments[0]: "yellow",
+                    environments[0]: "#0248ff",
                     environments[1]: "green",
                 }
 
@@ -1144,9 +1144,9 @@ class TerminalConsole(Console):
                     ]
                     column_table.columns = column_table.columns.str.split("__").str[0]
 
-                    table = Table(show_header=True, header_style="bold cyan")
+                    table = Table(show_header=True)
                     for column_name in column_table.columns:
-                        style = column_styles.get(column_name, "bold cyan")
+                        style = column_styles.get(column_name, "")
                         table.add_column(column_name, style=style, header_style=style)
 
                     for _, row in column_table.iterrows():

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -287,6 +287,8 @@ def make_progress_bar(message: str, console: t.Optional[RichConsole] = None) -> 
 class TerminalConsole(Console):
     """A rich based implementation of the console."""
 
+    TABLE_DIFF_SOURCE_BLUE = "#0248ff"
+
     def __init__(
         self,
         console: t.Optional[RichConsole] = None,
@@ -1036,7 +1038,7 @@ class TerminalConsole(Console):
         if schema_diff.target_alias:
             target_name = schema_diff.target_alias.upper()
 
-        first_line = f"\n[b]Schema Diff Between '[#0248ff]{source_name}[/#0248ff]' and '[green]{target_name}[/green]'"
+        first_line = f"\n[b]Schema Diff Between '[{self.TABLE_DIFF_SOURCE_BLUE}]{source_name}[/{self.TABLE_DIFF_SOURCE_BLUE}]' and '[green]{target_name}[/green]'"
         if schema_diff.model_name:
             first_line = (
                 first_line + f" environments for model '[blue]{schema_diff.model_name}[/blue]'"
@@ -1130,7 +1132,7 @@ class TerminalConsole(Console):
                         keys.append(col)
 
                 column_styles = {
-                    environments[0]: "#0248ff",
+                    environments[0]: self.TABLE_DIFF_SOURCE_BLUE,
                     environments[1]: "green",
                 }
 


### PR DESCRIPTION
This update aims to improve the readability of table diff CLI output, fixes: #2645 

This format will print the columns being compared individually along with their associated keys in source and target tables side by side:

#### COMMON ROWS Sample Data Differences:

Column: num_orders

| item_id | PROD | DEV |
|---------|------|-----|
| 1       | 5    | 26  |
| 2       | 1    | 22  |
| 3       | 1    | 22  |
