### PR TITLE
Fix(athena): Use 'catalog_name' as the default catalog

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -1657,6 +1657,9 @@ class AthenaConnectionConfig(ConnectionConfig):
 
         return connect
 
+    def get_catalog(self) -> t.Optional[str]:
+        return self.catalog_name
+
 
 CONNECTION_CONFIG_TO_TYPE = {
     # Map all subclasses of ConnectionConfig to the value of their `type_` field.

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -682,6 +682,21 @@ def test_athena(make_config):
     assert isinstance(config, AthenaConnectionConfig)
 
 
+def test_athena_catalog(make_config):
+    config = make_config(type="athena", work_group="primary", catalog_name="foo")
+    assert isinstance(config, AthenaConnectionConfig)
+
+    assert config.catalog_name == "foo"
+    adapter = config.create_engine_adapter()
+    assert adapter.default_catalog == "foo"
+
+    config = make_config(type="athena", work_group="primary")
+    assert isinstance(config, AthenaConnectionConfig)
+    assert config.catalog_name is None
+    adapter = config.create_engine_adapter()
+    assert adapter.default_catalog == "awsdatacatalog"
+
+
 def test_athena_s3_staging_dir_or_workgroup(make_config):
     with pytest.raises(
         ConfigError, match=r"At least one of work_group or s3_staging_dir must be set"


### PR DESCRIPTION
Prior to this change, the Athena default catalog was effectively always `awsdatacatalog`.  

This uses the `catalog_name` connection parameter was being passed to PyAthena but it was essentially ignored because SQLMesh would always use `awsdatacatalog` when fully qualifying table names