### PR TITLE
Fix: Don't cache snapshot intervals

### DIFF
--- a/sqlmesh/core/snapshot/cache.py
+++ b/sqlmesh/core/snapshot/cache.py
@@ -37,6 +37,8 @@ class SnapshotCache:
                 if snapshot.is_model:
                     self._optimized_query_cache.with_optimized_query(snapshot.model)
                 self._update_node_hash_cache(snapshot)
+                snapshot.intervals = []
+                snapshot.dev_intervals = []
                 snapshots[s_id] = snapshot
                 cache_hits.add(s_id)
 

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1207,6 +1207,14 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         if not self.version:
             raise SQLMeshError(f"Snapshot {self.snapshot_id} has not been versioned yet.")
 
+    def __getstate__(self) -> t.Dict[t.Any, t.Any]:
+        state = super().__getstate__()
+        state["__dict__"] = state["__dict__"].copy()
+        # Don't store intervals.
+        state["__dict__"]["intervals"] = []
+        state["__dict__"]["dev_intervals"] = []
+        return state
+
 
 class SnapshotTableCleanupTask(PydanticModel):
     snapshot: SnapshotTableInfo

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -1987,3 +1987,5 @@ def test_snapshot_pickle_intervals(make_snapshot):
     loaded_snapshot = pickle.loads(pickle.dumps(snapshot))
     assert not loaded_snapshot.intervals
     assert not loaded_snapshot.dev_intervals
+    assert len(snapshot.intervals) > 0
+    assert len(snapshot.dev_intervals) > 0


### PR DESCRIPTION
Intervals should never be cached so that they can be hydrated correctly after snapshots are loaded from cache.