### PR TITLE
Fix: ensure 'except' columns are always filtered out in star macro

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -890,7 +890,7 @@ def star(
         exp.column(column, table=table_identifier, quoted=quoted).as_(
             f"{prefix.this}{column}{suffix.this}", quoted=quoted
         )
-        for column, type_ in evaluator.columns_to_types(relation).items()
+        for column, type_ in columns_to_types.items()
     ]
 
 

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -101,7 +101,7 @@ def macro_evaluator() -> MacroEvaluator:
 
 def test_star(assert_exp_eq) -> None:
     sql = """SELECT @STAR(foo) FROM foo"""
-    expected_sql = """SELECT CAST([foo].[a] AS DATETIMEOFFSET) AS [a], CAST([foo].[b] AS INTEGER) AS [b] FROM foo"""
+    expected_sql = "SELECT CAST([foo].[a] AS DATETIMEOFFSET) AS [a], CAST([foo].[b] AS INTEGER) AS [b] FROM foo"
     schema = MappingSchema(
         {
             "foo": {
@@ -114,7 +114,7 @@ def test_star(assert_exp_eq) -> None:
     evaluator = MacroEvaluator(schema=schema, dialect="tsql")
     assert_exp_eq(evaluator.transform(parse_one(sql, read="tsql")), expected_sql, dialect="tsql")
 
-    sql = """SELECT @STAR(foo, exclude := [SomeColumn]) FROM foo"""
+    sql = "SELECT @STAR(foo, exclude := [SomeColumn]) FROM foo"
     expected_sql = "SELECT CAST(`foo`.`a` AS STRING) AS `a` FROM foo"
     schema = MappingSchema(
         {
@@ -131,6 +131,20 @@ def test_star(assert_exp_eq) -> None:
         expected_sql,
         dialect="databricks",
     )
+
+    sql = "SELECT @STAR(foo, exclude := ARRAY(b)) FROM foo"
+    expected_sql = "SELECT [foo].[a] AS [a] FROM foo"
+    schema = MappingSchema(
+        {
+            "foo": {
+                "a": exp.DataType.build("unknown"),
+                "b": "int",
+            },
+        },
+        dialect="tsql",
+    )
+    evaluator = MacroEvaluator(schema=schema, dialect="tsql")
+    assert_exp_eq(evaluator.transform(parse_one(sql, read="tsql")), expected_sql, dialect="tsql")
 
 
 def test_start_no_column_types(assert_exp_eq) -> None:


### PR DESCRIPTION
Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1729271791196899