### PR TITLE
Feat: allow formatter to use CAST over :: syntax

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -172,8 +172,8 @@ Options:
   -t, --transpile TEXT        Transpile project models to the specified
                               dialect.
   --append-newline            Include a newline at the end of each file.
-  --cast-function             Use the standard CAST function over the ::
-                              syntax.
+  --no-rewrite-casts          Preserve the existing casts, without rewriting
+                              them to use the :: syntax.
   --normalize                 Whether or not to normalize identifiers to
                               lowercase.
   --pad INTEGER               Determines the pad size in a formatted string.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -172,6 +172,8 @@ Options:
   -t, --transpile TEXT        Transpile project models to the specified
                               dialect.
   --append-newline            Include a newline at the end of each file.
+  --cast-function             Use the standard CAST function over the ::
+                              syntax.
   --normalize                 Whether or not to normalize identifiers to
                               lowercase.
   --pad INTEGER               Determines the pad size in a formatted string.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -93,7 +93,7 @@ Formatting settings for the `sqlmesh format` command and UI.
 | `leading_comma`       | Whether to use leading commas (Default: False)                                                 | boolean |    N     |
 | `max_text_width`      | The maximum text width in a segment before creating new lines (Default: 80)                    |   int   |    N     |
 | `append_newline`      | Whether to append a newline to the end of the file (Default: False)                            | boolean |    N     |
-| `cast_function`       | Whether to use the standard CAST function over the :: syntax (Default: False)                  | boolean |    N     |
+| `cast_function`       | Whether to preserve the existing casts, without rewriting them to use the :: syntax. (Default: False)                  | boolean |    N     |
 
 ## UI
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -93,7 +93,7 @@ Formatting settings for the `sqlmesh format` command and UI.
 | `leading_comma`       | Whether to use leading commas (Default: False)                                                 | boolean |    N     |
 | `max_text_width`      | The maximum text width in a segment before creating new lines (Default: 80)                    |   int   |    N     |
 | `append_newline`      | Whether to append a newline to the end of the file (Default: False)                            | boolean |    N     |
-| `cast_function`       | Whether to preserve the existing casts, without rewriting them to use the :: syntax. (Default: False)                  | boolean |    N     |
+| `no_rewrite_casts`    | Preserve the existing casts, without rewriting them to use the :: syntax. (Default: False)                  | boolean |    N     |
 
 ## UI
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -93,6 +93,7 @@ Formatting settings for the `sqlmesh format` command and UI.
 | `leading_comma`       | Whether to use leading commas (Default: False)                                                 | boolean |    N     |
 | `max_text_width`      | The maximum text width in a segment before creating new lines (Default: 80)                    |   int   |    N     |
 | `append_newline`      | Whether to append a newline to the end of the file (Default: False)                            | boolean |    N     |
+| `cast_function`       | Whether to use the standard CAST function over the :: syntax (Default: False)                  | boolean |    N     |
 
 ## UI
 

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -441,8 +441,8 @@ options:
 
 #### format
 ```
-%format [--transpile TRANSPILE] [--append-newline] [--normalize]
-              [--pad PAD] [--indent INDENT]
+%format [--transpile TRANSPILE] [--append-newline] [--cast-function]
+              [--normalize] [--pad PAD] [--indent INDENT]
               [--normalize-functions NORMALIZE_FUNCTIONS] [--leading-comma]
               [--max-text-width MAX_TEXT_WIDTH] [--check]
 
@@ -453,6 +453,7 @@ options:
                         Transpile project models to the specified dialect.
   --append-newline      Whether or not to append a newline to the end of the
                         file.
+  --cast-function       Use the standard CAST function over the :: syntax.
   --normalize           Whether or not to normalize identifiers to lowercase.
   --pad PAD             Determines the pad size in a formatted string.
   --indent INDENT       Determines the indentation size in a formatted string.

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -441,7 +441,7 @@ options:
 
 #### format
 ```
