### PR TITLE
Chore: Treat the target environment as missing during planning if it's expired

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1246,6 +1246,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             sync: If True, the call blocks until the environment is deleted. Otherwise, the environment will
                 be deleted asynchronously by the janitor process.
         """
+        name = Environment.sanitize_name(name)
         self.state_sync.invalidate_environment(name)
         if sync:
             self._cleanup_environments()

--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -87,7 +87,7 @@ class ContextDiff(PydanticModel):
         environment = environment.lower()
         env = state_reader.get_environment(environment)
 
-        if env is None:
+        if env is None or env.expired:
             env = state_reader.get_environment(create_from.lower())
             is_new_environment = True
             previously_promoted_snapshot_ids = set()

--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -10,7 +10,7 @@ from sqlmesh.core import constants as c
 from sqlmesh.core.config import EnvironmentSuffixTarget
 from sqlmesh.core.snapshot import SnapshotId, SnapshotTableInfo
 from sqlmesh.utils import word_characters_only
-from sqlmesh.utils.date import TimeLike
+from sqlmesh.utils.date import TimeLike, now_timestamp
 from sqlmesh.utils.pydantic import PydanticModel, field_validator
 
 T = t.TypeVar("T", bound="EnvironmentNamingInfo")
@@ -152,3 +152,7 @@ class Environment(EnvironmentNamingInfo):
             catalog_name_override=self.catalog_name_override,
             normalize_name=self.normalize_name,
         )
+
+    @property
+    def expired(self) -> bool:
+        return self.expiration_ts is not None and self.expiration_ts <= now_timestamp()

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -284,19 +284,20 @@ class EngineAdapterStateSync(StateSync):
                 )
                 != table_infos[name].qualified_view_name.for_environment(environment.naming_info)
             }
-            if environment.previous_plan_id != existing_environment.plan_id:
-                raise SQLMeshError(
-                    f"Plan '{environment.plan_id}' is no longer valid for the target environment '{environment.name}'. "
-                    f"Expected previous plan ID: '{environment.previous_plan_id}', actual previous plan ID: '{existing_environment.plan_id}'. "
-                    "Please recreate the plan and try again"
-                )
-            if no_gaps_snapshot_names != set():
-                snapshots = self._get_snapshots(environment.snapshots).values()
-                self._ensure_no_gaps(
-                    snapshots,
-                    existing_environment,
-                    no_gaps_snapshot_names,
-                )
+            if not existing_environment.expired:
+                if environment.previous_plan_id != existing_environment.plan_id:
+                    raise SQLMeshError(
+                        f"Plan '{environment.plan_id}' is no longer valid for the target environment '{environment.name}'. "
+                        f"Expected previous plan ID: '{environment.previous_plan_id}', actual previous plan ID: '{existing_environment.plan_id}'. "
+                        "Please recreate the plan and try again"
+                    )
+                if no_gaps_snapshot_names != set():
+                    snapshots = self._get_snapshots(environment.snapshots).values()
+                    self._ensure_no_gaps(
+                        snapshots,
+                        existing_environment,
+                        no_gaps_snapshot_names,
+                    )
             demoted_snapshots = set(existing_environment.snapshots) - set(environment.snapshots)
             # Update the updated_at attribute.
             self._update_snapshots(demoted_snapshots)


### PR DESCRIPTION
With this update, whenever the plan command targets an environment that has expired, it will behave as if it were missing instead.