### PR TITLE
Fix: Bigquery support of complex nested types

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -37,8 +37,8 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-NestedField = t.Tuple[str, str, list[str]]
-NestedFieldsDict = t.Dict[str, list[NestedField]]
+NestedField = t.Tuple[str, str, t.List[str]]
+NestedFieldsDict = t.Dict[str, t.List[NestedField]]
 
 
 @set_catalog()

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -311,16 +311,16 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin):
 
     def _build_nested_fields(
         self,
-        current_fields: list[bigquery.SchemaField],
-        fields_to_add: list[NestedField],
-    ) -> list[bigquery.SchemaField]:
+        current_fields: t.List[bigquery.SchemaField],
+        fields_to_add: t.List[NestedField],
+    ) -> t.List[bigquery.SchemaField]:
         """
         Recursively builds and updates the schema fields with the new nested fields.
         """
         from google.cloud import bigquery
 
         new_fields = []
-        root: list[t.Tuple[str, str]] = []
+        root: t.List[t.Tuple[str, str]] = []
         leaves: NestedFieldsDict = defaultdict(list)
         for new_field, data_type, leaf_fields in fields_to_add:
             if leaf_fields:

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -321,7 +321,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin):
             current_fields = list(field.fields)
             if field.name in nested_fields_to_add:
                 current_fields.extend(
-                    bigquery.SchemaField(new_field[1], new_field[0], mode="NULLABLE")
+                    self.__get_bq_schemafield(new_field[1], exp.DataType.build(new_field[0]))
                     for new_field in nested_fields_to_add[field.name]
                 )
             if current_fields:

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -282,11 +282,11 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin):
     def _split_alter_expressions(
         self,
         alter_expressions: t.List[exp.Alter],
-    ) -> t.Tuple[t.Dict[str, list[t.Tuple[str, str]]], t.List[exp.Alter]]:
+    ) -> t.Tuple[t.Dict[str, list[t.Tuple[str, str, list[str]]]], t.List[exp.Alter]]:
         """
         Returns a dictionary of the nested fields to add and a list of the non-nested alter expressions.
         """
-        nested_fields_to_add: t.Dict[str, list[t.Tuple[str, str]]] = defaultdict(list)
+        nested_fields_to_add: t.Dict[str, list[t.Tuple[str, str, list[str]]]] = defaultdict(list)
         non_nested_expressions = []
 
         for alter_expression in alter_expressions:
@@ -296,17 +296,58 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin):
                 and isinstance(action.this, exp.Dot)
                 and isinstance(action.kind, exp.DataType)
             ):
-                record = action.this.this.sql(dialect="bigquery")
-                field = action.this.expression.sql(dialect="bigquery")
-                data_type = action.kind.sql(dialect="bigquery")
-                nested_fields_to_add[record].append((data_type, field))
+                root_field, *leaf_fields = action.this.this.sql(dialect=self.dialect).split(".")
+                new_field = action.this.expression.sql(dialect=self.dialect)
+                data_type = action.kind.sql(dialect=self.dialect)
+                nested_fields_to_add[root_field].append((new_field, data_type, leaf_fields))
             else:
                 non_nested_expressions.append(alter_expression)
 
         return nested_fields_to_add, non_nested_expressions
 
