### PR TITLE
feat: add support for GCP postgres instance authentication using IAM with service account keyfile/keyfile json

### DIFF
--- a/docs/integrations/engines/gcp-postgres.md
+++ b/docs/integrations/engines/gcp-postgres.md
@@ -17,4 +17,6 @@ pip install "sqlmesh[gcppostgres]"
 | `user`                       | The username (posgres or IAM) to use for authentication                             | string  |    Y     |
 | `password`                   | The password to use for authentication. Required when connecting as a Postgres user | string  |    N     |
 | `enable_iam_auth`            | Enables IAM authentication. Required when connecting as an IAM user                 | boolean |    N     |
+| `keyfile`                    | Path to the keyfile to be used with enable_iam_auth instead of ADC                  | string  |    N     |
+| `keyfile_json`               | Keyfile information provided inline (not recommended)                               |  dict   |    N     |
 | `db`                         | The name of the database instance to connect to                                     | string  |    Y     |

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -914,7 +914,8 @@ class GCPPostgresConnectionConfig(ConnectionConfig):
         creds = None
         if self.keyfile:
             creds = service_account.Credentials.from_service_account_file(
-                self.keyfile, scopes=self.scopes)
+                self.keyfile, scopes=self.scopes
+            )
         elif self.keyfile_json:
             creds = service_account.Credentials.from_service_account_info(
                 self.keyfile_json, scopes=self.scopes


### PR DESCRIPTION
GCP Cloud SQL client libraries supports passing credentials built from service accounts keyfiles or json https://github.com/GoogleCloudPlatform/cloud-sql-python-connector?tab=readme-ov-file#configuring-the-connector