### PR TITLE
feat: support multiple when matched inc unique key

### DIFF
--- a/docs/concepts/models/model_kinds.md
+++ b/docs/concepts/models/model_kinds.md
@@ -259,6 +259,19 @@ MODEL (
 
 The `source` and `target` aliases are required when using the `when_matched` expression in order to distinguish between the source and target columns.
 
+Multiple `WHEN MATCHED` expressions can also be provided. Ex:
+
+```sql linenums="1" hl_lines="5-6"
+MODEL (
+  name db.employees,
+  kind INCREMENTAL_BY_UNIQUE_KEY (
+    unique_key name,
+    when_matched WHEN MATCHED AND source.value IS NULL THEN UPDATE SET target.salary = COALESCE(source.salary, target.salary),
+    WHEN MATCHED THEN UPDATE SET target.title = COALESCE(source.title, target.title)
+  )
+);
+```
+
 **Note**: `when_matched` is only available on engines that support the `MERGE` statement. Currently supported engines include:
 
 * BigQuery

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -398,7 +398,9 @@ def _parse_props(self: Parser) -> t.Optional[exp.Expression]:
 
     name = key.name.lower()
     if name == "when_matched":
-        value: t.Optional[exp.Expression] = self._parse_when_matched()[0]
+        value: t.Optional[t.Union[exp.Expression, t.List[exp.Expression]]] = (
+            self._parse_when_matched()  # type: ignore
+        )
     elif name == "time_data_type":
         # TODO: if we make *_data_type a convention to parse things into exp.DataType, we could make this more generic
         value = self._parse_types(schema=True)
@@ -410,7 +412,7 @@ def _parse_props(self: Parser) -> t.Optional[exp.Expression]:
 
     if name == "path" and value:
         # Make sure if we get a windows path that it is converted to posix
-        value = exp.Literal.string(value.this.replace("\\", "/"))
+        value = exp.Literal.string(value.this.replace("\\", "/"))  # type: ignore
 
     return self.expression(exp.Property, this=name, value=value)
 

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1726,7 +1726,7 @@ class EngineAdapter:
         source_table: QueryOrDF,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
-        when_matched: t.Optional[exp.When] = None,
+        when_matched: t.Optional[t.Union[exp.When, t.List[exp.When]]] = None,
     ) -> None:
         source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
             source_table, columns_to_types, target_table=target_table
@@ -1749,6 +1749,7 @@ class EngineAdapter:
                     ],
                 ),
             )
+        when_matched = ensure_list(when_matched)
         when_not_matched = exp.When(
             matched=False,
             source=False,
@@ -1759,13 +1760,14 @@ class EngineAdapter:
                 ),
             ),
         )
+        match_expressions = when_matched + [when_not_matched]
         for source_query in source_queries:
             with source_query as query:
                 self._merge(
                     target_table=target_table,
                     query=query,
                     on=on,
-                    match_expressions=[when_matched, when_not_matched],
+                    match_expressions=match_expressions,
                 )
 
     def rename_table(

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -25,7 +25,7 @@ class LogicalMergeMixin(EngineAdapter):
         source_table: QueryOrDF,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
-        when_matched: t.Optional[exp.When] = None,
+        when_matched: t.Optional[t.Union[exp.When, t.List[exp.When]]] = None,
     ) -> None:
         """
         Merge implementation for engine adapters that do not support merge natively.

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -439,7 +439,7 @@ class ModelMeta(_Node):
         return getattr(self.kind, "managed_columns", {})
 
     @property
-    def when_matched(self) -> t.Optional[exp.When]:
+    def when_matched(self) -> t.Optional[t.List[exp.When]]:
         if isinstance(self.kind, IncrementalByUniqueKeyKind):
             return self.kind.when_matched
         return None


### PR DESCRIPTION
Prior to this PR the when matched expression only supported a single expression. This PR makes it so you can pass in multiple. We assume the underlying engine will support it (will get an error at runtime if that is not the case). 