### PR TITLE
feat: Add SQLMesh warning when an exp.Command is parsed

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -318,9 +318,11 @@ def _parse_join(
 
 
 def _warn_unsupported(self: Parser) -> None:
-    self.__warn_unsupported()  # type: ignore
+    sql = self._find_sql(self._tokens[0], self._tokens[-1])[: self.error_message_context]
+
     logger.warning(
-        "SQLMesh is unable to resolve model references on unsupported syntax; Consider using Jinja as explained here https://sqlmesh.readthedocs.io/en/stable/concepts/macros/macro_variables/#audit-only-variables"
+        f"'{sql}' could not be semantically understood as it contains unsupported syntax, falling back to parsing as 'Command'. SQLMesh is unable to resolve any references to the model's "
+        "underlying physical table in this case, consider using Jinja as explained here https://sqlmesh.readthedocs.io/en/stable/concepts/macros/macro_variables/#audit-only-variables"
     )
 
 

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import logging
 import re
 import sys
 import typing as t
@@ -32,6 +33,8 @@ if t.TYPE_CHECKING:
 SQLMESH_MACRO_PREFIX = "@"
 
 TABLES_META = "sqlmesh.tables"
+
+logger = logging.getLogger(__name__)
 
 
 class Model(exp.Expression):
@@ -312,6 +315,13 @@ def _parse_join(
 
     macro.this.append("expressions", join)
     return macro
+
+
+def _warn_unsupported(self: Parser) -> None:
+    self.__warn_unsupported()  # type: ignore
+    logger.warning(
+        "SQLMesh is unable to resolve model references on unsupported syntax; Consider using Jinja as explained here https://sqlmesh.readthedocs.io/en/stable/concepts/macros/macro_variables/#audit-only-variables"
+    )
 
 
 def _parse_select(
@@ -886,6 +896,7 @@ def extend_sqlglot() -> None:
     _override(Parser, _parse_types)
     _override(Parser, _parse_if)
     _override(Parser, _parse_id_var)
+    _override(Parser, _warn_unsupported)
     _override(Snowflake.Parser, _parse_table_parts)
 
 

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -321,8 +321,8 @@ def _warn_unsupported(self: Parser) -> None:
     sql = self._find_sql(self._tokens[0], self._tokens[-1])[: self.error_message_context]
 
     logger.warning(
-        f"'{sql}' could not be semantically understood as it contains unsupported syntax, falling back to parsing as 'Command'. SQLMesh is unable to resolve any references to the model's "
-        "underlying physical table in this case, consider using Jinja as explained here https://sqlmesh.readthedocs.io/en/stable/concepts/macros/macro_variables/#audit-only-variables"
+        f"'{sql}' could not be semantically understood as it contains unsupported syntax, SQLMesh will treat the command as is. Note that any references to the model's "
+        "underlying physical table can't be resolved in this case, consider using Jinja as explained here https://sqlmesh.readthedocs.io/en/stable/concepts/macros/macro_variables/#audit-only-variables"
     )
 
 


### PR DESCRIPTION
[Public slack context](https://tobiko-data.slack.com/archives/C044BRE5W4S/p1726478874076549)


This PR overrides SQLGlot's `_warn_unsupported()` to suggest the usage of Jinja on the occasion that the (unsupported) statement is attempting to reference the physical table.

