### PR TITLE
feat!: run-all bot command errors if anything within it errors

### DIFF
--- a/tests/integrations/github/cicd/test_github_commands.py
+++ b/tests/integrations/github/cicd/test_github_commands.py
@@ -16,7 +16,7 @@ from sqlmesh.integrations.github.cicd.controller import (
     GithubCheckConclusion,
     GithubCheckStatus,
 )
-from sqlmesh.utils.errors import ConflictingPlanError, PlanError, TestError
+from sqlmesh.utils.errors import ConflictingPlanError, PlanError, TestError, CICDBotError
 
 pytest_plugins = ["tests.integrations.github.cicd.fixtures"]
 pytestmark = [
@@ -461,7 +461,8 @@ def test_run_all_test_failed(
     github_output_file = tmp_path / "github_output.txt"
 
     with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(github_output_file)}):
-        command._run_all(controller)
+        with pytest.raises(CICDBotError):
+            command._run_all(controller)
 
     assert "SQLMesh - Run Unit Tests" in controller._check_run_mapping
     test_checks_runs = controller._check_run_mapping["SQLMesh - Run Unit Tests"].all_kwargs
@@ -593,7 +594,8 @@ def test_run_all_test_exception(
     github_output_file = tmp_path / "github_output.txt"
 
     with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(github_output_file)}):
-        command._run_all(controller)
+        with pytest.raises(CICDBotError):
+            command._run_all(controller)
 
     assert "SQLMesh - Run Unit Tests" in controller._check_run_mapping
     test_checks_runs = controller._check_run_mapping["SQLMesh - Run Unit Tests"].all_kwargs
@@ -727,7 +729,8 @@ def test_pr_update_failure(
     github_output_file = tmp_path / "github_output.txt"
 
     with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(github_output_file)}):
-        command._run_all(controller)
+        with pytest.raises(CICDBotError):
+            command._run_all(controller)
 
     assert "SQLMesh - PR Environment Synced" in controller._check_run_mapping
     pr_checks_runs = controller._check_run_mapping["SQLMesh - PR Environment Synced"].all_kwargs
@@ -851,7 +854,8 @@ def make_test_prod_update_failure_case(
     github_output_file = tmp_path / "github_output.txt"
 
     with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(github_output_file)}):
-        command._run_all(controller)
+        with pytest.raises(CICDBotError):
+            command._run_all(controller)
 
     assert "SQLMesh - Prod Plan Preview" in controller._check_run_mapping
     prod_plan_preview_checks_runs = controller._check_run_mapping[

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -23,6 +23,7 @@ from sqlmesh.integrations.github.cicd.controller import (
     GithubCheckStatus,
     GithubController,
 )
+from sqlmesh.utils.errors import CICDBotError
 from tests.integrations.github.cicd.fixtures import MockIssueComment
 
 pytest_plugins = ["tests.integrations.github.cicd.fixtures"]
@@ -509,7 +510,8 @@ def test_merge_pr_has_non_breaking_change_no_categorization(
     github_output_file = tmp_path / "github_output.txt"
 
     with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(github_output_file)}):
-        command._run_all(controller)
+        with pytest.raises(CICDBotError):
+            command._run_all(controller)
 
     assert "SQLMesh - Run Unit Tests" in controller._check_run_mapping
     test_checks_runs = controller._check_run_mapping["SQLMesh - Run Unit Tests"].all_kwargs
@@ -1347,7 +1349,8 @@ def test_error_msg_when_applying_plan_with_bug(
     github_output_file = tmp_path / "github_output.txt"
 
     with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(github_output_file)}):
-        command._run_all(controller)
+        with pytest.raises(CICDBotError):
+            command._run_all(controller)
 
     assert "SQLMesh - Run Unit Tests" in controller._check_run_mapping
     test_checks_runs = controller._check_run_mapping["SQLMesh - Run Unit Tests"].all_kwargs


### PR DESCRIPTION
Prior to this change the `run-all` command would report it's status as a representation if the command itself ran successfully. If you want to get the status of any sub-command, then you would check the bot output. 

This change makes is to that if a test fails, a PR environment is not updated, a prod plan is not generated, or a user has provided approval to deploy and the deploy to prod did not happen, then it will error. You will still need to check bot outputs/check status to fully understand what happened. 

If a user has configured required approvers and no one has approved, then that is a fail on the condition check but the script will still pass. The argument for this is that this can likely be an expected state and not an issue at all. 