### PR TITLE
Fix(clickhouse): support non-datetime time column partitioning

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -335,8 +335,8 @@ workflows:
           name: cloud_engine_<< matrix.engine >>
           context:
             - sqlmesh_cloud_database_integration
-          requires:
-            - engine_tests_docker
+          # requires:
+          #   - engine_tests_docker
           matrix:
             parameters:
               engine:
@@ -346,10 +346,10 @@ workflows:
                 - bigquery
                 - clickhouse-cloud
                 - athena
-          filters:
-           branches:
-             only:
-               - main
+          # filters:
+          #  branches:
+          #    only:
+          #      - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -335,8 +335,8 @@ workflows:
           name: cloud_engine_<< matrix.engine >>
           context:
             - sqlmesh_cloud_database_integration
-          # requires:
-          #   - engine_tests_docker
+          requires:
+            - engine_tests_docker
           matrix:
             parameters:
               engine:
@@ -346,10 +346,10 @@ workflows:
                 - bigquery
                 - clickhouse-cloud
                 - athena
-          # filters:
-          #  branches:
-          #    only:
-          #      - main
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -985,9 +985,9 @@ class _Model(ModelMeta, frozen=True):
     @property
     def partitioned_by(self) -> t.List[exp.Expression]:
         """Columns to partition the model by, including the time column if it is not already included."""
