### PR TITLE
Fix: Snapshot parsing during migration

### DIFF
--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -1325,10 +1325,17 @@ class EngineAdapterStateSync(StateSync):
     ) -> t.Dict[SnapshotId, SnapshotTableInfo]:
         logger.info("Migrating snapshot rows...")
         raw_snapshots = {
-            SnapshotId(name=name, identifier=identifier): json.loads(raw_snapshot)
+            SnapshotId(name=name, identifier=identifier): {
+                **json.loads(raw_snapshot),
+                "updated_ts": updated_ts,
+                "unpaused_ts": unpaused_ts,
+                "unrestorable": unrestorable,
+            }
             for where in (self._snapshot_id_filter(snapshots) if snapshots is not None else [None])
-            for name, identifier, raw_snapshot in self._fetchall(
-                exp.select("name", "identifier", "snapshot")
+            for name, identifier, raw_snapshot, updated_ts, unpaused_ts, unrestorable in self._fetchall(
+                exp.select(
+                    "name", "identifier", "snapshot", "updated_ts", "unpaused_ts", "unrestorable"
+                )
                 .from_(self.snapshots_table)
                 .where(where)
                 .lock()

--- a/sqlmesh/migrations/v0055_add_updated_ts_unpaused_ts_ttl_ms_unrestorable_to_snapshot.py
+++ b/sqlmesh/migrations/v0055_add_updated_ts_unpaused_ts_ttl_ms_unrestorable_to_snapshot.py
@@ -73,7 +73,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
                 "name": name,
                 "identifier": identifier,
                 "version": version,
-                "snapshot": snapshot,
+                "snapshot": json.dumps(parsed_snapshot),
                 "kind_name": kind_name,
                 "updated_ts": updated_ts,
                 "unpaused_ts": unpaused_ts,


### PR DESCRIPTION
Fix for:
```
>>> from sqlmesh.core.context import Context
>>>
>>> ctx = Context()
>>> ctx.migrate()
Traceback (most recent call last):
  File "/Users/georgesittas/Code/tobiko/sqlmesh/sqlmesh/core/state_sync/engine_adapter.py", line 1218, in migrate
    self._migrate_rows(promoted_snapshots_only)
  File "/Users/georgesittas/Code/tobiko/sqlmesh/sqlmesh/core/state_sync/engine_adapter.py", line 1317, in _migrate_rows
    snapshot_mapping = self._migrate_snapshot_rows(snapshots_to_migrate)
  File "/Users/georgesittas/Code/tobiko/sqlmesh/sqlmesh/core/state_sync/engine_adapter.py", line 1462, in _migrate_snapshot_rows
    _visit(root_snapshot_id, {})
  File "/Users/georgesittas/Code/tobiko/sqlmesh/sqlmesh/core/state_sync/engine_adapter.py", line 1380, in _visit
    snapshot = parsed_snapshots[snapshot_id]
  File "/Users/georgesittas/Code/tobiko/sqlmesh/sqlmesh/core/state_sync/engine_adapter.py", line 1762, in __getitem__
    snapshot = self.get(snapshot_id)
  File "/Users/georgesittas/Code/tobiko/sqlmesh/sqlmesh/core/state_sync/engine_adapter.py", line 1753, in get
    self._parsed_snapshots[snapshot_id] = Snapshot.parse_obj(raw_snapshot)
  File "/Users/georgesittas/Code/tobiko/sqlmesh/sqlmesh/utils/pydantic.py", line 181, in parse_obj
    super().model_validate(obj) if PYDANTIC_MAJOR_VERSION >= 2 else super().parse_obj(obj)  # type: ignore
  File "/Users/georgesittas/Code/tobiko/sqlmesh/.venv/lib/python3.10/site-packages/pydantic/main.py", line 503, in model_validate
    return cls.__pydantic_validator__.validate_python(
pydantic_core._pydantic_core.ValidationError: 1 validation error for Snapshot
updated_ts
  Field required [type=missing, input_value={'name': '"db"."sqlmesh_e...913', 'migrated': False}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.5/v/missing
    ```