### PR TITLE
Feat: Add dlt_refresh command to update models from a dlt pipeline

### DIFF
--- a/docs/integrations/dlt.md
+++ b/docs/integrations/dlt.md
@@ -28,6 +28,28 @@ This will create the configuration file and directories, which are found in all 
 
 SQLMesh will also automatically generate models to ingest data from the pipeline incrementally. Incremental loading is ideal for large datasets where recomputing entire tables is resource-intensive. In this case utilizing the [`INCREMENTAL_BY_TIME_RANGE` model kind](../concepts/models/model_kinds.md#incremental_by_time_range). However, these model definitions can be customized to meet your specific project needs.
 
+### Generating models on demand
+
+To update the models in your SQLMesh project on demand, use the `dlt_refresh` command. This allows you to either specify individual tables to generate incremental models from or update all models at once.
+
+- **Generate all missing tables**:
+  
+```bash
+$ sqlmesh dlt_refresh <pipeline-name>
+```
+
+- **Generate all missing tables and overwrite existing ones** (use with `--force` or `-f`):
+  
+```bash
+$ sqlmesh dlt_refresh <pipeline-name> --force
+```
+
+- **Generate specific dlt tables** (using `--table` or `-t`):
+
+```bash
+$ sqlmesh dlt_refresh <pipeline-name> --table <dlt-table>
+```
+
 #### Configuration
 
 SQLMesh will retrieve the data warehouse connection credentials from your dlt project to configure the `config.yaml` file. This configuration can be modified or customized as needed. For more details, refer to the [configuration guide](../guides/configuration.md).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -121,16 +121,16 @@ Options:
   --help               Show this message and exit.
 ```
 
-## dlt
+## dlt_refresh
 
 ```
-Usage: dlt PIPELINE [OPTIONS]
+Usage: dlt_refresh PIPELINE [OPTIONS]
 
   Attaches to a DLT pipeline with the option to update specific or all models of the SQLMesh project.
 
 Options:
-  -u, --update TEXT  The DLT tables to generate SQLMesh models from. When none specified, all new missing tables will be generated.
-  -f, --force        If set it will overwrite existing models with the new generated models from the DLT tables.
+  -t, --table TEXT  The DLT tables to generate SQLMesh models from. When none specified, all new missing tables will be generated.
+  -f, --force       If set it will overwrite existing models with the new generated models from the DLT tables.
 ```
 
 ## diff

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -121,6 +121,18 @@ Options:
   --help               Show this message and exit.
 ```
 
+## dlt
+
+```
+Usage: dlt PIPELINE [OPTIONS]
+
+  Attaches to a DLT pipeline with the option to update specific or all models of the SQLMesh project.
+
+Options:
+  -u, --update TEXT  The DLT tables to generate SQLMesh models from. When none specified, all new missing tables will be generated.
+  -f, --force        If set it will overwrite existing models with the new generated models from the DLT tables.
+```
+
 ## diff
 
 ```

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -230,6 +230,17 @@ options:
   --file FILE, -f FILE  An optional file path to write the HTML output to.
 ```
 
+#### dlt
+```
+%dlt PIPELINE [--update] TABLE [--force]
+
+Attaches to a DLT pipeline with the option to update specific or all models of the SQLMesh project.
+
+options:
+  --update TABLE, -u TABLE  The DLT tables to generate SQLMesh models from. When none specified, all new missing tables will be generated.
+  --force, -f               If set it will overwrite existing models with the new generated models from the DLT tables.
+```
+
 #### fetchdf
 ```
 %%fetchdf [df_var]

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -230,15 +230,15 @@ options:
   --file FILE, -f FILE  An optional file path to write the HTML output to.
 ```
 
-#### dlt
+#### dlt_refresh
 ```
-%dlt PIPELINE [--update] TABLE [--force]
+%dlt_refresh PIPELINE [--table] TABLE [--force]
 
 Attaches to a DLT pipeline with the option to update specific or all models of the SQLMesh project.
 
 options:
-  --update TABLE, -u TABLE  The DLT tables to generate SQLMesh models from. When none specified, all new missing tables will be generated.
-  --force, -f               If set it will overwrite existing models with the new generated models from the DLT tables.
+  --table TABLE, -t TABLE  The DLT tables to generate SQLMesh models from. When none specified, all new missing tables will be generated.
+  --force, -f              If set it will overwrite existing models with the new generated models from the DLT tables.
 ```
 
 #### fetchdf

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -916,3 +916,38 @@ def clean(obj: Context) -> None:
 def table_name(obj: Context, model_name: str, dev: bool) -> None:
     """Prints the name of the physical table for the given model."""
     print(obj.table_name(model_name, dev))
+
+
+@cli.command("dlt")
+@click.argument("pipeline", required=True)
+@click.option(
+    "-u",
+    "--update",
+    type=str,
+    multiple=True,
+    is_flag=False,
+    flag_value="UpdateAllFlag",
+    help="The dlt tables to update in the SQLMesh models. When none specified, all missing tables will be added.",
+)
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    default=False,
+    help="If set it will overwrite the existing models with the new dlt tables.",
+)
+@click.pass_context
+@error_handler
+@cli_analytics
+def dlt(
+    ctx: click.Context,
+    pipeline: str,
+    force: bool,
+    update: t.List[str] = [],
+) -> None:
+    """Attaches to a DLT pipeline with the option to update specific or all models in the SQLMesh project."""
+    from sqlmesh.integrations.dlt import update_dlt_models
+
+    if update:
+        update_tables = list(update) if update[0] != "UpdateAllFlag" else []
+        ctx.obj.console.log_success(update_dlt_models(ctx.obj, pipeline, update_tables, force))

