### PR TITLE
fix: switch from pooling to default method to detect changes

### DIFF
--- a/web/client/openapi.json
+++ b/web/client/openapi.json
@@ -1163,11 +1163,7 @@
             "title": "Normalize Name",
             "default": true
           },
-          "snapshots": {
-            "items": { "$ref": "#/components/schemas/SnapshotTableInfo" },
-            "type": "array",
-            "title": "Snapshots"
-          },
+          "snapshots": { "items": {}, "type": "array", "title": "Snapshots" },
           "start_at": {
             "anyOf": [
               { "type": "string", "format": "date" },
@@ -1203,23 +1199,11 @@
             "title": "Finalized Ts"
           },
           "promoted_snapshot_ids": {
-            "anyOf": [
-              {
-                "items": { "$ref": "#/components/schemas/SnapshotId" },
-                "type": "array"
-              },
-              { "type": "null" }
-            ],
+            "anyOf": [{ "items": {}, "type": "array" }, { "type": "null" }],
             "title": "Promoted Snapshot Ids"
           },
           "previous_finalized_snapshots": {
-            "anyOf": [
-              {
-                "items": { "$ref": "#/components/schemas/SnapshotTableInfo" },
-                "type": "array"
-              },
-              { "type": "null" }
-            ],
+            "anyOf": [{ "items": {}, "type": "array" }, { "type": "null" }],
             "title": "Previous Finalized Snapshots"
           }
         },
@@ -1549,25 +1533,6 @@
         "additionalProperties": false,
         "type": "object",
         "title": "ModelDetails"
