### PR TITLE
Fix: Include models selected for backfill in the virtual layer even if they haven't been changed directly

### DIFF
--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -276,6 +276,7 @@ class PlanBuilder:
             deployability_index=deployability_index,
             restatements=restatements,
             interval_end_per_model=self._interval_end_per_model,
+            selected_models_to_backfill=self._backfill_models,
             models_to_backfill=models_to_backfill,
             effective_from=self._effective_from,
             execution_time=self._execution_time,

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -55,7 +55,10 @@ class Plan(PydanticModel, frozen=True):
     restatements: t.Dict[SnapshotId, Interval]
     interval_end_per_model: t.Optional[t.Dict[str, int]]
 
+    selected_models_to_backfill: t.Optional[t.Set[str]] = None
+    """Models that have been explicitly selected for backfill by a user."""
     models_to_backfill: t.Optional[t.Set[str]] = None
+    """All models that should be backfilled as part of this plan."""
     effective_from: t.Optional[TimeLike] = None
     execution_time: t.Optional[TimeLike] = None
 
@@ -183,17 +186,19 @@ class Plan(PydanticModel, frozen=True):
         snapshots = [s.table_info for s in self.snapshots.values()]
         promoted_snapshot_ids = None
         if self.is_dev and not self.include_unmodified:
-            promotable_snapshot_ids = self.context_diff.promotable_snapshot_ids.copy()
-            if self.models_to_backfill is not None:
+            if self.selected_models_to_backfill is not None:
                 # Only promote models that have been explicitly selected for backfill.
-                promotable_snapshot_ids &= {
+                promotable_snapshot_ids = {
                     *self.context_diff.previously_promoted_snapshot_ids,
                     *[
                         snapshots_by_name[m].snapshot_id
-                        for m in self.models_to_backfill
+                        for m in self.selected_models_to_backfill
                         if m in snapshots_by_name
                     ],
                 }
+            else:
+                promotable_snapshot_ids = self.context_diff.promotable_snapshot_ids.copy()
+
             promoted_snapshot_ids = [
                 s.snapshot_id for s in snapshots if s.snapshot_id in promotable_snapshot_ids
             ]

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -2217,7 +2217,7 @@ def test_models_selected_for_backfill(make_snapshot, mocker: MockerFixture):
     assert not plan.is_selected_for_backfill('"b"')
     assert plan.models_to_backfill == {'"a"'}
     assert {i.snapshot_id for i in plan.missing_intervals} == {snapshot_a.snapshot_id}
-    assert not plan.environment.promoted_snapshot_ids
+    assert plan.environment.promoted_snapshot_ids == [snapshot_a.snapshot_id]
 
     plan = PlanBuilder(context_diff, schema_differ, is_dev=True, backfill_models={'"b"'}).build()
     assert plan.is_selected_for_backfill('"a"')


### PR DESCRIPTION
This resolves the issue where a DAG has a structure like A <- B (B is downstream of A) and the model A is modified and selected (using `--select-model`) in a dev plan. A user then creates a follow-up plan and selects model B (again using `--select-model`) in order to backfill it. SQLMesh used to backfill B in the second plan but didn't create a view for it in the virtual layer, which rendered the changed model's output inaccessible.