### PR TITLE
Feat(clickhouse): use table/partition swap for insert-overwrite

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -330,21 +330,21 @@ workflows:
           name: cloud_engine_<< matrix.engine >>
           context:
             - sqlmesh_cloud_database_integration
-          requires:
-            - engine_tests_docker
+          # requires:
+          #   - engine_tests_docker
           matrix:
             parameters:
               engine:
-                - snowflake
-                - databricks
-                - redshift
-                - bigquery
+                # - snowflake
+                # - databricks
+                # - redshift
+                # - bigquery
                 - clickhouse-cloud
-                - athena
-          filters:
-           branches:
-             only:
-               - main
+                # - athena
+          # filters:
+          #  branches:
+          #    only:
+          #      - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -330,21 +330,21 @@ workflows:
           name: cloud_engine_<< matrix.engine >>
           context:
             - sqlmesh_cloud_database_integration
-          # requires:
-          #   - engine_tests_docker
+          requires:
+            - engine_tests_docker
           matrix:
             parameters:
               engine:
-                # - snowflake
-                # - databricks
-                # - redshift
-                # - bigquery
+                - snowflake
+                - databricks
+                - redshift
+                - bigquery
                 - clickhouse-cloud
-                # - athena
-          # filters:
-          #  branches:
-          #    only:
-          #      - main
+                - athena
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -339,6 +339,7 @@ class EngineAdapter:
                 exists=True,
                 table_description=table_description,
                 column_descriptions=column_descriptions,
+                **kwargs,
             )
         # All engines support `CREATE TABLE AS` so we use that if the table doesn't already exist and we
         # use `CREATE OR REPLACE TABLE AS` if the engine supports it
@@ -1284,6 +1285,7 @@ class EngineAdapter:
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         where: t.Optional[exp.Condition] = None,
         insert_overwrite_strategy_override: t.Optional[InsertOverwriteStrategy] = None,
+        **kwargs: t.Any,
     ) -> None:
         table = exp.to_table(table_name)
         insert_overwrite_strategy = (

--- a/sqlmesh/core/engine_adapter/clickhouse.py
+++ b/sqlmesh/core/engine_adapter/clickhouse.py
@@ -296,7 +296,7 @@ class ClickhouseEngineAdapter(EngineAdapterWithIndexSupport, LogicalMergeMixin):
                 partitions_to_replace = self._get_partition_ids(temp_table)
 
                 # drop affected partitions that have no records in temp_table
-                #   - NOTE: `all_affected_partitions` will be empty when is_inc_by_partition=True
+                #   - NOTE: `all_affected_partitions` will be empty when keep_existing_partition_rows=False
                 #      because previous code block is skipped
                 partitions_to_drop = all_affected_partitions - partitions_to_replace
 
@@ -347,7 +347,7 @@ class ClickhouseEngineAdapter(EngineAdapterWithIndexSupport, LogicalMergeMixin):
         )
 
         # limit existing records insert expression WHERE to affected target table partitions
