### PR TITLE
Fix!: Retain indexes when creating state table backups

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -781,22 +781,14 @@ class EngineAdapter:
         source_table_name: TableName,
         exists: bool = True,
     ) -> None:
+        """Create a table to store SQLMesh internal state based on the definition of another table, including any
+        column attributes and indexes defined in the original table.
+
+        Args:
+            target_table_name: The name of the table to create. Can be fully qualified or just table name.
+            source_table_name: The name of the table to base the new table on.
         """
-        Create a table like another table or view.
-        """
-        target_table = exp.to_table(target_table_name)
-        source_table = exp.to_table(source_table_name)
-        create_expression = exp.Create(
-            this=target_table,
-            kind="TABLE",
-            exists=exists,
-            properties=exp.Properties(
-                expressions=[
-                    exp.LikeProperty(this=source_table),
-                ]
-            ),
-        )
-        self.execute(create_expression)
+        self.create_table(target_table_name, self.columns(source_table_name), exists=exists)
 
     def clone_table(
         self,

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -162,5 +162,26 @@ class MySQLEngineAdapter(
                         exc_info=True,
                     )
 
+    def create_table_like(
+        self,
+        target_table_name: TableName,
+        source_table_name: TableName,
+        exists: bool = True,
+    ) -> None:
+        self.execute(
+            exp.Create(
+                this=exp.to_table(target_table_name),
+                kind="TABLE",
+                exists=exists,
+                properties=exp.Properties(
+                    expressions=[
+                        exp.LikeProperty(
+                            this=exp.to_table(source_table_name),
+                        ),
+                    ],
+                ),
+            )
+        )
+
     def ping(self) -> None:
         self._connection_pool.get().ping(reconnect=False)

--- a/sqlmesh/migrations/v0056_restore_table_indexes.py
+++ b/sqlmesh/migrations/v0056_restore_table_indexes.py
@@ -1,0 +1,116 @@
+"""Readds indexes and primary keys in case tables were restored from a backup."""
+
+from sqlglot import exp
+from sqlmesh.utils import random_id
+from sqlmesh.utils.migration import index_text_type
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    schema = state_sync.schema
+    engine_adapter = state_sync.engine_adapter
+    if not engine_adapter.SUPPORTS_INDEXES:
+        return
+
+    intervals_table = "_intervals"
+    snapshots_table = "_snapshots"
+    environments_table = "_environments"
+    if state_sync.schema:
+        intervals_table = f"{schema}.{intervals_table}"
+        snapshots_table = f"{schema}.{snapshots_table}"
+        environments_table = f"{schema}.{environments_table}"
+
+    table_suffix = random_id(short=True)
+
+    index_type = index_text_type(engine_adapter.dialect)
+
+    new_snapshots_table = f"{snapshots_table}__{table_suffix}"
+    snapshots_columns_to_types = {
+        "name": exp.DataType.build(index_type),
+        "identifier": exp.DataType.build(index_type),
+        "version": exp.DataType.build(index_type),
+        "snapshot": exp.DataType.build("text"),
+        "kind_name": exp.DataType.build(index_type),
+        "updated_ts": exp.DataType.build("bigint"),
+        "unpaused_ts": exp.DataType.build("bigint"),
+        "ttl_ms": exp.DataType.build("bigint"),
+        "unrestorable": exp.DataType.build("boolean"),
+    }
+
+    new_environments_table = f"{environments_table}__{table_suffix}"
+    environments_columns_to_types = {
+        "name": exp.DataType.build(index_type),
+        "snapshots": exp.DataType.build("text"),
+        "start_at": exp.DataType.build("text"),
+        "end_at": exp.DataType.build("text"),
+        "plan_id": exp.DataType.build("text"),
+        "previous_plan_id": exp.DataType.build("text"),
+        "expiration_ts": exp.DataType.build("bigint"),
+        "finalized_ts": exp.DataType.build("bigint"),
+        "promoted_snapshot_ids": exp.DataType.build("text"),
+        "suffix_target": exp.DataType.build("text"),
+        "catalog_name_override": exp.DataType.build("text"),
+        "previous_finalized_snapshots": exp.DataType.build("text"),
+        "normalize_name": exp.DataType.build("boolean"),
+    }
+
+    new_intervals_table = f"{intervals_table}__{table_suffix}"
+    intervals_columns_to_types = {
+        "id": exp.DataType.build(index_type),
+        "created_ts": exp.DataType.build("bigint"),
+        "name": exp.DataType.build(index_type),
+        "identifier": exp.DataType.build(index_type),
+        "version": exp.DataType.build(index_type),
+        "start_ts": exp.DataType.build("bigint"),
+        "end_ts": exp.DataType.build("bigint"),
+        "is_dev": exp.DataType.build("boolean"),
+        "is_removed": exp.DataType.build("boolean"),
+        "is_compacted": exp.DataType.build("boolean"),
+    }
+
+    # Recreate the snapshots table and its indexes.
+    engine_adapter.create_table(
+        new_snapshots_table, snapshots_columns_to_types, primary_key=("name", "identifier")
+    )
+    engine_adapter.create_index(
+        new_snapshots_table, "_snapshots_name_version_idx", ("name", "version")
+    )
+    engine_adapter.insert_append(
+        new_snapshots_table,
+        exp.select("*").from_(snapshots_table),
+        columns_to_types=snapshots_columns_to_types,
+    )
+
+    # Recreate the environments table and its indexes.
+    engine_adapter.create_table(
+        new_environments_table, environments_columns_to_types, primary_key=("name",)
+    )
+    engine_adapter.insert_append(
+        new_environments_table,
+        exp.select("*").from_(environments_table),
+        columns_to_types=environments_columns_to_types,
+    )
+
+    # Recreate the itnervals table and its indexes.
+    engine_adapter.create_table(
+        new_intervals_table, intervals_columns_to_types, primary_key=("id",)
+    )
+    engine_adapter.create_index(
+        new_intervals_table, "_intervals_name_identifier_idx", ("name", "identifier")
+    )
+    engine_adapter.create_index(
+        new_intervals_table, "_intervals_name_version_idx", ("name", "version")
+    )
+    engine_adapter.insert_append(
+        new_intervals_table,
+        exp.select("*").from_(intervals_table),
+        columns_to_types=intervals_columns_to_types,
+    )
+
+    # Drop old tables.
+    for table in (snapshots_table, environments_table, intervals_table):
+        engine_adapter.drop_table(table)
+
+    # Replace old tables with new ones.
+    engine_adapter.rename_table(new_snapshots_table, snapshots_table)
+    engine_adapter.rename_table(new_environments_table, environments_table)
+    engine_adapter.rename_table(new_intervals_table, intervals_table)

--- a/sqlmesh/migrations/v0056_restore_table_indexes.py
+++ b/sqlmesh/migrations/v0056_restore_table_indexes.py
@@ -90,7 +90,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         columns_to_types=environments_columns_to_types,
     )
 
-    # Recreate the itnervals table and its indexes.
+    # Recreate the intervals table and its indexes.
     engine_adapter.create_table(
         new_intervals_table, intervals_columns_to_types, primary_key=("id",)
     )

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -2375,12 +2375,19 @@ def test_replace_query_self_referencing_not_exists_known(
     ]
 
 
-def test_create_table_like(make_mocked_engine_adapter: t.Callable):
+def test_create_table_like(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(EngineAdapter)
+
+    columns_to_types = {
+        "cola": exp.DataType.build("INT"),
+        "colb": exp.DataType.build("TEXT"),
+    }
+    columns_mock = mocker.patch.object(adapter, "columns")
+    columns_mock.return_value = columns_to_types
 
     adapter.create_table_like("target_table", "source_table")
     adapter.cursor.execute.assert_called_once_with(
-        'CREATE TABLE IF NOT EXISTS "target_table" LIKE "source_table"'
+        'CREATE TABLE IF NOT EXISTS "target_table" ("cola" INT, "colb" TEXT)'
     )
 
 

--- a/tests/core/engine_adapter/test_mysql.py
+++ b/tests/core/engine_adapter/test_mysql.py
@@ -75,3 +75,12 @@ def test_pre_ping(mocker: MockerFixture, make_mocked_engine_adapter: t.Callable)
     ]
 
     adapter._connection_pool.get().ping.assert_called_once_with(reconnect=False)
+
+
+def test_create_table_like(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(MySQLEngineAdapter)
+
+    adapter.create_table_like("target_table", "source_table")
+    adapter.cursor.execute.assert_called_once_with(
+        "CREATE TABLE IF NOT EXISTS `target_table` LIKE `source_table`"
+    )

--- a/tests/core/engine_adapter/test_postgres.py
+++ b/tests/core/engine_adapter/test_postgres.py
@@ -80,3 +80,12 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
         """COMMENT ON TABLE "test_table" IS '\\'""",
         """COMMENT ON COLUMN "test_table"."a" IS '\\'""",
     ]
+
+
+def test_create_table_like(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(PostgresEngineAdapter)
+
+    adapter.create_table_like("target_table", "source_table")
+    adapter.cursor.execute.assert_called_once_with(
+        'CREATE TABLE IF NOT EXISTS "target_table" (LIKE "source_table" INCLUDING ALL)'
+    )


### PR DESCRIPTION
Previously, we created backup state tables using the CTAS statement, which didn't retain any table indexes or constraints. 

This change fixes the issue and also adds a migration script that recreates the original indexes for those who may have restored from a backup in the past.