### PR TITLE
Fix: Support comments in Jinja queries coming from dbt models

### DIFF
--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -424,6 +424,8 @@ class QueryRenderer(BaseExpressionRenderer):
             except ParsetimeAdapterCallError:
                 return None
 
+            expressions = [e for e in expressions if not isinstance(e, exp.Semicolon)]
+
             if not expressions:
                 raise ConfigError(f"Failed to render query at '{self._path}':\n{self._expression}")
 


### PR DESCRIPTION
Previously, the query rendering failed when the `JINJA_QUERY_BEGIN` block contained standalone comments.