### PR TITLE
Fix: Skip creation call for tables that already exist

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -265,7 +265,9 @@ class SnapshotEvaluator:
             is_snapshot_deployable = (
                 deployability_index.is_deployable(snapshot) if deployability_index else True
             )
-            for is_deployable in self._table_deployability_flags(snapshot, is_snapshot_deployable):
+            for is_deployable in set(
+                self._table_deployability_flags(snapshot, is_snapshot_deployable) + [True]
+            ):
                 table = exp.to_table(
                     snapshot.table_name(is_deployable), dialect=snapshot.model.dialect
                 )

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -314,7 +314,7 @@ class SnapshotEvaluator:
                 lambda s: self._create_snapshot(
                     s,
                     snapshots,
-                    target_deployability_flags,
+                    target_deployability_flags[s.name],
                     deployability_index,
                     on_complete,
                     allow_destructive_snapshots,
@@ -644,7 +644,7 @@ class SnapshotEvaluator:
         self,
         snapshot: Snapshot,
         snapshots: t.Dict[SnapshotId, Snapshot],
-        deployability_flags: t.Dict[str, t.List[bool]],
+        deployability_flags: t.List[bool],
         deployability_index: t.Optional[DeployabilityIndex],
         on_complete: t.Optional[t.Callable[[SnapshotInfoLike], None]],
         allow_destructive_snapshots: t.Set[str],
@@ -717,8 +717,8 @@ class SnapshotEvaluator:
                 finally:
                     self.adapter.drop_table(tmp_table_name)
             else:
-                dry_run = not (len(deployability_flags[snapshot.name]) > 1)
-                for is_table_deployable in deployability_flags[snapshot.name]:
+                dry_run = not (len(deployability_flags) > 1)
+                for is_table_deployable in deployability_flags:
                     evaluation_strategy.create(
                         table_name=snapshot.table_name(is_deployable=is_table_deployable),
                         model=snapshot.model,

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -295,11 +295,13 @@ class SnapshotEvaluator:
         snapshots_to_create = []
         target_deployability_flags: t.Dict[str, t.List[bool]] = defaultdict(list)
         for snapshot, table_names in snapshots_with_table_names.items():
-            missing_versions = table_names - existing_objects
-            if missing_versions or (snapshot.is_seed and not snapshot.intervals):
+            missing_tables = table_names - existing_objects
+            if missing_tables or (snapshot.is_seed and not snapshot.intervals):
                 snapshots_to_create.append(snapshot)
-                for version in missing_versions or table_names:
-                    target_deployability_flags[snapshot.name].append(table_deployability[version])
+                for table_name in missing_tables or table_names:
+                    target_deployability_flags[snapshot.name].append(
+                        table_deployability[table_name]
+                    )
                 target_deployability_flags[snapshot.name].sort()
             elif on_complete:
                 on_complete(snapshot)
@@ -717,7 +719,7 @@ class SnapshotEvaluator:
                 finally:
                     self.adapter.drop_table(tmp_table_name)
             else:
-                dry_run = not (len(deployability_flags) > 1)
+                dry_run = len(deployability_flags) == 1
                 for is_table_deployable in deployability_flags:
                     evaluation_strategy.create(
                         table_name=snapshot.table_name(is_deployable=is_table_deployable),

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -814,7 +814,7 @@ def test_create_tables_exist(
         schema_("sqlmesh__db"),
         {
             f"db__model__{snapshot.version}" if not flag else f"db__model__{snapshot.version}__temp"
-            for flag in deployability_flags
+            for flag in set(deployability_flags + [False])
         },
     )
     adapter_mock.create_schema.assert_not_called()
@@ -852,6 +852,7 @@ def test_create_prod_table_exists_forward_only(mocker: MockerFixture, adapter_mo
         schema_("sqlmesh__test_schema"),
         {
             f"test_schema__test_model__{snapshot.version}__temp",
+            f"test_schema__test_model__{snapshot.version}",
         },
     )
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -2891,7 +2891,7 @@ def test_create_snapshot(
     evaluator._create_snapshot(
         snapshot=snapshot,
         snapshots={},
-        deployability_flags={snapshot.name: deployability_flags},
+        deployability_flags=deployability_flags,
         deployability_index=deployability_index,
         on_complete=None,
         allow_destructive_snapshots=set(),

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -697,7 +697,6 @@ def test_create_tables_exists(mocker: MockerFixture, adapter_mock, make_snapshot
     adapter_mock.get_data_objects.assert_called_once_with(
         schema_("sqlmesh__test_schema"),
         {
-            f"test_schema__test_model__{snapshot.version}__temp",
             f"test_schema__test_model__{snapshot.version}",
         },
     )
@@ -736,7 +735,6 @@ def test_create_only_dev_table_exists(mocker: MockerFixture, adapter_mock, make_
     adapter_mock.get_data_objects.assert_called_once_with(
         schema_("sqlmesh__test_schema"),
         {
-            f"test_schema__test_model__{snapshot.version}__temp",
             f"test_schema__test_model__{snapshot.version}",
         },
     )

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -661,7 +661,7 @@ def test_evaluate_incremental_unmanaged_no_intervals(
     )
 
 
-def test_create_tables_exists(mocker: MockerFixture, adapter_mock, make_snapshot):
+def test_create_prod_table_exists(mocker: MockerFixture, adapter_mock, make_snapshot):
     model = load_sql_based_model(
         parse(  # type: ignore
             """
@@ -680,11 +680,6 @@ def test_create_tables_exists(mocker: MockerFixture, adapter_mock, make_snapshot
 
     adapter_mock.get_data_objects.return_value = [
         DataObject(
-            name=f"test_schema__test_model__{snapshot.version}__temp",
-            schema="sqlmesh__test_schema",
-            type=DataObjectType.VIEW,
-        ),
-        DataObject(
             name=f"test_schema__test_model__{snapshot.version}",
             schema="sqlmesh__test_schema",
             type=DataObjectType.VIEW,
@@ -694,6 +689,7 @@ def test_create_tables_exists(mocker: MockerFixture, adapter_mock, make_snapshot
 
     evaluator.create([snapshot], {})
     adapter_mock.create_view.assert_not_called()
+    adapter_mock.create_schema.assert_not_called()
     adapter_mock.get_data_objects.assert_called_once_with(
         schema_("sqlmesh__test_schema"),
         {
@@ -730,13 +726,147 @@ def test_create_only_dev_table_exists(mocker: MockerFixture, adapter_mock, make_
     evaluator = SnapshotEvaluator(adapter_mock)
 
     evaluator.create([snapshot], {})
-
-    adapter_mock.create_view.assert_not_called
+    adapter_mock.create_schema.assert_called_once_with(to_schema("sqlmesh__test_schema"))
+    adapter_mock.create_view.assert_not_called()
     adapter_mock.get_data_objects.assert_called_once_with(
         schema_("sqlmesh__test_schema"),
         {
             f"test_schema__test_model__{snapshot.version}",
         },
+    )
+
+
+@pytest.mark.parametrize(
+    "deployability_index,  snapshot_category, deployability_flags",
+    [
+        (DeployabilityIndex.all_deployable(), SnapshotChangeCategory.BREAKING, [False]),
+        (DeployabilityIndex.all_deployable(), SnapshotChangeCategory.NON_BREAKING, [False]),
+        (DeployabilityIndex.all_deployable(), SnapshotChangeCategory.FORWARD_ONLY, [True]),
+        (DeployabilityIndex.all_deployable(), SnapshotChangeCategory.INDIRECT_BREAKING, [False]),
+        (DeployabilityIndex.all_deployable(), SnapshotChangeCategory.INDIRECT_NON_BREAKING, [True]),
+        (DeployabilityIndex.all_deployable(), SnapshotChangeCategory.METADATA, [True]),
+        (
+            DeployabilityIndex.none_deployable(),
+            SnapshotChangeCategory.BREAKING,
+            [True, False],
+        ),
+        (
+            DeployabilityIndex.none_deployable(),
+            SnapshotChangeCategory.NON_BREAKING,
+            [True, False],
+        ),
+        (
+            DeployabilityIndex.none_deployable(),
+            SnapshotChangeCategory.FORWARD_ONLY,
+            [True],
+        ),
+        (
+            DeployabilityIndex.none_deployable(),
+            SnapshotChangeCategory.INDIRECT_BREAKING,
+            [True, False],
+        ),
+        (
+            DeployabilityIndex.none_deployable(),
+            SnapshotChangeCategory.INDIRECT_NON_BREAKING,
+            [True],
+        ),
+        (
+            DeployabilityIndex.none_deployable(),
+            SnapshotChangeCategory.METADATA,
+            [True],
+        ),
+    ],
+)
+def test_create_tables_exist(
+    snapshot: Snapshot,
+    mocker: MockerFixture,
+    adapter_mock,
+    deployability_index: DeployabilityIndex,
+    deployability_flags: t.List[bool],
+    snapshot_category: SnapshotChangeCategory,
+):
+    adapter_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter")
+    adapter_mock.dialect = "duckdb"
+
+    evaluator = SnapshotEvaluator(adapter_mock)
+    snapshot.categorize_as(category=snapshot_category)
+
+    adapter_mock.get_data_objects.return_value = [
+        DataObject(
+            name=f"db__model__{snapshot.version}__temp",
+            schema="sqlmesh__db",
+            type=DataObjectType.TABLE,
+        ),
+        DataObject(
+            name=f"db__model__{snapshot.version}",
+            schema="sqlmesh__db",
+            type=DataObjectType.TABLE,
+        ),
+    ]
+
+    evaluator.create(
+        target_snapshots=[snapshot],
+        snapshots={},
+        deployability_index=deployability_index,
+    )
+
+    adapter_mock.get_data_objects.assert_called_once_with(
+        schema_("sqlmesh__db"),
+        {
+            f"db__model__{snapshot.version}" if not flag else f"db__model__{snapshot.version}__temp"
+            for flag in deployability_flags
+        },
+    )
+    adapter_mock.create_schema.assert_not_called()
+    adapter_mock.create_table.assert_not_called()
+
+
+def test_create_prod_table_exists_forward_only(mocker: MockerFixture, adapter_mock, make_snapshot):
+    model = load_sql_based_model(
+        parse(  # type: ignore
+            """
+            MODEL (
+                name test_schema.test_model,
+                kind FULL
+            );
+
+            SELECT a::int FROM tbl;
+            """
+        ),
+    )
+
+    snapshot = make_snapshot(model)
+    snapshot.categorize_as(SnapshotChangeCategory.FORWARD_ONLY)
+
+    adapter_mock.get_data_objects.return_value = [
+        DataObject(
+            name=f"test_schema__test_model__{snapshot.version}",
+            schema="sqlmesh__test_schema",
+            type=DataObjectType.TABLE,
+        ),
+    ]
+    evaluator = SnapshotEvaluator(adapter_mock)
+    evaluator.create([snapshot], {})
+
+    adapter_mock.get_data_objects.assert_called_once_with(
+        schema_("sqlmesh__test_schema"),
+        {
+            f"test_schema__test_model__{snapshot.version}__temp",
+        },
+    )
+
+    adapter_mock.create_schema.assert_called_once_with(to_schema("sqlmesh__test_schema"))
+    adapter_mock.create_table.assert_called_once_with(
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp",
+        columns_to_types={"a": exp.DataType.build("int")},
+        table_format=None,
+        storage_format=None,
+        partitioned_by=[],
+        partition_interval_unit=IntervalUnit.DAY,
+        clustered_by=[],
+        table_properties={},
+        table_description=None,
+        column_descriptions=None,
     )
 
 
@@ -889,6 +1019,52 @@ def test_promote_model_info(mocker: MockerFixture, make_snapshot):
     adapter_mock.create_view.assert_called_once_with(
         "test_schema__test_env.test_model",
         parse_one(f"SELECT * FROM physical_schema.test_schema__test_model__{snapshot.version}"),
+        table_description=None,
+        column_descriptions=None,
+        view_properties={},
+    )
+
+
+def test_promote_deployable(mocker: MockerFixture, make_snapshot):
+    adapter_mock = mocker.patch("sqlmesh.core.engine_adapter.EngineAdapter")
+    adapter_mock.dialect = "duckdb"
+
+    evaluator = SnapshotEvaluator(adapter_mock)
+
+    model = SqlModel(
+        name="test_schema.test_model",
+        kind=FullKind(),
+        query=parse_one("SELECT a FROM tbl"),
+    )
+
+    snapshot = make_snapshot(model)
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    adapter_mock.get_data_objects.return_value = [
+        DataObject(
+            name=f"test_schema__test_model__{snapshot.version}",
+            schema="sqlmesh__test_schema",
+            type=DataObjectType.TABLE,
+        ),
+    ]
+
+    evaluator.create([snapshot], {})
+    adapter_mock.get_data_objects.assert_called_once_with(
+        schema_("sqlmesh__test_schema"),
+        {
+            f"test_schema__test_model__{snapshot.version}",
+        },
+    )
+    adapter_mock.create_table.assert_not_called()
+
+    evaluator.promote([snapshot], EnvironmentNamingInfo(name="test_env"))
+
+    adapter_mock.create_schema.assert_called_once_with(to_schema("test_schema__test_env"))
+    adapter_mock.create_view.assert_called_once_with(
+        "test_schema__test_env.test_model",
+        parse_one(
+            f"SELECT * FROM sqlmesh__test_schema.test_schema__test_model__{snapshot.version}"
+        ),
         table_description=None,
         column_descriptions=None,
         view_properties={},


### PR DESCRIPTION
This update aims to eliminate unnecessary calls to create schemas and tables when the required deployable or non-deployable versions already exist, by identifying if the tables that need to be created are missing, instead of checking for both versions.