### PR TITLE
fix!: properly nested update gateway configs

### DIFF
--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -118,7 +118,7 @@ class Config(BaseConfig):
     disable_anonymized_analytics: bool = False
 
     _FIELD_UPDATE_STRATEGY: t.ClassVar[t.Dict[str, UpdateStrategy]] = {
-        "gateways": UpdateStrategy.KEY_UPDATE,
+        "gateways": UpdateStrategy.NESTED_UPDATE,
         "notification_targets": UpdateStrategy.EXTEND,
         "ignore_patterns": UpdateStrategy.EXTEND,
         "users": UpdateStrategy.EXTEND,


### PR DESCRIPTION
Prior to this change nested updates to Gateways would only work with YAML config files. This update makes it work with Python config too. 

`test_load_yaml_config_env_var_gateway_override` passed without any changes (confirming expected behavior) while `test_load_py_config_env_var_gateway_override` fails without the change. 