### PR TITLE
Fix: refactor table part parsing for Snowflake

### DIFF
--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -93,17 +93,10 @@ class Loader(abc.ABC):
         self._config_mtimes = {path: max(mtimes) for path, mtimes in config_mtimes.items()}
 
         macros, jinja_macros = self._load_scripts()
-
-        # All macros need to be known at parse time
-        standard_macros = macro.get_registry()
-        macro.set_registry(macros)
-
         audits = self._load_audits(macros=macros, jinja_macros=jinja_macros)
         models = self._load_models(
             macros, jinja_macros, context.gateway or context.config.default_gateway, audits or None
         )
-
-        macro.set_registry(standard_macros)
 
         for model in models.values():
             self._add_model_to_dag(model)


### PR DESCRIPTION
I found out that my recent [fix](https://github.com/TobikoData/sqlmesh/commit/d70092e69e5e1f8a6fdec41adc3e1d052176e6ee) wasn't complete. It works when someone's loading their SQLMesh project for the first time, but when the models are loaded from cache we fail to parse them because the global macro registry has already been reset and only contains the standard macros.

Since relying on the registry proved to be brittle, I decided to refactor the existing parsing logic altogether. For context, these are some past commits that aimed to address staged file path parsing edge cases:

- https://github.com/TobikoData/sqlmesh/commit/30071ccb009c2eebad585065b095e976ca1bf5cd
- https://github.com/TobikoData/sqlmesh/pull/2412/files
- https://github.com/TobikoData/sqlmesh/pull/2714
- https://github.com/tobikoData/sqlmesh/commit/932167933877a2e7f50f12e180c68d4ff0e4506a