### PR TITLE
Feat: Snowflake: Handle forward_only changes to 'clustered_by'

### DIFF
--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -6,7 +6,8 @@ import typing as t
 
 import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype  # type: ignore
-from sqlglot import exp
+from sqlglot import exp, parse_one
+from sqlglot.helper import seq_get
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 from sqlglot.optimizer.qualify_columns import quote_identifiers
 
@@ -30,6 +31,14 @@ if t.TYPE_CHECKING:
     from sqlmesh.core._typing import SchemaName, SessionProperties, TableName
     from sqlmesh.core.engine_adapter._typing import DF, Query, SnowparkSession
     from sqlmesh.core.node import IntervalUnit
+
+
+class SnowflakeDataObject(DataObject):
+    clustering_key: t.Optional[str] = None
+
+    @property
+    def is_clustered(self) -> bool:
+        return bool(self.clustering_key)
 
 
 @set_catalog(
@@ -325,6 +334,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
                 )
                 .else_(exp.column("TABLE_TYPE"))
                 .as_("type"),
+                exp.column("CLUSTERING_KEY").as_("clustering_key"),
             )
             .from_(exp.table_("TABLES", db="INFORMATION_SCHEMA", catalog=catalog_name))
             .where(exp.column("TABLE_SCHEMA").eq(schema.db))
@@ -338,11 +348,12 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
         if df.empty:
             return []
         return [
-            DataObject(
+            SnowflakeDataObject(
                 catalog=row.catalog,  # type: ignore
                 schema=row.schema_name,  # type: ignore
                 name=row.name,  # type: ignore
                 type=DataObjectType.from_str(row.type),  # type: ignore
+                clustering_key=row.clustering_key,  # type: ignore
             )
             for row in df.itertuples()
         ]
@@ -422,3 +433,49 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
                 f"Column comments for table '{table.alias_or_name}' not registered - this may be due to limited permissions.",
                 exc_info=True,
             )
+
+    def get_alter_expressions(
+        self, current_table_name: TableName, target_table_name: TableName
+    ) -> t.List[exp.Alter]:
+        schema_expressions = super().get_alter_expressions(current_table_name, target_table_name)
+        additional_expressions = []
+
+        # check for a change in clustering
+        current_table = exp.to_table(current_table_name)
+        target_table = exp.to_table(target_table_name)
+
+        current_table_info = t.cast(
+            SnowflakeDataObject,
+            seq_get(self.get_data_objects(current_table.db, {current_table.name}), 0),
+        )
+        target_table_info = t.cast(
+            SnowflakeDataObject,
+            seq_get(self.get_data_objects(target_table.db, {target_table.name}), 0),
+        )
+
+        if current_table_info and target_table_info:
+            if any([current_table_info.is_clustered, target_table_info.is_clustered]):
+                if target_table_info.clustering_key:
+                    if current_table_info.clustering_key != target_table_info.clustering_key:
+                        # Note: If you create a table with eg `CLUSTER BY (c2, c1)` and read the info back from information_schema,
+                        # it gets returned as a string like "LINEAR(c2, c1)" which we need to parse back into a list of columns
+                        parsed_cluster_key = parse_one(
+                            target_table_info.clustering_key, dialect=self.dialect
+                        )
+                        additional_expressions.append(
+                            exp.Alter(
+                                this=current_table,
+                                kind="TABLE",
+                                actions=[exp.Cluster(expressions=parsed_cluster_key.expressions)],
+                            )
+                        )
+                else:
+                    additional_expressions.append(
+                        exp.Alter(
+                            this=current_table,
+                            kind="TABLE",
+                            actions=[exp.Command(this="DROP", expression="CLUSTERING KEY")],
+                        )
+                    )
+
+        return schema_expressions + additional_expressions

