### PR TITLE
Fix: avoid parsing column names into qualified columns in InsertOverwriteWithMergeMixin

### DIFF
--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -89,7 +89,7 @@ class InsertOverwriteWithMergeMixin(EngineAdapter):
         for source_query in source_queries:
             with source_query as query:
                 query = self._order_projections_and_filter(query, columns_to_types, where=where)
-                columns = [exp.to_column(col) for col in columns_to_types]
+                columns = [exp.column(col) for col in columns_to_types]
                 when_not_matched_by_source = exp.When(
                     matched=False,
                     source=True,


### PR DESCRIPTION
There was an issue with the mssql adapter where we'd get back a dotted column from its `columns` method, e.g. `foo.bar.baz`, and then we'd turn that into a qualified column instead of treating it as a single identifier with literal dot characters. This in turn caused problems in the context of the generated `MERGE` statement, because qualified columns are syntactically invalid within the `INSERT` clause.