### PR TITLE
Fix(clickhouse): remove fractional seconds when time column is datetime/timestamp type

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -629,11 +629,9 @@ class _Model(ModelMeta, frozen=True):
                 time,
                 time_column_type,
                 self.time_column.format,
-                include_fractional_seconds=not (
-                    self.dialect in TIME_COLUMN_NO_FRACTIONAL_SECOND_TYPES
-                    and time_column_type.is_type(
-                        *TIME_COLUMN_NO_FRACTIONAL_SECOND_TYPES[self.dialect]
-                    )
+                include_microseconds=not (
+                    self.dialect in NO_MICROSECONDS
+                    and time_column_type.is_type(*NO_MICROSECONDS[self.dialect])
                 ),
             )
         return exp.convert(time)
@@ -2452,6 +2450,4 @@ def get_model_name(path: Path) -> str:
     return ".".join(path_parts[-3:])
 
 
-TIME_COLUMN_NO_FRACTIONAL_SECOND_TYPES = {
-    "clickhouse": (exp.DataType.Type.DATETIME, exp.DataType.Type.TIMESTAMP)
-}
+NO_MICROSECONDS = {"clickhouse": (exp.DataType.Type.DATETIME, exp.DataType.Type.TIMESTAMP)}

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -625,7 +625,17 @@ class _Model(ModelMeta, frozen=True):
 
             time_column_type = columns_to_types[self.time_column.column.name]
 
-            return to_time_column(time, time_column_type, self.time_column.format)
+            return to_time_column(
+                time,
+                time_column_type,
+                self.time_column.format,
+                include_fractional_seconds=not (
+                    self.dialect in TIME_COLUMN_NO_FRACTIONAL_SECOND_TYPES
+                    and time_column_type.is_type(
+                        *TIME_COLUMN_NO_FRACTIONAL_SECOND_TYPES[self.dialect]
+                    )
+                ),
+            )
         return exp.convert(time)
 
     def set_mapping_schema(self, schema: t.Dict) -> None:
@@ -2440,3 +2450,8 @@ META_FIELD_CONVERTER: t.Dict[str, t.Callable] = {
 def get_model_name(path: Path) -> str:
     path_parts = list(path.parts[path.parts.index("models") + 1 : -1]) + [path.stem]
     return ".".join(path_parts[-3:])
+
+
+TIME_COLUMN_NO_FRACTIONAL_SECOND_TYPES = {
+    "clickhouse": (exp.DataType.Type.DATETIME, exp.DataType.Type.TIMESTAMP)
+}

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -630,8 +630,8 @@ class _Model(ModelMeta, frozen=True):
                 time_column_type,
                 self.time_column.format,
                 include_microseconds=not (
-                    self.dialect in NO_MICROSECONDS
-                    and time_column_type.is_type(*NO_MICROSECONDS[self.dialect])
+                    self.dialect in TIME_COLUMN_NO_MICROSECONDS_TYPES
+                    and time_column_type.is_type(*TIME_COLUMN_NO_MICROSECONDS_TYPES[self.dialect])
                 ),
             )
         return exp.convert(time)
@@ -2450,4 +2450,6 @@ def get_model_name(path: Path) -> str:
     return ".".join(path_parts[-3:])
 
 
-NO_MICROSECONDS = {"clickhouse": (exp.DataType.Type.DATETIME, exp.DataType.Type.TIMESTAMP)}
+TIME_COLUMN_NO_MICROSECONDS_TYPES = {
+    "clickhouse": (exp.DataType.Type.DATETIME, exp.DataType.Type.TIMESTAMP)
+}

--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -256,18 +256,18 @@ def to_ds(obj: TimeLike) -> str:
     return to_ts(obj)[0:10]
 
 
-def to_ts(obj: TimeLike, include_fractional_seconds: bool = True) -> str:
+def to_ts(obj: TimeLike, include_microseconds: bool = True) -> str:
     """Converts a TimeLike object into YYYY-MM-DD HH:MM:SS formatted string."""
     obj_dt = to_datetime(obj)
-    if not include_fractional_seconds:
+    if not include_microseconds:
         obj_dt = obj_dt.replace(microsecond=0)
     return obj_dt.replace(tzinfo=None).isoformat(sep=" ")
 
 
-def to_tstz(obj: TimeLike, include_fractional_seconds: bool = True) -> str:
+def to_tstz(obj: TimeLike, include_microseconds: bool = True) -> str:
     """Converts a TimeLike object into YYYY-MM-DD HH:MM:SS+00:00 formatted string."""
     obj_dt = to_datetime(obj)
-    if not include_fractional_seconds:
+    if not include_microseconds:
         obj_dt = obj_dt.replace(microsecond=0)
     return obj_dt.isoformat(sep=" ")
 
@@ -353,7 +353,7 @@ def to_time_column(
     time_column: t.Union[TimeLike, exp.Null],
     time_column_type: exp.DataType,
     time_column_format: t.Optional[str] = None,
-    include_fractional_seconds: bool = True,
+    include_microseconds: bool = True,
 ) -> exp.Expression:
     """Convert a TimeLike object to the same time format and type as the model's time column."""
     if isinstance(time_column, exp.Null):
@@ -362,12 +362,12 @@ def to_time_column(
         return exp.cast(exp.Literal.string(to_ds(time_column)), to="date")
     if time_column_type.is_type(*TEMPORAL_TZ_TYPES):
         return exp.cast(
-            exp.Literal.string(to_tstz(time_column, include_fractional_seconds)),
+            exp.Literal.string(to_tstz(time_column, include_microseconds)),
             to=time_column_type,
         )
     if time_column_type.is_type(*exp.DataType.TEMPORAL_TYPES):
         return exp.cast(
-            exp.Literal.string(to_ts(time_column, include_fractional_seconds)), to=time_column_type
+            exp.Literal.string(to_ts(time_column, include_microseconds)), to=time_column_type
         )
 
     if time_column_format:

--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -295,7 +295,7 @@ def make_inclusive(start: TimeLike, end: TimeLike) -> Interval:
     In the ds ('2020-01-01') case, because start_ds and end_ds are categorical, between works even if
     start_ds and end_ds are equivalent. However, when we move to ts ('2022-01-01 12:00:00'), because timestamps
     are numeric, using simple equality doesn't make sense. When the end is not a categorical date, then it is
-    treated as an exclusive range and converted to inclusive by subtracting 1 millisecond.
+    treated as an exclusive range and converted to inclusive by subtracting 1 microsecond.
 
     Args:
         start: Start timelike object.


### PR DESCRIPTION
In some scenarios, the end of SQLMesh's incremental by time filter is created by subtracting 1 microsecond from a date, resulting in fractional seconds. For example, `2024-01-02` minus 1 microsecond = `2024-01-01 23:59:59.999999`.

Clickhouse's `DateTime` data type (and alias timestamp) only support second precision, so an error is thrown when it tries to cast fractional seconds to `DateTime`.

This PR prevents that error by removing the fractional seconds when the time column is `DateTime` or timestamp types.