### PR TITLE
Fix: enable fetching schema for models querying INFORMATION_SCHEMA

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -223,17 +223,35 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
                 return "JSON"
             return kind.name
 
-        table = self._get_table(table_name)
-        columns = {
-            field.name: exp.DataType.build(
-                dtype_to_sql(field.to_standard_sql().type), dialect=self.dialect
-            )
-            for field in table.schema
-        }
-        if include_pseudo_columns and table.time_partitioning and not table.time_partitioning.field:
-            columns["_PARTITIONTIME"] = exp.DataType.build("TIMESTAMP")
-            if table.time_partitioning.type_ == "DAY":
-                columns["_PARTITIONDATE"] = exp.DataType.build("DATE")
+        def create_mapping_schema(
+            schema: t.Sequence[bigquery.SchemaField],
+        ) -> t.Dict[str, exp.DataType]:
+            return {
+                field.name: exp.DataType.build(
+                    dtype_to_sql(field.to_standard_sql().type), dialect=self.dialect
+                )
+                for field in schema
+            }
+
+        table = exp.to_table(table_name)
+        if len(table.parts) > 3:
+            # The client's `get_table` method can't handle paths with >3 identifiers
+            self.execute(exp.select("*").from_(table))
+            query_results = self._query_job._query_results
+            columns = create_mapping_schema(query_results.schema)
+        else:
+            bq_table = self._get_table(table)
+            columns = create_mapping_schema(bq_table.schema)
+
+            if (
+                include_pseudo_columns
+                and bq_table.time_partitioning
+                and not bq_table.time_partitioning.field
+            ):
+                columns["_PARTITIONTIME"] = exp.DataType.build("TIMESTAMP")
+                if bq_table.time_partitioning.type_ == "DAY":
+                    columns["_PARTITIONDATE"] = exp.DataType.build("DATE")
+
         return columns
 
     def alter_table(

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -236,7 +236,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
         table = exp.to_table(table_name)
         if len(table.parts) > 3:
             # The client's `get_table` method can't handle paths with >3 identifiers
-            self.execute(exp.select("*").from_(table))
+            self.execute(exp.select("*").from_(table).limit(1))
             query_results = self._query_job._query_results
             columns = create_mapping_schema(query_results.schema)
         else:

--- a/tests/core/engine_adapter/integration/__init__.py
+++ b/tests/core/engine_adapter/integration/__init__.py
@@ -23,6 +23,7 @@ from sqlmesh.utils.pydantic import PydanticModel
 from tests.utils.pandas import compare_dataframes
 
 if t.TYPE_CHECKING:
+    from sqlmesh.core._typing import TableName
     from sqlmesh.core.engine_adapter._typing import Query
 
 TEST_SCHEMA = "test_schema"
@@ -212,12 +213,16 @@ class TestContext:
     def output_data(self, data: pd.DataFrame) -> pd.DataFrame:
         return self._format_df(data)
 
-    def table(self, table_name: str, schema: str = TEST_SCHEMA) -> exp.Table:
+    def table(self, table_name: TableName, schema: str = TEST_SCHEMA) -> exp.Table:
         schema = self.add_test_suffix(schema)
         self._schemas.append(schema)
+
+        table = exp.to_table(table_name)
+        table.set("db", exp.parse_identifier(schema, dialect=self.dialect))
+
         return exp.to_table(
             normalize_model_name(
-                ".".join([schema, table_name]),
+                table,
                 default_catalog=self.engine_adapter.default_catalog,
                 dialect=self.dialect,
             )

--- a/tests/core/engine_adapter/integration/test_integration_bigquery.py
+++ b/tests/core/engine_adapter/integration/test_integration_bigquery.py
@@ -184,7 +184,7 @@ def test_fetch_schema_of_information_schema_tables(
     ctx: TestContext, engine_adapter: BigQueryEngineAdapter
 ):
     # We produce Table(this=Dot(this=INFORMATION_SCHEMA, expression=TABLES)) here,
-    # otherwise `db` or `catalog` wo3uld be set, which is not the right representation
+    # otherwise `db` or `catalog` would be set, which is not the right representation
     information_schema_tables = exp.to_table("_._.INFORMATION_SCHEMA.TABLES")
     information_schema_tables.set("db", None)
     information_schema_tables.set("catalog", None)

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -5945,12 +5945,12 @@ MODEL (
   dialect snowflake,
 );
 
-SELECT * FROM (@custom_macro(@foo, @bar)) AS q
+SELECT * FROM (@custom_macro(@a, @b)) AS q
     """)
 
     config = Config(
         model_defaults=ModelDefaultsConfig(dialect="duckdb"),
-        variables={"foo": "foo", "bar": "boo"},
+        variables={"a": "a", "b": "b"},
     )
     context = Context(paths=tmp_path, config=config)
 


### PR DESCRIPTION
This is related to #3317 but does not completely fix it. There are two problems at hand here:

1. We're currently parsing queries like `SELECT * FROM dataset.INFORMATION_SCHEMA.SOME_VIEW` incorrectly: the `Table` node's `catalog` field gets set to `dataset`, but the correct representation is to keep it in `db` and create a `Dot` node for the `INFORMATION_SCHEMA.SOME_VIEW` part. I'm planning to look into this issue separately, as it's gonna be more involved and will probably need some new logic in SQLGlot to detect references to `INFORMATION_SCHEMA` views.
2. Even if the table was fully-qualified, i.e. `SELECT * FROM project.dataset.INFORMATION_SCHEMA.SOME_VIEW`, we would still fail because the BigQuery client's `get_table` [method](https://github.com/TobikoData/sqlmesh/blob/feb96867c7a3242eab2b6d23e1f78dcca9c9c411/sqlmesh/core/engine_adapter/bigquery.py#L590-L596) doesn't work with table references that have more than 3 identifiers or "parts" in the referenced database object. Here's the [source code](https://github.com/googleapis/python-bigquery/blob/fef8b886bc86d355c7745585fc53dc8a5a019ab1/google/cloud/bigquery/client.py#L1132) in case anyone wants to verify this, the bottom line is that this [method](https://github.com/googleapis/python-bigquery/blob/fef8b886bc86d355c7745585fc53dc8a5a019ab1/google/cloud/bigquery/_helpers.py#L945) is called with a 4-part reference and fails:

```
ValueError: table_id must be a fully-qualified ID in standard SQL format, e.g., "project.dataset.table_id", got project.dataset.INFORMATION_SCHEMA.TABLES
```

This PR addresses (2), while https://github.com/tobymao/sqlglot/pull/4336 addresses (1).