--- a/sqlmesh/integrations/dlt.py
+++ b/sqlmesh/integrations/dlt.py
@@ -101,10 +101,7 @@ def update_dlt_models(
     )
 
     if not update_tables and not force:
-        existing_models = [
-            ".".join(model_name.replace('"', "").split(".")[-2:])
-            for model_name in context.models.keys()
-        ]
+        existing_models = [m.name for m in context.models.values()]
         sqlmesh_models = {model for model in sqlmesh_models if model[0] not in existing_models}
 
     if sqlmesh_models:

--- a/sqlmesh/integrations/dlt.py
+++ b/sqlmesh/integrations/dlt.py
@@ -4,11 +4,12 @@ from datetime import datetime, timedelta, timezone
 from pydantic import ValidationError
 from sqlglot import exp, parse_one
 from sqlmesh.core.config.connection import parse_connection_config
+from sqlmesh.core.context import Context
 from sqlmesh.utils.date import yesterday_ds
 
 
 def generate_dlt_models_and_settings(
-    pipeline_name: str, dialect: str
+    pipeline_name: str, dialect: str, update_tables: t.Optional[t.List[str]] = None
 ) -> t.Tuple[t.Set[t.Tuple[str, str]], str, str]:
     """This function attaches to a DLT pipeline and retrieves the connection configs and
     SQLMesh models based on the tables present in the pipeline's default schema.
@@ -42,8 +43,11 @@ def generate_dlt_models_and_settings(
     dlt_tables = {
         name: table
         for name, table in schema.tables.items()
-        if (has_table_seen_data(table) and not name.startswith(schema._dlt_tables_prefix))
-        or name == schema.loads_table_name
+        if (
+            (has_table_seen_data(table) and not name.startswith(schema._dlt_tables_prefix))
+            or name == schema.loads_table_name
+        )
+        and (name in update_tables if update_tables else True)
     }
 
     sqlmesh_models = set()
@@ -83,6 +87,32 @@ def generate_dlt_models_and_settings(
         sqlmesh_models.add((incremental_model_name, incremental_model_sql))
 
     return sqlmesh_models, format_config(configs, db_type), get_start_date(storage_ids)
+
+
+def update_dlt_models(
+    context: Context, pipeline_name: str, update_tables: t.List[str], force: bool
+) -> str:
+    from sqlmesh.cli.example_project import _create_models
+
+    sqlmesh_models, _, _ = generate_dlt_models_and_settings(
+        pipeline_name=pipeline_name,
+        dialect=context.config.dialect or "",
+        update_tables=update_tables if update_tables else None,
+    )
+
+    if not update_tables and not force:
+        existing_models = [
+            ".".join(model_name.replace('"', "").split(".")[-2:])
+            for model_name in context.models.keys()
+        ]
+        sqlmesh_models = {model for model in sqlmesh_models if model[0] not in existing_models}
+
+    if sqlmesh_models:
+        _create_models(models_path=context.path / "models", models=sqlmesh_models)
+        model_names = "\n".join([f"- {model[0]}" for model in sqlmesh_models])
+        return f"Updated SQLMesh models:\n{model_names}"
+    else:
+        return "All SQLMesh models are up to date."
 
 
 def generate_incremental_model(

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -699,12 +699,14 @@ class SQLMeshMagics(Magics):
     )
     @argument(
         "--update",
+        "-u",
         type=str,
         nargs="*",
         help="The dlt tables to update in the SQLMesh models. When none specified, all missing tables will be added.",
     )
     @argument(
         "--force",
+        "-f",
         action="store_true",
         help="If set it will overwrite the existing models with the new dlt tables.",
     )
@@ -715,7 +717,7 @@ class SQLMeshMagics(Magics):
         from sqlmesh.integrations.dlt import update_dlt_models
 
         args = parse_argstring(self.dlt, line)
-        if args.update:
+        if args.update is not None:
             context.console.log_status_update(
                 update_dlt_models(context, args.pipeline, list(args.update), args.force)
             )

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -692,6 +692,36 @@ class SQLMeshMagics(Magics):
 
     @magic_arguments()
     @argument(
+        "pipeline",
+        nargs="?",
+        type=str,
+        help="The dlt pipeline to attach for this SQLMesh project.",
+    )
+    @argument(
+        "--update",
+        type=str,
+        nargs="*",
+        help="The dlt tables to update in the SQLMesh models. When none specified, all missing tables will be added.",
+    )
+    @argument(
+        "--force",
+        action="store_true",
+        help="If set it will overwrite the existing models with the new dlt tables.",
+    )
+    @line_magic
+    @pass_sqlmesh_context
+    def dlt(self, context: Context, line: str) -> None:
+        """Attaches to a DLT pipeline with the option to update specific or all models in the SQLMesh project."""
+        from sqlmesh.integrations.dlt import update_dlt_models
+
+        args = parse_argstring(self.dlt, line)
+        if args.update:
+            context.console.log_status_update(
+                update_dlt_models(context, args.pipeline, list(args.update), args.force)
+            )
+
+    @magic_arguments()
+    @argument(
         "--read",
         type=str,
         default="",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -10,7 +10,7 @@ from freezegun import freeze_time
 from sqlmesh.cli.example_project import ProjectTemplate, init_example_project
 from sqlmesh.cli.main import cli
 from sqlmesh.core.context import Context
-from sqlmesh.integrations.dlt import update_dlt_models
+from sqlmesh.integrations.dlt import generate_dlt_models
 from sqlmesh.utils.date import yesterday_ds
 
 FREEZE_TIME = "2023-01-01 00:00:00"
@@ -792,10 +792,9 @@ WHERE
 
     # Update with force = False will generate only the missing model
     context = Context(paths=tmp_path)
-    assert (
-        update_dlt_models(context, "sushi", [], False)
-        == "Updated SQLMesh models:\n- sushi_dataset_sqlmesh.incremental_waiters"
-    )
+    assert generate_dlt_models(context, "sushi", [], False) == [
+        "sushi_dataset_sqlmesh.incremental_waiters"
+    ]
     assert dlt_waiters_model_path.exists()
 
     # Remove all models
@@ -804,18 +803,17 @@ WHERE
     remove(dlt_sushi_types_model_path)
 
     # Update to generate a specific model: sushi_types
-    assert (
-        update_dlt_models(context, "sushi", ["sushi_types"], False)
-        == "Updated SQLMesh models:\n- sushi_dataset_sqlmesh.incremental_sushi_types"
-    )
+    assert generate_dlt_models(context, "sushi", ["sushi_types"], False) == [
+        "sushi_dataset_sqlmesh.incremental_sushi_types"
+    ]
 
-    # Only the sushi_types now should be generated
+    # Only the sushi_types should be generated now
     assert not dlt_waiters_model_path.exists()
     assert not dlt_loads_model_path.exists()
     assert dlt_sushi_types_model_path.exists()
 
     # Update with force = True will generate all models and overwrite existing ones
-    update_dlt_models(context, "sushi", [], True)
+    generate_dlt_models(context, "sushi", [], True)
     assert dlt_loads_model_path.exists()
     assert dlt_sushi_types_model_path.exists()
     assert dlt_waiters_model_path.exists()


### PR DESCRIPTION
As part of the dlt integration, this update introduces the `dlt_refresh` command to attach to a dlt pipeline and update the SQLMesh models, either by specifying the tables to be generated or updating with all the new tables.
### Usage:

- **Generate all missing tables**:
  
```bash
$ sqlmesh dlt_refresh <pipeline-name>
```

- **Generate all missing tables and overwrite existing ones** (use with `--force` or `-f`):
  
```bash
$ sqlmesh dlt_refresh <pipeline-name> --force
```

- **Generate specific dlt tables** (using `--table` or `-t`):

```bash
$ sqlmesh dlt_refresh <pipeline-name> --table <dlt-table>
```
