### PR TITLE
Fix: Only set effective_from for evaluatable models

### DIFF
--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -797,6 +797,7 @@ class ManagedKind(_ModelKind):
 
 class EmbeddedKind(_ModelKind):
     name: Literal[ModelKindName.EMBEDDED] = ModelKindName.EMBEDDED
+    disable_restatement: t.Literal[True] = True
 
     @property
     def supports_python_models(self) -> bool:
@@ -805,6 +806,7 @@ class EmbeddedKind(_ModelKind):
 
 class ExternalKind(_ModelKind):
     name: Literal[ModelKindName.EXTERNAL] = ModelKindName.EXTERNAL
+    disable_restatement: t.Literal[True] = True
 
 
 class CustomKind(_ModelKind):

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -600,7 +600,11 @@ class PlanBuilder:
                 raise PlanError("Effective date cannot be in the future.")
 
         for snapshot in self._context_diff.new_snapshots.values():
-            if not snapshot.disable_restatement and not snapshot.full_history_restatement_only:
+            if (
+                snapshot.evaluatable
+                and not snapshot.disable_restatement
+                and not snapshot.full_history_restatement_only
+            ):
                 snapshot.effective_from = self._effective_from
 
     def _is_forward_only_change(self, s_id: SnapshotId) -> bool:

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -430,7 +430,10 @@ class EngineAdapterStateSync(StateSync):
                 unpaused_snapshots[snapshot.unpaused_ts].append(snapshot.snapshot_id)
             elif not is_target_snapshot:
                 target_snapshot = target_snapshots_by_version[(snapshot.name, snapshot.version)]
-                if target_snapshot.normalized_effective_from_ts:
+                if (
+                    target_snapshot.normalized_effective_from_ts
+                    and not target_snapshot.disable_restatement
+                ):
                     # Making sure that there are no overlapping intervals.
                     effective_from_ts = target_snapshot.normalized_effective_from_ts
                     logger.info(


### PR DESCRIPTION
Previously, SQLMesh assigned an effective_from date to external / embedded models which led to unexpected errors.