### PR TITLE
Chore!: bump sqlglot to v25.20.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=25.19.0",
+        "sqlglot[rs]~=25.20.1",
     ],
     extras_require={
         "bigquery": [

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -215,7 +215,7 @@ class Console(abc.ABC):
 
     @abc.abstractmethod
     def log_test_results(
-        self, result: unittest.result.TestResult, output: str, target_dialect: str
+        self, result: unittest.result.TestResult, output: t.Optional[str], target_dialect: str
     ) -> None:
         """Display the test result and output.
 
@@ -985,7 +985,7 @@ class TerminalConsole(Console):
             plan_builder.apply()
 
     def log_test_results(
-        self, result: unittest.result.TestResult, output: str, target_dialect: str
+        self, result: unittest.result.TestResult, output: t.Optional[str], target_dialect: str
     ) -> None:
         divider_length = 70
         if result.wasSuccessful():
@@ -1477,7 +1477,7 @@ class NotebookMagicConsole(TerminalConsole):
         self.display(radio)
 
     def log_test_results(
-        self, result: unittest.result.TestResult, output: str, target_dialect: str
+        self, result: unittest.result.TestResult, output: t.Optional[str], target_dialect: str
     ) -> None:
         import ipywidgets as widgets
 
@@ -1786,7 +1786,7 @@ class MarkdownConsole(CaptureTerminalConsole):
             self._print("\n```")
 
     def log_test_results(
-        self, result: unittest.result.TestResult, output: str, target_dialect: str
+        self, result: unittest.result.TestResult, output: t.Optional[str], target_dialect: str
     ) -> None:
         # import ipywidgets as widgets
         if result.wasSuccessful():
@@ -2079,7 +2079,7 @@ class DebuggerTerminalConsole(TerminalConsole):
             self._write(f"  Modified: {modified}")
 
     def log_test_results(
-        self, result: unittest.result.TestResult, output: str, target_dialect: str
+        self, result: unittest.result.TestResult, output: t.Optional[str], target_dialect: str
     ) -> None:
         self._write("Test Results:", result)
 

--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -41,7 +41,7 @@ if hasattr(os, "fork") and not mp.current_process().daemon:
         MAX_FORK_WORKERS: t.Optional[int] = int(os.getenv("MAX_FORK_WORKERS"))  # type: ignore
     except TypeError:
         MAX_FORK_WORKERS = (
-            len(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else None
+            len(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else None  # type: ignore
         )
 else:
     MAX_FORK_WORKERS = 1

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -665,7 +665,9 @@ class GithubController:
         """
 
         def conclusion_handler(
-            conclusion: GithubCheckConclusion, result: unittest.result.TestResult, output: str
+            conclusion: GithubCheckConclusion,
+            result: t.Optional[unittest.result.TestResult],
+            output: t.Optional[str],
         ) -> t.Tuple[GithubCheckConclusion, str, t.Optional[str]]:
             if result:
                 # Clear out console

--- a/web/server/console.py
+++ b/web/server/console.py
@@ -238,7 +238,7 @@ class ApiConsole(TerminalConsole):
         )
 
     def log_test_results(
-        self, result: unittest.result.TestResult, output: str, target_dialect: str
+        self, result: unittest.result.TestResult, output: t.Optional[str], target_dialect: str
     ) -> None:
         if result.wasSuccessful():
             self.log_event(


### PR DESCRIPTION
Changed some type hints due to the following errors I encountered while iterating locally:

```
sqlmesh/core/constants.py:44: error: Module has no attribute "sched_getaffinity"  [attr-defined]
sqlmesh/integrations/github/cicd/controller.py:698: error: Argument "result" to "conclusion_handler" has incompatible type "TestResult | None"; expected "TestResult"  [arg-type]
sqlmesh/integrations/github/cicd/controller.py:698: error: Argument "output" to "conclusion_handler" has incompatible type "str | None"; expected "str"  [arg-type]
```