### PR TITLE
chore: make connection creation consistent

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -145,6 +145,10 @@ class EngineAdapter:
         return self._connection_pool.get_cursor()
 
     @property
+    def connection(self) -> t.Any:
+        return self._connection_pool.get()
+
+    @property
     def spark(self) -> t.Optional[PySparkSession]:
         return None
 

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -26,7 +26,6 @@ if t.TYPE_CHECKING:
     from google.cloud import bigquery
     from google.cloud.bigquery import StandardSqlDataType
     from google.cloud.bigquery.client import Client as BigQueryClient
-    from google.cloud.bigquery.client import Connection as BigQueryConnection
     from google.cloud.bigquery.job.base import _AsyncJob as BigQueryQueryResult
     from google.cloud.bigquery.table import Table as BigQueryTable
 
@@ -89,10 +88,6 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
     @property
     def client(self) -> BigQueryClient:
         return self.connection._client
-
-    @property
-    def connection(self) -> BigQueryConnection:
-        return self.cursor.connection
 
     @property
     def _job_params(self) -> t.Dict[str, t.Any]:

--- a/sqlmesh/core/engine_adapter/trino.py
+++ b/sqlmesh/core/engine_adapter/trino.py
@@ -28,8 +28,6 @@ from sqlmesh.core.schema_diff import SchemaDiffer
 from sqlmesh.utils.date import TimeLike
 
 if t.TYPE_CHECKING:
-    from trino.dbapi import Connection as TrinoConnection
-
     from sqlmesh.core._typing import SchemaName, TableName
     from sqlmesh.core.engine_adapter._typing import DF, QueryOrDF
 
@@ -62,10 +60,6 @@ class TrinoEngineAdapter(
             exp.DataType.build("TIMESTAMP", dialect=DIALECT).this: [(3,)],
         },
     )
-
-    @property
-    def connection(self) -> TrinoConnection:
-        return self.cursor.connection
 
     def set_current_catalog(self, catalog: str) -> None:
         """Sets the catalog name of the current connection."""

--- a/tests/core/engine_adapter/test_integration.py
+++ b/tests/core/engine_adapter/test_integration.py
@@ -705,6 +705,14 @@ def cleanup(ctx: TestContext):
         ctx.cleanup()
 
 
+def test_connection(ctx: TestContext):
+    if ctx.test_type != "query":
+        pytest.skip("Connection tests only need to run once so we skip anything not query")
+    cursor_from_connection = ctx.engine_adapter.connection.cursor()
+    cursor_from_connection.execute("SELECT 1")
+    assert cursor_from_connection.fetchone()[0] == 1
+
+
 def test_catalog_operations(ctx: TestContext):
     if (
         ctx.engine_adapter.CATALOG_SUPPORT.is_unsupported


### PR DESCRIPTION
Prior to this PR some engines provided a connection while others did not. This makes the property consistent across all engine adapters and since it uses the connection created at the connection pool layer it can be done consistently across engines. 