### PR TITLE
Feat: allow a single macro function call in model definitions

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1676,7 +1676,7 @@ def load_sql_based_model(
             # Macro functions are allowed in place of model queries only when there are no
             # other statements in the model definition, otherwise they would be ambiguous
             isinstance(query_or_seed_insert, d.MacroFunc)
-            and (query_or_seed_insert.this.name.lower() == "union" or len(expressions[1:]) == 1)
+            and (query_or_seed_insert.this.name.lower() == "union" or len(expressions) == 2)
         )
     ):
         return create_sql_model(

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -431,7 +431,9 @@ class QueryRenderer(BaseExpressionRenderer):
             if not query:
                 return None
             if not isinstance(query, exp.Query):
-                raise_config_error(f"Query needs to be a SELECT or a UNION {query}.", self._path)
+                raise_config_error(
+                    f"Model query needs to be a SELECT or a UNION, got {query}.", self._path
+                )
                 raise
 
             if optimize:


### PR DESCRIPTION
This is a QOL improvement to allow some models to be more dynamic. For example, it could be used to easily define models that are based on a templated query (defined within the macro) and only need specific clauses of that query to be parameterized.

Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1722466563283509

cc: @crericha