### PR TITLE
Fix: reset macro registry *after* loading models

### DIFF
--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -93,10 +93,17 @@ class Loader(abc.ABC):
         self._config_mtimes = {path: max(mtimes) for path, mtimes in config_mtimes.items()}
 
         macros, jinja_macros = self._load_scripts()
+
+        # All macros need to be known at parse time
+        standard_macros = macro.get_registry()
+        macro.set_registry(macros)
+
         audits = self._load_audits(macros=macros, jinja_macros=jinja_macros)
         models = self._load_models(
             macros, jinja_macros, context.gateway or context.config.default_gateway, audits or None
         )
+
+        macro.set_registry(standard_macros)
 
         for model in models.values():
             self._add_model_to_dag(model)


### PR DESCRIPTION
This addresses a bug that was [reported](https://tobiko-data.slack.com/archives/C044BRE5W4S/p1728485147986839?thread_ts=1728478460.658349&cid=C044BRE5W4S) in the Slack channel.

Our override of `_parse_table_parts` for Snowflake checks whether `@some_name...` appears in the registry's macros as a heuristic, to disambiguate macro funcs/vars from staged paths. Since we're [resetting](https://github.com/TobikoData/sqlmesh/blob/main/sqlmesh/core/loader.py#L301) the macro registry to `standard_macros` after loading the macros, we won't have access to the user-defined macros when this method is called (models are loaded after macros), so there are cases where the parsing will fail, i.e. when user-defined macros are used as table functions (see added test).