### PR TITLE
Fix: Copy grants when replacing a view in snowflake

### DIFF
--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -33,7 +33,7 @@ snowpark = optional_import("snowflake.snowpark")
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import SchemaName, SessionProperties, TableName
-    from sqlmesh.core.engine_adapter._typing import DF, Query, SnowparkSession
+    from sqlmesh.core.engine_adapter._typing import DF, Query, QueryOrDF, SnowparkSession
     from sqlmesh.core.node import IntervalUnit
 
 
@@ -154,6 +154,38 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
             column_descriptions=column_descriptions,
             table_kind=self.MANAGED_TABLE_KIND,
             **kwargs,
+        )
+
+    def create_view(
+        self,
+        view_name: TableName,
+        query_or_df: QueryOrDF,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        replace: bool = True,
+        materialized: bool = False,
+        materialized_properties: t.Optional[t.Dict[str, t.Any]] = None,
+        table_description: t.Optional[str] = None,
+        column_descriptions: t.Optional[t.Dict[str, str]] = None,
+        view_properties: t.Optional[t.Dict[str, exp.Expression]] = None,
+        **create_kwargs: t.Any,
+    ) -> None:
+        properties = create_kwargs.pop("properties", None)
+        if not properties:
+            properties = exp.Properties(expressions=[])
+        properties.append("expressions", exp.CopyGrantsProperty())
+
+        super().create_view(
+            view_name=view_name,
+            query_or_df=query_or_df,
+            columns_to_types=columns_to_types,
+            replace=replace,
+            materialized=materialized,
+            materialized_properties=materialized_properties,
+            table_description=table_description,
+            column_descriptions=column_descriptions,
+            view_properties=view_properties,
+            properties=properties,
+            **create_kwargs,
         )
 
     def drop_managed_table(self, table_name: TableName, exists: bool = True) -> None:

--- a/tests/core/engine_adapter/test_snowflake.py
+++ b/tests/core/engine_adapter/test_snowflake.py
@@ -145,7 +145,7 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
     assert sql_calls == [
         """CREATE TABLE IF NOT EXISTS "test_table" ("a" INT COMMENT 'a column description', "b" INT) COMMENT='table description'""",
         """CREATE TABLE IF NOT EXISTS "test_table" ("a" INT COMMENT 'a column description', "b" INT) COMMENT='table description' AS SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (SELECT "a", "b" FROM "source_table") AS "_subquery\"""",
-        """CREATE OR REPLACE VIEW "test_view" COMMENT='table description' AS SELECT "a", "b" FROM "source_table\"""",
+        """CREATE OR REPLACE VIEW "test_view" COPY GRANTS COMMENT='table description' AS SELECT "a", "b" FROM "source_table\"""",
         """ALTER VIEW "test_view" ALTER COLUMN "a" COMMENT 'a column description'""",
         """COMMENT ON TABLE "test_table" IS 'table description'""",
         """ALTER TABLE "test_table" ALTER COLUMN "a" COMMENT 'a column description'""",
@@ -175,7 +175,7 @@ def test_multiple_column_comments(make_mocked_engine_adapter: t.Callable, mocker
     sql_calls = to_sql_calls(adapter)
     assert sql_calls == [
         """CREATE TABLE IF NOT EXISTS "test_table" ("a" INT COMMENT 'a column description', "b" INT COMMENT 'b column description')""",
-        """CREATE OR REPLACE VIEW "test_view" AS SELECT "a", "b" FROM "test_table\"""",
+        """CREATE OR REPLACE VIEW "test_view" COPY GRANTS AS SELECT "a", "b" FROM "test_table\"""",
         """ALTER VIEW "test_view" ALTER COLUMN "a" COMMENT 'a column description', COLUMN "b" COMMENT 'b column description'""",
         """ALTER TABLE "test_table" ALTER COLUMN "a" COMMENT 'a column description changed', COLUMN "b" COMMENT 'b column description changed'""",
     ]
@@ -447,7 +447,7 @@ def test_creatable_type_materialized_view_properties(make_mocked_engine_adapter:
     sql_calls = to_sql_calls(adapter)
     # https://docs.snowflake.com/en/sql-reference/sql/create-materialized-view#syntax
     assert sql_calls == [
-        'CREATE OR REPLACE MATERIALIZED VIEW "test_table" CLUSTER BY ("a") AS SELECT 1',
+        'CREATE OR REPLACE MATERIALIZED VIEW "test_table" COPY GRANTS CLUSTER BY ("a") AS SELECT 1',
     ]
 
 
@@ -465,7 +465,7 @@ def test_creatable_type_secure_view(make_mocked_engine_adapter: t.Callable):
     sql_calls = to_sql_calls(adapter)
     # https://docs.snowflake.com/en/sql-reference/sql/create-view.html
     assert sql_calls == [
-        'CREATE OR REPLACE SECURE VIEW "test_table" AS SELECT 1',
+        'CREATE OR REPLACE SECURE VIEW "test_table" COPY GRANTS AS SELECT 1',
     ]
 
 
@@ -484,7 +484,7 @@ def test_creatable_type_secure_materialized_view(make_mocked_engine_adapter: t.C
     sql_calls = to_sql_calls(adapter)
     # https://docs.snowflake.com/en/sql-reference/sql/create-view.html
     assert sql_calls == [
-        'CREATE OR REPLACE SECURE MATERIALIZED VIEW "test_table" AS SELECT 1',
+        'CREATE OR REPLACE SECURE MATERIALIZED VIEW "test_table" COPY GRANTS AS SELECT 1',
     ]
 
 
@@ -501,7 +501,7 @@ def test_creatable_type_temporary_view(make_mocked_engine_adapter: t.Callable):
 
     sql_calls = to_sql_calls(adapter)
     assert sql_calls == [
-        'CREATE OR REPLACE TEMPORARY VIEW "test_table" AS SELECT 1',
+        'CREATE OR REPLACE TEMPORARY VIEW "test_table" COPY GRANTS AS SELECT 1',
     ]
 
 


### PR DESCRIPTION
This ensures that any grans assigned to the view are not lost as a result of view replacement.