### PR TITLE
Fix!: Dont clone managed tables to create dev previews

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -1794,7 +1794,7 @@ class EngineManagedStrategy(MaterializableStrategy):
         if len(potential_alter_expressions) > 0:
             # this can happen if a user changes a managed model and deliberately overrides a plan to be forward only, eg `sqlmesh plan --forward-only`
             raise SQLMeshError(
-                f"Managed table '{target_table_name}' cannot be treated as forward only because its schema cannot be changed without a full rebuild"
+                f"The schema of the managed model '{target_table_name}' cannot be updated in a forward-only fashion."
             )
 
     def delete(self, name: str, **kwargs: t.Any) -> None:

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -667,7 +667,8 @@ class SnapshotEvaluator:
                 and snapshot.is_materialized
                 and snapshot.previous_versions
                 and self.adapter.SUPPORTS_CLONING
-                and evaluation_strategy.allow_clone_for_dev_preview(snapshot)
+                # managed models cannot have their schema mutated because theyre based on queries, so clone + alter wont work
+                and not snapshot.is_managed
             ):
                 target_table_name = snapshot.table_name(is_deployable=False)
                 tmp_table_name = f"{target_table_name}__schema_migration_source"
@@ -1059,14 +1060,6 @@ class EvaluationStrategy(abc.ABC):
             table_description=model.description,
             column_descriptions=model.column_descriptions,
         )
-
-    def allow_clone_for_dev_preview(self, snapshot: Snapshot) -> bool:
-        """
-        When creating tables to preview forward-only changes in dev environments,
-        should clones of existing tables be used (if the adapter supports it),
-        or should new tables be created
-        """
-        return True
 
 
 class SymbolicStrategy(EvaluationStrategy):
@@ -1799,25 +1792,9 @@ class EngineManagedStrategy(MaterializableStrategy):
             target_table_name, source_table_name
         )
         if len(potential_alter_expressions) > 0:
-            # this can happen when a forward-only change is applied directly to prod without going via a dev environment first
-            # in the normal case, the current prod snapshot is mutated via ALTER statements to match the schema of the dev preview table
-            # However, since we cant change the schema of a managed model, we have to create a new one instead
-            logger.info(
-                "Creating new managed table: %s to migrate %s to the schema of %s",
-                target_table_name,
-                snapshot.model.name,
-                source_table_name,
-            )
-
-            self.create(
-                table_name=target_table_name,
-                model=snapshot.model,
-                is_table_deployable=True,
-                is_snapshot_deployable=True,
-                # note: these are the same render kwargs that ViewStrategy uses for migrate() since it also has to render a query
-                render_kwargs=dict(
-                    execution_time=now(), engine_adapter=self.adapter, snapshots=kwargs["snapshots"]
-                ),
+            # this can happen if a user changes a managed model and deliberately overrides a plan to be forward only, eg `sqlmesh plan --forward-only`
+            raise SQLMeshError(
+                f"Managed table '{target_table_name}' cannot be treated as forward only because its schema cannot be changed without a full rebuild"
             )
 
     def delete(self, name: str, **kwargs: t.Any) -> None:
@@ -1829,11 +1806,6 @@ class EngineManagedStrategy(MaterializableStrategy):
         else:
             self.adapter.drop_table(name)
             logger.info("Dropped dev preview for managed table '%s'", name)
-
-    def allow_clone_for_dev_preview(self, snapshot: Snapshot) -> bool:
-        # You can't clone a managed table to a normal table (only to another managed table), so we can't use clones to
-        # create dev preview tables
-        return False
 
 
 def _intervals(snapshot: Snapshot, deployability_index: DeployabilityIndex) -> Intervals:

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -2601,7 +2601,7 @@ def test_migrate_managed(adapter_mock, make_snapshot, mocker: MockerFixture):
 
     cause = exc_info.value.__cause__
     assert isinstance(cause, SQLMeshError)
-    assert "cannot be treated as forward only" in str(cause)
+    assert "cannot be updated" in str(cause)
 
     adapter_mock.create_table.assert_not_called()
     adapter_mock.ctas.assert_not_called()


### PR DESCRIPTION
Prior to this change, making a forward-only change to a managed model only worked if you did it via a dev environment first.

Applying it directly to prod resulted in the following error on Snowflake: `SQL compilation error: Invalid operation Cannot clone from an dynamic table.` because in order to create the dev preview table (which [always gets created](https://github.com/TobikoData/sqlmesh/issues/2496) regardless of the environment), SQLMesh triggers a clone of the current prod table.

This PR does two things:
 - Allows the evaluation strategy to decide if `clone()` is suitable for creating dev preview tables
 - Implements `migrate()` for the `EngineManagedStrategy` now that I better understand the conditions that can trigger `migrate()` in the first place.

The usual function of `migrate()` is to mutate the schema of an existing table to match a new definition without re-creating that table (which can be expensive). However:

- Managed models are more like views in that you cant just mutate the schema, you have to replace the entire query backing the model
- So, if the new model definition results in schema changes, we throw an error because it has to be rebuilt which defeats the purpose of foward-only if we were to treat it as forward-only
- If there are no schema changes (eg an unrelated macro that doesn't affect the model schema got updated), `migrate()` is a no-op