### PR TITLE
Feat: Treat models with unaligned start as non-deployable insted of ignoring them

### DIFF
--- a/docs/concepts/plans.md
+++ b/docs/concepts/plans.md
@@ -127,7 +127,7 @@ However, some model kinds are inherently non-idempotent:
 Those model kinds will behave as follows in a non-prod plan that specifies a limited date range:
 
 - If the `--start` option date is the same as or before the model's start date, the model is fully refreshed for all of time
-- If the `--start` option date is after the model's start date, the model is ignored by the plan and is not backfilled
+- If the `--start` option date is after the model's start date, only a preview is computed for this model which can't be reused when deploying to production
 
 #### Example
 
@@ -217,7 +217,7 @@ Let's cancel that plan and start a new one, passing a start date of 2024-09-24.
 
 The `start_end_model` is of kind `INCREMENTAL_BY_UNIQUE_KEY`, which is non-idempotent and cannot be backfilled for a limited time range.
 
-Because the command's `--start` of 2024-09-24 is after `start_end_model`'s start date 2024-09-23, `start_end_model` is ignored:
+Because the command's `--start` of 2024-09-24 is after `start_end_model`'s start date 2024-09-23, `start_end_model` is marked as preview:
 
 ``` bash linenums="1" hl_lines="12-13 20-21"
 ❯ sqlmesh plan dev --start 2024-09-24
@@ -243,12 +243,6 @@ Models needing backfill (missing dates):
 └── sqlmesh_example__dev.incremental_model: 2024-09-24 - 2024-09-26
 Enter the backfill end date (eg. '1 month ago', '2020-01-01') or blank to backfill up until '2024-09-27 00:00:00':
 ```
