### PR TITLE
Fix: use parentheses for databricks' CLUSTER BY clause

### DIFF
--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -280,7 +280,10 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
             table_kind=table_kind,
         )
         if clustered_by:
-            clustered_by_exp = exp.Cluster(expressions=[exp.column(col) for col in clustered_by])
+            cluster_key = exp.maybe_parse(
+                f"({','.join(clustered_by)})", into=exp.Ordered, dialect="databricks"
+            )
+            clustered_by_exp = exp.Cluster(expressions=[cluster_key])
             expressions = properties.expressions if properties else []
             expressions.append(clustered_by_exp)
             properties = exp.Properties(expressions=expressions)

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -281,7 +281,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
         )
         if clustered_by:
             cluster_key = exp.maybe_parse(
-                f"({','.join(clustered_by)})", into=exp.Ordered, dialect="databricks"
+                f"({','.join(clustered_by)})", into=exp.Ordered, dialect=self.dialect
             )
             clustered_by_exp = exp.Cluster(expressions=[cluster_key])
             expressions = properties.expressions if properties else []

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -176,5 +176,5 @@ def test_create_table_clustered_by(make_mocked_engine_adapter: t.Callable):
 
     sql_calls = to_sql_calls(adapter)
     assert sql_calls == [
-        "CREATE TABLE IF NOT EXISTS `test_table` (`cola` INT, `colb` STRING) CLUSTER BY `cola`",
+        "CREATE TABLE IF NOT EXISTS `test_table` (`cola` INT, `colb` STRING) CLUSTER BY (`cola`)",
     ]


### PR DESCRIPTION
Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1728573925367219?thread_ts=1728490239.247289&cid=C044BRE5W4S