### PR TITLE
Fix: always make dataframes hashable when comparing them in unit tests

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -237,10 +237,11 @@ class ModelTest(unittest.TestCase):
                 return tuple((k, _to_hashable(v)) for k, v in x.items())
             return str(x) if not isinstance(x, t.Hashable) else x
 
+        actual = actual.apply(lambda col: col.map(_to_hashable))
+        expected = expected.apply(lambda col: col.map(_to_hashable))
+
         if sort:
-            actual = actual.apply(lambda col: col.map(_to_hashable))
             actual = actual.sort_values(by=actual.columns.to_list()).reset_index(drop=True)
-            expected = expected.apply(lambda col: col.map(_to_hashable))
             expected = expected.sort_values(by=expected.columns.to_list()).reset_index(drop=True)
 
         try:

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -388,7 +388,6 @@ test_array_order:
     )
 
 
-
 @pytest.mark.parametrize(
     "waiter_names_input",
     [


### PR DESCRIPTION
Fixes #3352