### PR TITLE
Fix: Only include used refs into jinja globals when converting dbt models

### DIFF
--- a/sqlmesh/dbt/context.py
+++ b/sqlmesh/dbt/context.py
@@ -273,6 +273,7 @@ class DbtContext:
         dependency_context.seeds = seeds
         dependency_context.models = models
         dependency_context.variables = variables
+        dependency_context._refs = {**dependency_context._seeds, **dependency_context._models}  # type: ignore
 
         return dependency_context
 


### PR DESCRIPTION
Previously we introduced a regression by including redundant references. 

For example, if a model references another model with `ref('some_model')`, we included both `some_model` and `model_package.some_model` entries in the Jinja macro registry, even though only `some_model` was necessary.