### PR TITLE
fix: mark changes in kind as breaking changes

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1170,6 +1170,15 @@ class SqlModel(_SqlBasedModel):
         if self.lookback != previous.lookback:
             return None
 
+        # Look if the kind has changed
+        # TODO: My understanding of this is that there are other properties inside of the structure that may cause breaking changes as well
+        #  - Change of incremental keys in all types
+        #  - Any chance to materialization strategy
+        #  - grains
+        #  - Generally I wonder if it is safer to do the other way around -> Assume is breaking unless we mark it as not relevant, for example mark comments as not breaking
+        if self.kind != previous.kind:
+            return True
+
         try:
             # the previous model which comes from disk could be unrenderable
             previous_query = previous.render_query()

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2524,6 +2524,12 @@ def test_is_breaking_change():
     )
 
 
+def test_is_breaking_change_sql_model_change_kind():
+    sql = parse_one("SELECT a FROM z")
+    model = create_sql_model("a", sql, kind="full")
+    assert model.is_breaking_change(create_sql_model("a", sql, kind="view")) is True
+
+
 def test_parse_expression_list_with_jinja():
     input = [
         "JINJA_STATEMENT_BEGIN;\n{{ log('log message') }}\nJINJA_END;",


### PR DESCRIPTION
This currently feels like a plaster and needs to be corrected in a few ways, but it's a start.

My understanding of this is that there are other properties inside of the definition structure that may cause breaking changes as well:
- Change in incremental key types
- Any change to materialization
- Grains

Generally, I wonder if it is safer to do this the other way around; by default, check every property, and mark changes to clearly safe properties as not breaking: description, owner ...

After looking at this slightly more, it gets called in:

```python
def categorize_change(
    new: Snapshot,
    old: Snapshot,
    config: t.Optional[CategorizerConfig] = None,
    is_breaking_change: t.Optional[t.Callable[..., t.Optional[bool]]] = None,
    **kwargs: t.Any,
) -> t.Optional[SnapshotChangeCategory]:
    """Attempts to automatically categorize a change between two snapshots.

    Presently the implementation only returns the NON_BREAKING category iff
    a new projections have been added to one or more SELECT statement(s). In
    all other cases None is returned.

    Args:
        new: The new snapshot.
        old: The old snapshot.
        config: Configuration for the automatic categorizer of snapshot changes.
        is_breaking_change: Callable that compares two models (new, old) and determines
            whether there is a breaking change between them.
        kwargs: Additional arguments to pass to is_breaking_change.

    Returns:
        The change category or None if the category can't be determined automatically.

    """
```

but before the `is_breaking_change` gets called, there is a comparison of hashes, which I am not quite sure why doesn't work/what the distinction is just in the `is_breaking_change` method and whether that should do it before?

