### PR TITLE
Fix: always sort DAG @ load time to check for cycles

### DIFF
--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -101,6 +101,10 @@ class Loader(abc.ABC):
         for model in models.values():
             self._add_model_to_dag(model)
 
+        # This topologically sorts the DAG & caches the result in-memory for later;
+        # we do it here to detect any cycles as early as possible and fail if needed
+        self._dag.sorted
+
         if update_schemas:
             update_model_schemas(
                 self._dag,


### PR DESCRIPTION
This [commit](https://github.com/TobikoData/sqlmesh/pull/3077/files) introduced `_update_model_schemas_parallel` which doesn't topologically sort the DAG, like the sequential one does. This results in skipping the cycle detection check hidden within `DAG.sorted`, and unfortunately crashing due to recursion issues if we _do_ get a cyclic graph, because we don't attempt to sort the project's DAG until later in the runtime. The function I noticed getting stuck in a loop is `Snapshot.from_node`, reached through `Context._snapshots`.

I decided to call `dag.sorted` as soon as the DAG is built, to avoid coupling the implicit cycle detection checks with the schema updating helpers.