### PR TITLE
Fix: User-provided plan end must take precedence over the max interval end per model

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1134,7 +1134,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         # to prevent unintended evaluation of the entire DAG.
         default_end: t.Optional[int] = None
         max_interval_end_per_model: t.Optional[t.Dict[str, int]] = None
-        if not run:
+        if not run and not end:
             models_for_interval_end: t.Optional[t.Set[str]] = None
             if backfill_models is not None:
                 models_for_interval_end = set()

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -257,6 +257,12 @@ class PlanBuilder:
             dag, earliest_interval_start(filtered_snapshots.values())
         )
 
+        interval_end_per_model = self._interval_end_per_model
+        if interval_end_per_model and self.override_end:
+            # If the end date was provided explicitly by a user, then interval end for each individual
+            # model should be ignored.
+            interval_end_per_model = None
+
         plan = Plan(
             context_diff=self._context_diff,
             plan_id=self._plan_id,
@@ -275,7 +281,7 @@ class PlanBuilder:
             ignored=ignored,
             deployability_index=deployability_index,
             restatements=restatements,
-            interval_end_per_model=self._interval_end_per_model,
+            interval_end_per_model=interval_end_per_model,
             selected_models_to_backfill=self._backfill_models,
             models_to_backfill=models_to_backfill,
             effective_from=self._effective_from,

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1628,9 +1628,14 @@ def missing_intervals(
     for snapshot in snapshots:
         if not snapshot.evaluatable:
             continue
-        interval = restatements.get(snapshot.snapshot_id)
         snapshot_start_date = start_dt
-        snapshot_end_date = interval_end_per_model.get(snapshot.name, end_date)
+        snapshot_end_date: TimeLike = end_date
+
+        existing_interval_end = interval_end_per_model.get(snapshot.name)
+        if existing_interval_end and existing_interval_end > to_timestamp(snapshot_start_date):
+            snapshot_end_date = existing_interval_end
+
+        interval = restatements.get(snapshot.snapshot_id)
         if interval:
             snapshot_start_date, snapshot_end_date = (to_datetime(i) for i in interval)
             snapshot = snapshot.copy()

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -1259,6 +1259,22 @@ def test_select_unchanged_model_for_backfill(init_and_plan_context: t.Callable):
 
 
 @freeze_time("2023-01-08 15:00:00")
+def test_max_interval_end_per_model_not_applied_when_end_is_provided(
+    init_and_plan_context: t.Callable,
+):
+    context, plan = init_and_plan_context("examples/sushi")
+    context.apply(plan)
+
+    with freeze_time("2023-01-09 00:00:00"):
+        context.run()
+
+        plan = context.plan(
+            no_prompts=True, restate_models=["*"], start="2023-01-09", end="2023-01-09"
+        )
+        context.apply(plan)
+
+
+@freeze_time("2023-01-08 15:00:00")
 def test_select_models_for_backfill(init_and_plan_context: t.Callable):
     context, _ = init_and_plan_context("examples/sushi")
 


### PR DESCRIPTION
The last backfilled interval for each model should only be take into account if no explicit end date was provided by a user. Otherwise the user provided value should always take precedence.

This resolves the issue for seed models that have been backfilled once, models with an end date, and models with a broad execution cadence (e.g., monthly) where the start date value ends up being greater than the end date value.
```
ValueError: Start date / time (2024-08-20 00:00:00+00:00) can't be greater than end date / time (1715126400000)
```