### PR TITLE
Feat: Support exit from the run command with a provided code when interrupted by an update to the target env

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -398,16 +398,19 @@ Usage: sqlmesh run [OPTIONS] [ENVIRONMENT]
   Evaluate missing intervals for the target environment.
 
 Options:
-  -s, --start TEXT     The start datetime of the interval for which this
-                       command will be applied.
-  -e, --end TEXT       The end datetime of the interval for which this command
-                       will be applied.
-  --skip-janitor       Skip the janitor task.
-  --ignore-cron        Run for all missing intervals, ignoring individual cron
-                       schedules.
-  --select-model TEXT  Select specific models to run. Note: this always
-                       includes upstream dependencies.
-  --help               Show this message and exit.
+  -s, --start TEXT              The start datetime of the interval for which
+                                this command will be applied.
+  -e, --end TEXT                The end datetime of the interval for which
+                                this command will be applied.
+  --skip-janitor                Skip the janitor task.
+  --ignore-cron                 Run for all missing intervals, ignoring
+                                individual cron schedules.
+  --select-model TEXT           Select specific models to run. Note: this
+                                always includes upstream dependencies.
+  --exit-on-env-update INTEGER  If set, the command will exit with the
+                                specified code if the run is interrupted by an
+                                update to the target environment.
+  --help                        Show this message and exit.
 ```
 
 ## table_diff

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -444,6 +444,11 @@ def plan(
     multiple=True,
     help="Select specific models to run. Note: this always includes upstream dependencies.",
 )
+@click.option(
+    "--exit-on-env-update",
+    type=int,
+    help="If set, the command will exit with the specified code if the run is interrupted by an update to the target environment.",
+)
 @click.pass_context
 @error_handler
 @cli_analytics

--- a/sqlmesh/core/analytics/collector.py
+++ b/sqlmesh/core/analytics/collector.py
@@ -252,11 +252,15 @@ class AnalyticsCollector:
         )
         return run_id
 
-    def on_run_end(self, *, run_id: str, succeeded: bool, error: t.Optional[t.Any] = None) -> None:
+    def on_run_end(
+        self, *, run_id: str, succeeded: bool, interrupted: bool, error: t.Optional[t.Any] = None
+    ) -> None:
         """Called after a run ends.
 
         Args:
             run_id: The ID of the run.
+            succeeded: Whether the run succeeded.
+            interrupted: Whether the run was interrupted.
             error: The error that occurred during the run, if any.
         """
         self._add_event(
@@ -264,6 +268,7 @@ class AnalyticsCollector:
             {
                 "run_id": run_id,
                 "succeeded": succeeded,
+                "interrupted": interrupted,
                 "error": type(error).__name__ if error else None,
             },
         )

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -451,6 +451,11 @@ class SQLMeshMagics(Magics):
         nargs="*",
         help="Select specific models to run. Note: this always includes upstream dependencies.",
     )
+    @argument(
+        "--exit-on-env-update",
+        type=int,
+        help="If set, the command will exit with the specified code if the run is interrupted by an update to the target environment.",
+    )
     @line_magic
     @pass_sqlmesh_context
     def run_dag(self, context: Context, line: str) -> None:
@@ -464,6 +469,7 @@ class SQLMeshMagics(Magics):
             skip_janitor=args.skip_janitor,
             ignore_cron=args.ignore_cron,
             select_models=args.select_model,
+            exit_on_env_update=args.exit_on_env_update,
         )
         if not success:
             raise SQLMeshError("Error Running DAG. Check logs for details.")


### PR DESCRIPTION
Restarting the run may sometimes lead to the run job taking longer than expected. This gives users ability to terminate the run job instead of restarting it in place if an update to the target environment took place.