-      },
-      "ModelKindName": {
-        "type": "string",
-        "enum": [
-          "INCREMENTAL_BY_TIME_RANGE",
-          "INCREMENTAL_BY_UNIQUE_KEY",
-          "INCREMENTAL_BY_PARTITION",
-          "INCREMENTAL_UNMANAGED",
-          "FULL",
-          "SCD_TYPE_2",
-          "SCD_TYPE_2_BY_TIME",
-          "SCD_TYPE_2_BY_COLUMN",
-          "VIEW",
-          "EMBEDDED",
-          "SEED",
-          "EXTERNAL"
-        ],
-        "title": "ModelKindName",
-        "description": "The kind of model, determining how this data is computed and stored in the warehouse."
       },
       "ModelType": {
         "type": "string",
@@ -2139,113 +2104,6 @@
         "enum": [1, 2, 3, 4, 5, 6],
         "title": "SnapshotChangeCategory",
         "description": "Values are ordered by decreasing severity and that ordering is required.\n\nBREAKING: The change requires that snapshot modified and downstream dependencies be rebuilt\nNON_BREAKING: The change requires that only the snapshot modified be rebuilt\nFORWARD_ONLY: The change requires no rebuilding\nINDIRECT_BREAKING: The change was caused indirectly and is breaking.\nINDIRECT_NON_BREAKING: The change was caused indirectly by a non-breaking change.\nMETADATA: The change was caused by a metadata update."
-      },
-      "SnapshotDataVersion": {
-        "properties": {
-          "fingerprint": { "$ref": "#/components/schemas/SnapshotFingerprint" },
-          "version": { "type": "string", "title": "Version" },
-          "temp_version": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "Temp Version"
-          },
-          "change_category": {
-            "anyOf": [
-              { "$ref": "#/components/schemas/SnapshotChangeCategory" },
-              { "type": "null" }
-            ]
-          },
-          "physical_schema": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "Physical Schema"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": ["fingerprint", "version"],
-        "title": "SnapshotDataVersion"
-      },
-      "SnapshotFingerprint": {
-        "properties": {
-          "data_hash": { "type": "string", "title": "Data Hash" },
-          "metadata_hash": { "type": "string", "title": "Metadata Hash" },
-          "parent_data_hash": {
-            "type": "string",
-            "title": "Parent Data Hash",
-            "default": "0"
-          },
-          "parent_metadata_hash": {
-            "type": "string",
-            "title": "Parent Metadata Hash",
-            "default": "0"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": ["data_hash", "metadata_hash"],
-        "title": "SnapshotFingerprint"
-      },
-      "SnapshotId": {
-        "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "identifier": { "type": "string", "title": "Identifier" }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": ["name", "identifier"],
-        "title": "SnapshotId"
-      },
-      "SnapshotTableInfo": {
-        "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "temp_version": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "Temp Version"
-          },
-          "change_category": {
-            "anyOf": [
-              { "$ref": "#/components/schemas/SnapshotChangeCategory" },
-              { "type": "null" }
-            ]
-          },
-          "fingerprint": { "$ref": "#/components/schemas/SnapshotFingerprint" },
-          "previous_versions": {
-            "items": { "$ref": "#/components/schemas/SnapshotDataVersion" },
-            "type": "array",
-            "title": "Previous Versions",
-            "default": []
-          },
-          "base_table_name_override": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "Base Table Name Override"
-          },
-          "version": { "type": "string", "title": "Version" },
-          "physical_schema": { "type": "string", "title": "Physical Schema" },
-          "parents": {
-            "items": { "$ref": "#/components/schemas/SnapshotId" },
-            "type": "array",
-            "title": "Parents"
-          },
-          "kind_name": {
-            "anyOf": [
-              { "$ref": "#/components/schemas/ModelKindName" },
-              { "type": "null" }
-            ]
-          },
-          "node_type": {
-            "allOf": [{ "$ref": "#/components/schemas/NodeType" }],
-            "default": "model"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "name",
-          "fingerprint",
-          "version",
-          "physical_schema",
-          "parents"
-        ],
-        "title": "SnapshotTableInfo"
       },
       "Status": {
         "type": "string",

--- a/web/client/src/library/components/fileExplorer/context.tsx
+++ b/web/client/src/library/components/fileExplorer/context.tsx
@@ -158,7 +158,7 @@ export default function FileExplorerProvider({
   }
 
   function renameArtifact(artifact: ModelArtifact, newName?: string): void {
-    newName = newName?.trim()
+    newName = newName?.replaceAll('/', '').trim()
 
     const parentArtifacts = artifact.parent?.artifacts ?? []
     const isDuplicate = parentArtifacts.some(a => a.name === newName)
@@ -300,7 +300,11 @@ export default function FileExplorerProvider({
         artifact.rename(artifact.copyName())
       }
 
-      const new_path = [target.path, artifact.name].join('/')
+      let new_path = [target.path, artifact.name].join('/')
+
+      while (new_path.startsWith('/')) {
+        new_path = new_path.slice(1).trim()
+      }
 
       if (artifact instanceof ModelDirectory) {
         moveArtifactCallbacks.push(() => {

--- a/web/client/src/library/pages/root/Navigation.tsx
+++ b/web/client/src/library/pages/root/Navigation.tsx
@@ -14,7 +14,7 @@ export default function PageNavigation(): JSX.Element {
   return (
     <div
       className={clsx(
-        'relative min-w-[10rem] px-2 min-h-8 max-h-8 w-full flex items-center',
+        'relative min-w-[10rem] px-2 min-h-[2rem] max-h-[2rem] w-full flex items-center',
         modules.showHistoryNavigation ? 'justify-between' : 'justify-end',
         isFetchingModels && 'overflow-hidden',
       )}

--- a/web/server/utils.py
+++ b/web/server/utils.py
@@ -104,22 +104,3 @@ def is_relative_to(path: PurePath, other: PurePath | str) -> bool:
         return True
     except ValueError:
         return False
-
-
-def ensure_list(value: t.Optional[t.Any] = None) -> t.List:
-    """Ensure that the value is a list. If None is provided, return an empty list.
-    If the value is not iterable, wrap it in a list."""
-
-    if value is None:
-        return []
-
-    if isinstance(value, list):
-        return value
-
-    if isinstance(value, (str, bytes)):
-        return [value]
-
-    try:
-        return list(value)
-    except TypeError:
-        return [value]

--- a/web/server/utils.py
+++ b/web/server/utils.py
@@ -104,3 +104,22 @@ def is_relative_to(path: PurePath, other: PurePath | str) -> bool:
         return True
     except ValueError:
         return False
+
+
+def ensure_list(value: t.Optional[t.Any] = None) -> t.List:
+    """Ensure that the value is a list. If None is provided, return an empty list.
+    If the value is not iterable, wrap it in a list."""
+
+    if value is None:
+        return []
+
+    if isinstance(value, list):
+        return value
+
+    if isinstance(value, (str, bytes)):
+        return [value]
+
+    try:
+        return list(value)
+    except TypeError:
+        return [value]

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -15,7 +15,8 @@ from web.server.settings import (
     get_settings,
     invalidate_context_cache,
 )
-from web.server.utils import ensure_list, is_relative_to
+from web.server.utils import is_relative_to
+from sqlglot.helper import ensure_list
 
 
 async def watch_project() -> None:
@@ -28,8 +29,8 @@ async def watch_project() -> None:
         (settings.project_path / c.METRICS).resolve(),
         (settings.project_path / c.SEEDS).resolve(),
     ]
-    ignore_dirs = ensure_list(".env")
-    ignore_paths = ensure_list((settings.project_path / c.CACHE).resolve())
+    ignore_dirs = [".env"]
+    ignore_paths: t.List[t.Union[str, Path]] = [(settings.project_path / c.CACHE).resolve()]
     ignore_entity_patterns = context.config.ignore_patterns if context else c.IGNORE_PATTERNS
     ignore_entity_patterns.append("^.*\\.db(\\.wal)?$")
 


### PR DESCRIPTION
fixing https://github.com/TobikoData/sqlmesh/issues/3109

so when using `pooling` (and pooling is not default option for wathfiles). It seems to treat some files (like symlinks for example) as deleted and just keeps emitting deletion change. And that results in UI keep triggering updates and API calls (an infinite loop)