### PR TITLE
suggestion: cleaner errors on failure

### DIFF
--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -371,12 +371,12 @@ class Scheduler:
         for error in errors:
             if isinstance(error.__cause__, CircuitBreakerError):
                 raise error.__cause__
-            sid = error.node[0]
-            formatted_exception = "".join(format_exception(error.__cause__ or error))
-            log_message = f"FAILED processing snapshot {sid}\n{formatted_exception}"
-            self.console.log_error(log_message)
-            # Log with INFO level to prevent duplicate messages in the console.
-            logger.info(log_message)
+            # sid = error.node[0]
+            # formatted_exception = "".join(format_exception(error.__cause__ or error))
+            # log_message = f"FAILED processing snapshot {sid}\n{formatted_exception}"
+            # self.console.log_error(log_message)
+            # # Log with INFO level to prevent duplicate messages in the console.
+            # logger.info(log_message)
 
         return not errors
 

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -488,7 +488,7 @@ def print_exception(
             )
         )
 
-    out.write(os.linesep.join(tb))
+    out.write(f"\033[31m{os.linesep.join(tb)}\033[0m")
 
 
 def import_python_file(path: Path, relative_base: Path = Path()) -> types.ModuleType:


### PR DESCRIPTION
I've recently started using sqlmesh and am really enjoying it! One place I've found it to be a bit difficult is parsing error messages. I've noticed that the error is frequently in the middle of a lot of other logs and it's been a bit verbose. 

This is by no means a PR to merge, but rather a suggestion/discussion opener for a potentially cleaner error log output. 

Here is the current state when I write a bug, for example yielding None
![image](https://github.com/user-attachments/assets/612560d7-dd4a-43ad-9a89-88e1d47318dc)
I zoomed out so you can see the full trace.

Here it is with the double logs commented out
![image](https://github.com/user-attachments/assets/5db8d638-fc18-4649-b8ec-ba5fbde84181)


Or something even more extreme, just to show the point
<img width="1092" alt="image" src="https://github.com/user-attachments/assets/7c08d454-775e-4e58-8013-9f1223661d7f">


We could also pick non-red to make it even more obvious, just wanted to start the discussion.

Thanks for the awesome tool!