### PR TITLE
Feat: Support BigQuery nested column additions without dropping

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -320,10 +320,10 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
         for field in original_schema:
             current_fields = list(field.fields)
             if field.name in nested_fields_to_add:
-                for new_field in nested_fields_to_add[field.name]:
-                    current_fields.append(
-                        bigquery.SchemaField(new_field[1], new_field[0], mode="NULLABLE")
-                    )
+                current_fields.extend(
+                    bigquery.SchemaField(new_field[1], new_field[0], mode="NULLABLE")
+                    for new_field in nested_fields_to_add[field.name]
+                )
             if current_fields:
                 new_schema.append(
                     bigquery.SchemaField(
@@ -331,9 +331,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin):
                     )
                 )
             else:
-                new_schema.append(
-                    bigquery.SchemaField(field.name, field.field_type, mode="NULLABLE")
-                )
+                new_schema.append(field)
 
         if new_schema != original_schema:
             table.schema = new_schema

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -39,6 +39,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
     SCHEMA_DIFFER = SchemaDiffer(
         support_positional_add=True,
         support_nested_operations=True,
+        support_nested_drop=True,
         array_element_selector="element",
         parameterized_type_defaults={
             exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(10, 0), (0,)],

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -474,6 +474,7 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
             {
                 "support_positional_add": True,
                 "support_nested_operations": True,
+                "support_nested_drop": True,
                 "array_element_selector": "element",
             },
             {
@@ -630,6 +631,7 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
             {
                 "support_positional_add": True,
                 "support_nested_operations": True,
+                "support_nested_drop": True,
                 "array_element_selector": "element",
             },
             {
@@ -659,6 +661,7 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
             {
                 "support_positional_add": True,
                 "support_nested_operations": True,
+                "support_nested_drop": True,
                 "array_element_selector": "element",
             },
             {
@@ -715,6 +718,7 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
         (
             {
                 "support_nested_operations": True,
+                "support_nested_drop": True,
                 "array_element_selector": "element",
             },
             {
@@ -772,6 +776,7 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
         (
             {
                 "support_nested_operations": True,
+                "support_nested_drop": True,
                 "array_element_selector": "element",
             },
             {

--- a/tests/core/test_schema_diff.py
+++ b/tests/core/test_schema_diff.py
@@ -458,13 +458,19 @@ def test_schema_diff_calculate_type_transitions():
             "STRUCT<id INT, info STRUCT<col_a INT, col_b INT, col_c INT>>",
             "STRUCT<id INT, info STRUCT<col_a INT, col_b INT>>",
             [
-                TableAlterOperation.alter_type(
+                TableAlterOperation.drop(
                     [
                         TableAlterColumn.struct("info"),
                     ],
-                    "STRUCT<col_a INT, col_b INT>",
+                    expected_table_struct="STRUCT<id INT>",
+                    column_type="STRUCT<col_a INT, col_b INT, col_c INT>",
+                ),
+                TableAlterOperation.add(
+                    [
+                        TableAlterColumn.struct("info"),
+                    ],
                     expected_table_struct="STRUCT<id INT, info STRUCT<col_a INT, col_b INT>>",
-                    current_type="STRUCT<col_a INT, col_b INT>",
+                    column_type="STRUCT<col_a INT, col_b INT>",
                 ),
             ],
             dict(
@@ -580,13 +586,19 @@ def test_schema_diff_calculate_type_transitions():
             "STRUCT<id INT, info STRUCT<col_a INT, col_b INT, col_c INT>>",
             "STRUCT<id INT, info STRUCT<col_a INT, col_b TEXT, col_d INT>>",
             [
-                TableAlterOperation.alter_type(
+                TableAlterOperation.drop(
                     [
                         TableAlterColumn.struct("info"),
                     ],
-                    "STRUCT<col_a INT, col_b TEXT, col_d INT>",
+                    expected_table_struct="STRUCT<id INT>",
+                    column_type="STRUCT<col_a INT, col_b INT, col_c INT>",
+                ),
+                TableAlterOperation.add(
+                    [
+                        TableAlterColumn.struct("info"),
+                    ],
                     expected_table_struct="STRUCT<id INT, info STRUCT<col_a INT, col_b TEXT, col_d INT>>",
-                    current_type="STRUCT<col_a INT, col_b TEXT, col_d INT>",
+                    column_type="STRUCT<col_a INT, col_b TEXT, col_d INT>",
                 ),
             ],
             dict(

--- a/tests/core/test_schema_diff.py
+++ b/tests/core/test_schema_diff.py
@@ -407,7 +407,11 @@ def test_schema_diff_calculate_type_transitions():
                     "INT",
                 ),
             ],
-            dict(support_positional_add=True, support_nested_operations=True),
+            dict(
+                support_positional_add=True,
+                support_nested_operations=True,
+                support_nested_drop=True,
+            ),
         ),
         # Remove a column from the end of a struct
         (
@@ -423,7 +427,11 @@ def test_schema_diff_calculate_type_transitions():
                     "INT",
                 ),
             ],
-            dict(support_positional_add=True, support_nested_operations=True),
+            dict(
+                support_positional_add=True,
+                support_nested_operations=True,
+                support_nested_drop=True,
+            ),
         ),
         # Remove a column from the middle of a struct
         (
@@ -439,7 +447,30 @@ def test_schema_diff_calculate_type_transitions():
                     "INT",
                 ),
             ],
-            dict(support_positional_add=True, support_nested_operations=True),
+            dict(
+                support_positional_add=True,
+                support_nested_operations=True,
+                support_nested_drop=True,
+            ),
+        ),
+        # Remove a column from a struct where nested drop is not supported
+        (
+            "STRUCT<id INT, info STRUCT<col_a INT, col_b INT, col_c INT>>",
+            "STRUCT<id INT, info STRUCT<col_a INT, col_b INT>>",
+            [
+                TableAlterOperation.alter_type(
+                    [
+                        TableAlterColumn.struct("info"),
+                    ],
+                    "STRUCT<col_a INT, col_b INT>",
+                    expected_table_struct="STRUCT<id INT, info STRUCT<col_a INT, col_b INT>>",
+                    current_type="STRUCT<col_a INT, col_b INT>",
+                ),
+            ],
+            dict(
+                support_nested_operations=True,
+                support_nested_drop=False,
+            ),
         ),
         # Remove two columns from the start of a struct
         (
@@ -463,7 +494,11 @@ def test_schema_diff_calculate_type_transitions():
                     "INT",
                 ),
             ],
-            dict(support_positional_add=True, support_nested_operations=True),
+            dict(
+                support_positional_add=True,
+                support_nested_operations=True,
+                support_nested_drop=True,
+            ),
         ),
         # Change a column type in a struct
         (
@@ -534,6 +569,29 @@ def test_schema_diff_calculate_type_transitions():
             dict(
                 support_positional_add=True,
                 support_nested_operations=True,
+                support_nested_drop=True,
+                compatible_types={
+                    exp.DataType.build("INT"): {exp.DataType.build("TEXT")},
+                },
+            ),
+        ),
+        # Add, remove and change a column from a struct where nested drop is not supported
+        (
+            "STRUCT<id INT, info STRUCT<col_a INT, col_b INT, col_c INT>>",
+            "STRUCT<id INT, info STRUCT<col_a INT, col_b TEXT, col_d INT>>",
+            [
+                TableAlterOperation.alter_type(
+                    [
+                        TableAlterColumn.struct("info"),
+                    ],
+                    "STRUCT<col_a INT, col_b TEXT, col_d INT>",
+                    expected_table_struct="STRUCT<id INT, info STRUCT<col_a INT, col_b TEXT, col_d INT>>",
+                    current_type="STRUCT<col_a INT, col_b TEXT, col_d INT>",
+                ),
+            ],
+            dict(
+                support_nested_operations=True,
+                support_nested_drop=False,
                 compatible_types={
                     exp.DataType.build("INT"): {exp.DataType.build("TEXT")},
                 },
@@ -581,7 +639,11 @@ def test_schema_diff_calculate_type_transitions():
                     position=TableAlterColumnPosition.last("nest_col_a"),
                 ),
             ],
-            dict(support_positional_add=True, support_nested_operations=True),
+            dict(
+                support_positional_add=True,
+                support_nested_operations=True,
+                support_nested_drop=True,
+            ),
         ),
         # #####################
         # # Array Struct Tests
@@ -617,7 +679,11 @@ def test_schema_diff_calculate_type_transitions():
                     "INT",
                 ),
             ],
-            dict(support_positional_add=True, support_nested_operations=True),
+            dict(
+                support_positional_add=True,
+                support_nested_operations=True,
+                support_nested_drop=True,
+            ),
         ),
         # Alter column type in array of structs
         (
@@ -754,6 +820,7 @@ def test_schema_diff_calculate_type_transitions():
             dict(
                 support_positional_add=True,
                 support_nested_operations=True,
+                support_nested_drop=True,
             ),
         ),
         # Type with precision to same type with no precision and no default is DROP/ADD


### PR DESCRIPTION
This update adds support for adding fields to a nested type in BigQuery without dropping the existing column by using the ([BigQuery API](https://cloud.google.com/bigquery/docs/managing-table-schemas#api_1)), fixes #2321 