### PR TITLE
Chore: Use factory method to create builtin scheduler

### DIFF
--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -137,7 +137,7 @@ class BuiltInSchedulerConfig(_EngineAdapterStateSyncSchedulerConfig, BaseConfig)
         return BuiltInPlanEvaluator(
             state_sync=context.state_sync,
             snapshot_evaluator=context.snapshot_evaluator,
-            create_scheduler=context._create_scheduler,
+            create_scheduler=context.create_scheduler,
             default_catalog=self.get_default_catalog(context),
             console=context.console,
         )

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -137,10 +137,9 @@ class BuiltInSchedulerConfig(_EngineAdapterStateSyncSchedulerConfig, BaseConfig)
         return BuiltInPlanEvaluator(
             state_sync=context.state_sync,
             snapshot_evaluator=context.snapshot_evaluator,
+            create_scheduler=context._create_scheduler,
             default_catalog=self.get_default_catalog(context),
-            backfill_concurrent_tasks=context.concurrent_tasks,
             console=context.console,
-            notification_target_manager=context.notification_target_manager,
         )
 
     def get_default_catalog(self, context: GenericContext) -> t.Optional[str]:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -479,6 +479,17 @@ class GenericContext(BaseContext, t.Generic[C]):
         if not snapshots:
             raise ConfigError("No models were found")
 
+        return self._create_scheduler(snapshots)
+
+    def _create_scheduler(self, snapshots: t.Iterable[Snapshot]) -> Scheduler:
+        """Creates the built-in scheduler.
+
+        Args:
+            snapshots: The snapshots to schedule.
+
+        Returns:
+            The built-in scheduler instance.
+        """
         return Scheduler(
             snapshots,
             self.snapshot_evaluator,

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -479,9 +479,9 @@ class GenericContext(BaseContext, t.Generic[C]):
         if not snapshots:
             raise ConfigError("No models were found")
 
-        return self._create_scheduler(snapshots)
+        return self.create_scheduler(snapshots)
 
-    def _create_scheduler(self, snapshots: t.Iterable[Snapshot]) -> Scheduler:
+    def create_scheduler(self, snapshots: t.Iterable[Snapshot]) -> Scheduler:
         """Creates the built-in scheduler.
 
         Args:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,7 +231,7 @@ def push_plan(context: Context, plan: Plan) -> None:
     plan_evaluator = BuiltInPlanEvaluator(
         context.state_sync,
         context.snapshot_evaluator,
-        context._create_scheduler,
+        context.create_scheduler,
         context.default_catalog,
     )
     plan_evaluator._push(plan)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,10 @@ def duck_conn() -> duckdb.DuckDBPyConnection:
 
 def push_plan(context: Context, plan: Plan) -> None:
     plan_evaluator = BuiltInPlanEvaluator(
-        context.state_sync, context.snapshot_evaluator, context.default_catalog
+        context.state_sync,
+        context.snapshot_evaluator,
+        context._create_scheduler,
+        context.default_catalog,
     )
     plan_evaluator._push(plan)
     promotion_result = plan_evaluator._promote(plan)

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -210,7 +210,7 @@ def test_diff(sushi_context: Context, mocker: MockerFixture):
     plan_evaluator = BuiltInPlanEvaluator(
         sushi_context.state_sync,
         sushi_context.snapshot_evaluator,
-        sushi_context._create_scheduler,
+        sushi_context.create_scheduler,
         sushi_context.default_catalog,
     )
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -208,7 +208,10 @@ def test_diff(sushi_context: Context, mocker: MockerFixture):
     success = sushi_context.run(start=yesterday, end=yesterday)
 
     plan_evaluator = BuiltInPlanEvaluator(
-        sushi_context.state_sync, sushi_context.snapshot_evaluator, sushi_context.default_catalog
+        sushi_context.state_sync,
+        sushi_context.snapshot_evaluator,
+        sushi_context._create_scheduler,
+        sushi_context.default_catalog,
     )
 
     plan = PlanBuilder(

--- a/tests/core/test_plan_evaluator.py
+++ b/tests/core/test_plan_evaluator.py
@@ -67,7 +67,7 @@ def test_builtin_evaluator_push(sushi_context: Context, make_snapshot):
     evaluator = BuiltInPlanEvaluator(
         sushi_context.state_sync,
         sushi_context.snapshot_evaluator,
-        sushi_context._create_scheduler,
+        sushi_context.create_scheduler,
         sushi_context.default_catalog,
         console=sushi_context.console,
     )

--- a/tests/core/test_plan_evaluator.py
+++ b/tests/core/test_plan_evaluator.py
@@ -67,6 +67,7 @@ def test_builtin_evaluator_push(sushi_context: Context, make_snapshot):
     evaluator = BuiltInPlanEvaluator(
         sushi_context.state_sync,
         sushi_context.snapshot_evaluator,
+        sushi_context._create_scheduler,
         sushi_context.default_catalog,
         console=sushi_context.console,
     )


### PR DESCRIPTION
Introduce a common factory method to create the builtin scheduler instead of directly constructing the `Scheduler` class.