### PR TITLE
Fix(clickhouse): use DateTime64(6) type in incremental time filter

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -330,21 +330,21 @@ workflows:
           name: cloud_engine_<< matrix.engine >>
           context:
             - sqlmesh_cloud_database_integration
-          requires:
-            - engine_tests_docker
+          # requires:
+          #   - engine_tests_docker
           matrix:
             parameters:
               engine:
-                - snowflake
-                - databricks
-                - redshift
-                - bigquery
+                # - snowflake
+                # - databricks
+                # - redshift
+                # - bigquery
                 - clickhouse-cloud
-                - athena
-          filters:
-           branches:
-             only:
-               - main
+                # - athena
+          # filters:
+          #  branches:
+          #    only:
+          #      - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -330,21 +330,21 @@ workflows:
           name: cloud_engine_<< matrix.engine >>
           context:
             - sqlmesh_cloud_database_integration
-          # requires:
-          #   - engine_tests_docker
+          requires:
+            - engine_tests_docker
           matrix:
             parameters:
               engine:
-                # - snowflake
-                # - databricks
-                # - redshift
-                # - bigquery
+                - snowflake
+                - databricks
+                - redshift
+                - bigquery
                 - clickhouse-cloud
-                # - athena
-          # filters:
-          #  branches:
-          #    only:
-          #      - main
+                - athena
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1460,7 +1460,7 @@ class EngineAdapter:
         # column names and then remove them from the unmanaged_columns
         if check_columns and check_columns == exp.Star():
             check_columns = [exp.column(col) for col in unmanaged_columns_to_types]
