### PR TITLE
Fix: Set yesterday before plan for the Airflow end-to-end and integration tests

### DIFF
--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -23,7 +23,7 @@ from sqlmesh.core.engine_adapter.shared import DataObject, DataObjectType
 from sqlmesh.core.model.definition import create_sql_model
 from sqlmesh.core.plan import Plan
 from sqlmesh.core.snapshot import Snapshot, SnapshotChangeCategory
-from sqlmesh.utils.date import now, to_date, to_time_column, yesterday
+from sqlmesh.utils.date import now, to_date, to_time_column
 from sqlmesh.utils.pydantic import PydanticModel
 from tests.conftest import SushiDataValidator
 from tests.core.engine_adapter.integration import TestContext, MetadataResults, TEST_SCHEMA
@@ -1340,8 +1340,9 @@ def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
 
     context = Context(paths=tmp_path, config=config, gateway=ctx.gateway)
 
-    start = to_date(now() - timedelta(days=7))
     end = now()
+    start = to_date(end - timedelta(days=7))
+    yesterday = to_date(end - timedelta(days=1))
 
     # Databricks requires the table property `delta.columnMapping.mode = 'name'` for
     # spaces in column names. Other engines error if it is set in the model definition,
@@ -1422,7 +1423,7 @@ def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
     data_validator.validate(
         f"{sushi_test_schema}.customer_revenue_lifetime",
         start,
-        yesterday(),
+        yesterday,
         env_name="test_prod",
         dialect=ctx.dialect,
         environment_naming_info=plan.environment_naming_info,
@@ -1643,7 +1644,7 @@ def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
     data_validator.validate(
         f"{sushi_test_schema}.customer_revenue_lifetime",
         start,
-        yesterday(),
+        yesterday,
         env_name="test_dev",
         dialect=ctx.dialect,
         environment_naming_info=no_change_plan.environment_naming_info,

--- a/tests/schedulers/airflow/test_end_to_end.py
+++ b/tests/schedulers/airflow/test_end_to_end.py
@@ -6,7 +6,7 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 
 from sqlmesh.core.context import Context
 from sqlmesh.schedulers.airflow.client import AirflowClient
-from sqlmesh.utils.date import now, to_date, yesterday
+from sqlmesh.utils.date import now, to_date
 from tests.conftest import SushiDataValidator
 
 pytestmark = [
@@ -25,8 +25,9 @@ def wait_for_airflow(airflow_client: AirflowClient):
 
 
 def test_sushi(mocker: MockerFixture, is_docker: bool):
-    start = to_date(now() - timedelta(days=7))
     end = now()
+    start = to_date(end - timedelta(days=7))
+    yesterday = to_date(end - timedelta(days=1))
 
     airflow_config = "airflow_config_docker" if is_docker else "airflow_config"
     context = Context(paths="./examples/sushi", config=airflow_config)
@@ -45,7 +46,7 @@ def test_sushi(mocker: MockerFixture, is_docker: bool):
     )
 
     data_validator.validate(
-        "sushi.customer_revenue_lifetime", start, yesterday(), env_name="test_dev"
+        "sushi.customer_revenue_lifetime", start, yesterday, env_name="test_dev"
     )
 
     # Ensure that the plan has been applied successfully.


### PR DESCRIPTION
Update to the airflow end-to-end test and the engine adapter integration tests to set the date of `yesterday` before plan execution. This is to ensure that in the unlikely event the tests are run just before midnight, the date is aligned with the `end` date that was set from `now()`.