### PR TITLE
Fix: Invalidate the optimized query cache entry when a macro definition changes within the model model definition

### DIFF
--- a/sqlmesh/core/model/cache.py
+++ b/sqlmesh/core/model/cache.py
@@ -133,6 +133,7 @@ class OptimizedQueryCache:
     def _entry_name(model: SqlModel) -> str:
         hash_data = _mapping_schema_hash_data(model.mapping_schema)
         hash_data.append(gen(model.query))
+        hash_data.append(str([gen(d) for d in model.macro_definitions]))
         hash_data.append(str([(k, v) for k, v in model.sorted_python_env]))
         hash_data.extend(model.jinja_macros.data_hash_values)
         return f"{model.name}_{crc32(hash_data)}"


### PR DESCRIPTION
Model example:
```
MODEL (
  name agreement.stg_testing,
  kind FULL,
);

@DEF(filter_, txmetasource IN ('A'));

SELECT
  *
FROM iceberg.dbo.table1
WHERE
  @filter_
LIMIT 10
```
Prior to this fix, changing the `filter_` macro resulted in a metadata change unless the cache was manually cleaned up.