### PR TITLE
Chore!: Introduce the evaluatable version of a plan object

### DIFF
--- a/sqlmesh/core/analytics/collector.py
+++ b/sqlmesh/core/analytics/collector.py
@@ -17,7 +17,7 @@ from sqlmesh.utils.yaml import load as yaml_load
 
 if t.TYPE_CHECKING:
     from sqlmesh.cicd.config import CICDBotConfig
-    from sqlmesh.core.plan import Plan
+    from sqlmesh.core.plan import EvaluatablePlan
     from sqlmesh.core.snapshot import Snapshot
 
 
@@ -146,7 +146,7 @@ class AnalyticsCollector:
     def on_plan_apply_start(
         self,
         *,
-        plan: Plan,
+        plan: EvaluatablePlan,
         engine_type: t.Optional[str],
         state_sync_type: t.Optional[str],
         scheduler_type: str,
@@ -172,11 +172,15 @@ class AnalyticsCollector:
                 "forward_only": plan.forward_only,
                 "ensure_finalized_snapshots": plan.ensure_finalized_snapshots,
                 "has_restatements": bool(plan.restatements),
-                "directly_modified_count": len(plan.directly_modified),
+                "directly_modified_count": len(plan.directly_modified_snapshots),
                 "indirectly_modified_count": len(
-                    {s_id for s_ids in plan.indirectly_modified.values() for s_id in s_ids}
+                    {
+                        s_id
+                        for s_ids in plan.indirectly_modified_snapshots.values()
+                        for s_id in s_ids
+                    }
                 ),
-                "environment_name_hash": _anonymize(plan.environment_naming_info.name),
+                "environment_name_hash": _anonymize(plan.environment.name),
             },
         )
 

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -40,7 +40,7 @@ if t.TYPE_CHECKING:
 
     from sqlglot.dialects.dialect import DialectType
     from sqlmesh.core.context_diff import ContextDiff
-    from sqlmesh.core.plan import Plan, PlanBuilder
+    from sqlmesh.core.plan import Plan, EvaluatablePlan, PlanBuilder
     from sqlmesh.core.table_diff import RowDiff, SchemaDiff
 
     LayoutWidget = t.TypeVar("LayoutWidget", bound=t.Union[widgets.VBox, widgets.HBox])
@@ -64,7 +64,7 @@ class Console(abc.ABC):
     INDIRECTLY_MODIFIED_DISPLAY_THRESHOLD = 10
 
     @abc.abstractmethod
-    def start_plan_evaluation(self, plan: Plan) -> None:
+    def start_plan_evaluation(self, plan: EvaluatablePlan) -> None:
         """Indicates that a new evaluation has begun."""
 
     @abc.abstractmethod
@@ -335,7 +335,7 @@ class TerminalConsole(Console):
     def _confirm(self, message: str, **kwargs: t.Any) -> bool:
         return Confirm.ask(message, console=self.console, **kwargs)
 
-    def start_plan_evaluation(self, plan: Plan) -> None:
+    def start_plan_evaluation(self, plan: EvaluatablePlan) -> None:
         pass
 
     def stop_plan_evaluation(self) -> None:
@@ -1985,7 +1985,7 @@ class DebuggerTerminalConsole(TerminalConsole):
     def _write(self, msg: t.Any, *args: t.Any, **kwargs: t.Any) -> None:
         self.console.log(msg, *args, **kwargs)
 
-    def start_plan_evaluation(self, plan: Plan) -> None:
+    def start_plan_evaluation(self, plan: EvaluatablePlan) -> None:
         self._write("Starting plan", plan.plan_id)
 
     def stop_plan_evaluation(self) -> None:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1828,7 +1828,9 @@ class GenericContext(BaseContext, t.Generic[C]):
         return success
 
     def _apply(self, plan: Plan, circuit_breaker: t.Optional[t.Callable[[], bool]]) -> None:
-        self._scheduler.create_plan_evaluator(self).evaluate(plan, circuit_breaker=circuit_breaker)
+        self._scheduler.create_plan_evaluator(self).evaluate(
+            plan.to_evaluatable(), circuit_breaker=circuit_breaker
+        )
 
     @python_api_analytics
     def table_name(self, model_name: str, dev: bool) -> str:

--- a/sqlmesh/core/plan/__init__.py
+++ b/sqlmesh/core/plan/__init__.py
@@ -1,6 +1,7 @@
 from sqlmesh.core.plan.builder import PlanBuilder as PlanBuilder
 from sqlmesh.core.plan.definition import (
     Plan as Plan,
+    EvaluatablePlan as EvaluatablePlan,
     PlanStatus as PlanStatus,
     SnapshotIntervals as SnapshotIntervals,
 )

