### PR TITLE
Fix python sql explicit column declaration

### DIFF
--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -134,6 +134,8 @@ class model(registry_decorator):
 
         if self.is_sql:
             query = MacroFunc(this=exp.Anonymous(this=entrypoint))
+            if self.columns:
+                common_kwargs["columns"] = self.columns
             return create_sql_model(
                 self.name, query, module_path=module_path, dialect=dialect, **common_kwargs
             )

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -4564,6 +4564,32 @@ def test_variables_python_sql_model(mocker: MockerFixture) -> None:
     )
 
 
+def test_columns_python_sql_model() -> None:
+    @model(
+        "test_columns_python_model",
+        is_sql=True,
+        kind="full",
+        columns={"d": "Date", "s": "String", "dt": "DateTime"},
+    )
+    def model_with_columns(evaluator, **kwargs):
+        return exp.select("*").from_("fake")
+    
+    python_sql_model = model.get_registry()["test_columns_python_model"].model(
+        module_path=Path("."),
+        path=Path("."),
+    )
+
+    columns_to_types = python_sql_model.columns_to_types
+
+    assert columns_to_types is not None
+    assert isinstance(columns_to_types["d"], exp.DataType)
+    assert columns_to_types["d"].this == exp.DataType.Type.DATE
+    assert isinstance(columns_to_types["s"], exp.DataType)
+    assert columns_to_types["s"].this == exp.DataType.Type.TEXT
+    assert isinstance(columns_to_types["dt"], exp.DataType)
+    assert columns_to_types["dt"].this == exp.DataType.Type.DATETIME
+
+
 def test_named_variables_python_model(mocker: MockerFixture) -> None:
     @model(
         "test_named_variables_python_model",


### PR DESCRIPTION
We encountered this while making a python model that had `is_sql=True`. We send some generative things to our clickhouse instance and because we use the clickhouse dialect this seems to cause some issues when attempting to transpile to other dialects like `duckdb` due to the `Nullable` type appearing as a derived type for a specific column of the final result. So to solve this we decided to just explicitly set the columns in the python sql model. However we encountered a bug in doing this.