### PR TITLE
fix: slack user warning :: the top level `text` argument is missing in the request payload

### DIFF
--- a/sqlmesh/core/notification_target.py
+++ b/sqlmesh/core/notification_target.py
@@ -283,6 +283,8 @@ class BaseSlackNotificationTarget(BaseNotificationTarget):
             ),
         )
 
+        composed.add_text(msg)
+
         self._send_slack_message(
             composed=composed.slack_message,
         )
@@ -318,6 +320,7 @@ class SlackWebhookNotificationTarget(BaseSlackNotificationTarget):
 
     def _send_slack_message(self, composed: slack.TSlackMessage) -> None:
         self.client.send(
+            text=composed["text"],
             blocks=composed["blocks"],
             attachments=composed["attachments"],  # type: ignore
         )
@@ -352,6 +355,7 @@ class SlackApiNotificationTarget(BaseSlackNotificationTarget):
 
         self.client.chat_postMessage(
             channel=self.channel,
+            text=composed["text"],
             blocks=composed["blocks"],
             attachments=composed["attachments"],  # type: ignore
         )

--- a/sqlmesh/integrations/slack.py
+++ b/sqlmesh/integrations/slack.py
@@ -35,7 +35,11 @@ class SlackMessageComposer:
 
     def __init__(self, initial_message: t.Optional[TSlackMessage] = None) -> None:
         """Initialize the Slack message builder"""
-        self.slack_message = initial_message or {"blocks": [], "attachments": [{"blocks": []}]}
+        self.slack_message: TSlackMessage = initial_message or {
+            "text": "",
+            "blocks": [],
+            "attachments": [{"blocks": []}],
+        }
 
     def add_primary_blocks(self, *blocks: TSlackBlock) -> "SlackMessageComposer":
         """Add blocks to the message. Blocks are always displayed"""

--- a/sqlmesh/integrations/slack.py
+++ b/sqlmesh/integrations/slack.py
@@ -27,6 +27,7 @@ class TSlackBlocks(TypedDict):
 
 class TSlackMessage(TSlackBlocks):
     attachments: t.List[TSlackBlocks]
+    text: str
 
 
 class SlackMessageComposer:
@@ -50,6 +51,14 @@ class SlackMessageComposer:
         self.slack_message["attachments"][0]["blocks"].extend(blocks)
         if len(self.slack_message["attachments"][0]["blocks"]) >= SLACK_MAX_ATTACHMENTS_BLOCKS:
             raise ValueError("Too many attachments")
+        return self
+
+    def add_text(self, text: str) -> "SlackMessageComposer":
+        """Add text to the message
+
+        This text is used in places where content cannot be rendered such as: system push notifications, assistive technology such as screen readers, etc.
+        """
+        self.slack_message["text"] = normalize_message(text)
         return self
 
     def _introspect(self) -> "SlackMessageComposer":


### PR DESCRIPTION
Each time the SQLMesh CI bot runs, we see these warnings:
```
/home/runner/.cache/pypoetry/virtualenvs/pipe-dwh-Jd5RneRz-py3.11/lib/python3.11/site-packages/slack_sdk/web/internal_utils.py:288: UserWarning: The top-level `text` argument is missing in the request payload for a chat.postMessage call - It's a best practice to always provide a `text` argument when posting a message. The `text` argument is used in places where content cannot be rendered such as: system push notifications, assistive technology such as screen readers, etc.
  warnings.warn(missing_text_message, UserWarning)
/home/runner/.cache/pypoetry/virtualenvs/pipe-dwh-Jd5RneRz-py3.11/lib/python3.11/site-packages/slack_sdk/web/internal_utils.py:289: UserWarning: Additionally, the attachment-level `fallback` argument is missing in the request payload for a chat.postMessage call - To avoid this warning, it is recommended to always provide a top-level `text` argument when posting a message. Alternatively you can provide an attachment-level `fallback` argument, though this is now considered a legacy field (see https://api.slack.com/reference/messaging/attachments#legacy_fields for more details).
  warnings.warn(missing_fallback_message, UserWarning)
```

Here is an issue that describes the problem: https://github.com/slackapi/bolt-js/issues/1249

I tested both the Slack Webhook and Slack API notifications and they seem to still work without issues. I'm not quite sure how to verify what the `text` field actually looks like though. 