### PR TITLE
Fix: use default instead of engine dialect in sushi python models

### DIFF
--- a/examples/sushi/models/order_items.py
+++ b/examples/sushi/models/order_items.py
@@ -50,7 +50,7 @@ def execute(
     **kwargs: t.Any,
 ) -> t.Generator[pd.DataFrame, None, None]:
     orders_table = context.table("sushi.orders")
-    engine_dialect = context.engine_adapter.dialect
+    default_dialect = context.default_dialect
 
     items_table = get_items_table(context)
 
@@ -62,7 +62,7 @@ def execute(
         # Generate query with sqlglot dialect/quoting
         orders = context.fetchdf(
             exp.select("*")
-            .from_(orders_table, dialect=engine_dialect)
+            .from_(orders_table, dialect=default_dialect)
             .where(f"event_date = CAST('{to_ds(dt)}' AS DATE)"),
             quote_identifiers=True,
         )
@@ -73,7 +73,7 @@ def execute(
         # Generate query with sqlglot dialect/quoting
         items = context.fetchdf(
             exp.select("*")
-            .from_(items_table, dialect=engine_dialect)
+            .from_(items_table, dialect=default_dialect)
             .where(f"event_date = CAST('{to_ds(dt)}' AS DATE)"),
             quote_identifiers=True,
         )

--- a/examples/sushi/models/raw_marketing.py
+++ b/examples/sushi/models/raw_marketing.py
@@ -36,11 +36,11 @@ def execute(
 ) -> pd.DataFrame:
     # Generate query with sqlglot dialect/quoting
     existing_table = context.table("sushi.raw_marketing")
-    engine_dialect = context.engine_adapter.dialect
+    default_dialect = context.default_dialect
 
     df_existing = context.fetchdf(
         exp.select("customer_id", "status", "updated_at").from_(
-            existing_table, dialect=engine_dialect
+            existing_table, dialect=default_dialect
         ),
         quote_identifiers=True,
     )


### PR DESCRIPTION
Back in May, I [changed](https://github.com/tobikoData/sqlmesh/commit/95be17d2dfe653e2c7142e3cf7afa1095b6dd1ab#diff-48bc3a8f222ba11b6ae21ba613536ea4a54144f866b4dc489be2f27a0d95f080) a couple of sushi python models to use the engine adapter's dialect. I think this was done to fix some transpilation bug, but I forgot the context.

In any case, @tobymao recently [changed](https://github.com/TobikoData/sqlmesh/commit/c174ce55501e8d139236c29b7ab9331e2d6e472d) `BaseContext.table` to ensure quotes are always added in table names, meaning that we also need to change the dialect in said python models to the default one, otherwise we may get parsing errors.

For example, running `plan` in the sushi project with a BigQuery connection now fails because we get a backtick-quoted name from `context.table`, which can't be parsed by the testing engine adapter's dialect - duckdb.