### PR TITLE
Fix: Handle missing source target aliases in sample data diff

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1120,33 +1120,28 @@ class TerminalConsole(Console):
             self.console.print("\n[b][blue]COMMON ROWS[/blue] sample data differences:[/b]")
             if sample.shape[0] > 0:
                 keys: list[str] = []
-                columns: dict[str, None] = {}
-                environments: dict[str, None] = {}
+                columns: dict[str, list[str]] = {}
+                source_env = row_diff.source_alias.upper() if row_diff.source_alias else "SOURCE"
+                target_env = row_diff.target_alias.upper() if row_diff.target_alias else "TARGET"
 
-                # Extract environment, key and column names from the joined sample
-                for col in sample.columns:
-                    if "__" in col:
-                        column_parts = col.split("__")
-                        environments[column_parts[0]] = None
-                        columns["__".join(column_parts[1:])] = None
-                    else:
-                        keys.append(col)
-
-                assert len(environments) == 2
-                source_env, target_env = environments
+                # Extract key and column names from the joined sample
+                for column in row_diff.joined_sample.columns:
+                    if f"{source_env}__" in column:
+                        column_name = "__".join(column.split(f"{source_env}__")[1:])
+                        columns[column_name] = [column, f"{target_env}__{column_name}"]
+                    elif f"{target_env}__" not in column:
+                        keys.append(column)
 
                 column_styles = {
                     source_env: self.TABLE_DIFF_SOURCE_BLUE,
                     target_env: "green",
                 }
 
-                for column in columns:
+                for column, [source_column, target_column] in columns.items():
                     # Create a table with the joined keys and comparison columns
-                    source_column = source_env + "__" + column
-                    target_column = target_env + "__" + column
-                    column_table = sample[keys + [source_column, target_column]]
+                    column_table = row_diff.joined_sample[keys + [source_column, target_column]]
 
-                    # Filter to keep the rows where the values differ
+                    # Filter out identical-valued rows
                     column_table = column_table[
                         column_table[source_column] != column_table[target_column]
                     ]

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1121,20 +1121,28 @@ class TerminalConsole(Console):
             if sample.shape[0] > 0:
                 keys: list[str] = []
                 columns: dict[str, list[str]] = {}
-                source_env = row_diff.source_alias.upper() if row_diff.source_alias else "SOURCE"
-                target_env = row_diff.target_alias.upper() if row_diff.target_alias else "TARGET"
+                source_prefix, source_name = (
+                    (f"{source_name}__", source_name)
+                    if source_name != row_diff.source
+                    else ("s__", "SOURCE")
+                )
+                target_prefix, target_name = (
+                    (f"{target_name}__", target_name)
+                    if target_name != row_diff.target
+                    else ("t__", "TARGET")
+                )
 
                 # Extract key and column names from the joined sample
                 for column in row_diff.joined_sample.columns:
-                    if f"{source_env}__" in column:
-                        column_name = "__".join(column.split(f"{source_env}__")[1:])
-                        columns[column_name] = [column, f"{target_env}__{column_name}"]
-                    elif f"{target_env}__" not in column:
+                    if source_prefix in column:
+                        column_name = "__".join(column.split(source_prefix)[1:])
+                        columns[column_name] = [column, target_prefix + column_name]
+                    elif target_prefix not in column:
                         keys.append(column)
 
                 column_styles = {
-                    source_env: self.TABLE_DIFF_SOURCE_BLUE,
-                    target_env: "green",
+                    source_name: self.TABLE_DIFF_SOURCE_BLUE,
+                    target_name: "green",
                 }
 
                 for column, [source_column, target_column] in columns.items():
@@ -1147,8 +1155,8 @@ class TerminalConsole(Console):
                     ]
                     column_table = column_table.rename(
                         columns={
-                            source_column: source_env,
-                            target_column: target_env,
+                            source_column: source_name,
+                            target_column: target_name,
                         }
                     )
 

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -436,12 +436,18 @@ class TableDiff:
                     c: c.split("__")[1] if c.split("__")[1] in index_cols else c
                     for c in joined_sample_cols
                 }
-                if self.source != self.source_alias and self.target != self.target_alias:
+
+                if (
+                    self.source_alias
+                    and self.target_alias
+                    and self.source != self.source_alias
+                    and self.target != self.target_alias
+                ):
                     joined_renamed_cols = {
                         c: (
                             n.replace(
                                 "s__",
-                                f"{self.source_alias.upper() if self.source_alias else 'SOURCE'}__",
+                                f"{self.source_alias.upper()}__",
                             )
                             if n.startswith("s__")
                             else n
@@ -452,7 +458,7 @@ class TableDiff:
                         c: (
                             n.replace(
                                 "t__",
-                                f"{self.target_alias.upper() if self.target_alias else 'TARGET'}__",
+                                f"{self.target_alias.upper()}__",
                             )
                             if n.startswith("t__")
                             else n

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -440,7 +440,8 @@ class TableDiff:
                     joined_renamed_cols = {
                         c: (
                             n.replace(
-                                "s__", f"{self.source_alias.upper() if self.source_alias else ''}__"
+                                "s__",
+                                f"{self.source_alias.upper() if self.source_alias else 'SOURCE'}__",
                             )
                             if n.startswith("s__")
                             else n
@@ -450,7 +451,8 @@ class TableDiff:
                     joined_renamed_cols = {
                         c: (
                             n.replace(
-                                "t__", f"{self.target_alias.upper() if self.target_alias else ''}__"
+                                "t__",
+                                f"{self.target_alias.upper() if self.target_alias else 'TARGET'}__",
                             )
                             if n.startswith("t__")
                             else n


### PR DESCRIPTION
This update adds placeholder environment source and target names to the joined sample (when `source_alias` and `target_alias` are not defined during the construction of the TableDiff) in order to differentiate the output results in row_diff and display results when calling `show_row_diff`.