### PR TITLE
Fix: mark kind changes as breaking in forward only plan

### DIFF
--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -532,11 +532,20 @@ class PlanBuilder:
                 # In case of the forward only plan any modifications result in reuse of the
                 # previous version for non-seed models.
                 # New snapshots of seed models are considered non-breaking ones.
-                snapshot.categorize_as(
+                category_in_no_change_kind = (
                     SnapshotChangeCategory.NON_BREAKING
                     if snapshot.is_seed
                     else SnapshotChangeCategory.FORWARD_ONLY
                 )
+                # If the model kind changes mark as breaking
+                if snapshot.is_model and snapshot.name in self._context_diff.modified_snapshots:
+                    _, old = self._context_diff.modified_snapshots[snapshot.name]
+                    if old.model.kind.name != snapshot.model.kind.name:
+                        snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+                    else:
+                        snapshot.categorize_as(category_in_no_change_kind)
+                else:
+                    snapshot.categorize_as(category_in_no_change_kind)
             elif s_id.name in self._context_diff.modified_snapshots:
                 self._categorize_snapshot(snapshot, dag, indirectly_modified)
 

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -532,7 +532,7 @@ class PlanBuilder:
                 # In case of the forward only plan any modifications result in reuse of the
                 # previous version for non-seed models.
                 # New snapshots of seed models are considered non-breaking ones.
-                category_in_no_change_kind = (
+                category = (
                     SnapshotChangeCategory.NON_BREAKING
                     if snapshot.is_seed
                     else SnapshotChangeCategory.FORWARD_ONLY
@@ -541,11 +541,9 @@ class PlanBuilder:
                 if snapshot.is_model and snapshot.name in self._context_diff.modified_snapshots:
                     _, old = self._context_diff.modified_snapshots[snapshot.name]
                     if old.model.kind.name != snapshot.model.kind.name:
-                        snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
-                    else:
-                        snapshot.categorize_as(category_in_no_change_kind)
-                else:
-                    snapshot.categorize_as(category_in_no_change_kind)
+                        category = SnapshotChangeCategory.BREAKING
+
+                snapshot.categorize_as(category)
             elif s_id.name in self._context_diff.modified_snapshots:
                 self._categorize_snapshot(snapshot, dag, indirectly_modified)
 


### PR DESCRIPTION
Related to #3196 

This PR addresses the issue by marking all changes in model types as breaking even in the case of a `forward-only` plan. 

The test hopefully ensures the validity of the work, but I was also able to recreate the issue in a more "complete" environment with the following steps:

1.`sqlmesh init duckdb`
2. `sqlmesh plan` and apply
3. Changing the incremental model to 

```
MODEL (
  name sqlmesh_example.incremental_model,
  kind VIEW,
  start '2020-01-01',
  cron '@daily',
  grain (id, event_date)
);

SELECT
  id,
  item_id,
  event_date,
FROM
  sqlmesh_example.seed_model 
```

4. Running `sqlmesh plan --forward-only` and apply again. This gave the error:

```
  File "..../sqlmesh/sqlmesh/core/engine_adapter/base.py", line 2007, in _execute
    self.cursor.execute(sql, **kwargs)
duckdb.duckdb.CatalogException: Catalog Error: Existing object sqlmesh_example__incremental_model__888251848 is of type Table, trying to replace with type View
```

A final observation made along the way that I made that may want to be improved is that if you run `sqlmesh plan --forward-only` on an empty project (e.g. one where plan has never run), you get the exception 

```
  File ".../sqlmesh/sqlmesh/core/plan/builder.py", line 227, in build
    self._check_destructive_changes(directly_modified)
  File ".../sqlmesh/sqlmesh/core/plan/builder.py", line 485, in _check_destructive_changes
    new, old = self._context_diff.modified_snapshots[snapshot.name]
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: '"db"."sqlmesh_example"."incremental_model"'
```


