### PR TITLE
Chore: refactor flaky test

### DIFF
--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -5945,13 +5945,13 @@ MODEL (
   dialect snowflake,
 );
 
-@DEF(foo, foo);
-@DEF(bar, bar);
-
 SELECT * FROM (@custom_macro(@foo, @bar)) AS q
     """)
 
-    config = Config(model_defaults=ModelDefaultsConfig(dialect="duckdb"))
+    config = Config(
+        model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+        variables={"foo": "foo", "bar": "boo"},
+    )
     context = Context(paths=tmp_path, config=config)
 
     query = context.get_model("sqlmesh_example.test").render_query()


### PR DESCRIPTION
For some reason this test have been showing flaky behavior, in particular this error has come up a few times in CI:

```
>   ???
E   ImportError: cannot import name 'bar' from 'tests.core.test_model' (/home/circleci/project/sqlmesh/tests/core/test_model.py)
```

I suspect it may be triggered by global state, but I'm not sure yet what caused it (couldn't repro locally). I just rewrote this slightly in this PR with the hope it will address the flakiness.