### PR TITLE
Feat: allow formatting specific models via path posargs for more typi…

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -221,6 +221,7 @@ def evaluate(
 
 
 @cli.command("format")
+@click.argument("paths", nargs=-1)
 @click.option(
     "-t",
     "--transpile",
@@ -280,12 +281,14 @@ def evaluate(
 @click.pass_context
 @error_handler
 @cli_analytics
-def format(ctx: click.Context, **kwargs: t.Any) -> None:
+def format(
+    ctx: click.Context, paths: t.Optional[t.Tuple[str, ...]] = None, **kwargs: t.Any
+) -> None:
     """Format all SQL models and audits."""
     if kwargs.pop("no_rewrite_casts", None):
         kwargs["rewrite_casts"] = False
 
-    if not ctx.obj.format(**{k: v for k, v in kwargs.items() if v is not None}):
+    if not ctx.obj.format(**{k: v for k, v in kwargs.items() if v is not None}, paths=paths):
         ctx.exit(1)
 
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -971,12 +971,15 @@ class GenericContext(BaseContext, t.Generic[C]):
         append_newline: t.Optional[bool] = None,
         *,
         check: t.Optional[bool] = None,
+        paths: t.Optional[t.Tuple[t.Union[str, Path], ...]] = None,
         **kwargs: t.Any,
     ) -> bool:
         """Format all SQL models and audits."""
         format_targets = {**self._models, **self._audits}
         for target in format_targets.values():
             if target._path is None or target._path.suffix != ".sql":
+                continue
+            if paths and not any(target._path.samefile(p) for p in paths):
                 continue
 
             with open(target._path, "r+", encoding="utf-8") as file:


### PR DESCRIPTION
…cal and robust cli behavior.

This allows `sqlmesh format` to be used much more prescriptively. Furthermore it can be used in pre-commit hooks correctly this way too. The all or nothing was very limiting so we get this discernment almost for free given small change. 