### PR TITLE
Fix: load custom materializations on run

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -616,10 +616,11 @@ class GenericContext(BaseContext, t.Generic[C]):
         )
 
         if not self._loaded:
-            # Signals should be loaded to run correctly.
+            # Signals and materializations should be loaded to run correctly.
             for context_loader in self._loaders.values():
                 with sys_path(*context_loader.configs):
                     context_loader.loader.load_signals(self)
+                    context_loader.loader.load_materializations(self)
 
         success = False
         try:

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -129,6 +129,11 @@ class Loader(abc.ABC):
         self._context = context
         self._load_signals()
 
+    def load_materializations(self, context: GenericContext) -> None:
+        """Loads materializations for the built-in scheduler."""
+        self._context = context
+        self._load_materializations()
+
     def reload_needed(self) -> bool:
         """
         Checks for any modifications to the files the macros and models depend on


### PR DESCRIPTION
No one can use custom materializations currently as far as I can surmise because of this. 
So perhaps I am kicking in the gears before others here. But we have a nifty custom materialization use cases that requires this fix. 