### PR TITLE
fix: types

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2332,7 +2332,7 @@ def _list_of_calls_to_exp(value: t.List[t.Tuple[str, t.Dict[str, t.Any]]]) -> ex
 
 def _extract_audit_expressions(
     audits: t.Optional[dict[str, Audit]] = None,
-    inline_audits: t.Optional[dict[str, Audit]] = None,
+    inline_audits: t.Optional[t.Mapping[str, Audit]] = None,
     model_audits: t.Optional[t.Any] = None,
     default_audits: t.Optional[t.List[AuditReference]] = None,
 ) -> list:

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -65,7 +65,7 @@ def random_id(short: bool = False) -> str:
     return uuid.uuid4().hex
 
 
-class UniqueKeyDict(dict, t.Mapping[KEY, VALUE]):
+class UniqueKeyDict(t.Dict[KEY, VALUE]):
     """Dict that raises when a duplicate key is set."""
 
     def __init__(self, name: str, *args: t.Dict[KEY, VALUE], **kwargs: VALUE) -> None:


### PR DESCRIPTION
We've started building off the Python APIs and noticed that `UniqueKeyDict` has a number of methods that are not type-safe, including `__getitem__`, `values`, and `items`. This PR attempts to correct that. Correcting `UniqueKeyDict` made it necessary to make some changes elsewhere to satisfy `mypy`. Let me know if I did those correctly or not.