-        #   by adding `AND _partition_id IN (affected partition IDs)`
+        #   by adding `AND _partition_id IN (SELECT partition_id FROM partitions_temp_table)`
         existing_records_insert_exp.set(
             "expression",
             existing_records_insert_exp.expression.where(

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -74,6 +74,7 @@ class InsertOverwriteWithMergeMixin(EngineAdapter):
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         where: t.Optional[exp.Condition] = None,
         insert_overwrite_strategy_override: t.Optional[InsertOverwriteStrategy] = None,
+        **kwargs: t.Any,
     ) -> None:
         """
         Some engines do not support `INSERT OVERWRITE` but instead support

--- a/sqlmesh/core/engine_adapter/trino.py
+++ b/sqlmesh/core/engine_adapter/trino.py
@@ -87,6 +87,7 @@ class TrinoEngineAdapter(
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         where: t.Optional[exp.Condition] = None,
         insert_overwrite_strategy_override: t.Optional[InsertOverwriteStrategy] = None,
+        **kwargs: t.Any,
     ) -> None:
         catalog = exp.to_table(table_name).catalog or self.get_current_catalog()
 

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -375,12 +375,15 @@ class ModelMeta(_Node):
     @property
     def partitioned_by(self) -> t.List[exp.Expression]:
         """Columns to partition the model by, including the time column if it is not already included."""
-        if (
-            self.time_column
-            and self.time_column.column not in [col for col in self._partition_by_columns]
-            and self.dialect not in NO_PARTITIONED_TIME_COLUMN_DIALECTS
-        ):
-            return [self.time_column.column, *self.partitioned_by_]
+        if self.time_column and self.time_column.column not in [
+            col for col in self._partition_by_columns
+        ]:
+            return [
+                (TIME_COL_PARTITION_FUNC.get(self.dialect) or (lambda x: x))(
+                    self.time_column.column
+                ),
+                *self.partitioned_by_,
+            ]
         return self.partitioned_by_
 
     @property
@@ -480,5 +483,6 @@ class ModelMeta(_Node):
         return getattr(self.kind, "on_destructive_change", OnDestructiveChange.ALLOW)
 
 
-# dialects for which time_column should not automatically be added to partitioned_by
-NO_PARTITIONED_TIME_COLUMN_DIALECTS = {"clickhouse"}
+# function applied to time column when automatically used for partitioning in
+#   INCREMENTAL_BY_TIME_RANGE models
+TIME_COL_PARTITION_FUNC = {"clickhouse": lambda x: exp.func("toMonday", x)}

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -379,9 +379,7 @@ class ModelMeta(_Node):
             col for col in self._partition_by_columns
         ]:
             return [
-                (TIME_COL_PARTITION_FUNC.get(self.dialect) or (lambda x: x))(
-                    self.time_column.column
-                ),
+                TIME_COL_PARTITION_FUNC.get(self.dialect, lambda x: x)(self.time_column.column),
                 *self.partitioned_by_,
             ]
         return self.partitioned_by_

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -735,8 +735,7 @@ def test_insert_overwrite_by_time_partition(ctx: TestContext):
     results = ctx.get_metadata_results()
     assert len(results.views) == 0
     assert len(results.materialized_views) == 0
-    assert len(results.tables) == 2 if ctx.dialect == "clickhouse" else 1
-    assert len(results.non_temp_tables) == 1
+    assert len(results.tables) == len(results.non_temp_tables) == 1
     assert results.non_temp_tables[0] == table.name
     ctx.compare_with_current(table, input_data.iloc[1:])
 
@@ -760,8 +759,7 @@ def test_insert_overwrite_by_time_partition(ctx: TestContext):
         results = ctx.get_metadata_results()
         assert len(results.views) == 0
         assert len(results.materialized_views) == 0
-        assert len(results.tables) == 3 if ctx.dialect == "clickhouse" else 1
-        assert len(results.non_temp_tables) == 1
+        assert len(results.tables) == len(results.non_temp_tables) == 1
         assert results.non_temp_tables[0] == table.name
         ctx.compare_with_current(
             table,

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -735,7 +735,7 @@ def test_insert_overwrite_by_time_partition(ctx: TestContext):
     results = ctx.get_metadata_results()
     assert len(results.views) == 0
     assert len(results.materialized_views) == 0
-    assert len(results.tables) == len(results.non_temp_tables) == 1
+    assert len(results.tables) == 2 if ctx.dialect == "clickhouse" else 1
     assert len(results.non_temp_tables) == 1
     assert results.non_temp_tables[0] == table.name
     ctx.compare_with_current(table, input_data.iloc[1:])
@@ -760,7 +760,8 @@ def test_insert_overwrite_by_time_partition(ctx: TestContext):
         results = ctx.get_metadata_results()
         assert len(results.views) == 0
         assert len(results.materialized_views) == 0
-        assert len(results.tables) == len(results.non_temp_tables) == 1
+        assert len(results.tables) == 3 if ctx.dialect == "clickhouse" else 1
+        assert len(results.non_temp_tables) == 1
         assert results.non_temp_tables[0] == table.name
         ctx.compare_with_current(
             table,

--- a/tests/core/engine_adapter/integration/test_integration_clickhouse.py
+++ b/tests/core/engine_adapter/integration/test_integration_clickhouse.py
@@ -1,0 +1,83 @@
+import typing as t
+import pytest
+from tests.core.engine_adapter.integration import TestContext
+import pandas as pd
+from sqlglot import exp, parse_one
+
+if t.TYPE_CHECKING:
+    pass
+
+pytestmark = [pytest.mark.docker, pytest.mark.engine, pytest.mark.clickhouse]
+
+
+@pytest.fixture
+def mark_gateway() -> t.Tuple[str, str]:
+    return "clickhouse", "inttest_clickhouse"
+
+
+@pytest.fixture
+def test_type() -> str:
+    return "query"
+
+
+def test_insert_overwrite_by_condition_partition(ctx: TestContext):
+    ctx.init()
+
+    existing_data = pd.DataFrame(
+        [
+            {"id": 1, "ds": "2024-01-01"},
+            {"id": 2, "ds": "2024-02-01"},
+            {"id": 3, "ds": "2024-02-28"},
+            {"id": 4, "ds": "2024-03-01"},
+        ]
+    )
+    existing_table_name = ctx.table("data_existing")
+    ctx.engine_adapter.ctas(
+        existing_table_name.sql(),
+        ctx.input_data(existing_data),
+        {
+            "id": exp.DataType.build("Int8", ctx.dialect),
+            "ds": exp.DataType.build("Date", ctx.dialect),
+        },
+        partitioned_by=[parse_one("toMonth(ds)", dialect=ctx.dialect)],
+    )
+
+    insert_data = pd.DataFrame(
+        [
+            {"id": 5, "ds": "2024-02-29"},
+            {"id": 6, "ds": "2024-04-01"},
+        ]
+    )
+    insert_table_name = ctx.table("data_insert")
+
+    with ctx.engine_adapter.temp_table(
+        ctx.input_data(insert_data), insert_table_name.sql()
+    ) as insert_table:
+        source_queries, columns_to_types = (
+            ctx.engine_adapter._get_source_queries_and_columns_to_types(
+                parse_one(f"SELECT * FROM {insert_table.sql()}"),  # type: ignore
+                {"id": exp.DataType.build("INT"), "ds": exp.DataType.build("Date")},
+                target_table=existing_table_name.sql(),
+            )
+        )
+        ctx.engine_adapter._insert_overwrite_by_condition(
+            existing_table_name.sql(),
+            source_queries,
+            columns_to_types,
+            exp.Between(
+                this=exp.column("ds"), low=parse_one("'2024-02-15'"), high=parse_one("'2024-04-30'")
+            ),
+        )
+
+    ctx.compare_with_current(
+        existing_table_name,
+        pd.DataFrame(
+            [
+                {"id": 1, "ds": pd.Timestamp("2024-01-01")},
+                {"id": 2, "ds": pd.Timestamp("2024-02-01")},
+                {"id": 5, "ds": pd.Timestamp("2024-02-29")},
+                {"id": 6, "ds": pd.Timestamp("2024-04-01")},
+            ]
+        ),
+    )
+    ctx.engine_adapter.drop_table(existing_table_name.sql())

--- a/tests/core/engine_adapter/integration/test_integration_clickhouse.py
+++ b/tests/core/engine_adapter/integration/test_integration_clickhouse.py
@@ -4,15 +4,40 @@ from tests.core.engine_adapter.integration import TestContext
 import pandas as pd
 from sqlglot import exp, parse_one
 
-if t.TYPE_CHECKING:
-    pass
 
-pytestmark = [pytest.mark.docker, pytest.mark.engine, pytest.mark.clickhouse]
-
-
-@pytest.fixture
-def mark_gateway() -> t.Tuple[str, str]:
-    return "clickhouse", "inttest_clickhouse"
+@pytest.fixture(
+    params=[
+        pytest.param(
+            "clickhouse",
+            marks=[
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.clickhouse,
+                pytest.mark.xdist_group("engine_integration_clickhouse"),
+            ],
+        ),
+        pytest.param(
+            "clickhouse_cluster",
+            marks=[
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.clickhouse_cluster,
+                pytest.mark.xdist_group("engine_integration_clickhouse_cluster"),
+            ],
+        ),
+        pytest.param(
+            "clickhouse_cloud",
+            marks=[
+                pytest.mark.engine,
+                pytest.mark.remote,
+                pytest.mark.clickhouse_cloud,
+                pytest.mark.xdist_group("engine_integration_clickhouse_cloud"),
+            ],
+        ),
+    ]
+)
+def mark_gateway(request) -> t.Tuple[str, str]:
+    return request.param, f"inttest_{request.param}"
 
 
 @pytest.fixture
@@ -20,28 +45,58 @@ def test_type() -> str:
     return "query"
 
 
-def test_insert_overwrite_by_condition_partition(ctx: TestContext):
-    ctx.init()
+def _get_source_queries_and_columns_to_types(
+    ctx,
+    insert_table: exp.Table,
+    target_table: exp.Table,
+    columns_to_types: t.Dict[str, exp.DataType] = {
+        "id": exp.DataType.build("Int8", dialect="clickhouse"),
+        "ds": exp.DataType.build("Date", dialect="clickhouse"),
+    },
+):
+    return ctx.engine_adapter._get_source_queries_and_columns_to_types(
+        parse_one(f"SELECT * FROM {insert_table.sql()}"),  # type: ignore
+        columns_to_types,
+        target_table=target_table.sql(),
+    )
 
-    existing_data = pd.DataFrame(
+
+def _create_table_and_insert_existing_data(
+    ctx: TestContext,
+    existing_data: pd.DataFrame = pd.DataFrame(
         [
             {"id": 1, "ds": "2024-01-01"},
             {"id": 2, "ds": "2024-02-01"},
             {"id": 3, "ds": "2024-02-28"},
             {"id": 4, "ds": "2024-03-01"},
         ]
-    )
-    existing_table_name = ctx.table("data_existing")
+    ),
+    columns_to_types: t.Dict[str, exp.DataType] = {
+        "id": exp.DataType.build("Int8", "clickhouse"),
+        "ds": exp.DataType.build("Date", "clickhouse"),
+    },
+    table_name: str = "data_existing",
+    partitioned_by: t.Optional[t.List[exp.Expression]] = [
+        parse_one("toMonth(ds)", dialect="clickhouse")
+    ],
+) -> exp.Table:
+    existing_data = existing_data
+    existing_table_name: exp.Table = ctx.table(table_name)
     ctx.engine_adapter.ctas(
         existing_table_name.sql(),
-        ctx.input_data(existing_data),
-        {
-            "id": exp.DataType.build("Int8", ctx.dialect),
-            "ds": exp.DataType.build("Date", ctx.dialect),
-        },
-        partitioned_by=[parse_one("toMonth(ds)", dialect=ctx.dialect)],
+        ctx.input_data(existing_data, columns_to_types),
+        columns_to_types,
+        partitioned_by=partitioned_by,
     )
+    return existing_table_name
 
+
+def test_insert_overwrite_by_condition_replace_partitioned(ctx: TestContext):
+    ctx.init()
+
+    existing_table_name = _create_table_and_insert_existing_data(ctx)
+
+    # new data to insert
     insert_data = pd.DataFrame(
         [
             {"id": 5, "ds": "2024-02-29"},
@@ -53,19 +108,100 @@ def test_insert_overwrite_by_condition_partition(ctx: TestContext):
     with ctx.engine_adapter.temp_table(
         ctx.input_data(insert_data), insert_table_name.sql()
     ) as insert_table:
-        source_queries, columns_to_types = (
-            ctx.engine_adapter._get_source_queries_and_columns_to_types(
-                parse_one(f"SELECT * FROM {insert_table.sql()}"),  # type: ignore
-                {"id": exp.DataType.build("INT"), "ds": exp.DataType.build("Date")},
-                target_table=existing_table_name.sql(),
-            )
+        source_queries, columns_to_types = _get_source_queries_and_columns_to_types(
+            ctx, insert_table, existing_table_name
+        )
+
+        ctx.engine_adapter._insert_overwrite_by_condition(
+            existing_table_name.sql(),
+            source_queries,
+            columns_to_types,
+        )
+
+    ctx.compare_with_current(
+        existing_table_name,
+        pd.DataFrame(
+            [
+                {"id": 5, "ds": pd.Timestamp("2024-02-29")},
+                {"id": 6, "ds": pd.Timestamp("2024-04-01")},
+            ]
+        ),
+    )
+    ctx.engine_adapter.drop_table(existing_table_name.sql())
+
+
+def test_insert_overwrite_by_condition_replace(ctx: TestContext):
+    ctx.init()
+
+    existing_table_name = _create_table_and_insert_existing_data(ctx, partitioned_by=None)
+
+    # new data to insert
+    insert_data = pd.DataFrame(
+        [
+            {"id": 5, "ds": "2024-02-29"},
+            {"id": 6, "ds": "2024-04-01"},
+        ]
+    )
+    insert_table_name = ctx.table("data_insert")
+
+    with ctx.engine_adapter.temp_table(
+        ctx.input_data(insert_data), insert_table_name.sql()
+    ) as insert_table:
+        source_queries, columns_to_types = _get_source_queries_and_columns_to_types(
+            ctx, insert_table, existing_table_name
+        )
+
+        ctx.engine_adapter._insert_overwrite_by_condition(
+            existing_table_name.sql(),
+            source_queries,
+            columns_to_types,
+        )
+
+    ctx.compare_with_current(
+        existing_table_name,
+        pd.DataFrame(
+            [
+                {"id": 5, "ds": pd.Timestamp("2024-02-29")},
+                {"id": 6, "ds": pd.Timestamp("2024-04-01")},
+            ]
+        ),
+    )
+    ctx.engine_adapter.drop_table(existing_table_name.sql())
+
+
+def test_insert_overwrite_by_condition_where_partitioned(ctx: TestContext):
+    ctx.init()
+
+    # `where` time window
+    start_date = "2024-02-15"
+    end_date = "2024-04-30"
+
+    # data currently in target table
+    existing_table_name = _create_table_and_insert_existing_data(ctx)
+
+    # new data to insert
+    insert_data = pd.DataFrame(
+        [
+            {"id": 5, "ds": "2024-02-29"},
+            {"id": 6, "ds": "2024-04-01"},
+        ]
+    )
+    insert_table_name = ctx.table("data_insert")
+
+    with ctx.engine_adapter.temp_table(
+        ctx.input_data(insert_data), insert_table_name.sql()
+    ) as insert_table:
+        source_queries, columns_to_types = _get_source_queries_and_columns_to_types(
+            ctx, insert_table, existing_table_name
         )
         ctx.engine_adapter._insert_overwrite_by_condition(
             existing_table_name.sql(),
             source_queries,
             columns_to_types,
             exp.Between(
-                this=exp.column("ds"), low=parse_one("'2024-02-15'"), high=parse_one("'2024-04-30'")
+                this=exp.column("ds"),
+                low=parse_one(f"'{start_date}'"),
+                high=parse_one(f"'{end_date}'"),
             ),
         )
 
@@ -73,9 +209,312 @@ def test_insert_overwrite_by_condition_partition(ctx: TestContext):
         existing_table_name,
         pd.DataFrame(
             [
+                {"id": 1, "ds": pd.Timestamp("2024-01-01")},  # retained
+                {"id": 2, "ds": pd.Timestamp("2024-02-01")},  # retained
+                {"id": 5, "ds": pd.Timestamp("2024-02-29")},  # inserted
+                {"id": 6, "ds": pd.Timestamp("2024-04-01")},  # inserted
+            ]
+        ),
+    )
+    ctx.engine_adapter.drop_table(existing_table_name.sql())
+
+
+def test_insert_overwrite_by_condition_where_compound_partitioned(ctx: TestContext):
+    ctx.init()
+
+    # `where` time window
+    start_date = "2024-02-15"
+    end_date = "2024-04-30"
+
+    compound_columns_to_types = {
+        "id": exp.DataType.build("Int8", ctx.dialect),
+        "ds": exp.DataType.build("Date", ctx.dialect),
+        "city": exp.DataType.build("String", ctx.dialect),
+    }
+
+    # data currently in target table
+    existing_table_name = _create_table_and_insert_existing_data(
+        ctx,
+        existing_data=pd.DataFrame(
+            [
+                {"id": 1, "ds": "2024-01-01", "city": "1"},
+                {"id": 2, "ds": "2024-01-02", "city": "2"},
+                {"id": 3, "ds": "2024-02-01", "city": "1"},
+                {"id": 4, "ds": "2024-02-02", "city": "2"},
+                {"id": 5, "ds": "2024-02-27", "city": "1"},
+                {"id": 6, "ds": "2024-02-28", "city": "2"},
+                {"id": 7, "ds": "2024-03-01", "city": "1"},
+                {"id": 8, "ds": "2024-03-02", "city": "2"},
+            ]
+        ),
+        columns_to_types=compound_columns_to_types,
+        partitioned_by=[parse_one("toMonth(ds)", dialect=ctx.dialect), exp.column("city")],
+    )
+
+    # new data to insert
+    insert_data = pd.DataFrame(
+        [
+            {"id": 9, "ds": "2024-02-26", "city": "1"},
+            {"id": 10, "ds": "2024-02-29", "city": "2"},
+            {"id": 11, "ds": "2024-04-01", "city": "1"},
+            {"id": 12, "ds": "2024-04-02", "city": "2"},
+        ]
+    )
+    insert_table_name = ctx.table("data_insert")
+
+    with ctx.engine_adapter.temp_table(
+        ctx.input_data(insert_data, compound_columns_to_types), insert_table_name.sql()
+    ) as insert_table:
+        source_queries, columns_to_types = _get_source_queries_and_columns_to_types(
+            ctx,
+            insert_table,
+            existing_table_name,
+            compound_columns_to_types,
+        )
+        ctx.engine_adapter._insert_overwrite_by_condition(
+            existing_table_name.sql(),
+            source_queries,
+            columns_to_types,
+            exp.Between(
+                this=exp.column("ds"),
+                low=parse_one(f"'{start_date}'"),
+                high=parse_one(f"'{end_date}'"),
+            ),
+        )
+
+    ctx.compare_with_current(
+        existing_table_name,
+        pd.DataFrame(
+            [
+                {"id": 1, "ds": pd.Timestamp("2024-01-01"), "city": "1"},
+                {"id": 2, "ds": pd.Timestamp("2024-01-02"), "city": "2"},
+                {"id": 3, "ds": pd.Timestamp("2024-02-01"), "city": "1"},
+                {"id": 4, "ds": pd.Timestamp("2024-02-02"), "city": "2"},
+                {"id": 9, "ds": pd.Timestamp("2024-02-26"), "city": "1"},
+                {"id": 10, "ds": pd.Timestamp("2024-02-29"), "city": "2"},
+                {"id": 11, "ds": pd.Timestamp("2024-04-01"), "city": "1"},
+                {"id": 12, "ds": pd.Timestamp("2024-04-02"), "city": "2"},
+            ]
+        ),
+    )
+    ctx.engine_adapter.drop_table(existing_table_name.sql())
+
+
+def test_insert_overwrite_by_condition_by_key(ctx: TestContext):
+    ctx.init()
+
+    # key parameters
+    key = [exp.column("id")]
+    key_exp = key[0]
+
+    # data currently in target table
+    existing_table_name = _create_table_and_insert_existing_data(ctx, partitioned_by=None)
+
+    # new data to insert
+    insert_data = pd.DataFrame(
+        [
+            {"id": 4, "ds": "2024-05-01"},  # will overwrite existing record
+            {"id": 4, "ds": "2024-05-02"},  # only inserted if unique_key = False
+            {"id": 5, "ds": "2024-02-29"},
+            {"id": 6, "ds": "2024-04-01"},
+        ]
+    )
+
+    # unique_key = True
+    with ctx.engine_adapter.temp_table(
+        ctx.input_data(insert_data), ctx.table("data_insert").sql()
+    ) as insert_table:
+        source_queries, columns_to_types = _get_source_queries_and_columns_to_types(
+            ctx, insert_table, existing_table_name
+        )
+        ctx.engine_adapter._insert_overwrite_by_condition(
+            existing_table_name.sql(),
+            source_queries,
+            columns_to_types,
+            dynamic_key=key,
+            dynamic_key_exp=key_exp,
+            dynamic_key_unique=True,
+        )
+
+        ctx.compare_with_current(
+            existing_table_name,
+            pd.DataFrame(
+                [
+                    {"id": 1, "ds": pd.Timestamp("2024-01-01")},
+                    {"id": 2, "ds": pd.Timestamp("2024-02-01")},
+                    {"id": 3, "ds": pd.Timestamp("2024-02-28")},
+                    {"id": 4, "ds": pd.Timestamp("2024-05-01")},
+                    {"id": 5, "ds": pd.Timestamp("2024-02-29")},
+                    {"id": 6, "ds": pd.Timestamp("2024-04-01")},
+                ]
+            ),
+        )
+    ctx.engine_adapter.drop_table(existing_table_name.sql())
+
+    # unique_key = False
+    existing_table_name = _create_table_and_insert_existing_data(
+        ctx, table_name="data_existing_no_unique", partitioned_by=None
+    )
+
+    with ctx.engine_adapter.temp_table(
+        ctx.input_data(insert_data), ctx.table("data_insert_no_unique").sql()
+    ) as insert_table:
+        source_queries, columns_to_types = _get_source_queries_and_columns_to_types(
+            ctx, insert_table, existing_table_name
+        )
+        ctx.engine_adapter._insert_overwrite_by_condition(
+            existing_table_name.sql(),
+            source_queries,
+            columns_to_types,
+            dynamic_key=key,
+            dynamic_key_exp=key_exp,
+            dynamic_key_unique=False,
+        )
+
+        ctx.compare_with_current(
+            existing_table_name,
+            pd.DataFrame(
+                [
+                    {"id": 1, "ds": pd.Timestamp("2024-01-01")},
+                    {"id": 2, "ds": pd.Timestamp("2024-02-01")},
+                    {"id": 3, "ds": pd.Timestamp("2024-02-28")},
+                    {"id": 4, "ds": pd.Timestamp("2024-05-01")},
+                    {"id": 4, "ds": pd.Timestamp("2024-05-02")},
+                    {"id": 5, "ds": pd.Timestamp("2024-02-29")},
+                    {"id": 6, "ds": pd.Timestamp("2024-04-01")},
+                ]
+            ),
+        )
+
+    ctx.engine_adapter.drop_table(existing_table_name.sql())
+
+
+def test_insert_overwrite_by_condition_by_key_partitioned(ctx: TestContext):
+    ctx.init()
+
+    # key parameters
+    key = [exp.column("id")]
+    key_exp = key[0]
+
+    # data currently in target table
+    existing_table_name = _create_table_and_insert_existing_data(ctx)
+
+    # new data to insert
+    insert_data = pd.DataFrame(
+        [
+            {"id": 4, "ds": "2024-05-01"},  # will overwrite existing record
+            {"id": 4, "ds": "2024-05-02"},  # only inserted if unique_key = False
+            {"id": 5, "ds": "2024-02-29"},
+            {"id": 6, "ds": "2024-04-01"},
+        ]
+    )
+
+    # unique_key = True
+    with ctx.engine_adapter.temp_table(
+        ctx.input_data(insert_data), ctx.table("data_insert").sql()
+    ) as insert_table:
+        source_queries, columns_to_types = _get_source_queries_and_columns_to_types(
+            ctx, insert_table, existing_table_name
+        )
+        ctx.engine_adapter._insert_overwrite_by_condition(
+            existing_table_name.sql(),
+            source_queries,
+            columns_to_types,
+            dynamic_key=key,
+            dynamic_key_exp=key_exp,
+            dynamic_key_unique=True,
+        )
+
+        ctx.compare_with_current(
+            existing_table_name,
+            pd.DataFrame(
+                [
+                    {"id": 1, "ds": pd.Timestamp("2024-01-01")},
+                    {"id": 2, "ds": pd.Timestamp("2024-02-01")},
+                    {"id": 3, "ds": pd.Timestamp("2024-02-28")},
+                    {"id": 4, "ds": pd.Timestamp("2024-05-01")},
+                    {"id": 5, "ds": pd.Timestamp("2024-02-29")},
+                    {"id": 6, "ds": pd.Timestamp("2024-04-01")},
+                ]
+            ),
+        )
+    ctx.engine_adapter.drop_table(existing_table_name.sql())
+
+    # unique_key = False
+    existing_table_name = _create_table_and_insert_existing_data(
+        ctx, table_name="data_existing_no_unique"
+    )
+
+    with ctx.engine_adapter.temp_table(
+        ctx.input_data(insert_data), ctx.table("data_insert_no_unique").sql()
+    ) as insert_table:
+        source_queries, columns_to_types = _get_source_queries_and_columns_to_types(
+            ctx, insert_table, existing_table_name
+        )
+        ctx.engine_adapter._insert_overwrite_by_condition(
+            existing_table_name.sql(),
+            source_queries,
+            columns_to_types,
+            dynamic_key=key,
+            dynamic_key_exp=key_exp,
+            dynamic_key_unique=False,
+        )
+
+        ctx.compare_with_current(
+            existing_table_name,
+            pd.DataFrame(
+                [
+                    {"id": 1, "ds": pd.Timestamp("2024-01-01")},
+                    {"id": 2, "ds": pd.Timestamp("2024-02-01")},
+                    {"id": 3, "ds": pd.Timestamp("2024-02-28")},
+                    {"id": 4, "ds": pd.Timestamp("2024-05-01")},
+                    {
+                        "id": 4,
+                        "ds": pd.Timestamp("2024-05-02"),
+                    },  # second ID=4 row because unique_key=False
+                    {"id": 5, "ds": pd.Timestamp("2024-02-29")},
+                    {"id": 6, "ds": pd.Timestamp("2024-04-01")},
+                ]
+            ),
+        )
+
+    ctx.engine_adapter.drop_table(existing_table_name.sql())
+
+
+def test_insert_overwrite_by_condition_inc_by_partition(ctx: TestContext):
+    ctx.init()
+
+    existing_table_name = _create_table_and_insert_existing_data(ctx)
+
+    # new data to insert
+    insert_data = pd.DataFrame(
+        [
+            {"id": 5, "ds": "2024-02-29"},
+            {"id": 6, "ds": "2024-04-01"},
+        ]
+    )
+    insert_table_name = ctx.table("data_insert")
+
+    with ctx.engine_adapter.temp_table(
+        ctx.input_data(insert_data), insert_table_name.sql()
+    ) as insert_table:
+        source_queries, columns_to_types = _get_source_queries_and_columns_to_types(
+            ctx, insert_table, existing_table_name
+        )
+        ctx.engine_adapter._insert_overwrite_by_condition(
+            existing_table_name.sql(), source_queries, columns_to_types, is_inc_by_partition=True
+        )
+
+    ctx.compare_with_current(
+        existing_table_name,
+        pd.DataFrame(
+            [
                 {"id": 1, "ds": pd.Timestamp("2024-01-01")},
-                {"id": 2, "ds": pd.Timestamp("2024-02-01")},
-                {"id": 5, "ds": pd.Timestamp("2024-02-29")},
+                {
+                    "id": 5,
+                    "ds": pd.Timestamp("2024-02-29"),
+                },  # all existing Feb records overwritten by this row
+                {"id": 4, "ds": pd.Timestamp("2024-03-01")},
                 {"id": 6, "ds": pd.Timestamp("2024-04-01")},
             ]
         ),

--- a/tests/core/engine_adapter/integration/test_integration_clickhouse.py
+++ b/tests/core/engine_adapter/integration/test_integration_clickhouse.py
@@ -13,7 +13,6 @@ from sqlglot import exp, parse_one
                 pytest.mark.docker,
                 pytest.mark.engine,
                 pytest.mark.clickhouse,
-                pytest.mark.xdist_group("engine_integration_clickhouse"),
             ],
         ),
         pytest.param(
@@ -22,7 +21,6 @@ from sqlglot import exp, parse_one
                 pytest.mark.docker,
                 pytest.mark.engine,
                 pytest.mark.clickhouse_cluster,
-                pytest.mark.xdist_group("engine_integration_clickhouse_cluster"),
             ],
         ),
         pytest.param(
@@ -31,7 +29,6 @@ from sqlglot import exp, parse_one
                 pytest.mark.engine,
                 pytest.mark.remote,
                 pytest.mark.clickhouse_cloud,
-                pytest.mark.xdist_group("engine_integration_clickhouse_cloud"),
             ],
         ),
     ]
@@ -92,8 +89,6 @@ def _create_table_and_insert_existing_data(
 
 
 def test_insert_overwrite_by_condition_replace_partitioned(ctx: TestContext):
-    ctx.init()
-
     existing_table_name = _create_table_and_insert_existing_data(ctx)
 
     # new data to insert
@@ -127,12 +122,9 @@ def test_insert_overwrite_by_condition_replace_partitioned(ctx: TestContext):
             ]
         ),
     )
-    ctx.engine_adapter.drop_table(existing_table_name.sql())
 
 
 def test_insert_overwrite_by_condition_replace(ctx: TestContext):
-    ctx.init()
-
     existing_table_name = _create_table_and_insert_existing_data(ctx, partitioned_by=None)
 
     # new data to insert
@@ -166,12 +158,9 @@ def test_insert_overwrite_by_condition_replace(ctx: TestContext):
             ]
         ),
     )
-    ctx.engine_adapter.drop_table(existing_table_name.sql())
 
 
 def test_insert_overwrite_by_condition_where_partitioned(ctx: TestContext):
-    ctx.init()
-
     # `where` time window
     start_date = "2024-02-15"
     end_date = "2024-04-30"
@@ -216,12 +205,9 @@ def test_insert_overwrite_by_condition_where_partitioned(ctx: TestContext):
             ]
         ),
     )
-    ctx.engine_adapter.drop_table(existing_table_name.sql())
 
 
 def test_insert_overwrite_by_condition_where_compound_partitioned(ctx: TestContext):
-    ctx.init()
-
     # `where` time window
     start_date = "2024-02-15"
     end_date = "2024-04-30"
@@ -297,12 +283,9 @@ def test_insert_overwrite_by_condition_where_compound_partitioned(ctx: TestConte
             ]
         ),
     )
-    ctx.engine_adapter.drop_table(existing_table_name.sql())
 
 
 def test_insert_overwrite_by_condition_by_key(ctx: TestContext):
-    ctx.init()
-
     # key parameters
     key = [exp.column("id")]
     key_exp = key[0]
@@ -386,12 +369,8 @@ def test_insert_overwrite_by_condition_by_key(ctx: TestContext):
             ),
         )
 
-    ctx.engine_adapter.drop_table(existing_table_name.sql())
-
 
 def test_insert_overwrite_by_condition_by_key_partitioned(ctx: TestContext):
-    ctx.init()
-
     # key parameters
     key = [exp.column("id")]
     key_exp = key[0]
@@ -478,12 +457,8 @@ def test_insert_overwrite_by_condition_by_key_partitioned(ctx: TestContext):
             ),
         )
 
-    ctx.engine_adapter.drop_table(existing_table_name.sql())
-
 
 def test_insert_overwrite_by_condition_inc_by_partition(ctx: TestContext):
-    ctx.init()
-
     existing_table_name = _create_table_and_insert_existing_data(ctx)
 
     # new data to insert
@@ -502,7 +477,10 @@ def test_insert_overwrite_by_condition_inc_by_partition(ctx: TestContext):
             ctx, insert_table, existing_table_name
         )
         ctx.engine_adapter._insert_overwrite_by_condition(
-            existing_table_name.sql(), source_queries, columns_to_types, is_inc_by_partition=True
+            existing_table_name.sql(),
+            source_queries,
+            columns_to_types,
+            keep_existing_partition_rows=False,
         )
 
     ctx.compare_with_current(
@@ -519,4 +497,3 @@ def test_insert_overwrite_by_condition_inc_by_partition(ctx: TestContext):
             ]
         ),
     )
-    ctx.engine_adapter.drop_table(existing_table_name.sql())

--- a/tests/core/engine_adapter/test_clickhouse.py
+++ b/tests/core/engine_adapter/test_clickhouse.py
@@ -11,7 +11,6 @@ from sqlmesh.core.schema_diff import SchemaDiffer
 from datetime import datetime
 from pytest_mock.plugin import MockerFixture
 from sqlmesh.core import dialect as d
-from sqlmesh.utils.date import to_datetime
 
 pytestmark = [pytest.mark.clickhouse, pytest.mark.engine]
 

--- a/tests/core/engine_adapter/test_clickhouse.py
+++ b/tests/core/engine_adapter/test_clickhouse.py
@@ -510,8 +510,8 @@ def test_scd_type_2_by_time(
     temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "target"
     temp_table_mock.side_effect = [
-        make_temp_table_name(table_name, "abcd"),
         make_temp_table_name(table_name, "efgh"),
+        make_temp_table_name(table_name, "abcd"),
     ]
 
     # The SCD query we build must specify the setting join_use_nulls = 1. We need to ensure that our
@@ -548,7 +548,7 @@ def test_scd_type_2_by_time(
 
     assert to_sql_calls(adapter)[4] == parse_one(
         """
-INSERT INTO "__temp_target_efgh" ("id", "name", "price", "test_UPDATED_at", "test_valid_from", "test_valid_to")
+INSERT INTO "__temp_target_abcd" ("id", "name", "price", "test_UPDATED_at", "test_valid_from", "test_valid_to")
 WITH "source" AS (
   SELECT DISTINCT ON (COALESCE("id", '') || '|' || COALESCE("name", ''), COALESCE("name", ''))
     TRUE AS "_exists",
@@ -573,7 +573,7 @@ WITH "source" AS (
     "test_valid_from",
     "test_valid_to",
     TRUE AS "_exists"
-  FROM ""__temp_target_abcd""
+  FROM ""__temp_target_efgh""
   WHERE
     NOT "test_valid_to" IS NULL
 ), "latest" AS (
@@ -585,7 +585,7 @@ WITH "source" AS (
     "test_valid_from",
     "test_valid_to",
     TRUE AS "_exists"
-  FROM ""__temp_target_abcd""
+  FROM ""__temp_target_efgh""
   WHERE
     "test_valid_to" IS NULL
 ), "deleted" AS (
@@ -719,8 +719,8 @@ def test_scd_type_2_by_column(
     temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter._get_temp_table")
     table_name = "target"
     temp_table_mock.side_effect = [
-        make_temp_table_name(table_name, "abcd"),
         make_temp_table_name(table_name, "efgh"),
+        make_temp_table_name(table_name, "abcd"),
     ]
 
     # The SCD query we build must specify the setting join_use_nulls = 1. We need to ensure that our
@@ -750,7 +750,7 @@ def test_scd_type_2_by_column(
 
     assert to_sql_calls(adapter)[4] == parse_one(
         """
-INSERT INTO "__temp_target_efgh" ("id", "name", "price", "test_VALID_from", "test_valid_to")
+INSERT INTO "__temp_target_abcd" ("id", "name", "price", "test_VALID_from", "test_valid_to")
 WITH "source" AS (
   SELECT DISTINCT ON ("id")
     TRUE AS "_exists",
@@ -773,7 +773,7 @@ WITH "source" AS (
     "test_VALID_from",
     "test_valid_to",
     TRUE AS "_exists"
-  FROM "__temp_target_abcd"
+  FROM "__temp_target_efgh"
   WHERE
     NOT "test_valid_to" IS NULL
 ), "latest" AS (
@@ -784,7 +784,7 @@ WITH "source" AS (
     "test_VALID_from",
     "test_valid_to",
     TRUE AS "_exists"
-  FROM "__temp_target_abcd"
+  FROM "__temp_target_efgh"
   WHERE
     "test_valid_to" IS NULL
 ), "deleted" AS (

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -990,7 +990,7 @@ def test_replace_query_with_wap_self_reference(
 
     sql_calls = to_sql_calls(adapter)
     assert sql_calls == [
-        "CREATE TABLE IF NOT EXISTS `catalog`.`schema`.`table` (`a` INT)",
+        "CREATE TABLE IF NOT EXISTS `catalog`.`schema`.`table` (`a` INT) USING ICEBERG",
         "CREATE SCHEMA IF NOT EXISTS `catalog`.`schema`",
         "CREATE TABLE IF NOT EXISTS `catalog`.`schema`.`temp_branch_wap_12345_abcdefgh` USING ICEBERG AS SELECT CAST(`a` AS INT) AS `a` FROM (SELECT `a` FROM `catalog`.`schema`.`table`.`branch_wap_12345`) AS `_subquery`",
         "INSERT OVERWRITE TABLE `catalog`.`schema`.`table`.`branch_wap_12345` (`a`) SELECT 1 AS `a` FROM `catalog`.`schema`.`temp_branch_wap_12345_abcdefgh`",


### PR DESCRIPTION
The current Clickhouse adapter uses the delete-insert loading approach. Clickhouse is not designed for deletes/updates, so its performance may be unusably slow.

This PR replaces delete-insert with a table/partition swap approach. At a high level, it operates by creating a temp table that contains new records to insert, adding existing records that should be retained to the temp table, then swapping the temp table for the current table.

To improve performance, the swapping occurs at the partition level for partitioned tables (potentially processing much less data). Incremental by time models now automatically partition the underlying table by calendar week (`toMonday(timecol)`).

Implementation note:
- Almost all of the implementation is in the `_insert_overwrite_by_condition()` adapter method, which is called by other methods like `replace_by_unique_key()`.