### PR TITLE
Feat!: Create temp tables only when needed

### DIFF
--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -1614,14 +1614,8 @@ def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
             return None
 
         # confirm physical layer comments are registered
-        validate_comments(f"sqlmesh__{sushi_test_schema}", prod_schema_name=sushi_test_schema)
-        # confirm physical temp table comments are not registered
-        validate_no_comments(
-            f"sqlmesh__{sushi_test_schema}",
-            table_name_suffix="__temp",
-            check_temp_tables=True,
-            prod_schema_name=sushi_test_schema,
-        )
+        validate_comments("sqlmesh__sushi")
+
         # confirm view layer comments are not registered in non-PROD environment
         env_name = "test_prod"
         if plan.environment_naming_info and plan.environment_naming_info.normalize_name:
@@ -1752,7 +1746,7 @@ def test_init_project(ctx: TestContext, tmp_path: pathlib.Path):
     physical_layer_results = ctx.get_metadata_results(object_names["physical_schema"][0])
     assert len(physical_layer_results.views) == 0
     assert len(physical_layer_results.materialized_views) == 0
-    assert len(physical_layer_results.tables) == len(physical_layer_results.non_temp_tables) == 6
+    assert len(physical_layer_results.tables) == len(physical_layer_results.non_temp_tables) == 3
 
     # make and validate unmodified dev environment
     no_change_plan: Plan = context.plan(

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -1613,8 +1613,7 @@ def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
 
             return None
 
-        # confirm physical layer comments are registered
-        validate_comments("sqlmesh__sushi")
+        validate_comments(f"sqlmesh__{sushi_test_schema}", prod_schema_name=sushi_test_schema)
 
         # confirm view layer comments are not registered in non-PROD environment
         env_name = "test_prod"

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -1202,9 +1202,6 @@ def test_select_models(init_and_plan_context: t.Callable):
     assert context.engine_adapter.table_exists(
         context.get_snapshot("sushi.top_waiters").table_name()
     )
-    assert context.engine_adapter.table_exists(
-        context.get_snapshot("sushi.top_waiters").table_name(False)
-    )
 
 
 @freeze_time("2023-01-08 15:00:00")
@@ -2380,7 +2377,7 @@ def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
     ) = get_default_catalog_and_non_tables(metadata, context.default_catalog)
     assert len(prod_views) == 13
     assert len(dev_views) == 0
-    assert len(user_default_tables) == 24
+    assert len(user_default_tables) == 12
     assert state_metadata.schemas == ["sqlmesh"]
     assert {x.sql() for x in state_metadata.qualified_tables}.issuperset(
         {
@@ -2399,7 +2396,7 @@ def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
     ) = get_default_catalog_and_non_tables(metadata, context.default_catalog)
     assert len(prod_views) == 13
     assert len(dev_views) == 13
-    assert len(user_default_tables) == 24
+    assert len(user_default_tables) == 12
     assert len(non_default_tables) == 0
     assert state_metadata.schemas == ["sqlmesh"]
     assert {x.sql() for x in state_metadata.qualified_tables}.issuperset(
@@ -2419,7 +2416,7 @@ def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
     ) = get_default_catalog_and_non_tables(metadata, context.default_catalog)
     assert len(prod_views) == 13
     assert len(dev_views) == 26
-    assert len(user_default_tables) == 24
+    assert len(user_default_tables) == 12
     assert len(non_default_tables) == 0
     assert state_metadata.schemas == ["sqlmesh"]
     assert {x.sql() for x in state_metadata.qualified_tables}.issuperset(
@@ -2440,7 +2437,7 @@ def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
     ) = get_default_catalog_and_non_tables(metadata, context.default_catalog)
     assert len(prod_views) == 13
     assert len(dev_views) == 13
-    assert len(user_default_tables) == 24
+    assert len(user_default_tables) == 12
     assert len(non_default_tables) == 0
     assert state_metadata.schemas == ["sqlmesh"]
     assert {x.sql() for x in state_metadata.qualified_tables}.issuperset(


### PR DESCRIPTION
This aims to minimise unnecessary table creation (fixes: #2496 ) by skipping the creation of dev `__temp tables` when not needed, ie if snapshot `is_deployable` and doesn't reuse previous version (`forward_only`, `indirect_non_breaking`, `metadata`). In that case only prod table is created and the dry run is performed on this.