-        execution_ts = to_time_column(execution_time, time_data_type)
+        execution_ts = to_time_column(execution_time, time_data_type, self.dialect, nullable=True)
         if updated_at_as_valid_from:
             if not updated_at_col:
                 raise SQLMeshError(
@@ -1473,7 +1473,9 @@ class EngineAdapter:
         elif check_columns and (execution_time_as_valid_from or not truncate):
             update_valid_from_start = execution_ts
         else:
-            update_valid_from_start = to_time_column("1970-01-01 00:00:00+00:00", time_data_type)
+            update_valid_from_start = to_time_column(
+                "1970-01-01 00:00:00+00:00", time_data_type, self.dialect, nullable=True
+            )
         insert_valid_from_start = execution_ts if check_columns else updated_at_col  # type: ignore
         # joined._exists IS NULL is saying "if the row is deleted"
         delete_check = (
@@ -1739,7 +1741,9 @@ class EngineAdapter:
                     exp.select(
                         *unmanaged_columns_to_types,
                         insert_valid_from_start.as_(valid_from_col.this),  # type: ignore
-                        to_time_column(exp.null(), time_data_type).as_(valid_to_col.this),
+                        to_time_column(exp.null(), time_data_type, self.dialect, nullable=True).as_(
+                            valid_to_col.this
+                        ),
                     )
                     .from_("joined")
                     .where(updated_row_filter),

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -630,11 +630,8 @@ class _Model(ModelMeta, frozen=True):
             return to_time_column(
                 time,
                 time_column_type,
+                self.dialect,
                 self.time_column.format,
-                include_microseconds=not (
-                    self.dialect in TIME_COLUMN_NO_MICROSECONDS_TYPES
-                    and time_column_type.is_type(*TIME_COLUMN_NO_MICROSECONDS_TYPES[self.dialect])
-                ),
             )
         return exp.convert(time)
 
@@ -2452,8 +2449,3 @@ META_FIELD_CONVERTER: t.Dict[str, t.Callable] = {
 def get_model_name(path: Path) -> str:
     path_parts = list(path.parts[path.parts.index("models") + 1 : -1]) + [path.stem]
     return ".".join(path_parts[-3:])
-
-
-TIME_COLUMN_NO_MICROSECONDS_TYPES = {
-    "clickhouse": (exp.DataType.Type.DATETIME, exp.DataType.Type.TIMESTAMP)
-}

--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -256,20 +256,14 @@ def to_ds(obj: TimeLike) -> str:
     return to_ts(obj)[0:10]
 
 
-def to_ts(obj: TimeLike, include_microseconds: bool = True) -> str:
+def to_ts(obj: TimeLike) -> str:
     """Converts a TimeLike object into YYYY-MM-DD HH:MM:SS formatted string."""
-    obj_dt = to_datetime(obj)
-    if not include_microseconds:
-        obj_dt = obj_dt.replace(microsecond=0)
-    return obj_dt.replace(tzinfo=None).isoformat(sep=" ")
+    return to_datetime(obj).replace(tzinfo=None).isoformat(sep=" ")
 
 
-def to_tstz(obj: TimeLike, include_microseconds: bool = True) -> str:
+def to_tstz(obj: TimeLike) -> str:
     """Converts a TimeLike object into YYYY-MM-DD HH:MM:SS+00:00 formatted string."""
-    obj_dt = to_datetime(obj)
-    if not include_microseconds:
-        obj_dt = obj_dt.replace(microsecond=0)
-    return obj_dt.isoformat(sep=" ")
+    return to_datetime(obj).isoformat(sep=" ")
 
 
 def is_date(obj: TimeLike) -> bool:
@@ -352,23 +346,41 @@ def is_categorical_relative_expression(expression: str) -> bool:
 def to_time_column(
     time_column: t.Union[TimeLike, exp.Null],
     time_column_type: exp.DataType,
+    dialect: str,
     time_column_format: t.Optional[str] = None,
-    include_microseconds: bool = True,
+    nullable: bool = False,
 ) -> exp.Expression:
     """Convert a TimeLike object to the same time format and type as the model's time column."""
+    if dialect == "clickhouse" and time_column_type.is_type(
+        *(exp.DataType.TEMPORAL_TYPES - {exp.DataType.Type.DATE, exp.DataType.Type.DATE32})
+    ):
+        if time_column_type.is_type(exp.DataType.Type.DATETIME64):
+            if nullable:
+                time_column_type.set("nullable", nullable)
+        else:
+            # Clickhouse will error if we pass fractional seconds to DateTime, so we always
+            # use DateTime64 for timestamps.
+            #
+            # `datetime` objects have microsecond precision, so we specify the type precision as 6.
+            # If a timezone is present in the passed type object, it is included in the DateTime64 type
+            # via the `expressions` arg.
+            time_column_type = exp.DataType.build(
+                exp.DataType.Type.DATETIME64,
+                expressions=[
+                    exp.DataTypeParam(this=exp.Literal(this=6, is_string=False)),
+                    *time_column_type.expressions,
+                ],
+                nullable=nullable or time_column_type.args.get("nullable", False),
+            )
+
     if isinstance(time_column, exp.Null):
         return exp.cast(time_column, to=time_column_type)
-    if time_column_type.is_type(exp.DataType.Type.DATE):
+    if time_column_type.is_type(exp.DataType.Type.DATE, exp.DataType.Type.DATE32):
         return exp.cast(exp.Literal.string(to_ds(time_column)), to="date")
     if time_column_type.is_type(*TEMPORAL_TZ_TYPES):
-        return exp.cast(
-            exp.Literal.string(to_tstz(time_column, include_microseconds)),
-            to=time_column_type,
-        )
+        return exp.cast(exp.Literal.string(to_tstz(time_column)), to=time_column_type)
     if time_column_type.is_type(*exp.DataType.TEMPORAL_TYPES):
-        return exp.cast(
-            exp.Literal.string(to_ts(time_column, include_microseconds)), to=time_column_type
-        )
+        return exp.cast(exp.Literal.string(to_ts(time_column)), to=time_column_type)
 
     if time_column_format:
         time_column = to_datetime(time_column).strftime(time_column_format)

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -1838,7 +1838,7 @@ def test_dialects(ctx: TestContext):
     [
         (
             exp.null(),
-            exp.DataType.build("TIMESTAMP"),
+            exp.DataType.build("TIMESTAMP", nullable=True),
             None,
             {
                 "default": None,
@@ -1913,7 +1913,7 @@ def test_to_time_column(
         time_column = re.match(r"^(.*?)\+", time_column).group(1)
         time_column_type = exp.DataType.build("TIMESTAMP('UTC')", dialect="clickhouse")
 
-    time_column = to_time_column(time_column, time_column_type, time_column_format)
+    time_column = to_time_column(time_column, time_column_type, ctx.dialect, time_column_format)
     df = ctx.engine_adapter.fetchdf(exp.select(time_column).as_("the_col"))
     expected = result.get(ctx.dialect, result.get("default"))
     col_name = "THE_COL" if ctx.dialect == "snowflake" else "the_col"

--- a/tests/core/engine_adapter/test_clickhouse.py
+++ b/tests/core/engine_adapter/test_clickhouse.py
@@ -11,7 +11,6 @@ from sqlmesh.core.schema_diff import SchemaDiffer
 from datetime import datetime
 from pytest_mock.plugin import MockerFixture
 from sqlmesh.core import dialect as d
-from sqlmesh.utils.date import to_datetime
 
 pytestmark = [pytest.mark.clickhouse, pytest.mark.engine]
 
@@ -581,14 +580,14 @@ WITH "source" AS (
         ELSE "test_UPDATED_at"
       END
       WHEN "t_test_valid_from" IS NULL
-      THEN CAST('1970-01-01 00:00:00' AS Nullable(DateTime))
+      THEN CAST('1970-01-01 00:00:00' AS Nullable(DateTime64(6)))
       ELSE "t_test_valid_from"
     END AS "test_valid_from",
     CASE
       WHEN "joined"."test_UPDATED_at" > "joined"."t_test_UPDATED_at"
       THEN "joined"."test_UPDATED_at"
       WHEN "joined"."_exists" IS NULL
-      THEN CAST('2020-01-01 00:00:00' AS Nullable(DateTime))
+      THEN CAST('2020-01-01 00:00:00' AS Nullable(DateTime64(6)))
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
   FROM "joined"
@@ -604,7 +603,7 @@ WITH "source" AS (
     "price",
     "test_UPDATED_at",
     "test_UPDATED_at" AS "test_valid_from",
-    CAST(NULL AS Nullable(DateTime)) AS "test_valid_to"
+    CAST(NULL AS Nullable(DateTime64(6))) AS "test_valid_to"
   FROM "joined"
   WHERE
     "joined"."test_UPDATED_at" > "joined"."t_test_UPDATED_at"
@@ -747,7 +746,7 @@ WITH "source" AS (
     COALESCE("joined"."t_id", "joined"."id") AS "id",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
     COALESCE("joined"."t_price", "joined"."price") AS "price",
-    COALESCE("t_test_VALID_from", CAST('2020-01-01 00:00:00' AS Nullable(DateTime))) AS "test_VALID_from",
+    COALESCE("t_test_VALID_from", CAST('2020-01-01 00:00:00' AS Nullable(DateTime64(6)))) AS "test_VALID_from",
     CASE
       WHEN "joined"."_exists" IS NULL
       OR (
@@ -771,7 +770,7 @@ WITH "source" AS (
           )
         )
       )
-      THEN CAST('2020-01-01 00:00:00' AS Nullable(DateTime))
+      THEN CAST('2020-01-01 00:00:00' AS Nullable(DateTime64(6)))
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
   FROM "joined"
@@ -782,8 +781,8 @@ WITH "source" AS (
     "id",
     "name",
     "price",
-    CAST('2020-01-01 00:00:00' AS Nullable(DateTime)) AS "test_VALID_from",
-    CAST(NULL AS Nullable(DateTime)) AS "test_valid_to"
+    CAST('2020-01-01 00:00:00' AS Nullable(DateTime64(6))) AS "test_VALID_from",
+    CAST(NULL AS Nullable(DateTime64(6))) AS "test_valid_to"
   FROM "joined"
   WHERE
     (
@@ -813,7 +812,7 @@ SELECT "id", "name", "price", "test_VALID_from", "test_valid_to" FROM "static" U
 
 
 def test_to_time_column():
-    # datetime/timestamp data type should remove fractional seconds
+    # we should get DateTime64(6) back for any temporal type other than explicit DateTime64
     expressions = d.parse(
         """
         MODEL (
@@ -828,14 +827,12 @@ def test_to_time_column():
     """
     )
     model = load_sql_based_model(expressions)
-    assert model.convert_to_time_column("2022-01-01 00:00:00.000001").this == d.parse_one(
-        "'2022-01-01 00:00:00'"
+    assert (
+        model.convert_to_time_column("2022-01-01 00:00:00.000001").sql("clickhouse")
+        == "CAST('2022-01-01 00:00:00.000001' AS DateTime64(6))"
     )
-    assert model.convert_to_time_column(
-        to_datetime("2022-01-01 00:00:00.000001")
-    ).this == d.parse_one("'2022-01-01 00:00:00'")
 
-    # DateTime64 data type should retain fractional seconds
+    # We should respect the user's DateTime64 precision if specified
     expressions = d.parse(
         """
         MODEL (
@@ -846,13 +843,38 @@ def test_to_time_column():
             dialect clickhouse
         );
 
-        SELECT ds::DateTime64
+        SELECT ds::DateTime64(4)
     """
     )
     model = load_sql_based_model(expressions)
-    assert model.convert_to_time_column("2022-01-01 00:00:00.000001").this == d.parse_one(
-        "'2022-01-01 00:00:00.000001'"
+    assert (
+        model.convert_to_time_column("2022-01-01 00:00:00.000001").sql("clickhouse")
+        == "CAST('2022-01-01 00:00:00.000001' AS DateTime64(4))"
     )
-    assert model.convert_to_time_column(
-        to_datetime("2022-01-01 00:00:00.000001")
-    ).this == d.parse_one("'2022-01-01 00:00:00.000001'")
+
+    # We should respect the user's DateTime64 precision if specified, even if we're making it nullable
+    from sqlmesh.utils.date import to_time_column
+
+    expressions = d.parse(
+        """
+        MODEL (
+            name db.table,
+            kind INCREMENTAL_BY_TIME_RANGE(
+                time_column (ds)
+            ),
+            dialect clickhouse
+        );
+
+        SELECT ds::DateTime64(4)
+    """
+    )
+    model = load_sql_based_model(expressions)
+    assert (
+        to_time_column(
+            "2022-01-01 00:00:00.000001",
+            exp.DataType.build("DateTime64(4)", dialect="clickhouse"),
+            dialect="clickhouse",
+            nullable=True,
+        ).sql("clickhouse")
+        == "CAST('2022-01-01 00:00:00.000001' AS Nullable(DateTime64(4)))"
+    )

--- a/tests/utils/test_date.py
+++ b/tests/utils/test_date.py
@@ -134,41 +134,47 @@ def test_to_tstz():
 
 
 @pytest.mark.parametrize(
-    "time_column, time_column_type, time_column_format, result",
+    "time_column, time_column_type, dialect, time_column_format, result",
     [
         (
             exp.null(),
             exp.DataType.build("TIMESTAMP"),
+            "",
             None,
             "CAST(NULL AS TIMESTAMP)",
         ),
         (
             "2020-01-01 00:00:00+00:00",
             exp.DataType.build("DATE"),
+            "",
             None,
             "CAST('2020-01-01' AS DATE)",
         ),
         (
             "2020-01-01 00:00:00+00:00",
             exp.DataType.build("TIMESTAMPTZ"),
+            "",
             None,
             "CAST('2020-01-01 00:00:00+00:00' AS TIMESTAMPTZ)",
         ),
         (
             "2020-01-01 00:00:00+00:00",
             exp.DataType.build("TIMESTAMP"),
+            "",
             None,
             "CAST('2020-01-01 00:00:00' AS TIMESTAMP)",
         ),
         (
             "2020-01-01 00:00:00+00:00",
             exp.DataType.build("TEXT"),
+            "",
             "%Y-%m-%dT%H:%M:%S%z",
             "'2020-01-01T00:00:00+0000'",
         ),
         (
             "2020-01-01 00:00:00+00:00",
             exp.DataType.build("INT"),
+            "",
             "%Y%m%d",
             "20200101",
         ),
@@ -177,10 +183,13 @@ def test_to_tstz():
 def test_to_time_column(
     time_column: t.Union[TimeLike, exp.Null],
     time_column_type: exp.DataType,
+    dialect: str,
     time_column_format: t.Optional[str],
     result: str,
 ):
-    assert to_time_column(time_column, time_column_type, time_column_format).sql() == result
+    assert (
+        to_time_column(time_column, time_column_type, dialect, time_column_format).sql() == result
+    )
 
 
 def test_date_dict():


### PR DESCRIPTION
### Clickhouse background
Clickhouse has two datetime types:
- `DateTime`: fixed one second precision
- `DateTime64`: user-specified precision (default of 3/millisecond when bare type passed)

Clickhouse errors if you try to cast a string containing fractional seconds to `DateTime`. 

### Current PR
SQLMesh time intervals are sometimes calculated as [datetime - 1 microsecond], returning values containing fractional seconds.

This PR prevents fractional second casting errors by always using `DateTime64` in incremental time filters. It uses a default precision of 6 unless the user explicitly passed `DateTime64`.

The returned type is non-nullable by default. In SCD models, however, we generate statements like `CAST(NULL AS DateTime64)` that require a nullable type. Therefore, we force nullable types when calling `to_time_column()` in the SCD adapter method.