### PR TITLE
Fix: hardcode dateparser to use UTC so it works in environments where /etc/localtime may have been modified

### DIFF
--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -179,7 +179,13 @@ def to_datetime(
                 expression
             ):
                 relative_base = relative_base.replace(hour=0, minute=0, second=0, microsecond=0)
-            dt = dateparser.parse(expression, settings={"RELATIVE_BASE": relative_base})
+
+            # note: we hardcode TIMEZONE: UTC to work around this bug: https://github.com/scrapinghub/dateparser/issues/896
+            # where dateparser just silently fails if it cant interpret the contents of /etc/localtime
+            # this works because SQLMesh only deals with UTC, there is no concept of user local time
+            dt = dateparser.parse(
+                expression, settings={"RELATIVE_BASE": relative_base, "TIMEZONE": "UTC"}
+            )
         else:
             try:
                 dt = datetime.strptime(str(value), DATE_INT_FMT)


### PR DESCRIPTION
This bug stems from https://github.com/scrapinghub/dateparser/issues/896

Before this change, on systems with a modified `/etc/localtime` which can be Docker containers or also AWS Lambda / EC2:
```
$ python -c "import sqlmesh.utils.date"
...SNIP
ValueError: Could not convert `1970-01-01` to datetime.
```

After this change:
```
$ python -c "import sqlmesh.utils.date"
$
```

Slack context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1729126261397739