### PR TITLE
Fix: use model fqns when generating unit tests

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -709,7 +709,7 @@ def generate_test(
     # ruamel.yaml does not support pandas Timestamps, so we must convert them to python
     # datetime or datetime.date objects based on column type
     inputs = {
-        models[dep].name: pandas_timestamp_to_pydatetime(
+        dep: pandas_timestamp_to_pydatetime(
             engine_adapter.fetchdf(query).apply(lambda col: col.map(_normalize_df_value)),
             models[dep].columns_to_types,
         )
@@ -719,7 +719,7 @@ def generate_test(
     }
     outputs: t.Dict[str, t.Any] = {"query": {}}
     variables = variables or {}
-    test_body = {"model": model.name, "inputs": inputs, "outputs": outputs}
+    test_body = {"model": model.fqn, "inputs": inputs, "outputs": outputs}
 
     if variables:
         test_body["vars"] = variables

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -1854,7 +1854,7 @@ def test_test_generation_with_data_structures(tmp_path: Path, column: str, expec
     bar_sql_file.write_text("MODEL (name sqlmesh_example.bar); SELECT col FROM external_table;")
 
     test = create_test(Context(paths=tmp_path, config=config), f"SELECT {column} AS col")
-    assert test["test_foo"]["inputs"] == {"sqlmesh_example.bar": expected}
+    assert test["test_foo"]["inputs"] == {'"memory"."sqlmesh_example"."bar"': expected}
     assert test["test_foo"]["outputs"] == {"query": expected}
 
 
@@ -1884,7 +1884,9 @@ def test_test_generation_with_timestamp(tmp_path: Path) -> None:
     assert len(test) == 1
     assert "test_foo" in test
     assert test["test_foo"]["inputs"] == {
-        "sqlmesh_example.bar": [{"ts_col": datetime.datetime(2024, 9, 20, 11, 30, 0, 123456)}]
+        '"memory"."sqlmesh_example"."bar"': [
+            {"ts_col": datetime.datetime(2024, 9, 20, 11, 30, 0, 123456)}
+        ]
     }
     assert test["test_foo"]["outputs"] == {
         "query": [{"ts_col": datetime.datetime(2024, 9, 20, 11, 30, 0, 123456)}]
@@ -1908,7 +1910,9 @@ def test_test_generation_with_decimal(tmp_path: Path, mocker: MockerFixture) -> 
     bar_sql_file.write_text("MODEL (name sqlmesh_example.bar); SELECT dec_col FROM external_table;")
 
     context = Context(paths=tmp_path, config=config)
-    input_queries = {"sqlmesh_example.bar": "SELECT CAST(1.23 AS DECIMAL(10,2)) AS dec_col"}
+    input_queries = {
+        '"memory"."sqlmesh_example"."bar"': "SELECT CAST(1.23 AS DECIMAL(10,2)) AS dec_col"
+    }
 
     # DuckDB actually returns a numpy.float64, even though the value is cast into a DECIMAL,
     # but other engines don't behave the same. E.g. BigQuery returns a proper Decimal value.
@@ -1923,7 +1927,7 @@ def test_test_generation_with_decimal(tmp_path: Path, mocker: MockerFixture) -> 
 
     assert len(test) == 1
     assert "test_foo" in test
-    assert test["test_foo"]["inputs"] == {"sqlmesh_example.bar": [{"dec_col": "1.23"}]}
+    assert test["test_foo"]["inputs"] == {'"memory"."sqlmesh_example"."bar"': [{"dec_col": "1.23"}]}
     assert test["test_foo"]["outputs"] == {"query": [{"dec_col": "1.23"}]}
 
 

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -468,9 +468,9 @@ def test_create_test(notebook, sushi_context):
     assert (
         test_file.read_text()
         == """test_top_waiters:
-  model: sushi.top_waiters
+  model: '"memory"."sushi"."top_waiters"'
   inputs:
-    sushi.waiter_revenue_by_day:
+    '"memory"."sushi"."waiter_revenue_by_day"':
     - waiter_id: 1
   outputs:
     query: []


### PR DESCRIPTION
Using the models' `name` attribute when generating unit tests could sometimes lead to discrepancies. For example, a BigQuery project with models named as:

```sql
`project.dataset.name`
```

Resulted in tests that looked like:

```sql
test_name:
  model: ...
  inputs:
    '`project.dataset.name`':
```

This is problematic when, e.g., the testing adapter is DuckDB, because these references would be parsed as `"project.dataset.name"` and some weird behavior was observed when executing the model's query: the generated test had an empty output.

I think the issue was probably due to these being invalid references, but haven't fully investigated yet. Using the fully-qualified names seemed like a reasonable thing to do here, anyway.