### PR TITLE
Fix: Modify dlt query filter not to use alias reference

### DIFF
--- a/sqlmesh/integrations/dlt.py
+++ b/sqlmesh/integrations/dlt.py
@@ -111,7 +111,7 @@ SELECT
 FROM
   {from_table}
 WHERE
-  _dlt_load_time BETWEEN @start_ds AND @end_ds
+  {time_column} BETWEEN @start_ds AND @end_ds
 """
 
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -728,7 +728,7 @@ SELECT
 FROM
   sushi_dataset.sushi_types
 WHERE
-  _dlt_load_time BETWEEN @start_ds AND @end_ds
+  TO_TIMESTAMP(CAST(_dlt_load_id AS DOUBLE)) BETWEEN @start_ds AND @end_ds
 """
 
     with open(tmp_path / "models/incremental_sushi_types.sql") as file:
@@ -759,7 +759,7 @@ SELECT
 FROM
   sushi_dataset._dlt_loads
 WHERE
-  _dlt_load_time BETWEEN @start_ds AND @end_ds
+  TO_TIMESTAMP(CAST(load_id AS DOUBLE)) BETWEEN @start_ds AND @end_ds
 """
 
     with open(tmp_path / "models/incremental__dlt_loads.sql") as file:


### PR DESCRIPTION
Fix issue with generated dlt incremental query for dialects that don't support using alias reference for filtering by using the table column from the from clause