### PR TITLE
Feat: Add multiple gateway support for DuckDB and Postgres

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -1152,6 +1152,14 @@ class PostgresConnectionConfig(ConnectionConfig):
 
         return init
 
+    @property
+    def _libpq_string(self) -> str:
+        return (
+            f"dbname={self.database} user={self.user} "
+            f"host={self.host} password={self.password} "
+            f"port={self.port}"
+        )
+
 
 class MySQLConnectionConfig(ConnectionConfig):
     host: str

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -58,6 +58,7 @@ class Config(BaseConfig):
         default_test_connection: The default connection to use for tests if one is not specified in a gateway.
         default_scheduler: The default scheduler configuration to use if one is not specified in a gateway.
         default_gateway: The default gateway.
+        cross_gateway: Whether the project sources from multiple gateways. Currently supports DuckDB and PostgreSQL.
         notification_targets: The notification targets to use.
         project: The project name of this config. Used for multi-repo setups.
         snapshot_ttl: The period of time that a model snapshot that is not a part of any environment should exist before being deleted.
@@ -93,6 +94,7 @@ class Config(BaseConfig):
     )
     default_scheduler: SchedulerConfig = BuiltInSchedulerConfig()
     default_gateway: str = ""
+    cross_gateway: bool = False
     notification_targets: t.List[NotificationTarget] = []
     project: str = ""
     snapshot_ttl: str = c.DEFAULT_SNAPSHOT_TTL


### PR DESCRIPTION
This update enables sourcing data from multiple PostgreSQL and DuckDB gateways, allowing references to the databases defined in the config file's `gateways` by setting the `cross_gateway` key to `true` :

```yaml
gateways:
    main_db:
        connection:
            type: duckdb
            database: main_db.db
    postgres_db:
        connection:
            type: postgres
            host: 127.0.0.1
            port: 5432
            user: admin
            password: 1234
            database: postgres_db
    secondary_db:
        connection:
            type: duckdb
            database: secondary_db.duckdb
            
default_gateway: main_db
cross_gateway: true
```

Then in the model definitions, data can be sourced from any of the gateways, allowing for operations like joining tables across them:

```sql
MODEL (
  name main_db.sales_summary,
  kind FULL
);

SELECT
  s.customer_id,
  s.order_id,
  s.order_date,
  p.product_name
FROM 
  postgres_db.public.orders AS s
JOIN 
  secondary_db.products AS p
ON 
  s.product_id = p.product_id;
```
