### PR TITLE
fix: support dbt sqlserver 1.8.0

### DIFF
--- a/sqlmesh/dbt/target.py
+++ b/sqlmesh/dbt/target.py
@@ -689,7 +689,12 @@ class MSSQLConfig(TargetConfig):
 
     @classproperty
     def column_class(cls) -> t.Type[Column]:
-        from dbt.adapters.sqlserver.sql_server_column import SQLServerColumn
+        try:
+            # 1.8.0+
+            from dbt.adapters.sqlserver.sqlserver_column import SQLServerColumn
+        except ImportError:
+            # <1.8.0
+            from dbt.adapters.sqlserver.sql_server_column import SQLServerColumn  # type: ignore
 
         return SQLServerColumn
 

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -767,7 +767,7 @@ def test_db_type_to_column_class():
     from dbt.adapters.bigquery import BigQueryColumn
     from dbt.adapters.databricks.column import DatabricksColumn
     from dbt.adapters.snowflake import SnowflakeColumn
-    from dbt.adapters.sqlserver.sql_server_column import SQLServerColumn
+    from dbt.adapters.sqlserver.sqlserver_column import SQLServerColumn
     from dbt.adapters.trino.column import TrinoColumn
 
     assert (TARGET_TYPE_TO_CONFIG_CLASS["bigquery"].column_class) == BigQueryColumn


### PR DESCRIPTION
Fixes this issue due to latest dbt-sqlserver release:
```
FAILED sqlmesh/tests/dbt/test_config.py::test_db_type_to_column_class - ModuleNotFoundError: No module named 'dbt.adapters.sqlserver.sql_server_column'
```