### PR TITLE
Fix: Seed and model column mismatch due to normalization

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1266,12 +1266,14 @@ class SeedModel(_SqlBasedModel):
     def render_seed(self) -> t.Iterator[QueryOrDF]:
         self._ensure_hydrated()
 
+        type_columns = []
         date_columns = []
         datetime_columns = []
         bool_columns = []
         string_columns = []
 
         for name, tpe in (self.columns_to_types_ or {}).items():
+            type_columns.append(name)
             if tpe.this in (exp.DataType.Type.DATE, exp.DataType.Type.DATE32):
                 date_columns.append(name)
             elif tpe.this in exp.DataType.TEMPORAL_TYPES:
@@ -1282,7 +1284,7 @@ class SeedModel(_SqlBasedModel):
                 string_columns.append(name)
 
         for df in self._reader.read(batch_size=self.kind.batch_size):
-            for column in [*date_columns, *datetime_columns, *bool_columns, *string_columns]:
+            for column in type_columns:
                 if column not in df:
                     normalized_name = normalize_identifiers(column, dialect=self.dialect).name
                     if normalized_name in df:

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1266,14 +1266,13 @@ class SeedModel(_SqlBasedModel):
     def render_seed(self) -> t.Iterator[QueryOrDF]:
         self._ensure_hydrated()
 
-        columns = []
         date_columns = []
         datetime_columns = []
         bool_columns = []
         string_columns = []
 
-        for name, tpe in (self.columns_to_types_ or {}).items():
-            columns.append(name)
+        columns_to_types = self.columns_to_types_ or {}
+        for name, tpe in columns_to_types.items():
             if tpe.this in (exp.DataType.Type.DATE, exp.DataType.Type.DATE32):
                 date_columns.append(name)
             elif tpe.this in exp.DataType.TEMPORAL_TYPES:
@@ -1285,7 +1284,7 @@ class SeedModel(_SqlBasedModel):
 
         for df in self._reader.read(batch_size=self.kind.batch_size):
             rename_dict = {}
-            for column in columns:
+            for column in columns_to_types:
                 if column not in df:
                     normalized_name = normalize_identifiers(column, dialect=self.dialect).name
                     if normalized_name in df:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -813,6 +813,7 @@ def test_seed_case_sensitive_columns(tmp_path):
         f"""
         MODEL (
             name db.seed,
+            dialect postgres,
             kind SEED (
               path '{str(model_csv_path)}',
             ),

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -818,10 +818,10 @@ def test_seed_case_sensitive_columns(tmp_path):
               path '{str(model_csv_path)}',
             ),
             columns (
-              'camelCaseId' int,
-              'camelCaseBool' boolean,
-              'camelCaseString' text,
-              'camelCaseTimestamp' timestamp
+              "camelCaseId" int,
+              "camelCaseBool" boolean,
+              "camelCaseString" text,
+              "camelCaseTimestamp" timestamp
             )
         );
     """


### PR DESCRIPTION
This update aims to resolve a lookup issue in `render_seed` by renaming the columns that are looked up and can't be resolved (due to being [normalised](https://github.com/TobikoData/sqlmesh/blob/aa3ee94e1d41c18d41d95565dc1b7d0d4e331921/sqlmesh/core/model/seed.py#L78C9-L78C16)) with the names from the model definition columns, fixes: #2698 