### PR TITLE
Fix: ensure Redshift's _fetch_native_df respects case-sensitivity

### DIFF
--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import typing as t
 
 import pandas as pd
@@ -25,6 +26,8 @@ from sqlmesh.core.schema_diff import SchemaDiffer
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import SchemaName, TableName
     from sqlmesh.core.engine_adapter.base import QueryOrDF
+
+logger = logging.getLogger(__name__)
 
 
 @set_catalog()
@@ -128,7 +131,23 @@ class RedshiftEngineAdapter(
     ) -> pd.DataFrame:
         """Fetches a Pandas DataFrame from the cursor"""
         self.execute(query, quote_identifiers=quote_identifiers)
-        return self.cursor.fetch_dataframe()
+
+        # We manually build the `DataFrame` here because the driver's `fetch_dataframe`
+        # method does not respect the active case-sensitivity configuration.
+        #
+        # Context: https://github.com/aws/amazon-redshift-python-driver/issues/238
+        fetcheddata = self.cursor.fetchall()
+
+        try:
+            columns = [column[0] for column in self.cursor.description]
+        except Exception:
+            columns = None
+            logging.warning(
+                "No row description was found, pandas dataframe will be missing column labels."
+            )
+
+        result = [tuple(row) for row in fetcheddata]
+        return pd.DataFrame(result, columns=columns)
 
     def _create_table_from_source_queries(
         self,

--- a/tests/core/engine_adapter/integration/test_integration_redshift.py
+++ b/tests/core/engine_adapter/integration/test_integration_redshift.py
@@ -85,3 +85,12 @@ def test_columns(ctx: TestContext):
             {k: columns[k] for k in max_cols}
         ).values()
     ] == ["CHAR(max)", "CHAR(max)", "CHAR(max)", "VARCHAR(max)", "VARCHAR(max)", "VARCHAR(max)"]
+
+
+def test_fetch_native_df_respects_case_sensitivity(ctx: TestContext):
+    adapter = ctx.engine_adapter
+    adapter.execute("SET enable_case_sensitive_identifier TO true")
+    assert adapter.fetchdf('WITH t AS (SELECT 1 AS "C", 2 AS "c") SELECT * FROM t').to_dict() == {
+        "C": {0: 1},
+        "c": {0: 2},
+    }


### PR DESCRIPTION
Motivation behind this: an issue [reported](https://tobiko-data.slack.com/archives/C044BRE5W4S/p1729069676277209) by a user in our public Slack. FYI, I've opened a [ticket](https://github.com/aws/amazon-redshift-python-driver/issues/238) and a PR for this upstream.