### PR TITLE
mkdocs.yml: add favicon

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
 theme:
   name: material
   logo: _readthedocs/html/sqlmesh.png
+  favicon: https://pbs.twimg.com/profile_images/1783223124743335936/uqPPe0wD_200x200.png  
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default


### PR DESCRIPTION
Added a favicon in sqlmesh doc site. 

It is a shame to have the mkdocs-material favicon. 
I can't find the tab in my browser of sqlmesho doc among all my open tabs.


I put the logo of sqlmesh I found on twitter, but you may prefer to add a proper favicon in html folder in this repo.


![image](https://github.com/user-attachments/assets/8679840e-0b0d-43d8-8dfb-ed610dd7faa1)
