### PR TITLE
fix: always provide feedback during plan execution

### DIFF
--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -72,7 +72,7 @@ from sqlmesh.core.state_sync.common import transactional
 from sqlmesh.utils import major_minor, random_id, unique
 from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.date import TimeLike, now, now_timestamp, time_like_to_str, to_timestamp
-from sqlmesh.utils.errors import SQLMeshError
+from sqlmesh.utils.errors import ConflictingPlanError, SQLMeshError
 
 logger = logging.getLogger(__name__)
 
@@ -286,7 +286,7 @@ class EngineAdapterStateSync(StateSync):
             }
             if not existing_environment.expired:
                 if environment.previous_plan_id != existing_environment.plan_id:
-                    raise SQLMeshError(
+                    raise ConflictingPlanError(
                         f"Plan '{environment.plan_id}' is no longer valid for the target environment '{environment.name}'. "
                         f"Expected previous plan ID: '{environment.previous_plan_id}', actual previous plan ID: '{existing_environment.plan_id}'. "
                         "Please recreate the plan and try again"

--- a/sqlmesh/utils/errors.py
+++ b/sqlmesh/utils/errors.py
@@ -47,6 +47,10 @@ class UncategorizedPlanError(PlanError):
     pass
 
 
+class ConflictingPlanError(PlanError):
+    pass
+
+
 class MissingContextException(Exception):
     pass
 

--- a/tests/integrations/github/cicd/test_github_commands.py
+++ b/tests/integrations/github/cicd/test_github_commands.py
@@ -952,7 +952,7 @@ def test_prod_update_failure(
         make_pull_request_review=make_pull_request_review,
         tmp_path=tmp_path,
         mocker=mocker,
-        raise_on_prod_plan=PlanError("Failed to update Prod environment"),
+        to_raise_on_prod_plan=PlanError("Failed to update Prod environment"),
         expect_prod_sync_conclusion=GithubCheckConclusion.ACTION_REQUIRED,
     )
 
@@ -984,7 +984,7 @@ def test_prod_update_conflict(
         make_pull_request_review=make_pull_request_review,
         tmp_path=tmp_path,
         mocker=mocker,
-        raise_on_prod_plan=ConflictingPlanError("Plan a conflicts with plan b"),
+        to_raise_on_prod_plan=ConflictingPlanError("Plan a conflicts with plan b"),
         expect_prod_sync_conclusion=GithubCheckConclusion.SKIPPED,
     )
 
@@ -1016,7 +1016,7 @@ def test_prod_update_exception(
         make_pull_request_review=make_pull_request_review,
         tmp_path=tmp_path,
         mocker=mocker,
-        raise_on_prod_plan=RuntimeError("boom"),
+        to_raise_on_prod_plan=RuntimeError("boom"),
         expect_prod_sync_conclusion=GithubCheckConclusion.FAILURE,
     )
 

--- a/tests/integrations/github/cicd/test_github_commands.py
+++ b/tests/integrations/github/cicd/test_github_commands.py
@@ -921,7 +921,7 @@ def make_test_prod_update_failure_case(
         output = f.read()
         assert (
             output
-            == "run_unit_tests=success\nhas_required_approval=success\ncreated_pr_environment=true\npr_environment_name=hello_world_2\npr_environment_synced=success\nprod_plan_preview=success\nprod_environment_synced=action_required\n"
+            == f"run_unit_tests=success\nhas_required_approval=success\ncreated_pr_environment=true\npr_environment_name=hello_world_2\npr_environment_synced=success\nprod_plan_preview=success\nprod_environment_synced={expect_prod_sync_conclusion.value}\n"
         )
 
 

--- a/tests/integrations/github/cicd/test_github_commands.py
+++ b/tests/integrations/github/cicd/test_github_commands.py
@@ -16,7 +16,7 @@ from sqlmesh.integrations.github.cicd.controller import (
     GithubCheckConclusion,
     GithubCheckStatus,
 )
-from sqlmesh.utils.errors import PlanError, TestError
+from sqlmesh.utils.errors import ConflictingPlanError, PlanError, TestError
 
 pytest_plugins = ["tests.integrations.github.cicd.fixtures"]
 pytestmark = [
@@ -788,7 +788,7 @@ def test_pr_update_failure(
         )
 
 
-def test_prod_update_failure(
+def make_test_prod_update_failure_case(
     github_client,
     make_controller,
     make_mock_check_run,
@@ -796,6 +796,8 @@ def test_prod_update_failure(
     make_pull_request_review,
     tmp_path: pathlib.Path,
     mocker: MockerFixture,
+    to_raise_on_prod_plan: Exception,
+    expect_prod_sync_conclusion: GithubCheckConclusion,
 ):
     """
     Scenario:
@@ -842,7 +844,7 @@ def test_prod_update_failure(
 
     def raise_on_prod_plan(plan: Plan):
         if plan.environment.name == c.PROD:
-            raise PlanError("Failed to update Prod environment")
+            raise to_raise_on_prod_plan
 
     controller._context.apply = mocker.MagicMock(side_effect=lambda plan: raise_on_prod_plan(plan))
 
@@ -875,7 +877,7 @@ def test_prod_update_failure(
     assert GithubCheckStatus(prod_checks_runs[0]["status"]).is_queued
     assert GithubCheckStatus(prod_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(prod_checks_runs[2]["status"]).is_completed
-    assert GithubCheckConclusion(prod_checks_runs[2]["conclusion"]).is_action_required
+    assert GithubCheckConclusion(prod_checks_runs[2]["conclusion"]) == expect_prod_sync_conclusion
 
     assert "SQLMesh - Run Unit Tests" in controller._check_run_mapping
     test_checks_runs = controller._check_run_mapping["SQLMesh - Run Unit Tests"].all_kwargs
@@ -921,6 +923,102 @@ def test_prod_update_failure(
             output
             == "run_unit_tests=success\nhas_required_approval=success\ncreated_pr_environment=true\npr_environment_name=hello_world_2\npr_environment_synced=success\nprod_plan_preview=success\nprod_environment_synced=action_required\n"
         )
+
+
+def test_prod_update_failure(
+    github_client,
+    make_controller,
+    make_mock_check_run,
+    make_mock_issue_comment,
+    make_pull_request_review,
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+):
+    """
+    Scenario:
+    - PR is not merged
+    - PR has been approved by a required reviewer
+    - Tests passed
+    - PR Merge Method defined
+    - Delete environment is enabled
+    - Prod environment update failed
+    """
+
+    make_test_prod_update_failure_case(
+        github_client=github_client,
+        make_controller=make_controller,
+        make_mock_check_run=make_mock_check_run,
+        make_mock_issue_comment=make_mock_issue_comment,
+        make_pull_request_review=make_pull_request_review,
+        tmp_path=tmp_path,
+        mocker=mocker,
+        raise_on_prod_plan=PlanError("Failed to update Prod environment"),
+        expect_prod_sync_conclusion=GithubCheckConclusion.ACTION_REQUIRED,
+    )
+
+
+def test_prod_update_conflict(
+    github_client,
+    make_controller,
+    make_mock_check_run,
+    make_mock_issue_comment,
+    make_pull_request_review,
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+):
+    """
+    Scenario:
+    - PR is not merged
+    - PR has been approved by a required reviewer
+    - Tests passed
+    - PR Merge Method defined
+    - Delete environment is enabled
+    - Prod environment update conflicted
+    """
+
+    make_test_prod_update_failure_case(
+        github_client=github_client,
+        make_controller=make_controller,
+        make_mock_check_run=make_mock_check_run,
+        make_mock_issue_comment=make_mock_issue_comment,
+        make_pull_request_review=make_pull_request_review,
+        tmp_path=tmp_path,
+        mocker=mocker,
+        raise_on_prod_plan=ConflictingPlanError("Plan a conflicts with plan b"),
+        expect_prod_sync_conclusion=GithubCheckConclusion.SKIPPED,
+    )
+
+
+def test_prod_update_exception(
+    github_client,
+    make_controller,
+    make_mock_check_run,
+    make_mock_issue_comment,
+    make_pull_request_review,
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+):
+    """
+    Scenario:
+    - PR is not merged
+    - PR has been approved by a required reviewer
+    - Tests passed
+    - PR Merge Method defined
+    - Delete environment is enabled
+    - Prod environment update fails with an unknown exception
+    """
+
+    make_test_prod_update_failure_case(
+        github_client=github_client,
+        make_controller=make_controller,
+        make_mock_check_run=make_mock_check_run,
+        make_mock_issue_comment=make_mock_issue_comment,
+        make_pull_request_review=make_pull_request_review,
+        tmp_path=tmp_path,
+        mocker=mocker,
+        raise_on_prod_plan=RuntimeError("boom"),
+        expect_prod_sync_conclusion=GithubCheckConclusion.FAILURE,
+    )
 
 
 def test_comment_command_invalid(


### PR DESCRIPTION
This fixes 2 issues:

* when a plan fails to apply for any reason, the bot provided no feedback and would appear running forever; this ensures that we always provide feedback by cacthing all exceptions
* when a plan fails to to a conflict, the user can typically solve this by simply `/deploy`ing again, so this handles that case by treating it like a `skipped` plan which is less scary than a failure.