### PR TITLE
Allows setting a clickhouse connection pool

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -1427,17 +1427,6 @@ class ClickhouseConnectionConfig(ConnectionConfig):
 
     @property
     def _connection_factory(self) -> t.Callable:
-        """Returns a clickhouse connection. If the pool_manager_factory is set
-        the connect function is returned with the `pool_mgr` value set. The
-        factory should be something like:
-
-            def pool_manager_factory(config: ClickhouseConnectionConfig):
-                from clickhouse_connect.driver import httputil
-
-                return httputil.get_pool_manager(
-                    num_pools=config.concurrent_tasks
-                )
-        """
         from clickhouse_connect.dbapi import connect  # type: ignore
         from clickhouse_connect.driver import httputil  # type: ignore
         from functools import partial


### PR DESCRIPTION
We have actually been finding some issues in general with clickhouse (I'll be putting together some notes soon). However, one of the important things we found was the clickhouse performance can be improved by allowing the creation of a connection pool. 

I figured the easiest thing to do would be to allow the user to just create the pool manager directly rather than attempt to expose the necessary config on the `ClickhouseConnectionConfig` class