-        if self.time_column and self.time_column.column not in [
-            col for col in self._partition_by_columns
-        ]:
+        if self.time_column and self.time_column.column not in {
+            col for expr in self.partitioned_by_ for col in expr.find_all(exp.Column)
+        }:
             return [
                 TIME_COL_PARTITION_FUNC.get(self.dialect, lambda x, y: x)(
                     self.time_column.column, self.columns_to_types

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2477,8 +2477,8 @@ def clickhouse_partition_func(
 ) -> exp.Expression:
     # `toMonday()` function accepts a Date or DateTime type column
 
-    col_type_present = columns_to_types and column.name in columns_to_types
-    col_type_is_conformable = col_type_present and columns_to_types[column.name].is_type(
+    col_type = columns_to_types.get(column.name) or exp.DataType.build("UNKNOWN")
+    col_type_is_conformable = col_type.is_type(
         exp.DataType.Type.DATE,
         exp.DataType.Type.DATE32,
         exp.DataType.Type.DATETIME,

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2508,4 +2508,4 @@ def clickhouse_partition_func(
     )
 
 
-TIME_COL_PARTITION_FUNC = {"clickhouse": lambda x, y: clickhouse_partition_func(x, y)}
+TIME_COL_PARTITION_FUNC = {"clickhouse": clickhouse_partition_func}

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -982,6 +982,20 @@ class _Model(ModelMeta, frozen=True):
 
         return self._full_depends_on
 
+    @property
+    def partitioned_by(self) -> t.List[exp.Expression]:
+        """Columns to partition the model by, including the time column if it is not already included."""
+        if self.time_column and self.time_column.column not in [
+            col for col in self._partition_by_columns
+        ]:
+            return [
+                TIME_COL_PARTITION_FUNC.get(self.dialect, lambda x, y: x)(
+                    self.time_column.column, self.columns_to_types
+                ),
+                *self.partitioned_by_,
+            ]
+        return self.partitioned_by_
+
 
 class _SqlBasedModel(_Model):
     inline_audits_: t.Dict[str, t.Any] = Field(default={}, alias="inline_audits")
@@ -2455,3 +2469,43 @@ META_FIELD_CONVERTER: t.Dict[str, t.Callable] = {
 def get_model_name(path: Path) -> str:
     path_parts = list(path.parts[path.parts.index("models") + 1 : -1]) + [path.stem]
     return ".".join(path_parts[-3:])
+
+
+# function applied to time column when automatically used for partitioning in INCREMENTAL_BY_TIME_RANGE models
+def clickhouse_partition_func(
+    column: exp.Expression, columns_to_types: t.Dict[str, exp.DataType]
+) -> exp.Expression:
+    # `toMonday()` function accepts a Date or DateTime type column
+
+    col_type_present = columns_to_types and column.name in columns_to_types
+    col_type_is_conformable = col_type_present and columns_to_types[column.name].is_type(
+        exp.DataType.Type.DATE,
+        exp.DataType.Type.DATE32,
+        exp.DataType.Type.DATETIME,
+        exp.DataType.Type.DATETIME64,
+    )
+
+    #  if input column is already a conformable type, just pass the column
+    if col_type_is_conformable:
+        return exp.func("toMonday", column)
+
+    # if input column type is not known, cast input to DateTime64
+    if not col_type_present or (
+        col_type_present and columns_to_types[column.name].is_type(exp.DataType.Type.UNKNOWN)
+    ):
+        return exp.func(
+            "toMonday",
+            exp.cast(column, exp.DataType.build("DateTime64('UTC')", dialect="clickhouse")),
+        )
+
+    # if input column type is known but not conformable, cast input to DateTime64 and cast output back to original type
+    return exp.cast(
+        exp.func(
+            "toMonday",
+            exp.cast(column, exp.DataType.build("DateTime64('UTC')", dialect="clickhouse")),
+        ),
+        columns_to_types[column.name],
+    )
+
+
+TIME_COL_PARTITION_FUNC = {"clickhouse": lambda x, y: clickhouse_partition_func(x, y)}

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -373,8 +373,16 @@ class ModelMeta(_Node):
         if self.time_column and self.time_column.column not in [
             col for col in self._partition_by_columns
         ]:
+            # get `Model` superclass columns_to_types if available
+            try:
+                columns_to_types = self.columns_to_types  # type: ignore
+            except AttributeError:
+                columns_to_types = self.columns_to_types_
+
             return [
-                TIME_COL_PARTITION_FUNC.get(self.dialect, lambda x: x)(self.time_column.column),
+                TIME_COL_PARTITION_FUNC.get(self.dialect, lambda x, y: x)(
+                    self.time_column.column, columns_to_types
+                ),
                 *self.partitioned_by_,
             ]
         return self.partitioned_by_
@@ -480,10 +488,41 @@ class ModelMeta(_Node):
         return getattr(self.kind, "on_destructive_change", OnDestructiveChange.ALLOW)
 
 
-# function applied to time column when automatically used for partitioning in
-#   INCREMENTAL_BY_TIME_RANGE models
-TIME_COL_PARTITION_FUNC = {
-    "clickhouse": lambda x: exp.func(
-        "toMonday", exp.cast(x, exp.DataType.build("DateTime64", dialect="clickhouse"))
+# function applied to time column when automatically used for partitioning in INCREMENTAL_BY_TIME_RANGE models
+def clickhouse_partition_func(
+    column: exp.Expression, columns_to_types: t.Dict[str, exp.DataType]
+) -> exp.Expression:
+    # `toMonday()` function accepts a Date or DateTime type column
+
+    col_type_present = columns_to_types and column.name in columns_to_types
+    col_type_is_conformable = col_type_present and columns_to_types[column.name].is_type(
+        exp.DataType.Type.DATE,
+        exp.DataType.Type.DATE32,
+        exp.DataType.Type.DATETIME,
+        exp.DataType.Type.DATETIME64,
     )
-}
+
+    #  if input column is already a conformable type, just pass the column
+    if col_type_is_conformable:
+        return exp.func("toMonday", column)
+
+    # if input column type is not known, cast input to DateTime64
+    if not col_type_present or (
+        col_type_present and columns_to_types[column.name].is_type(exp.DataType.Type.UNKNOWN)
+    ):
+        return exp.func(
+            "toMonday",
+            exp.cast(column, exp.DataType.build("DateTime64('UTC')", dialect="clickhouse")),
+        )
+
+    # if input column type is known but not conformable, cast input to DateTime64 and cast output back to original type
+    return exp.cast(
+        exp.func(
+            "toMonday",
+            exp.cast(column, exp.DataType.build("DateTime64('UTC')", dialect="clickhouse")),
+        ),
+        columns_to_types[column.name],
+    )
+
+
+TIME_COL_PARTITION_FUNC = {"clickhouse": lambda x, y: clickhouse_partition_func(x, y)}

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -435,10 +435,6 @@ class ModelMeta(_Node):
         ]
 
     @property
-    def _partition_by_columns(self) -> t.List[exp.Column]:
-        return [col for expr in self.partitioned_by_ for col in expr.find_all(exp.Column)]
-
-    @property
     def managed_columns(self) -> t.Dict[str, exp.DataType]:
         return getattr(self.kind, "managed_columns", {})
 


### PR DESCRIPTION
The Clickhouse adapter automatically partitions incremental by time models if the time column is not included in any partitioning expression.

Clickhouse strongly recommends against fine-grained/small partitions. Therefore, the automatic partitioning "floors" the time column to weekly granularity with the `toMonday()` function.

`toMonday()` only accepts date/datetime input types, so we currently error if the time column is string type.

This PR allows non-date/datetime time columns by:
- If time column type known and date/datetime, pass column directly
- If time column type known and NOT date/datetime, cast time column to `DateTime64` before passing to `toMonday()` then cast output back to original time column type
- If time column type not known, cast time column to `DateTime64` before passing to `toMonday()`

### Implementation note

This PR moves the `partitioned_by` property from the `ModelMeta` to `_Model` class so it can access the `_Model` `column_to_types` property.
