### PR TITLE
Fix(redshift): regression in varchar length workaround

### DIFF
--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -68,6 +68,7 @@ class MSSQLEngineAdapter(
             exp.DataType.build("NVARCHAR", dialect=DIALECT).this: 2147483647,
         },
     )
+    VARIABLE_LENGTH_DATA_TYPES = {"binary", "varbinary", "char", "varchar", "nchar", "nvarchar"}
 
     def columns(
         self,
@@ -95,8 +96,6 @@ class MSSQLEngineAdapter(
 
         columns_raw = self.fetchall(sql, quote_identifiers=True)
 
-        var_len_types = {"binary", "varbinary", "char", "varchar", "nchar", "nvarchar"}
-
         def build_var_length_col(
             column_name: str,
             data_type: str,
@@ -106,7 +105,7 @@ class MSSQLEngineAdapter(
         ) -> tuple:
             data_type = data_type.lower()
             if (
-                data_type in var_len_types
+                data_type in self.VARIABLE_LENGTH_DATA_TYPES
                 and character_maximum_length is not None
                 and character_maximum_length > 0
             ):

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -95,23 +95,36 @@ class MSSQLEngineAdapter(
 
         columns_raw = self.fetchall(sql, quote_identifiers=True)
 
-        def build_var_length_col(row: tuple) -> tuple:
-            var_len_chars = ("binary", "varbinary", "char", "varchar", "nchar", "nvarchar")
-            if row[1] in var_len_chars and row[2] > 0:
-                return (row[0], f"{row[1]}({row[2]})")
-            if row[1] in ("varbinary", "varchar", "nvarchar") and row[2] == -1:
-                return (row[0], f"{row[1]}(max)")
-            if row[1] in (
-                "decimal",
-                "numeric",
+        var_len_types = {"binary", "varbinary", "char", "varchar", "nchar", "nvarchar"}
+
+        def build_var_length_col(
+            column_name: str,
+            data_type: str,
+            character_maximum_length: t.Optional[int] = None,
+            numeric_precision: t.Optional[int] = None,
+            numeric_scale: t.Optional[int] = None,
+        ) -> tuple:
+            data_type = data_type.lower()
+            if (
+                data_type in var_len_types
+                and character_maximum_length is not None
+                and character_maximum_length > 0
             ):
-                return (row[0], f"{row[1]}({row[3]}, {row[4]})")
-            if row[1] == "float":
-                return (row[0], f"{row[1]}({row[3]})")
+                return (column_name, f"{data_type}({character_maximum_length})")
+            if (
+                data_type in ("varbinary", "varchar", "nvarchar")
+                and character_maximum_length is not None
+                and character_maximum_length == -1
+            ):
+                return (column_name, f"{data_type}(max)")
+            if data_type in ("decimal", "numeric"):
+                return (column_name, f"{data_type}({numeric_precision}, {numeric_scale})")
+            if data_type == "float":
+                return (column_name, f"{data_type}({numeric_precision})")
 
-            return (row[0], row[1])
+            return (column_name, data_type)
 
-        columns = [build_var_length_col(col) for col in columns_raw]
+        columns = [build_var_length_col(*row) for row in columns_raw]
 
         return {
             column_name: exp.DataType.build(data_type, dialect=self.dialect)

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -54,6 +54,17 @@ class RedshiftEngineAdapter(
             exp.DataType.build("VARCHAR", dialect=DIALECT).this: 65535,
         },
     )
+    VARIABLE_LENGTH_DATA_TYPES = {
+        "char",
+        "character",
+        "nchar",
+        "varchar",
+        "character varying",
+        "nvarchar",
+        "varbyte",
+        "varbinary",
+        "binary varying",
+    }
 
     def columns(
         self,
@@ -78,18 +89,6 @@ class RedshiftEngineAdapter(
 
         columns_raw = self.fetchall(sql, quote_identifiers=True)
 
-        var_len_types = {
-            "char",
-            "character",
-            "nchar",
-            "varchar",
-            "character varying",
-            "nvarchar",
-            "varbyte",
-            "varbinary",
-            "binary varying",
-        }
-
         def build_var_length_col(
             column_name: str,
             data_type: str,
@@ -98,7 +97,10 @@ class RedshiftEngineAdapter(
             numeric_scale: t.Optional[int] = None,
         ) -> tuple:
             data_type = data_type.lower()
-            if data_type in var_len_types and character_maximum_length is not None:
+            if (
+                data_type in self.VARIABLE_LENGTH_DATA_TYPES
+                and character_maximum_length is not None
+            ):
                 return (column_name, f"{data_type}({character_maximum_length})")
             if data_type in ("decimal", "numeric"):
                 return (column_name, f"{data_type}({numeric_precision}, {numeric_scale})")

--- a/tests/core/engine_adapter/integration/test_integration_redshift.py
+++ b/tests/core/engine_adapter/integration/test_integration_redshift.py
@@ -1,0 +1,87 @@
+import typing as t
+import pytest
+from tests.core.engine_adapter.integration import TestContext
+from sqlglot import exp
+
+pytestmark = [pytest.mark.remote, pytest.mark.engine, pytest.mark.redshift]
+
+
+@pytest.fixture
+def mark_gateway() -> t.Tuple[str, str]:
+    return "redshift", "inttest_redshift"
+
+
+@pytest.fixture
+def test_type() -> str:
+    return "query"
+
+
+def test_columns(ctx: TestContext):
+    ctx.init()
+
+    table = ctx.table("column_types")
+    col_strings = {
+        "char": ["char", "character", "nchar"],
+        "varchar": ["varchar", "character varying", "nvarchar"],
+        "varbinary": ["varbyte", "varbinary", "binary varying"],
+        "decimal": ["decimal", "numeric"],
+    }
+
+    # raw ddl
+    sql = f"CREATE TABLE {table} ("
+    sql += (
+        ", ".join(
+            f"{col.replace(' ', '_')}10 {col}(10)"
+            for col in [*col_strings["char"], *col_strings["varchar"], *col_strings["varbinary"]]
+        )
+        + ", "
+    )
+    # bare types that should have their default lengths of 1 added by columns()
+    sql += ", ".join(f"{col.replace(' ', '_')}1 {col}" for col in col_strings["char"]) + ", "
+    # bare types that should have their default lengths of 256 added by columns()
+    sql += ", ".join(f"{col.replace(' ', '_')}256 {col}" for col in col_strings["varchar"]) + ", "
+    sql += (
+        ", ".join(f"{col.replace(' ', '_')}172 {col}(17, 2)" for col in col_strings["decimal"])
+        + ")"
+    )
+
+    ctx.engine_adapter.cursor.execute(sql)
+    columns = ctx.engine_adapter.columns(table)
+
+    # columns to types
+    cols_to_types = {
+        f"{col.replace(' ', '_')}10": exp.DataType.build(f"{col}(10)", dialect=ctx.dialect)
+        for col in [*col_strings["char"], *col_strings["varchar"], *col_strings["varbinary"]]
+    }
+    cols_to_types.update(
+        {
+            f"{col.replace(' ', '_')}1": exp.DataType.build(f"{col}(1)", dialect=ctx.dialect)
+            for col in col_strings["char"]
+        }
+    )
+    cols_to_types.update(
+        {
+            f"{col.replace(' ', '_')}256": exp.DataType.build(f"{col}(256)", dialect=ctx.dialect)
+            for col in col_strings["varchar"]
+        }
+    )
+    cols_to_types.update(
+        {
+            f"{col.replace(' ', '_')}172": exp.DataType.build(f"{col}(17, 2)", dialect=ctx.dialect)
+            for col in col_strings["decimal"]
+        }
+    )
+
+    # did we convert the types from redshift correctly?
+    assert [col.sql(ctx.dialect) for col in columns.values()] == [
+        col.sql(ctx.dialect) for col in cols_to_types.values()
+    ]
+
+    # did we replace default char/varchar lengths with MAX correctly?
+    max_cols = [col for col in columns if col.endswith("1") or col.endswith("256")]
+    assert [
+        col.sql(ctx.dialect)
+        for col in ctx.engine_adapter._default_precision_to_max(  # type: ignore
+            {k: columns[k] for k in max_cols}
+        ).values()
+    ] == ["CHAR(max)", "CHAR(max)", "CHAR(max)", "VARCHAR(max)", "VARCHAR(max)", "VARCHAR(max)"]

--- a/tests/core/engine_adapter/test_redshift.py
+++ b/tests/core/engine_adapter/test_redshift.py
@@ -24,7 +24,7 @@ def test_columns(adapter: t.Callable):
     adapter.cursor.fetchall.return_value = [("col", "INT")]
     resp = adapter.columns("db.table")
     adapter.cursor.execute.assert_called_once_with(
-        """SELECT "column_name", "data_type" FROM "svv_columns" WHERE "table_name" = 'table' AND "table_schema" = 'db'"""
+        """SELECT "column_name", "data_type", "character_maximum_length", "numeric_precision", "numeric_scale" FROM "svv_columns" WHERE "table_name" = 'table' AND "table_schema" = 'db'"""
     )
     assert resp == {"col": exp.DataType.build("INT")}
 


### PR DESCRIPTION
***NOTE: redshift integration tests won't pass until sqlglot is bumped > 25.24.4***

#2791 introduced a regression in the varchar length workaround because it assumed the `columns()` method returned data types including their length/precision. That was true for MSSQL, but wasn't for Redshift.

This PR updates Redshift's `columns()` method to attach length/precision to data types.

Note: the `_columns_query()` method allowed postgres and redshift to use different columns queries inside postgres' `columns()` method. Redshift now needs to override the entire `columns()` method, so `_columns_query()` has been removed from postgres.