-
-The plan output contains a new `Ignored Models` entry telling us that `sqlmesh_example__dev.start_end_model` was ignored.
-
-It also displays the expected plan start date `2024-09-23`, which is the date our `--start` should include if we want the model to be included in the plan.
-
-Because it is ignored, `start_end_model` is not in the list of `Models needing backfill` at the bottom.
 
 ### Data preview for forward-only changes
 As mentioned earlier, the data output produced by [forward-only changes](#forward-only-change) in a development environment can only be used for preview and will not be reused in production.

--- a/docs/concepts/plans.md
+++ b/docs/concepts/plans.md
@@ -228,19 +228,17 @@ New environment `dev` will be created from `prod`
 Summary of differences against `dev`:
 Models:
 ├── Directly Modified:
+│   ├── sqlmesh_example__dev.start_end_model
 │   └── sqlmesh_example__dev.incremental_model
-├── Indirectly Modified:
-│   └── sqlmesh_example__dev.full_model
-└── Ignored Models (Expected Plan Start):
-    └── sqlmesh_example__dev.start_end_model (2024-09-23 00:00:00+00:00)
+└── Indirectly Modified:
+    └── sqlmesh_example__dev.full_model
 
 [...model diff omitted...]
 
-Directly Modified: sqlmesh_example__dev.incremental_model (Non-breaking)
-└── Indirectly Modified Children:
-    └── sqlmesh_example__dev.full_model (Indirect Non-breaking)
+Directly Modified: sqlmesh_example__dev.start_end_model (Non-breaking)
 Models needing backfill (missing dates):
-└── sqlmesh_example__dev.incremental_model: 2024-09-24 - 2024-09-26
+├── sqlmesh_example__dev.incremental_model: 2024-09-24 - 2024-09-26
+└── sqlmesh_example__dev.start_end_model: 2024-09-24 - 2024-09-26 (preview)
 Enter the backfill end date (eg. '1 month ago', '2020-01-01') or blank to backfill up until '2024-09-27 00:00:00':
 ```
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -842,7 +842,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             return next(pandas_to_sql(t.cast(pd.DataFrame, df), model.columns_to_types))
 
         snapshots = self.snapshots
-        deployability_index = DeployabilityIndex.create(snapshots.values())
+        deployability_index = DeployabilityIndex.create(snapshots.values(), start=start)
 
         return model.render_query_or_raise(
             start=start,

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -5,7 +5,6 @@ import re
 import sys
 import typing as t
 from collections import defaultdict
-from datetime import datetime
 from functools import cached_property
 
 
@@ -25,7 +24,7 @@ from sqlmesh.core.snapshot import (
     SnapshotChangeCategory,
 )
 from sqlmesh.core.snapshot.categorizer import categorize_change
-from sqlmesh.core.snapshot.definition import Interval, SnapshotId, start_date
+from sqlmesh.core.snapshot.definition import Interval, SnapshotId
 from sqlmesh.utils import columns_to_types_all_known, random_id
 from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.date import TimeLike, now, to_datetime, yesterday_ds
@@ -229,32 +228,14 @@ class PlanBuilder:
         self._adjust_new_snapshot_intervals()
 
         deployability_index = (
-            DeployabilityIndex.create(self._context_diff.snapshots.values())
+            DeployabilityIndex.create(self._context_diff.snapshots.values(), start=self._start)
             if self._is_dev
             else DeployabilityIndex.all_deployable()
         )
 
-        filtered_dag, ignored = self._build_filtered_dag(dag, deployability_index)
-
-        # Exclude ignored snapshots from the modified sets.
-        directly_modified = {s_id for s_id in directly_modified if s_id not in ignored}
-        for s_id in list(indirectly_modified):
-            if s_id in ignored:
-                indirectly_modified.pop(s_id, None)
-            else:
-                indirectly_modified[s_id] = {
-                    s_id for s_id in indirectly_modified[s_id] if s_id not in ignored
-                }
-
-        filtered_snapshots = {
-            s.snapshot_id: s
-            for s in self._context_diff.snapshots.values()
-            if s.snapshot_id not in ignored
-        }
-
-        models_to_backfill = self._build_models_to_backfill(filtered_dag)
+        models_to_backfill = self._build_models_to_backfill(dag)
         restatements = self._build_restatements(
-            dag, earliest_interval_start(filtered_snapshots.values()), ignored
+            dag, earliest_interval_start(self._context_diff.snapshots.values())
         )
 
         interval_end_per_model = self._interval_end_per_model
@@ -278,7 +259,7 @@ class PlanBuilder:
             environment_naming_info=self.environment_naming_info,
             directly_modified=directly_modified,
             indirectly_modified=indirectly_modified,
-            ignored=ignored,
+            ignored=set(),
             deployability_index=deployability_index,
             restatements=restatements,
             interval_end_per_model=interval_end_per_model,
@@ -298,44 +279,13 @@ class PlanBuilder:
             dag.add(s_id, context_snapshot.parents)
         return dag
 
-    def _build_filtered_dag(
-        self, full_dag: DAG[SnapshotId], deployability_index: DeployabilityIndex
-    ) -> t.Tuple[DAG[SnapshotId], t.Set[SnapshotId]]:
-        ignored_snapshot_ids: t.Set[SnapshotId] = set()
-        filtered_dag: DAG[SnapshotId] = DAG()
-        cache: t.Optional[t.Dict[str, datetime]] = {}
-        for s_id in full_dag:
-            snapshot = self._context_diff.snapshots.get(s_id)
-            # If the snapshot doesn't exist then it must be an external model
-            if not snapshot:
-                continue
-
-            is_deployable = deployability_index.is_deployable(s_id)
-            is_valid_start = snapshot.is_valid_start(
-                self._start, start_date(snapshot, self._context_diff.snapshots.values(), cache)
-            )
-            if set(snapshot.parents).isdisjoint(ignored_snapshot_ids) and (
-                not is_deployable or is_valid_start
-            ):
-                filtered_dag.add(s_id, snapshot.parents)
-            else:
-                ignored_snapshot_ids.add(s_id)
-        return filtered_dag, ignored_snapshot_ids
-
     def _build_restatements(
-        self,
-        dag: DAG[SnapshotId],
-        earliest_interval_start: TimeLike,
-        ignored_snapshots: t.Set[SnapshotId],
+        self, dag: DAG[SnapshotId], earliest_interval_start: TimeLike
     ) -> t.Dict[SnapshotId, Interval]:
         def is_restateable_snapshot(snapshot: Snapshot) -> bool:
             if not self._is_dev and snapshot.disable_restatement:
                 return False
-            return (
-                not snapshot.is_symbolic
-                and not snapshot.is_seed
-                and snapshot.snapshot_id not in ignored_snapshots
-            )
+            return not snapshot.is_symbolic and not snapshot.is_seed
 
         restate_models = self._restate_models
         if restate_models == set():
@@ -361,7 +311,6 @@ class PlanBuilder:
                     self._context_diff.directly_modified(s.name)
                     or self._context_diff.indirectly_modified(s.name)
                 )
-                and s.snapshot_id not in ignored_snapshots
             }
             is_preview = True
 

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -259,7 +259,6 @@ class PlanBuilder:
             environment_naming_info=self.environment_naming_info,
             directly_modified=directly_modified,
             indirectly_modified=indirectly_modified,
-            ignored=set(),
             deployability_index=deployability_index,
             restatements=restatements,
             interval_end_per_model=interval_end_per_model,

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -97,7 +97,9 @@ class BuiltInPlanEvaluator(PlanEvaluator):
 
             all_names = {name for name in snapshots_by_name if plan.is_selected_for_backfill(name)}
 
-            deployability_index_for_evaluation = DeployabilityIndex.create(snapshots)
+            deployability_index_for_evaluation = DeployabilityIndex.create(
+                snapshots, start=plan.start
+            )
             deployability_index_for_creation = deployability_index_for_evaluation
             if plan.is_dev:
                 before_promote_snapshots = all_names

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -328,7 +328,7 @@ class Scheduler:
             environment_naming_info = environment
 
         deployability_index = deployability_index or (
-            DeployabilityIndex.create(self.snapshots.values())
+            DeployabilityIndex.create(self.snapshots.values(), start=start)
             if environment_naming_info.name != c.PROD
             else DeployabilityIndex.all_deployable()
         )

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -460,7 +460,6 @@ class GithubController:
                 environment_naming_info=plan.environment_naming_info,
                 default_catalog=self._context.default_catalog,
                 no_diff=False,
-                ignored_snapshot_ids=plan.ignored,
             )
             difference_summary = self._console.consume_captured_output()
             self._console._show_missing_dates(plan, self._context.default_catalog)

--- a/sqlmesh/schedulers/airflow/plan.py
+++ b/sqlmesh/schedulers/airflow/plan.py
@@ -121,7 +121,7 @@ def create_plan_dag_spec(
         for s, interval in intervals_to_remove:
             all_snapshots[s.snapshot_id].remove_interval(interval)
 
-    deployability_index_for_creation = DeployabilityIndex.create(all_snapshots)
+    deployability_index_for_creation = DeployabilityIndex.create(all_snapshots, start=plan.start)
     deployability_index_for_evaluation = (
         deployability_index_for_creation if plan.is_dev else DeployabilityIndex.all_deployable()
     )

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -2553,7 +2553,6 @@ def execute(
 
     assert plan.has_changes
     assert not plan.indirectly_modified
-    assert not plan.ignored
 
     assert len(plan.directly_modified) == 1
     snapshot_id = list(plan.directly_modified)[0]

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -44,6 +44,7 @@ from sqlmesh.core.model import (
 from sqlmesh.core.model.kind import model_kind_type_from_name
 from sqlmesh.core.plan import Plan, PlanBuilder, SnapshotIntervals
 from sqlmesh.core.snapshot import (
+    DeployabilityIndex,
     Snapshot,
     SnapshotChangeCategory,
     SnapshotId,
@@ -1497,7 +1498,7 @@ def test_custom_materialization(init_and_plan_context: t.Callable):
 
 
 @freeze_time("2023-01-08 15:00:00")
-def test_ignored_snapshot_with_non_deployable_downstream(init_and_plan_context: t.Callable):
+def test_unaligned_start_snapshot_with_non_deployable_downstream(init_and_plan_context: t.Callable):
     context, _ = init_and_plan_context("examples/sushi")
 
     downstream_model_name = "memory.sushi.customer_max_revenue"
@@ -1542,12 +1543,13 @@ def test_ignored_snapshot_with_non_deployable_downstream(init_and_plan_context: 
     )
 
     plan = context.plan("dev", no_prompts=True, enable_preview=True)
-    assert {s.name for s in plan.ignored} == {
+    assert {s.name for s in plan.new_snapshots} == {
         '"memory"."sushi"."customer_revenue_lifetime_new"',
         '"memory"."sushi"."customer_max_revenue"',
     }
-    assert not plan.new_snapshots
-    assert not plan.missing_intervals
+    for snapshot_interval in plan.missing_intervals:
+        assert not plan.deployability_index.is_deployable(snapshot_interval.snapshot_id)
+        assert snapshot_interval.intervals[0][0] == to_timestamp("2023-01-07")
 
 
 @freeze_time("2023-01-08 15:00:00")
@@ -2455,7 +2457,7 @@ def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
     "context_fixture",
     ["sushi_context", "sushi_no_default_catalog"],
 )
-def test_ignored_snapshots(context_fixture: Context, request):
+def test_unaligned_start_snapshots(context_fixture: Context, request):
     context = request.getfixturevalue(context_fixture)
     environment = "dev"
     apply_to_environment(context, environment)
@@ -2463,25 +2465,17 @@ def test_ignored_snapshots(context_fixture: Context, request):
     context.upsert_model("sushi.order_items", stamp="1")
     # Apply the change starting at a date later then the beginning of the downstream depends_on_self model
     plan = apply_to_environment(
-        context, environment, choice=SnapshotChangeCategory.BREAKING, plan_start="2 days ago"
+        context,
+        environment,
+        choice=SnapshotChangeCategory.BREAKING,
+        plan_start="2 days ago",
+        enable_preview=True,
     )
     revenue_lifetime_snapshot = context.get_snapshot(
         "sushi.customer_revenue_lifetime", raise_if_missing=True
     )
-    # Validate that the depends_on_self model is ignored
-    assert plan.ignored == {revenue_lifetime_snapshot.snapshot_id}
-    # Validate that the table was really ignored
-    metadata = DuckDBMetadata.from_context(context)
-    # Make sure prod view exists
-    catalog = context.default_catalog or "memory"
-    assert exp.table_("customer_revenue_lifetime", "sushi", catalog) in metadata.qualified_views
-    # Make sure dev view doesn't exist since it was ignored
-    assert (
-        exp.table_("customer_revenue_lifetime", "sushi__dev", catalog)
-        not in metadata.qualified_views
-    )
-    # Make sure that dev view for order items was created
-    assert exp.table_("order_items", "sushi__dev", catalog) in metadata.qualified_views
+    # Validate that the depends_on_self model is non-deployable
+    assert not plan.deployability_index.is_deployable(revenue_lifetime_snapshot)
 
 
 class OldPythonModel(PythonModel):
@@ -2590,6 +2584,7 @@ def apply_to_environment(
     apply_validators: t.Optional[t.Iterable[t.Callable]] = None,
     plan_start: t.Optional[TimeLike] = None,
     allow_destructive_models: t.Optional[t.List[str]] = None,
+    enable_preview: bool = False,
 ):
     plan_validators = plan_validators or []
     apply_validators = apply_validators or []
@@ -2600,6 +2595,7 @@ def apply_to_environment(
         forward_only=choice == SnapshotChangeCategory.FORWARD_ONLY,
         include_unmodified=True,
         allow_destructive_models=allow_destructive_models if allow_destructive_models else [],
+        enable_preview=enable_preview,
     )
     if environment != c.PROD:
         plan_builder.set_start(plan_start or start(context))
@@ -2612,7 +2608,7 @@ def apply_to_environment(
     plan = plan_builder.build()
     context.apply(plan)
 
-    validate_apply_basics(context, environment, plan.snapshots.values())
+    validate_apply_basics(context, environment, plan.snapshots.values(), plan.deployability_index)
     for validator in apply_validators:
         validator(context)
     return plan
@@ -2671,12 +2667,15 @@ def validate_versions_different(
 
 
 def validate_apply_basics(
-    context: Context, environment: str, snapshots: t.Iterable[Snapshot]
+    context: Context,
+    environment: str,
+    snapshots: t.Iterable[Snapshot],
+    deployability_index: t.Optional[DeployabilityIndex] = None,
 ) -> None:
     validate_snapshots_in_state_sync(snapshots, context)
     validate_state_sync_environment(snapshots, environment, context)
-    validate_tables(snapshots, context)
-    validate_environment_views(snapshots, environment, context)
+    validate_tables(snapshots, context, deployability_index)
+    validate_environment_views(snapshots, environment, context, deployability_index)
 
 
 def validate_snapshots_in_state_sync(snapshots: t.Iterable[Snapshot], context: Context) -> None:
@@ -2697,22 +2696,33 @@ def validate_state_sync_environment(
     assert set(snapshot_infos) == set(environment_table_infos)
 
 
-def validate_tables(snapshots: t.Iterable[Snapshot], context: Context) -> None:
+def validate_tables(
+    snapshots: t.Iterable[Snapshot],
+    context: Context,
+    deployability_index: t.Optional[DeployabilityIndex] = None,
+) -> None:
     adapter = context.engine_adapter
+    deployability_index = deployability_index or DeployabilityIndex.all_deployable()
     for snapshot in snapshots:
+        is_deployable = deployability_index.is_representative(snapshot)
         if not snapshot.is_model or snapshot.is_external:
             continue
         table_should_exist = not snapshot.is_embedded
-        assert adapter.table_exists(snapshot.table_name()) == table_should_exist
+        assert adapter.table_exists(snapshot.table_name(is_deployable)) == table_should_exist
         if table_should_exist:
-            assert select_all(snapshot.table_name(), adapter)
+            assert select_all(snapshot.table_name(is_deployable), adapter)
 
 
 def validate_environment_views(
-    snapshots: t.Iterable[Snapshot], environment: str, context: Context
+    snapshots: t.Iterable[Snapshot],
+    environment: str,
+    context: Context,
+    deployability_index: t.Optional[DeployabilityIndex] = None,
 ) -> None:
     adapter = context.engine_adapter
+    deployability_index = deployability_index or DeployabilityIndex.all_deployable()
     for snapshot in snapshots:
+        is_deployable = deployability_index.is_representative(snapshot)
         if not snapshot.is_model or snapshot.is_symbolic:
             continue
         view_name = snapshot.qualified_view_name.for_environment(
@@ -2722,8 +2732,6 @@ def validate_environment_views(
                 suffix_target=context.config.environment_suffix_target,
             )
         )
-
-        is_deployable = environment == c.PROD or not snapshot.is_paused_forward_only
 
         assert adapter.table_exists(view_name)
         assert select_all(snapshot.table_name(is_deployable), adapter) == select_all(

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -702,7 +702,6 @@ def test_missing_intervals_lookback(make_snapshot, mocker: MockerFixture):
         environment_naming_info=EnvironmentNamingInfo(),
         directly_modified={snapshot_a.snapshot_id},
         indirectly_modified={},
-        ignored=set(),
         deployability_index=DeployabilityIndex.all_deployable(),
         restatements={},
         end_bounded=False,
@@ -2140,7 +2139,6 @@ def test_dev_plan_depends_past(make_snapshot, mocker: MockerFixture):
         context_diff, schema_differ, start="2023-01-02", end="2023-01-10", is_dev=True
     ).build()
     assert len(dev_plan_start_ahead_of_model.new_snapshots) == 3
-    assert not dev_plan_start_ahead_of_model.ignored
     assert not dev_plan_start_ahead_of_model.deployability_index.is_deployable(snapshot)
     assert not dev_plan_start_ahead_of_model.deployability_index.is_deployable(snapshot_child)
     assert dev_plan_start_ahead_of_model.deployability_index.is_deployable(unrelated_snapshot)
@@ -2237,15 +2235,6 @@ def test_dev_plan_depends_past_non_deployable(make_snapshot, mocker: MockerFixtu
         '"a_child"',
         '"b"',
     ]
-
-    # There should be no ignored snapshots because all changes are non-deployable.
-    dev_plan_start_ahead_of_model = new_builder(start="2023-01-02", end="2023-01-10").build()
-    assert sorted([x.name for x in dev_plan_start_ahead_of_model.new_snapshots]) == [
-        '"a"',
-        '"a_child"',
-        '"b"',
-    ]
-    assert not dev_plan_start_ahead_of_model.ignored
 
 
 def test_restatement_intervals_after_updating_start(sushi_context: Context):

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -2139,14 +2139,16 @@ def test_dev_plan_depends_past(make_snapshot, mocker: MockerFixture):
     dev_plan_start_ahead_of_model = PlanBuilder(
         context_diff, schema_differ, start="2023-01-02", end="2023-01-10", is_dev=True
     ).build()
-    assert len(dev_plan_start_ahead_of_model.new_snapshots) == 1
-    assert [x.name for x in dev_plan_start_ahead_of_model.new_snapshots] == ['"b"']
-    assert len(dev_plan_start_ahead_of_model.ignored) == 2
-    assert sorted(list(dev_plan_start_ahead_of_model.ignored)) == [
+    assert len(dev_plan_start_ahead_of_model.new_snapshots) == 3
+    assert not dev_plan_start_ahead_of_model.ignored
+    assert not dev_plan_start_ahead_of_model.deployability_index.is_deployable(snapshot)
+    assert not dev_plan_start_ahead_of_model.deployability_index.is_deployable(snapshot_child)
+    assert dev_plan_start_ahead_of_model.deployability_index.is_deployable(unrelated_snapshot)
+    assert dev_plan_start_ahead_of_model.directly_modified == {
         snapshot.snapshot_id,
         snapshot_child.snapshot_id,
-    ]
-    assert dev_plan_start_ahead_of_model.directly_modified == {unrelated_snapshot.snapshot_id}
+        unrelated_snapshot.snapshot_id,
+    }
     assert dev_plan_start_ahead_of_model.indirectly_modified == {}
 
 
@@ -2579,7 +2581,7 @@ def test_plan_requirements():
     assert set(plan) == {"ipywidgets", "numpy", "pandas", "ruamel.yaml", "ruamel.yaml.clib"}
 
 
-def test_ignored_model_with_forward_only_preview(make_snapshot):
+def test_unaligned_start_model_with_forward_only_preview(make_snapshot):
     snapshot_a = make_snapshot(
         SqlModel(
             name="a",
@@ -2641,5 +2643,6 @@ def test_ignored_model_with_forward_only_preview(make_snapshot):
     )
     plan = plan_builder.build()
 
-    assert plan.ignored == {snapshot_b.snapshot_id}
-    assert set(plan.restatements) == {new_snapshot_a.snapshot_id}
+    assert set(plan.restatements) == {new_snapshot_a.snapshot_id, snapshot_b.snapshot_id}
+    assert not plan.deployability_index.is_deployable(new_snapshot_a)
+    assert not plan.deployability_index.is_deployable(snapshot_b)


### PR DESCRIPTION
Previously, SQLMesh ignored models that depend on past when the model's start date was before the specified plan start. This logic was introduced before we had the concepts of deployability and the deployability index. In practice, it caused a lot of confusion since it wasn't always obvious why a particular model wasn't evaluated when it was supposed to.

This update removes the concept of 'ignored' models and instead treats models with an invalid plan start date as non-deployable. This means that the model will still be evaluated, and its results will be available for preview in dev but will not be reused when deploying to prod.