--- a/sqlmesh/schedulers/airflow/common.py
+++ b/sqlmesh/schedulers/airflow/common.py
@@ -5,6 +5,7 @@ import typing as t
 from sqlmesh.core import constants as c
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.notification_target import NotificationTarget
+from sqlmesh.core.plan.definition import EvaluatablePlan
 from sqlmesh.core.scheduler import Interval
 from sqlmesh.core.snapshot import (
     DeployabilityIndex,
@@ -14,7 +15,6 @@ from sqlmesh.core.snapshot import (
     SnapshotIntervals,
     SnapshotTableInfo,
 )
-from sqlmesh.core.snapshot.definition import Interval as SnapshotInterval
 from sqlmesh.core.user import User
 from sqlmesh.utils import sanitize_name
 from sqlmesh.utils.date import TimeLike
@@ -37,30 +37,11 @@ SQLMESH_API_BASE_PATH: str = f"{c.SQLMESH}/api/v1"
 
 
 class PlanApplicationRequest(PydanticModel):
-    request_id: str
-    new_snapshots: t.List[Snapshot]
-    environment: Environment
-    no_gaps: bool
-    skip_backfill: bool
-    restatements: t.Dict[str, SnapshotInterval]
+    plan: EvaluatablePlan
     notification_targets: t.List[NotificationTarget]
     backfill_concurrent_tasks: int
     ddl_concurrent_tasks: int
     users: t.List[User]
-    is_dev: bool
-    allow_destructive_snapshots: t.Set[str] = set()
-    forward_only: bool
-    models_to_backfill: t.Optional[t.Set[str]] = None
-    end_bounded: bool
-    ensure_finalized_snapshots: bool
-    directly_modified_snapshots: t.List[SnapshotId]
-    indirectly_modified_snapshots: t.Dict[str, t.List[SnapshotId]]
-    removed_snapshots: t.List[SnapshotId]
-    interval_end_per_model: t.Optional[t.Dict[str, int]] = None
-    execution_time: t.Optional[TimeLike] = None
-
-    def is_selected_for_backfill(self, model_fqn: str) -> bool:
-        return self.models_to_backfill is None or model_fqn in self.models_to_backfill
 
 
 class BackfillIntervalsPerSnapshot(PydanticModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,9 +234,9 @@ def push_plan(context: Context, plan: Plan) -> None:
         context.create_scheduler,
         context.default_catalog,
     )
-    plan_evaluator._push(plan)
-    promotion_result = plan_evaluator._promote(plan)
-    plan_evaluator._update_views(plan, promotion_result)
+    plan_evaluator._push(plan.to_evaluatable(), plan.snapshots)
+    promotion_result = plan_evaluator._promote(plan.to_evaluatable(), plan.snapshots)
+    plan_evaluator._update_views(plan.to_evaluatable(), plan.snapshots, promotion_result)
 
 
 @pytest.fixture()

--- a/tests/core/analytics/test_collector.py
+++ b/tests/core/analytics/test_collector.py
@@ -169,7 +169,10 @@ def test_on_plan_apply(
 
     plan_id = plan.plan_id
     collector.on_plan_apply_start(
-        plan=plan, engine_type="bigquery", state_sync_type="mysql", scheduler_type="builtin"
+        plan=plan.to_evaluatable(),
+        engine_type="bigquery",
+        state_sync_type="mysql",
+        scheduler_type="builtin",
     )
     collector.on_plan_apply_end(plan_id=plan_id)
     collector.on_plan_apply_end(plan_id=plan_id, error=SQLMeshError("test_error"))

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -223,8 +223,8 @@ def test_diff(sushi_context: Context, mocker: MockerFixture):
     # https://github.com/pydantic/pydantic/issues/8016
     assert str(plan) != ""
 
-    promotion_result = plan_evaluator._promote(plan)
-    plan_evaluator._update_views(plan, promotion_result)
+    promotion_result = plan_evaluator._promote(plan.to_evaluatable(), plan.snapshots)
+    plan_evaluator._update_views(plan.to_evaluatable(), plan.snapshots, promotion_result)
 
     sushi_context.upsert_model("sushi.customers", query=parse_one("select 1 as customer_id"))
     sushi_context.diff("test")

--- a/web/server/console.py
+++ b/web/server/console.py
@@ -10,7 +10,7 @@ from sse_starlette.sse import ServerSentEvent
 
 from sqlmesh.core.console import TerminalConsole
 from sqlmesh.core.environment import EnvironmentNamingInfo
-from sqlmesh.core.plan.definition import Plan
+from sqlmesh.core.plan.definition import EvaluatablePlan
 from sqlmesh.core.snapshot import Snapshot, SnapshotInfoLike
 from sqlmesh.core.test import ModelTest
 from sqlmesh.utils.date import now_timestamp
@@ -28,7 +28,7 @@ class ApiConsole(TerminalConsole):
         self.current_task_status: t.Dict[str, t.Dict[str, t.Any]] = {}
         self.queue: asyncio.Queue = asyncio.Queue()
 
-    def start_plan_evaluation(self, plan: Plan) -> None:
+    def start_plan_evaluation(self, plan: EvaluatablePlan) -> None:
         self.plan_apply_stage_tracker = (
             self.plan_apply_stage_tracker
             or models.PlanApplyStageTracker(environment=plan.environment.name)


### PR DESCRIPTION
This update introduces a light-weight serializable version of the plan object which is used specifically for evaluation. This allows us to keep a consistent interface across various variances of plan evaluation (eg. airflow / builtin).