### PR TITLE
Feat: Support column types for dbt seeds

### DIFF
--- a/docs/integrations/dbt.md
+++ b/docs/integrations/dbt.md
@@ -202,19 +202,7 @@ SQLMesh parses seed CSV files using [Panda's `read_csv` utility](https://pandas.
 
 dbt parses seed CSV files using [agate's csv reader](https://agate.readthedocs.io/en/latest/api/csv.html#csv-reader-and-writer) and [customizes agate's default type inference](https://github.com/dbt-labs/dbt-common/blob/ae8ffe082926fdb3ef2a15486588f40c7739aea9/dbt_common/clients/agate_helper.py#L59).
 
-If SQLMesh and dbt infer different column types for a seed CSV file, you may specify your desired data types in a [seed properties configuration file](https://docs.getdbt.com/reference/seed-properties).
-
-Specify a column's SQL data type in its `data_type` key, as shown below. The file must list all columns present in the CSV file; SQLMesh's default type inference will be used for columns that do not specify the `data_type` key.
-
-``` yaml
-seeds:
-  - name: <seed name>
-    columns:
-      - name: <column name>
-        data_type: <SQL data type>
-```
-
-Alternatively, you can specify a [column_types](https://docs.getdbt.com/reference/resource-configs/column_types) dictionary in your `dbt_project.yml` file, where the keys define the column names and the values the data types.
+If SQLMesh and dbt infer different column types for a seed CSV file, you may specify a [column_types](https://docs.getdbt.com/reference/resource-configs/column_types) dictionary in your `dbt_project.yml` file, where the keys define the column names and the values the data types.
 
 ``` yaml
 seeds:
@@ -223,7 +211,7 @@ seeds:
       <column name>: <SQL data type>
 ```
 
-You can also define this dictionary in the seed properties configuration file.
+Alternatively, you can define this dictionary in the seed [seed properties configuration file](https://docs.getdbt.com/reference/seed-properties).
 
 ``` yaml
 seeds:
@@ -231,6 +219,16 @@ seeds:
     config:
       column_types:
         <column name>: <SQL data type>
+```
+
+You may also specify a column's SQL data type in its `data_type` key, as shown below. The file must list all columns present in the CSV file; SQLMesh's default type inference will be used for columns that do not specify the `data_type` key.
+
+``` yaml
+seeds:
+  - name: <seed name>
+    columns:
+      - name: <column name>
+        data_type: <SQL data type>
 ```
 
 ## Package Management

--- a/docs/integrations/dbt.md
+++ b/docs/integrations/dbt.md
@@ -220,7 +220,7 @@ Alternatively, you can specify a [column_types](https://docs.getdbt.com/referenc
 seeds:
   <seed name>
     +column_types:
-        <column name> : <SQL data type>
+      <column name>: <SQL data type>
 ```
 
 You can also define this dictionary in the seed properties configuration file.
@@ -229,8 +229,8 @@ You can also define this dictionary in the seed properties configuration file.
 seeds:
   - name: <seed name>
     config:
-        column_types:
-            <column name> : <SQL data type>
+      column_types:
+        <column name>: <SQL data type>
 ```
 
 ## Package Management

--- a/docs/integrations/dbt.md
+++ b/docs/integrations/dbt.md
@@ -214,6 +214,25 @@ seeds:
         data_type: <SQL data type>
 ```
 
+Alternatively, you can specify a [column_types](https://docs.getdbt.com/reference/resource-configs/column_types) dictionary in your `dbt_project.yml` file, where the keys define the column names and the values the data types.
+
+``` yaml
+seeds:
+  <seed name>
+    +column_types:
+        <column name> : <SQL data type>
+```
+
+You can also define this dictionary in the seed properties configuration file.
+
+``` yaml
+seeds:
+  - name: <seed name>
+    config:
+        column_types:
+            <column name> : <SQL data type>
+```
+
 ## Package Management
 SQLMesh does not have its own package manager; however, SQLMesh's dbt adapter is compatible with dbt's package manager. Continue to use [dbt deps](https://docs.getdbt.com/reference/commands/deps) and [dbt clean](https://docs.getdbt.com/reference/commands/clean) to update, add, or remove packages.
 

--- a/sqlmesh/dbt/basemodel.py
+++ b/sqlmesh/dbt/basemodel.py
@@ -285,7 +285,11 @@ class BaseModelConfig(GeneralConfig):
             node_name += f".v{self.version}"
         return node_name
 
-    def sqlmesh_model_kwargs(self, context: DbtContext) -> t.Dict[str, t.Any]:
+    def sqlmesh_model_kwargs(
+        self,
+        context: DbtContext,
+        column_types_override: t.Optional[t.Dict[str, ColumnConfig]] = None,
+    ) -> t.Dict[str, t.Any]:
         """Get common sqlmesh model parameters"""
         self.check_for_circular_test_refs(context)
         model_context = context.context_for_dependencies(
@@ -316,7 +320,10 @@ class BaseModelConfig(GeneralConfig):
         )
         return {
             "audits": [(test.name, {}) for test in self.tests],
-            "columns": column_types_to_sqlmesh(self.columns, self.dialect(context)) or None,
+            "columns": column_types_to_sqlmesh(
+                column_types_override or self.columns, self.dialect(context)
+            )
+            or None,
             "column_descriptions": column_descriptions_to_sqlmesh(self.columns) or None,
             "depends_on": {
                 model.canonical_name(context) for model in model_context.refs.values()

--- a/sqlmesh/dbt/seed.py
+++ b/sqlmesh/dbt/seed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import typing as t
 
 import agate
@@ -39,12 +40,15 @@ class SeedConfig(BaseModelConfig):
         """Converts the dbt seed into a SQLMesh model."""
         seed_path = self.path.absolute().as_posix()
 
+        # Store a copy to reset after getting the sqlmesh column types
+        columns = copy.deepcopy(self.columns)
         for name, data_type in (self.column_types or {}).items():
             column = self.columns.setdefault(name, ColumnConfig(name=name))
             column.data_type = data_type
             column.quote = self.quote_columns or column.quote
 
         kwargs = self.sqlmesh_model_kwargs(context)
+        self.columns = columns
         if kwargs.get("columns") is None:
             agate_table = (
                 agate_helper.from_csv(seed_path, [], delimiter=self.delimiter)

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -438,8 +438,6 @@ def test_seed_column_types():
     context.target = DuckDbConfig(name="target", schema="test")
     sqlmesh_seed = seed.to_sqlmesh(context)
 
-    assert seed.columns["zipcode"].quote
-    assert seed.columns["address"].quote
     assert sqlmesh_seed.columns_to_types == expected_column_types
     assert sqlmesh_seed.column_descriptions == expected_column_descriptions
 

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -11,7 +11,7 @@ from dbt.adapters.base import BaseRelation
 from dbt.exceptions import CompilationError
 from freezegun import freeze_time
 from pytest_mock.plugin import MockerFixture
-from sqlglot import exp, parse_one
+from sqlglot import exp
 from sqlmesh.core import dialect as d
 from sqlmesh.core.audit import StandaloneAudit
 from sqlmesh.core.context import Context
@@ -355,9 +355,9 @@ def test_model_columns():
     )
 
     expected_column_types = {
-        "ADDRESS": parse_one("text", into=exp.DataType),
-        "ZIPCODE": parse_one("varchar(5)", into=exp.DataType),
-        "DATE": parse_one("timestamp_ntz", into=exp.DataType, dialect="snowflake"),
+        "ADDRESS": exp.DataType.build("text"),
+        "ZIPCODE": exp.DataType.build("varchar(5)"),
+        "DATE": exp.DataType.build("timestamp_ntz", dialect="snowflake"),
     }
     expected_column_descriptions = {
         "ADDRESS": "Business address",
@@ -394,8 +394,8 @@ def test_seed_columns():
     )
 
     expected_column_types = {
-        "address": parse_one("text", into=exp.DataType),
-        "zipcode": parse_one("text", into=exp.DataType),
+        "address": exp.DataType.build("text"),
+        "zipcode": exp.DataType.build("text"),
     }
     expected_column_descriptions = {
         "address": "Business address",
@@ -426,8 +426,8 @@ def test_seed_column_types():
     )
 
     expected_column_types = {
-        "address": parse_one("text", into=exp.DataType),
-        "zipcode": parse_one("text", into=exp.DataType),
+        "address": exp.DataType.build("text"),
+        "zipcode": exp.DataType.build("text"),
     }
     expected_column_descriptions = {
         "zipcode": "Business zipcode",


### PR DESCRIPTION
Add support for the `column_types` attribute for seeds in dbt, fixes: #3163 

If either or both `column_types` and `columns` are defined, they are reconciled to determine the seed configs. Additionally, support for the `quote_columns` property has been added. They can be defined in the `dbt_project.yml` file:

```yaml
seeds:
  <seed name>:
    +quote_columns: true
    +column_types:
      <column name>: <SQL data type>
```

or in the seed properties configuration file:

```yaml
seeds:
  - name: <seed name>
    config:
      quote_columns: true
      column_types:
        <column name>: <SQL data type>
    columns:
        - name: <column name>
          description: "column description"
```

[dbt docs](https://docs.getdbt.com/reference/resource-configs/column_types)