### PR TITLE
Fix: regression caused by optionally normalizing identifiers in renderer

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -297,7 +297,11 @@ class ModelTest(unittest.TestCase):
             path: An optional path to the test definition yaml file.
             preserve_fixtures: Preserve the fixture tables in the testing database, useful for debugging.
         """
-        name = normalize_model_name(body["model"], default_catalog=default_catalog, dialect=dialect)
+        name = body.get("model")
+        if name is None:
+            _raise_error("Missing required 'model' field", path)
+
+        name = normalize_model_name(name, default_catalog=default_catalog, dialect=dialect)
         model = models.get(name)
         if not model:
             _raise_error(f"Model '{name}' was not found", path)

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -108,7 +108,7 @@ def full_model_with_two_ctes(request) -> SqlModel:
         renamed AS (
             SELECT id AS fid FROM source
         )
-        SELECT fid FROM renamed;
+        SELECT fid FROM RENAMED;
         """,
         dialect=getattr(request, "param", None),
         default_catalog="memory",


### PR DESCRIPTION
This PR reverts the `normalize_identifiers` changes introduced in https://github.com/TobikoData/sqlmesh/pull/3077. Switching off identifier normalization has unintended side effects, e.g. `find_tables` treats CTE references like models if there's a casing mismatch, which can lead to more errors.

The motivation was a unit testing issue where we raised an error saying that input data for a model was missing, even though it was a CTE that we knew how to populate.

Not sure if this PR is breaking, please let me know if you think of a case where we'd need a migration and I can update the title accordingly.