### PR TITLE
chore: rescope lineage cache in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ from sqlmesh.core.context import Context
 from sqlmesh.core.engine_adapter import SparkEngineAdapter
 from sqlmesh.core.engine_adapter.base import EngineAdapter
 from sqlmesh.core.environment import EnvironmentNamingInfo
+from sqlmesh.core import lineage
 from sqlmesh.core.macros import macro
 from sqlmesh.core.model import IncrementalByTimeRangeKind, SqlModel, model
 from sqlmesh.core.model.kind import OnDestructiveChange
@@ -219,6 +220,12 @@ def rescope_duckdb_classvar(request):
 @pytest.fixture(scope="module", autouse=True)
 def rescope_log_handlers():
     logging.getLogger().handlers.clear()
+    yield
+
+
+@pytest.fixture(scope="function", autouse=True)
+def rescope_lineage_cache(request):
+    lineage.CACHE.clear()
     yield
 
 


### PR DESCRIPTION
This resolves the flakiness I was able to recreate locally.

If we continue to have issues, then I would suggest using `pytest-antilru` and disabling lru cache here: https://github.com/TobikoData/sqlmesh/blob/0384db3ac42c869cb9941d508037e29c055feaba/web/server/settings.py#L58

I don't want to add this if it isn't needed but it seems like it could cause issues. 