+    def _build_nested_fields(
+        self,
+        current_fields: list[bigquery.SchemaField],
+        fields_to_add: list[t.Tuple[str, str, list[str]]],
+    ) -> list[bigquery.SchemaField]:
+        """
+        Recursively builds and updates the schema fields with the new nested fields.
+        """
+        from google.cloud import bigquery
+
+        new_fields = []
+        root: list[t.Tuple[str, str]] = []
+        leaves: t.Dict[str, list[t.Tuple[str, str, list[str]]]] = defaultdict(list)
+        for new_field, data_type, leaf_fields in fields_to_add:
+            if leaf_fields:
+                leaves[leaf_fields[0]].append((new_field, data_type, leaf_fields[1:]))
+            else:
+                root.append((new_field, data_type))
+
+        for field in current_fields:
+            # If the new fields are nested, we need to recursively build them
+            if field.name in leaves:
+                subfields = list(field.fields)
+                subfields = self._build_nested_fields(subfields, leaves[field.name])
+                new_fields.append(
+                    bigquery.SchemaField(
+                        field.name, "RECORD", mode=field.mode, fields=tuple(subfields)
+                    )
+                )
+            else:
+                new_fields.append(field)
+
+        # Build and append the new root-level fields
+        new_fields.extend(
+            self.__get_bq_schemafield(
+                new_field[0], exp.DataType.build(new_field[1], dialect=self.dialect)
+            )
+            for new_field in root
+        )
+        return new_fields
+
     def _update_table_schema_nested_fields(
-        self, nested_fields_to_add: t.Dict[str, list[t.Tuple[str, str]]], table_name: str
+        self, nested_fields_to_add: t.Dict[str, list[t.Tuple[str, str, list[str]]]], table_name: str
     ) -> None:
         """
         Updates a BigQuery table schema by adding the new nested fields provided.
@@ -316,18 +357,17 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin):
         table = self._get_table(table_name)
         original_schema = table.schema
         new_schema = []
-
         for field in original_schema:
-            current_fields = list(field.fields)
             if field.name in nested_fields_to_add:
-                current_fields.extend(
-                    self.__get_bq_schemafield(new_field[1], exp.DataType.build(new_field[0]))
-                    for new_field in nested_fields_to_add[field.name]
+                fields = self._build_nested_fields(
+                    list(field.fields), nested_fields_to_add[field.name]
                 )
-            if current_fields:
                 new_schema.append(
                     bigquery.SchemaField(
-                        field.name, "RECORD", mode="NULLABLE", fields=tuple(current_fields)
+                        field.name,
+                        "RECORD",
+                        mode=field.mode,
+                        fields=tuple(fields),
                     )
                 )
             else:

--- a/tests/core/test_schema_diff.py
+++ b/tests/core/test_schema_diff.py
@@ -393,6 +393,29 @@ def test_schema_diff_calculate_type_transitions():
             ],
             dict(support_positional_add=True, support_nested_operations=True),
         ),
+        # Add columns in different levels of nesting of structs
+        (
+            "STRUCT<id INT, info STRUCT<col_a INT, col_b INT, col_c INT>>",
+            "STRUCT<id INT, info STRUCT<col_a INT, col_b INT, col_c INT, col_d INT>, txt TEXT>",
+            [
+                TableAlterOperation.add(
+                    [
+                        TableAlterColumn.primitive("txt"),
+                    ],
+                    "TEXT",
+                    expected_table_struct="STRUCT<id INT, info STRUCT<col_a INT, col_b INT, col_c INT>, txt TEXT>",
+                ),
+                TableAlterOperation.add(
+                    [
+                        TableAlterColumn.struct("info"),
+                        TableAlterColumn.primitive("col_d"),
+                    ],
+                    "INT",
+                    expected_table_struct="STRUCT<id INT, info STRUCT<col_a INT, col_b INT, col_c INT, col_d INT>, txt TEXT>",
+                ),
+            ],
+            dict(support_positional_add=False, support_nested_operations=True),
+        ),
         # Remove a column from the start of a struct
         (
             "STRUCT<id INT, info STRUCT<col_a INT, col_b INT, col_c INT>>",
@@ -720,6 +743,29 @@ def test_schema_diff_calculate_type_transitions():
                     exp.DataType.build("INT"): {exp.DataType.build("TEXT")},
                 },
             ),
+        ),
+        # Add columns to struct of array within different nesting levels
+        (
+            "STRUCT<id INT, infos ARRAY<STRUCT<col_a INT, col_b INT, col_c INT>>>",
+            "STRUCT<id INT, infos ARRAY<STRUCT<col_a INT, col_b INT, col_c INT, col_d INT >>, col_e INT>",
+            [
+                TableAlterOperation.add(
+                    [
+                        TableAlterColumn.primitive("col_e"),
+                    ],
+                    "INT",
+                    expected_table_struct="STRUCT<id INT, infos ARRAY<STRUCT<col_a INT, col_b INT, col_c INT>>, col_e INT>",
+                ),
+                TableAlterOperation.add(
+                    [
+                        TableAlterColumn.array_of_struct("infos"),
+                        TableAlterColumn.primitive("col_d"),
+                    ],
+                    "INT",
+                    expected_table_struct="STRUCT<id INT, infos ARRAY<STRUCT<col_a INT, col_b INT,  col_c INT, col_d INT>>, col_e INT>",
+                ),
+            ],
+            dict(support_positional_add=False, support_nested_operations=True),
         ),
         # Add an array of primitives
         (


### PR DESCRIPTION
Fix issue of constructing schema fields for nested and array types, by using the function `__get_bq_schemafield` from https://github.com/TobikoData/sqlmesh/pull/3185 when constructing a record or array schema field and the function `_build_nested_fields` to recursively build nested fields, when appending to a record
fixes: #3184 