### PR TITLE
Feat: Add support for model selector expressions to the run command

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -312,8 +312,7 @@ Options:
   --select-model TEXT             Select specific model changes that should be
                                   included in the plan.
   --backfill-model TEXT           Backfill only the models whose names match
-                                  the expression. This is supported only when
-                                  targeting a development environment.
+                                  the expression.
   --no-diff                       Hide text differences for changed models.
   --run                           Run latest intervals as part of the plan
                                   application (prod environment only).
@@ -399,14 +398,16 @@ Usage: sqlmesh run [OPTIONS] [ENVIRONMENT]
   Evaluate missing intervals for the target environment.
 
 Options:
-  -s, --start TEXT  The start datetime of the interval for which this command
-                    will be applied.
-  -e, --end TEXT    The end datetime of the interval for which this command
-                    will be applied.
-  --skip-janitor    Skip the janitor task.
-  --ignore-cron     Run for all missing intervals, ignoring individual cron
-                    schedules.
-  --help            Show this message and exit.
+  -s, --start TEXT     The start datetime of the interval for which this
+                       command will be applied.
+  -e, --end TEXT       The end datetime of the interval for which this command
+                       will be applied.
+  --skip-janitor       Skip the janitor task.
+  --ignore-cron        Run for all missing intervals, ignoring individual cron
+                       schedules.
+  --select-model TEXT  Select specific models to run. Note: this always
+                       includes upstream dependencies.
+  --help               Show this message and exit.
 ```
 
 ## table_diff

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -385,7 +385,7 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
     "--backfill-model",
     type=str,
     multiple=True,
-    help="Backfill only the models whose names match the expression. This is supported only when targeting a development environment.",
+    help="Backfill only the models whose names match the expression.",
 )
 @click.option(
     "--no-diff",
@@ -438,13 +438,20 @@ def plan(
     is_flag=True,
     help="Run for all missing intervals, ignoring individual cron schedules.",
 )
+@click.option(
+    "--select-model",
+    type=str,
+    multiple=True,
+    help="Select specific models to run. Note: this always includes upstream dependencies.",
+)
 @click.pass_context
 @error_handler
 @cli_analytics
 def run(ctx: click.Context, environment: t.Optional[str] = None, **kwargs: t.Any) -> None:
     """Evaluate missing intervals for the target environment."""
     context = ctx.obj
-    success = context.run(environment, **kwargs)
+    select_models = kwargs.pop("select_model") or None
+    success = context.run(environment, select_models=select_models, **kwargs)
     if not success:
         raise click.ClickException("Run DAG Failed. See output for details.")
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -591,6 +591,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         execution_time: t.Optional[TimeLike] = None,
         skip_janitor: bool = False,
         ignore_cron: bool = False,
+        select_models: t.Optional[t.Collection[str]] = None,
     ) -> bool:
         """Run the entire dag through the scheduler.
 
@@ -601,6 +602,8 @@ class GenericContext(BaseContext, t.Generic[C]):
             execution_time: The date/time time reference to use for execution time. Defaults to now.
             skip_janitor: Whether to skip the janitor task.
             ignore_cron: Whether to ignore the model's cron schedule and run all available missing intervals.
+            select_models: A list of model selection expressions to filter models that should run. Note that
+                upstream dependencies of selected models will also be evaluated.
 
         Returns:
             True if the run was successful, False otherwise.
@@ -625,6 +628,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 execution_time=execution_time,
                 skip_janitor=skip_janitor,
                 ignore_cron=ignore_cron,
+                select_models=select_models,
             )
         except Exception as e:
             self.notification_target_manager.notify(
@@ -1795,6 +1799,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         execution_time: t.Optional[TimeLike],
         skip_janitor: bool,
         ignore_cron: bool,
+        select_models: t.Optional[t.Collection[str]],
     ) -> bool:
         if not skip_janitor and environment.lower() == c.PROD:
             self._run_janitor()
@@ -1826,6 +1831,19 @@ class GenericContext(BaseContext, t.Generic[C]):
                 "See https://sqlmesh.readthedocs.io/en/stable/reference/configuration/#run to adjust the timeout settings."
             )
 
+        scheduler = self.scheduler(environment=environment)
+        snapshots = scheduler.snapshots
+
+        if select_models is not None:
+            models: UniqueKeyDict[str, Model] = UniqueKeyDict(
+                "models", **{s.name: s.model for s in snapshots.values() if s.is_model}
+            )
+            dag: DAG[str] = DAG()
+            for fqn, model in models.items():
+                dag.add(fqn, model.depends_on)
+            model_selector = self._new_selector(models=models, dag=dag)
+            select_models = set(dag.subdag(*model_selector.expand_model_selections(select_models)))
+
         done = False
         while not done:
             plan_id_at_start = _block_until_finalized()
@@ -1840,13 +1858,14 @@ class GenericContext(BaseContext, t.Generic[C]):
                 )
 
             try:
-                success = self.scheduler(environment=environment).run(
+                success = scheduler.run(
                     environment,
                     start=start,
                     end=end,
                     execution_time=execution_time,
                     ignore_cron=ignore_cron,
                     circuit_breaker=_has_environment_changed,
+                    selected_snapshots=select_models,
                 )
                 done = True
             except CircuitBreakerError:
@@ -2051,12 +2070,15 @@ class GenericContext(BaseContext, t.Generic[C]):
     def _new_state_sync(self) -> StateSync:
         return self._provided_state_sync or self._scheduler.create_state_sync(self)
 
-    def _new_selector(self) -> Selector:
+    def _new_selector(
+        self, models: t.Optional[UniqueKeyDict[str, Model]] = None, dag: t.Optional[DAG[str]] = None
+    ) -> Selector:
         return Selector(
             self.state_reader,
-            models=self._models,
+            models=models or self._models,
             audits=self._audits,
             context_path=self.path,
+            dag=dag,
             default_catalog=self.default_catalog,
             dialect=self.default_dialect,
         )

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -396,10 +396,6 @@ class PlanBuilder:
     def _build_models_to_backfill(self, dag: DAG[SnapshotId]) -> t.Optional[t.Set[str]]:
         if self._backfill_models is None:
             return None
-        if not self._is_dev:
-            raise PlanError(
-                "Selecting models to backfill is only supported for development environments."
-            )
         return {
             self._context_diff.snapshots[s_id].name
             for s_id in dag.subdag(

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -382,7 +382,7 @@ class SQLMeshMagics(Magics):
         "--backfill-model",
         type=str,
         nargs="*",
-        help="Backfill only the models whose names match the expression. This is supported only when targeting a development environment.",
+        help="Backfill only the models whose names match the expression.",
     )
     @argument(
         "--no-diff",
@@ -445,6 +445,12 @@ class SQLMeshMagics(Magics):
         action="store_true",
         help="Run for all missing intervals, ignoring individual cron schedules.",
     )
+    @argument(
+        "--select-model",
+        type=str,
+        nargs="*",
+        help="Select specific models to run. Note: this always includes upstream dependencies.",
+    )
     @line_magic
     @pass_sqlmesh_context
     def run_dag(self, context: Context, line: str) -> None:
@@ -457,6 +463,7 @@ class SQLMeshMagics(Magics):
             end=args.end,
             skip_janitor=args.skip_janitor,
             ignore_cron=args.ignore_cron,
+            select_models=args.select_model,
         )
         if not success:
             raise SQLMeshError("Error Running DAG. Check logs for details.")

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -1128,6 +1128,37 @@ def test_forward_only_precedence_over_indirect_non_breaking(init_and_plan_contex
 
 
 @freeze_time("2023-01-08 15:00:00")
+def test_run_with_select_models(
+    init_and_plan_context: t.Callable,
+):
+    context, plan = init_and_plan_context("examples/sushi")
+    context.apply(plan)
+
+    with freeze_time("2023-01-09 00:00:00"):
+        assert context.run(select_models=["*waiter_revenue_by_day"])
+
+        snapshots = context.state_sync.state_sync.get_snapshots(context.snapshots.values())
+        # Only waiter_revenue_by_day and its parents should be backfilled up to 2023-01-09.
+        assert {s.name: s.intervals[0][1] for s in snapshots.values() if s.intervals} == {
+            '"memory"."sushi"."waiter_revenue_by_day"': to_timestamp("2023-01-09"),
+            '"memory"."sushi"."order_items"': to_timestamp("2023-01-09"),
+            '"memory"."sushi"."orders"': to_timestamp("2023-01-09"),
+            '"memory"."sushi"."items"': to_timestamp("2023-01-09"),
+            '"memory"."sushi"."customer_revenue_lifetime"': to_timestamp("2023-01-08"),
+            '"memory"."sushi"."customer_revenue_by_day"': to_timestamp("2023-01-08"),
+            '"memory"."sushi"."waiter_names"': to_timestamp("2023-01-08"),
+            '"memory"."sushi"."raw_marketing"': to_timestamp("2023-01-08"),
+            '"memory"."sushi"."marketing"': to_timestamp("2023-01-08"),
+            '"memory"."sushi"."waiter_as_customer_by_day"': to_timestamp("2023-01-08"),
+            '"memory"."sushi"."top_waiters"': to_timestamp("2023-01-08"),
+            '"memory"."raw"."demographics"': to_timestamp("2023-01-08"),
+            "assert_item_price_above_zero": to_timestamp("2023-01-08"),
+            '"memory"."sushi"."active_customers"': to_timestamp("2023-01-08"),
+            '"memory"."sushi"."customers"': to_timestamp("2023-01-08"),
+        }
+
+
+@freeze_time("2023-01-08 15:00:00")
 def test_select_models(init_and_plan_context: t.Callable):
     context, plan = init_and_plan_context("examples/sushi")
     context.apply(plan)

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -2286,11 +2286,6 @@ def test_models_selected_for_backfill(make_snapshot, mocker: MockerFixture):
     )
 
     schema_differ = DuckDBEngineAdapter.SCHEMA_DIFFER
-    with pytest.raises(
-        PlanError,
-        match="Selecting models to backfill is only supported for development environments",
-    ):
-        PlanBuilder(context_diff, schema_differ, backfill_models={'"a"'}).build()
 
     plan = PlanBuilder(context_diff, schema_differ).build()
     assert plan.is_selected_for_backfill('"a"')


### PR DESCRIPTION
This update lets users select specific models to backfill as part of the `sqlmesh run` command. To ensure correctness, the set of selected models always includes the upstream dependencies of models that match the provided expression, regardless of whether the leading `+` was included in the original expression.

This should allow users to split their cadence runs into multiple non-overlapping jobs, helping to improve scalability.