-%format [--transpile TRANSPILE] [--append-newline] [--cast-function]
+%format [--transpile TRANSPILE] [--append-newline] [--no-rewrite-casts]
               [--normalize] [--pad PAD] [--indent INDENT]
               [--normalize-functions NORMALIZE_FUNCTIONS] [--leading-comma]
               [--max-text-width MAX_TEXT_WIDTH] [--check]
@@ -453,7 +453,8 @@ options:
                         Transpile project models to the specified dialect.
   --append-newline      Whether or not to append a newline to the end of the
                         file.
-  --cast-function       Use the standard CAST function over the :: syntax.
+  --no-rewrite-casts    Preserve the existing casts, without rewriting them
+                        to use the :: syntax.
   --normalize           Whether or not to normalize identifiers to lowercase.
   --pad PAD             Determines the pad size in a formatted string.
   --indent INDENT       Determines the indentation size in a formatted string.

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -224,6 +224,12 @@ def evaluate(
     default=None,
 )
 @click.option(
+    "--cast-function",
+    is_flag=True,
+    help="Use the standard CAST function over the :: syntax.",
+    default=None,
+)
+@click.option(
     "--normalize",
     is_flag=True,
     help="Whether or not to normalize identifiers to lowercase.",

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -224,9 +224,9 @@ def evaluate(
     default=None,
 )
 @click.option(
-    "--cast-function",
+    "--no-rewrite-casts",
     is_flag=True,
-    help="Use the standard CAST function over the :: syntax.",
+    help="Preserve the existing casts, without rewriting them to use the :: syntax.",
     default=None,
 )
 @click.option(

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -272,6 +272,9 @@ def evaluate(
 @cli_analytics
 def format(ctx: click.Context, **kwargs: t.Any) -> None:
     """Format all SQL models and audits."""
+    if kwargs.pop("no_rewrite_casts", None):
+        kwargs["rewrite_casts"] = False
+
     if not ctx.obj.format(**{k: v for k, v in kwargs.items() if v is not None}):
         ctx.exit(1)
 

--- a/sqlmesh/core/config/format.py
+++ b/sqlmesh/core/config/format.py
@@ -16,6 +16,7 @@ class FormatConfig(BaseConfig):
         leading_comma: Whether to use leading commas or not.
         max_text_width: The maximum text width in a segment before creating new lines.
         append_newline: Whether to append a newline to the end of the file or not.
+        cast_function: Whether to use the standard CAST function over the :: syntax.
     """
 
     normalize: bool = False
@@ -25,6 +26,7 @@ class FormatConfig(BaseConfig):
     leading_comma: bool = False
     max_text_width: int = 80
     append_newline: bool = False
+    cast_function: bool = False
 
     @property
     def generator_options(self) -> t.Dict[str, t.Any]:
@@ -33,4 +35,4 @@ class FormatConfig(BaseConfig):
         Returns:
             The generator options.
         """
-        return self.dict(exclude={"append_newline"})
+        return self.dict(exclude={"append_newline", "cast_function"})

--- a/sqlmesh/core/config/format.py
+++ b/sqlmesh/core/config/format.py
@@ -16,7 +16,7 @@ class FormatConfig(BaseConfig):
         leading_comma: Whether to use leading commas or not.
         max_text_width: The maximum text width in a segment before creating new lines.
         append_newline: Whether to append a newline to the end of the file or not.
-        cast_function: Whether to use the standard CAST function over the :: syntax.
+        no_rewrite_casts: Preserve the existing casts, without rewriting them to use the :: syntax.
     """
 
     normalize: bool = False
@@ -26,7 +26,7 @@ class FormatConfig(BaseConfig):
     leading_comma: bool = False
     max_text_width: int = 80
     append_newline: bool = False
-    cast_function: bool = False
+    no_rewrite_casts: bool = False
 
     @property
     def generator_options(self) -> t.Dict[str, t.Any]:
@@ -35,4 +35,4 @@ class FormatConfig(BaseConfig):
         Returns:
             The generator options.
         """
-        return self.dict(exclude={"append_newline", "cast_function"})
+        return self.dict(exclude={"append_newline", "no_rewrite_casts"})

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -900,7 +900,7 @@ class GenericContext(BaseContext, t.Generic[C]):
     def format(
         self,
         transpile: t.Optional[str] = None,
-        cast_function: t.Optional[bool] = None,
+        no_rewrite_casts: t.Optional[bool] = None,
         append_newline: t.Optional[bool] = None,
         *,
         check: t.Optional[bool] = None,
@@ -929,7 +929,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 after = format_model_expressions(
                     expressions,
                     transpile or target.dialect,
-                    cast_function=cast_function or format_config.cast_function,
+                    no_rewrite_casts=no_rewrite_casts or format_config.no_rewrite_casts,
                     **{**format_config.generator_options, **kwargs},
                 )
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -900,7 +900,7 @@ class GenericContext(BaseContext, t.Generic[C]):
     def format(
         self,
         transpile: t.Optional[str] = None,
-        no_rewrite_casts: t.Optional[bool] = None,
+        rewrite_casts: bool = True,
         append_newline: t.Optional[bool] = None,
         *,
         check: t.Optional[bool] = None,
@@ -929,7 +929,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 after = format_model_expressions(
                     expressions,
                     transpile or target.dialect,
-                    no_rewrite_casts=no_rewrite_casts or format_config.no_rewrite_casts,
+                    rewrite_casts=rewrite_casts or not format_config.no_rewrite_casts,
                     **{**format_config.generator_options, **kwargs},
                 )
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -900,7 +900,7 @@ class GenericContext(BaseContext, t.Generic[C]):
     def format(
         self,
         transpile: t.Optional[str] = None,
-        rewrite_casts: bool = True,
+        rewrite_casts: t.Optional[bool] = None,
         append_newline: t.Optional[bool] = None,
         *,
         check: t.Optional[bool] = None,
@@ -929,7 +929,11 @@ class GenericContext(BaseContext, t.Generic[C]):
                 after = format_model_expressions(
                     expressions,
                     transpile or target.dialect,
-                    rewrite_casts=rewrite_casts or not format_config.no_rewrite_casts,
+                    rewrite_casts=(
+                        rewrite_casts
+                        if rewrite_casts is not None
+                        else not format_config.no_rewrite_casts
+                    ),
                     **{**format_config.generator_options, **kwargs},
                 )
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -900,6 +900,7 @@ class GenericContext(BaseContext, t.Generic[C]):
     def format(
         self,
         transpile: t.Optional[str] = None,
+        cast_function: t.Optional[bool] = None,
         append_newline: t.Optional[bool] = None,
         *,
         check: t.Optional[bool] = None,
@@ -910,6 +911,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         for target in format_targets.values():
             if target._path is None or target._path.suffix != ".sql":
                 continue
+
             with open(target._path, "r+", encoding="utf-8") as file:
                 before = file.read()
                 expressions = parse(before, default_dialect=self.config_for_node(target).dialect)
@@ -922,13 +924,20 @@ class GenericContext(BaseContext, t.Generic[C]):
                                     value=exp.Literal.string(transpile or target.dialect),
                                 )
                             )
-                format = self.config_for_node(target).format
-                opts = {**format.generator_options, **kwargs}
-                after = format_model_expressions(expressions, transpile or target.dialect, **opts)
+
+                format_config = self.config_for_node(target).format
+                after = format_model_expressions(
+                    expressions,
+                    transpile or target.dialect,
+                    cast_function=cast_function or format_config.cast_function,
+                    **{**format_config.generator_options, **kwargs},
+                )
+
                 if append_newline is None:
-                    append_newline = format.append_newline
+                    append_newline = format_config.append_newline
                 if append_newline:
                     after += "\n"
+
                 if not check:
                     file.seek(0)
                     file.write(after)

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -645,7 +645,7 @@ def _override(klass: t.Type[Tokenizer | Parser], func: t.Callable) -> None:
 def format_model_expressions(
     expressions: t.List[exp.Expression],
     dialect: t.Optional[str] = None,
-    cast_function: bool = False,
+    no_rewrite_casts: bool = False,
     **kwargs: t.Any,
 ) -> str:
     """Format a model's expressions into a standardized format.
@@ -653,7 +653,7 @@ def format_model_expressions(
     Args:
         expressions: The model's expressions, must be at least model def + query.
         dialect: The dialect to render the expressions as.
-        cast_function: Whether to use the standard CAST function over the :: syntax.
+        no_rewrite_casts: Preserve the existing casts, without rewriting them to use the :: syntax.
         **kwargs: Additional keyword arguments to pass to the sql generator.
 
     Returns:
@@ -664,7 +664,7 @@ def format_model_expressions(
 
     *statements, query = expressions
 
-    if not cast_function:
+    if not no_rewrite_casts:
 
         def cast_to_colon(node: exp.Expression) -> exp.Expression:
             if isinstance(node, exp.Cast) and not any(

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -643,13 +643,17 @@ def _override(klass: t.Type[Tokenizer | Parser], func: t.Callable) -> None:
 
 
 def format_model_expressions(
-    expressions: t.List[exp.Expression], dialect: t.Optional[str] = None, **kwargs: t.Any
+    expressions: t.List[exp.Expression],
+    dialect: t.Optional[str] = None,
+    cast_function: bool = False,
+    **kwargs: t.Any,
 ) -> str:
     """Format a model's expressions into a standardized format.
 
     Args:
         expressions: The model's expressions, must be at least model def + query.
         dialect: The dialect to render the expressions as.
+        cast_function: Whether to use the standard CAST function over the :: syntax.
         **kwargs: Additional keyword arguments to pass to the sql generator.
 
     Returns:
@@ -660,26 +664,28 @@ def format_model_expressions(
 
     *statements, query = expressions
 
-    def cast_to_colon(node: exp.Expression) -> exp.Expression:
-        if isinstance(node, exp.Cast) and not any(
-            # Only convert CAST into :: if it doesn't have additional args set, otherwise this
-            # conversion could alter the semantics (eg. changing SAFE_CAST in BigQuery to CAST)
-            arg
-            for name, arg in node.args.items()
-            if name not in ("this", "to")
-        ):
-            this = node.this
+    if not cast_function:
 
-            if not isinstance(this, (exp.Binary, exp.Unary)) or isinstance(this, exp.Paren):
-                cast = DColonCast(this=this, to=node.to)
-                cast.comments = node.comments
-                node = cast
+        def cast_to_colon(node: exp.Expression) -> exp.Expression:
+            if isinstance(node, exp.Cast) and not any(
+                # Only convert CAST into :: if it doesn't have additional args set, otherwise this
+                # conversion could alter the semantics (eg. changing SAFE_CAST in BigQuery to CAST)
+                arg
+                for name, arg in node.args.items()
+                if name not in ("this", "to")
+            ):
+                this = node.this
 
-        exp.replace_children(node, cast_to_colon)
-        return node
+                if not isinstance(this, (exp.Binary, exp.Unary)) or isinstance(this, exp.Paren):
+                    cast = DColonCast(this=this, to=node.to)
+                    cast.comments = node.comments
+                    node = cast
 
-    query = query.copy()
-    exp.replace_children(query, cast_to_colon)
+            exp.replace_children(node, cast_to_colon)
+            return node
+
+        query = query.copy()
+        exp.replace_children(query, cast_to_colon)
 
     return ";\n\n".join(
         [

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -645,7 +645,7 @@ def _override(klass: t.Type[Tokenizer | Parser], func: t.Callable) -> None:
 def format_model_expressions(
     expressions: t.List[exp.Expression],
     dialect: t.Optional[str] = None,
-    no_rewrite_casts: bool = False,
+    rewrite_casts: bool = True,
     **kwargs: t.Any,
 ) -> str:
     """Format a model's expressions into a standardized format.
@@ -653,7 +653,7 @@ def format_model_expressions(
     Args:
         expressions: The model's expressions, must be at least model def + query.
         dialect: The dialect to render the expressions as.
-        no_rewrite_casts: Preserve the existing casts, without rewriting them to use the :: syntax.
+        rewrite_casts: Whether to rewrite all casts to use the :: syntax.
         **kwargs: Additional keyword arguments to pass to the sql generator.
 
     Returns:
@@ -664,7 +664,7 @@ def format_model_expressions(
 
     *statements, query = expressions
 
-    if not no_rewrite_casts:
+    if rewrite_casts:
 
         def cast_to_colon(node: exp.Expression) -> exp.Expression:
             if isinstance(node, exp.Cast) and not any(

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -199,7 +199,10 @@ class SQLMeshMagics(Magics):
                 expressions = parse(file.read(), default_dialect=config.dialect)
 
         formatted = format_model_expressions(
-            expressions, model.dialect, **config.format.generator_options
+            expressions,
+            model.dialect,
+            cast_function=config.format.cast_function,
+            **config.format.generator_options,
         )
 
         self._shell.set_next_input(
@@ -701,6 +704,12 @@ class SQLMeshMagics(Magics):
         "--append-newline",
         action="store_true",
         help="Whether or not to append a newline to the end of the file.",
+        default=None,
+    )
+    @argument(
+        "--cast-function",
+        action="store_true",
+        help="Use the standard CAST function over the :: syntax.",
         default=None,
     )
     @argument(

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -201,7 +201,7 @@ class SQLMeshMagics(Magics):
         formatted = format_model_expressions(
             expressions,
             model.dialect,
-            no_rewrite_casts=config.format.no_rewrite_casts,
+            rewrite_casts=not config.format.no_rewrite_casts,
             **config.format.generator_options,
         )
 
@@ -754,8 +754,11 @@ class SQLMeshMagics(Magics):
     @pass_sqlmesh_context
     def format(self, context: Context, line: str) -> bool:
         """Format all SQL models and audits."""
-        args = parse_argstring(self.format, line)
-        return context.format(**{k: v for k, v in vars(args).items() if v is not None})
+        format_opts = vars(parse_argstring(self.format, line))
+        if format_opts.pop("no_rewrite_casts", None):
+            format_opts["rewrite_casts"] = False
+
+        return context.format(**{k: v for k, v in format_opts.items() if v is not None})
 
     @magic_arguments()
     @argument("environment", type=str, help="The environment to diff local state against.")

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -201,7 +201,7 @@ class SQLMeshMagics(Magics):
         formatted = format_model_expressions(
             expressions,
             model.dialect,
-            cast_function=config.format.cast_function,
+            no_rewrite_casts=config.format.no_rewrite_casts,
             **config.format.generator_options,
         )
 
@@ -707,9 +707,9 @@ class SQLMeshMagics(Magics):
         default=None,
     )
     @argument(
-        "--cast-function",
+        "--no-rewrite-casts",
         action="store_true",
-        help="Use the standard CAST function over the :: syntax.",
+        help="Whether or not to preserve the existing casts, without rewriting them to use the :: syntax.",
         default=None,
     )
     @argument(

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -201,7 +201,7 @@ SELECT
             SELECT 1::INT AS bla
             """
         ),
-        cast_function=True,
+        no_rewrite_casts=True,
     )
     assert (
         x

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -201,7 +201,7 @@ SELECT
             SELECT 1::INT AS bla
             """
         ),
-        no_rewrite_casts=True,
+        rewrite_casts=False,
     )
     assert (
         x

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -194,6 +194,25 @@ SELECT
   SAFE_CAST('bla' AS INT64) AS FOO"""
     )
 
+    x = format_model_expressions(
+        parse(
+            """
+            MODEL(name foo);
+            SELECT 1::INT AS bla
+            """
+        ),
+        cast_function=True,
+    )
+    assert (
+        x
+        == """MODEL (
+  name foo
+);
+
+SELECT
+  CAST(1 AS INT) AS bla"""
+    )
+
 
 def test_macro_format():
     assert parse_one("@EACH(ARRAY(1,2), x -> x)").sql() == "@EACH(ARRAY(1, 2), x -> x)"


### PR DESCRIPTION
Allows users to change the formatter so that it always produces the `CAST(foo AS type)` syntax over `::`. This may come in handy for users that want to easily copy-paste their model queries without having to switch back the `::` manually.

Context: https://tobiko-data.slack.com/archives/C07HJH22U9Z/p1727216482891999