### PR TITLE
chore: make it so duplicate snapshot push doesn't raise because this …

### DIFF
--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -208,7 +208,14 @@ class EngineAdapterStateSync(StateSync):
         existing = self.snapshots_exist(snapshots_by_id)
 
         if existing:
-            raise SQLMeshError(f"Snapshots {existing} already exists.")
+            logger.error(
+                "Snapshots %s already exists. This could be due to a concurrent plan or a hash collision. If this is a hash collision, add a stamp to your model.",
+                str(existing),
+            )
+
+            for sid in tuple(snapshots_by_id):
+                if sid in existing:
+                    snapshots_by_id.pop(sid)
 
         snapshots = snapshots_by_id.values()
 

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 import typing as t
 from unittest.mock import call, patch
@@ -141,17 +142,12 @@ def test_push_snapshots(
         snapshot_b.snapshot_id: snapshot_b,
     }
 
-    with pytest.raises(
-        SQLMeshError,
-        match=r".*already exists.*",
-    ):
+    logger = logging.getLogger("sqlmesh.core.state_sync.engine_adapter")
+    with patch.object(logger, "error") as mock_logger:
         state_sync.push_snapshots([snapshot_a])
-
-    with pytest.raises(
-        SQLMeshError,
-        match=r".*already exists.*",
-    ):
+        assert str({snapshot_a.snapshot_id}) == mock_logger.call_args[0][1]
         state_sync.push_snapshots([snapshot_a, snapshot_b])
+        assert str({snapshot_a.snapshot_id, snapshot_b.snapshot_id}) == mock_logger.call_args[0][1]
 
     # test serialization
     state_sync.push_snapshots(


### PR DESCRIPTION
…often happens due to concurrent plan applications