--- a/tests/core/engine_adapter/integration/test_integration_snowflake.py
+++ b/tests/core/engine_adapter/integration/test_integration_snowflake.py
@@ -1,0 +1,165 @@
+import typing as t
+import pytest
+from sqlglot import exp
+from sqlglot.optimizer.qualify_columns import quote_identifiers
+from sqlglot.helper import seq_get
+from sqlmesh.core.engine_adapter import SnowflakeEngineAdapter
+from sqlmesh.core.engine_adapter.snowflake import SnowflakeDataObject
+import sqlmesh.core.dialect as d
+from sqlmesh.core.model import SqlModel, load_sql_based_model
+from sqlmesh.core.plan import Plan
+from tests.core.engine_adapter.integration import TestContext
+
+pytestmark = [pytest.mark.engine, pytest.mark.remote, pytest.mark.snowflake]
+
+
+@pytest.fixture
+def mark_gateway() -> t.Tuple[str, str]:
+    return "snowflake", "inttest_snowflake"
+
+
+@pytest.fixture
+def test_type() -> str:
+    return "query"
+
+
+def test_get_alter_expressions_includes_clustering(
+    ctx: TestContext, engine_adapter: SnowflakeEngineAdapter
+):
+    ctx.init()
+
+    clustered_table = ctx.table("clustered_table")
+    clustered_differently_table = ctx.table("clustered_differently_table")
+    normal_table = ctx.table("normal_table")
+
+    engine_adapter.execute(f"CREATE TABLE {clustered_table} (c1 int, c2 timestamp) CLUSTER BY (c1)")
+    engine_adapter.execute(
+        f"CREATE TABLE {clustered_differently_table} (c1 int, c2 timestamp) CLUSTER BY (c1, to_date(c2))"
+    )
+    engine_adapter.execute(f"CREATE TABLE {normal_table} (c1 int, c2 timestamp)")
+
+    assert len(engine_adapter.get_alter_expressions(normal_table, normal_table)) == 0
+    assert len(engine_adapter.get_alter_expressions(clustered_table, clustered_table)) == 0
+
+    # alter table drop clustered
+    clustered_to_normal = engine_adapter.get_alter_expressions(clustered_table, normal_table)
+    assert len(clustered_to_normal) == 1
+    assert (
+        clustered_to_normal[0].sql(dialect=ctx.dialect)
+        == f"ALTER TABLE {clustered_table} DROP CLUSTERING KEY"
+    )
+
+    # alter table add clustered
+    normal_to_clustered = engine_adapter.get_alter_expressions(normal_table, clustered_table)
+    assert len(normal_to_clustered) == 1
+    assert (
+        normal_to_clustered[0].sql(dialect=ctx.dialect)
+        == f"ALTER TABLE {normal_table} CLUSTER BY (c1)"
+    )
+
+    # alter table change clustering
+    clustered_to_clustered_differently = engine_adapter.get_alter_expressions(
+        clustered_table, clustered_differently_table
+    )
+    assert len(clustered_to_clustered_differently) == 1
+    assert (
+        clustered_to_clustered_differently[0].sql(dialect=ctx.dialect)
+        == f"ALTER TABLE {clustered_table} CLUSTER BY (c1, TO_DATE(c2))"
+    )
+
+    # alter table change clustering
+    clustered_differently_to_clustered = engine_adapter.get_alter_expressions(
+        clustered_differently_table, clustered_table
+    )
+    assert len(clustered_differently_to_clustered) == 1
+    assert (
+        clustered_differently_to_clustered[0].sql(dialect=ctx.dialect)
+        == f"ALTER TABLE {clustered_differently_table} CLUSTER BY (c1)"
+    )
+
+
+def test_adding_clustered_by_forward_only(ctx: TestContext, engine_adapter: SnowflakeEngineAdapter):
+    model_name = ctx.table("TEST")
+
+    sqlmesh = ctx.create_context()
+
+    def _create_model(**kwargs: t.Any) -> SqlModel:
+        extra_props = "\n".join([f"{k} {v}," for k, v in kwargs.items()])
+        return t.cast(
+            SqlModel,
+            load_sql_based_model(
+                d.parse(
+                    f"""
+                MODEL (
+                    name {model_name},
+                    kind INCREMENTAL_BY_TIME_RANGE (
+                        time_column PARTITIONDATE
+                    ),
+                    {extra_props}
+                    start '2021-01-01',
+                    cron '@daily',
+                    dialect 'snowflake'
+                );
+
+                select 1 as ID, current_timestamp() as PARTITIONDATE
+                """
+                )
+            ),
+        )
+
+    def _get_data_object(table: exp.Table) -> SnowflakeDataObject:
+        data_object = seq_get(engine_adapter.get_data_objects(table.db, {table.name}), 0)
+        if not data_object:
+            raise ValueError(f"Expected metadata for {table}")
+        return t.cast(SnowflakeDataObject, data_object)
+
+    m1 = _create_model()
+    m2 = _create_model(clustered_by="PARTITIONDATE")
+    m3 = _create_model(clustered_by="(ID, PARTITIONDATE)")
+
+    # Initial plan - non-clustered table
+    sqlmesh.upsert_model(m1)
+    plan_1: Plan = sqlmesh.plan(auto_apply=True, no_prompts=True)
+    assert len(plan_1.snapshots) == 1
+    target_table_1 = exp.to_table(list(plan_1.snapshots.values())[0].table_name())
+    quote_identifiers(target_table_1)
+
+    assert not _get_data_object(target_table_1).is_clustered
+
+    # Next plan - add clustering key (non-clustered -> clustered)
+    sqlmesh.upsert_model(m2)
+    plan_2: Plan = sqlmesh.plan(auto_apply=True, no_prompts=True, forward_only=True)
+    assert len(plan_2.snapshots) == 1
+    target_table_2 = exp.to_table(list(plan_2.snapshots.values())[0].table_name())
+    quote_identifiers(target_table_2)
+
+    assert target_table_1 == target_table_2
+
+    metadata = _get_data_object(target_table_1)
+    assert metadata.is_clustered
+    assert metadata.clustering_key == 'LINEAR("PARTITIONDATE")'
+
+    # Next plan - change clustering key (clustered -> clustered differently)
+    sqlmesh.upsert_model(m3)
+    plan_3: Plan = sqlmesh.plan(auto_apply=True, no_prompts=True, forward_only=True)
+    assert len(plan_3.snapshots) == 1
+    target_table_3 = exp.to_table(list(plan_3.snapshots.values())[0].table_name())
+    quote_identifiers(target_table_3)
+
+    assert target_table_1 == target_table_3
+
+    metadata = _get_data_object(target_table_1)
+    assert metadata.is_clustered
+    assert metadata.clustering_key == 'LINEAR("ID", "PARTITIONDATE")'
+
+    # Next plan - drop clustering key
+    sqlmesh.upsert_model(m1)
+    plan_4: Plan = sqlmesh.plan(auto_apply=True, no_prompts=True, forward_only=True)
+    assert len(plan_4.snapshots) == 1
+    target_table_4 = exp.to_table(list(plan_4.snapshots.values())[0].table_name())
+    quote_identifiers(target_table_4)
+
+    assert target_table_1 == target_table_4
+
+    metadata = _get_data_object(target_table_1)
+    assert not metadata.is_clustered


### PR DESCRIPTION
This change allows you to update `clustered_by` on a Snowflake model, trigger a forward-only plan and have the cluster key on the table be altered.

Previously, it would be a no-op which was a bit misleading