### PR TITLE
Fix: Make sure signals are loaded when running models

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -327,6 +327,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         self._metrics: UniqueKeyDict[str, Metric] = UniqueKeyDict("metrics")
         self._jinja_macros = JinjaMacroRegistry()
         self._default_catalog: t.Optional[str] = None
+        self._loaded: bool = False
 
         self.path, self.config = t.cast(t.Tuple[Path, C], next(iter(self.configs.items())))
 
@@ -550,6 +551,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             project_name=self.config.project,
         )
 
+        self._loaded = True
         return self
 
     @python_api_analytics
@@ -585,6 +587,11 @@ class GenericContext(BaseContext, t.Generic[C]):
             engine_type=self.snapshot_evaluator.adapter.dialect,
             state_sync_type=self.state_sync.state_type(),
         )
+
+        if not self._loaded:
+            # Signals should be loade to run correctly.
+            with sys_path(*self.configs):
+                self._loader.load_signals(self)
 
         success = False
         try:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -589,7 +589,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         )
 
         if not self._loaded:
-            # Signals should be loade to run correctly.
+            # Signals should be loaded to run correctly.
             with sys_path(*self.configs):
                 self._loader.load_signals(self)
 

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -123,6 +123,11 @@ class Loader(abc.ABC):
         )
         return project
 
+    def load_signals(self, context: GenericContext) -> None:
+        """Loads signals for the built-in scheduler."""
+        self._context = context
+        self._load_signals()
+
     def reload_needed(self) -> bool:
         """
         Checks for any modifications to the files the macros and models depend on


### PR DESCRIPTION
Normally, we don't load the project on `sqlmesh run` command. However, we still need to load user-defined signals in order for the run to work correctly.

This update ensures that SQLMesh loads just signals when running models.

Closes #3104