### PR TITLE
Feat: BigQuery - Handle forward_only changes to clustered_by

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -336,15 +336,15 @@ workflows:
             parameters:
               engine:
                 - snowflake
-                #- databricks
-                #- redshift
+                - databricks
+                - redshift
                 - bigquery
-                #- clickhouse-cloud
-                #- athena
-          #filters:
-          # branches:
-          #   only:
-          #     - main
+                - clickhouse-cloud
+                - athena
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -336,15 +336,15 @@ workflows:
             parameters:
               engine:
                 - snowflake
-                - databricks
-                - redshift
+                #- databricks
+                #- redshift
                 - bigquery
-                - clickhouse-cloud
-                - athena
-          filters:
-           branches:
-             only:
-               - main
+                #- clickhouse-cloud
+                #- athena
+          #filters:
+          # branches:
+          #   only:
+          #     - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/sqlmesh/core/engine_adapter/shared.py
+++ b/sqlmesh/core/engine_adapter/shared.py
@@ -164,6 +164,13 @@ class DataObject(PydanticModel):
     name: str
     type: DataObjectType
 
+    # for type=DataObjectType.Table, only if the DB supports it
+    clustering_key: t.Optional[str] = None
+
+    @property
+    def is_clustered(self) -> bool:
+        return bool(self.clustering_key)
+
 
 class CatalogSupport(Enum):
     UNSUPPORTED = 1

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -6,8 +6,7 @@ import typing as t
 
 import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype  # type: ignore
-from sqlglot import exp, parse_one
-from sqlglot.helper import seq_get
+from sqlglot import exp
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 from sqlglot.optimizer.qualify_columns import quote_identifiers
 
@@ -31,14 +30,6 @@ if t.TYPE_CHECKING:
     from sqlmesh.core._typing import SchemaName, SessionProperties, TableName
     from sqlmesh.core.engine_adapter._typing import DF, Query, SnowparkSession
     from sqlmesh.core.node import IntervalUnit
-
-
-class SnowflakeDataObject(DataObject):
-    clustering_key: t.Optional[str] = None
-
-    @property
-    def is_clustered(self) -> bool:
-        return bool(self.clustering_key)
 
 
 @set_catalog(
@@ -348,7 +339,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
         if df.empty:
             return []
         return [
-            SnowflakeDataObject(
+            DataObject(
                 catalog=row.catalog,  # type: ignore
                 schema=row.schema_name,  # type: ignore
                 name=row.name,  # type: ignore
@@ -433,50 +424,3 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
                 f"Column comments for table '{table.alias_or_name}' not registered - this may be due to limited permissions.",
                 exc_info=True,
             )
-
-    def get_alter_expressions(
-        self, current_table_name: TableName, target_table_name: TableName
-    ) -> t.List[exp.Alter]:
-        schema_expressions = super().get_alter_expressions(current_table_name, target_table_name)
-        additional_expressions = []
-
-        # check for a change in clustering
-        current_table = exp.to_table(current_table_name)
-        target_table = exp.to_table(target_table_name)
-
-        current_table_info = t.cast(
-            SnowflakeDataObject,
-            seq_get(self.get_data_objects(current_table.db, {current_table.name}), 0),
-        )
-        target_table_info = t.cast(
-            SnowflakeDataObject,
-            seq_get(self.get_data_objects(target_table.db, {target_table.name}), 0),
-        )
-
-        if current_table_info and target_table_info:
-            if target_table_info.is_clustered:
-                if target_table_info.clustering_key and (
-                    current_table_info.clustering_key != target_table_info.clustering_key
-                ):
-                    # Note: If you create a table with eg `CLUSTER BY (c2, c1)` and read the info back from information_schema,
-                    # it gets returned as a string like "LINEAR(c2, c1)" which we need to parse back into a list of columns
-                    parsed_cluster_key = parse_one(
-                        target_table_info.clustering_key, dialect=self.dialect
-                    )
-                    additional_expressions.append(
-                        exp.Alter(
-                            this=current_table,
-                            kind="TABLE",
-                            actions=[exp.Cluster(expressions=parsed_cluster_key.expressions)],
-                        )
-                    )
-            elif current_table_info.is_clustered:
-                additional_expressions.append(
-                    exp.Alter(
-                        this=current_table,
-                        kind="TABLE",
-                        actions=[exp.Command(this="DROP", expression="CLUSTERING KEY")],
-                    )
-                )
-
-        return schema_expressions + additional_expressions


### PR DESCRIPTION
Follow-up PR from https://github.com/TobikoData/sqlmesh/pull/3205

Add the ability to change `clustered_by` in BigQuery tables in a forward_only fashion. Previously, we would silently succeed