### PR TITLE
fix!: correctly use execution time on new rows for scd type 2 by column

### DIFF
--- a/docs/concepts/models/model_kinds.md
+++ b/docs/concepts/models/model_kinds.md
@@ -736,10 +736,10 @@ This is the most accurate representation of the menu based on the source data pr
 
 ### SCD Type 2 By Column Configuration Options
 
-| Name                         | Description                                                                                                                                                                   | Type                      |
-|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------|
-| columns                      | The name of the columns to check for changes. `*` to represent that all columns should be checked.                                                                            | List of strings or string |
-| execution_time_as_valid_from | By default, for new rows `valid_from` is set to `1970-01-01 00:00:00`. This changes the behavior to set it to the `execution_time` of when the pipeline ran. Default: `false` | bool                      |
+| Name                         | Description                                                                                                                                                                                                                                 | Type                      |
+|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------|
+| columns                      | The name of the columns to check for changes. `*` to represent that all columns should be checked.                                                                                                                                          | List of strings or string |
+| execution_time_as_valid_from | By default, when the model is first loaded `valid_from` is set to `1970-01-01 00:00:00` and future new rows will have `execution_time` of when the pipeline ran. This changes the behavior to always use `execution_time`. Default: `false` | bool                      |
 
 ### Querying SCD Type 2 Models
 

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -869,6 +869,7 @@ def test_scd_type_2_by_time(ctx: TestContext):
         updated_at_as_valid_from=False,
         columns_to_types=input_schema,
         table_format=table_format,
+        truncate=True,
     )
     results = ctx.get_metadata_results()
     assert len(results.views) == 0
@@ -930,6 +931,7 @@ def test_scd_type_2_by_time(ctx: TestContext):
         updated_at_as_valid_from=False,
         columns_to_types=input_schema,
         table_format=table_format,
+        truncate=False,
     )
     results = ctx.get_metadata_results()
     assert len(results.views) == 0
@@ -1018,6 +1020,7 @@ def test_scd_type_2_by_column(ctx: TestContext):
         execution_time="2023-01-01",
         execution_time_as_valid_from=False,
         columns_to_types=ctx.columns_to_types,
+        truncate=True,
     )
     results = ctx.get_metadata_results()
     assert len(results.views) == 0
@@ -1087,6 +1090,7 @@ def test_scd_type_2_by_column(ctx: TestContext):
         execution_time="2023-01-05 00:00:00",
         execution_time_as_valid_from=False,
         columns_to_types=ctx.columns_to_types,
+        truncate=False,
     )
     results = ctx.get_metadata_results()
     assert len(results.views) == 0
@@ -1143,7 +1147,7 @@ def test_scd_type_2_by_column(ctx: TestContext):
                     "id": 5,
                     "name": "e",
                     "status": "inactive",
-                    "valid_from": "1970-01-01 00:00:00",
+                    "valid_from": "2023-01-05 00:00:00",
                     "valid_to": pd.NaT,
                 },
             ]

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -1756,7 +1756,7 @@ WITH "source" AS (
     COALESCE("joined"."t_id", "joined"."id") AS "id",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
     COALESCE("joined"."t_price", "joined"."price") AS "price",
-    COALESCE("t_test_VALID_from", CAST('1970-01-01 00:00:00' AS TIMESTAMP)) AS "test_VALID_from",
+    COALESCE("t_test_VALID_from", CAST('2020-01-01 00:00:00' AS TIMESTAMP)) AS "test_VALID_from",
     CASE
       WHEN "joined"."_exists" IS NULL
       OR (
@@ -1947,7 +1947,7 @@ WITH "source" AS (
     COALESCE("joined"."t_id_b", "joined"."id_b") AS "id_b",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
     COALESCE("joined"."t_price", "joined"."price") AS "price",
-    COALESCE("t_test_VALID_from", CAST('1970-01-01 00:00:00' AS TIMESTAMP)) AS "test_VALID_from",
+    COALESCE("t_test_VALID_from", CAST('2020-01-01 00:00:00' AS TIMESTAMP)) AS "test_VALID_from",
     CASE
       WHEN "joined"."_exists" IS NULL
       OR (
@@ -2311,7 +2311,7 @@ WITH "source" AS (
     COALESCE("joined"."t_id", "joined"."id") AS "id",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
     COALESCE("joined"."t_price", "joined"."price") AS "price",
-    COALESCE("t_test_valid_from", CAST('1970-01-01 00:00:00' AS TIMESTAMP)) AS "test_valid_from",
+    COALESCE("t_test_valid_from", CAST('2020-01-01 00:00:00' AS TIMESTAMP)) AS "test_valid_from",
     CASE
       WHEN "joined"."_exists" IS NULL
       OR (
@@ -2506,7 +2506,7 @@ WITH "source" AS (
     COALESCE("joined"."t_id", "joined"."id") AS "id",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
     COALESCE("joined"."t_price", "joined"."price") AS "price",
-    COALESCE("t_test_valid_from", CAST('1970-01-01 00:00:00' AS TIMESTAMP)) AS "test_valid_from",
+    COALESCE("t_test_valid_from", CAST('2020-01-01 00:00:00' AS TIMESTAMP)) AS "test_valid_from",
     CASE
       WHEN (
         NOT "joined"."t_id" IS NULL AND NOT "joined"."id" IS NULL

--- a/tests/core/engine_adapter/test_clickhouse.py
+++ b/tests/core/engine_adapter/test_clickhouse.py
@@ -745,7 +745,7 @@ WITH "source" AS (
     COALESCE("joined"."t_id", "joined"."id") AS "id",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
     COALESCE("joined"."t_price", "joined"."price") AS "price",
-    COALESCE("t_test_VALID_from", CAST('1970-01-01 00:00:00' AS Nullable(DateTime))) AS "test_VALID_from",
+    COALESCE("t_test_VALID_from", CAST('2020-01-01 00:00:00' AS Nullable(DateTime))) AS "test_VALID_from",
     CASE
       WHEN "joined"."_exists" IS NULL
       OR (


### PR DESCRIPTION
This corrects the SCD Type 2 By Column default behavior to use execution time for new rows after the table is initially loaded. This matches what the documentation example says it should behave. This does mean there is a behavior change for current users but the current behavior seems to be a bug. There is not a way for a user to maintain old behavior if they wanted it since we consider it a bug. 

From reviewing the code, `truncate` is a great way to identify if a table is being loaded for the first time. This also means that if a user issues a restatement on the table and wants to rebuild from scratch then it would also be set to `truncate` and would mimic loading the rows for the first time. 