### PR TITLE
Fix: Normalise column names in schema differ based on engine

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -118,6 +118,7 @@ class EngineAdapter:
         **kwargs: t.Any,
     ):
         self.dialect = dialect.lower() or self.DIALECT
+        self.SCHEMA_DIFFER.dialect = self.dialect
         self._connection_pool = create_connection_pool(
             connection_factory, multithreaded, cursor_kwargs=cursor_kwargs, cursor_init=cursor_init
         )

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -64,6 +64,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
     MAX_COLUMN_COMMENT_LENGTH = 1024
 
     SCHEMA_DIFFER = SchemaDiffer(
+        dialect=DIALECT,
         compatible_types={
             exp.DataType.build("INT64", dialect=DIALECT): {
                 exp.DataType.build("NUMERIC", dialect=DIALECT),

--- a/sqlmesh/core/engine_adapter/clickhouse.py
+++ b/sqlmesh/core/engine_adapter/clickhouse.py
@@ -35,7 +35,7 @@ class ClickhouseEngineAdapter(EngineAdapterWithIndexSupport, LogicalMergeMixin):
     SUPPORTS_REPLACE_TABLE = False
     COMMENT_CREATION_VIEW = CommentCreationView.COMMENT_COMMAND_ONLY
 
-    SCHEMA_DIFFER = SchemaDiffer()
+    SCHEMA_DIFFER = SchemaDiffer(dialect=DIALECT)
 
     DEFAULT_TABLE_ENGINE = "MergeTree"
     ORDER_BY_TABLE_ENGINE_REGEX = "^.*?MergeTree.*$"

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -38,6 +38,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
     SUPPORTS_MATERIALIZED_VIEWS = True
     SUPPORTS_MATERIALIZED_VIEW_SCHEMA = True
     SCHEMA_DIFFER = SchemaDiffer(
+        dialect=DIALECT,
         support_positional_add=True,
         support_nested_operations=True,
         support_nested_drop=True,

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -32,6 +32,7 @@ class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin,
     SUPPORTS_TRANSACTIONS = False
     CATALOG_SUPPORT = CatalogSupport.FULL_SUPPORT
     SCHEMA_DIFFER = SchemaDiffer(
+        dialect=DIALECT,
         parameterized_type_defaults={
             exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(18, 3), (0,)],
         },

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -52,6 +52,7 @@ class MSSQLEngineAdapter(
     COMMENT_CREATION_VIEW = CommentCreationView.UNSUPPORTED
     SUPPORTS_REPLACE_TABLE = False
     SCHEMA_DIFFER = SchemaDiffer(
+        dialect=DIALECT,
         parameterized_type_defaults={
             exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(18, 0), (0,)],
             exp.DataType.build("BINARY", dialect=DIALECT).this: [(1,)],

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -40,6 +40,7 @@ class MySQLEngineAdapter(
     MAX_COLUMN_COMMENT_LENGTH = 1024
     SUPPORTS_REPLACE_TABLE = False
     SCHEMA_DIFFER = SchemaDiffer(
+        dialect=DIALECT,
         parameterized_type_defaults={
             exp.DataType.build("BIT", dialect=DIALECT).this: [(1,)],
             exp.DataType.build("BINARY", dialect=DIALECT).this: [(1,)],

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -35,6 +35,7 @@ class PostgresEngineAdapter(
     CURRENT_CATALOG_EXPRESSION = exp.column("current_catalog")
     SUPPORTS_REPLACE_TABLE = False
     SCHEMA_DIFFER = SchemaDiffer(
+        dialect=DIALECT,
         parameterized_type_defaults={
             # DECIMAL without precision is "up to 131072 digits before the decimal point; up to 16383 digits after the decimal point"
             exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(131072 + 16383, 16383), (0,)],

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -46,6 +46,7 @@ class RedshiftEngineAdapter(
     COMMENT_CREATION_VIEW = CommentCreationView.UNSUPPORTED
     SUPPORTS_REPLACE_TABLE = False
     SCHEMA_DIFFER = SchemaDiffer(
+        dialect=DIALECT,
         parameterized_type_defaults={
             exp.DataType.build("VARBYTE", dialect=DIALECT).this: [(64000,)],
             exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(18, 0), (0,)],

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -53,6 +53,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
     CATALOG_SUPPORT = CatalogSupport.FULL_SUPPORT
     CURRENT_CATALOG_EXPRESSION = exp.func("current_database")
     SCHEMA_DIFFER = SchemaDiffer(
+        dialect=DIALECT,
         parameterized_type_defaults={
             exp.DataType.build("BINARY", dialect=DIALECT).this: [(8388608,)],
             exp.DataType.build("VARBINARY", dialect=DIALECT).this: [(8388608,)],

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -62,6 +62,7 @@ class SparkEngineAdapter(
     WAP_PREFIX = "wap_"
     BRANCH_PREFIX = "branch_"
     SCHEMA_DIFFER = SchemaDiffer(
+        dialect=DIALECT,
         parameterized_type_defaults={
             # default decimal precision varies across backends
             exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(), (0,)],

--- a/sqlmesh/core/engine_adapter/trino.py
+++ b/sqlmesh/core/engine_adapter/trino.py
@@ -53,6 +53,7 @@ class TrinoEngineAdapter(
     DEFAULT_CATALOG_TYPE = "hive"
     QUOTE_IDENTIFIERS_IN_VIEWS = False
     SCHEMA_DIFFER = SchemaDiffer(
+        dialect=DIALECT,
         parameterized_type_defaults={
             # default decimal precision varies across backends
             exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(), (0,)],

--- a/sqlmesh/core/schema_diff.py
+++ b/sqlmesh/core/schema_diff.py
@@ -298,6 +298,7 @@ class SchemaDiffer(PydanticModel):
     1. Support column moves. Databricks Delta supports moves and would allow exact matches.
 
     Args:
+        dialect: The dialect of the engine to normalise the columns accordingly to the case sensitivity.
         support_positional_add: Whether the engine for which the diff is being computed supports adding columns in a
             specific position in the set of existing columns.
         support_nested_operations: Whether the engine for which the diff is being computed supports modifications to

--- a/sqlmesh/core/schema_diff.py
+++ b/sqlmesh/core/schema_diff.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from enum import Enum, auto
 from sqlglot import exp
 from sqlglot.helper import ensure_list, seq_get
+from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
 from sqlmesh.utils import columns_to_types_to_struct
 from sqlmesh.utils.pydantic import PydanticModel
@@ -321,6 +322,7 @@ class SchemaDiffer(PydanticModel):
             parameterized type can ALTER to its unlimited length version, along with different types in some engines.
     """
 
+    dialect: str = ""
     support_positional_add: bool = False
     support_nested_operations: bool = False
     support_nested_drop: bool = False
@@ -655,7 +657,10 @@ class SchemaDiffer(PydanticModel):
         """
         return [
             op.expression(table_name, self.array_element_selector)
-            for op in self._from_structs(current, new)
+            for op in self._from_structs(
+                normalize_identifiers(current, dialect=self.dialect),
+                normalize_identifiers(new, dialect=self.dialect),
+            )
         ]
 
     def compare_columns(

--- a/tests/core/test_schema_diff.py
+++ b/tests/core/test_schema_diff.py
@@ -45,6 +45,7 @@ def test_schema_diff_calculate():
     ]
 
 
+@pytest.mark.parametrize(
     "dialect, alter_expression_list",
     [
         ("", []),

--- a/tests/core/test_schema_diff.py
+++ b/tests/core/test_schema_diff.py
@@ -45,6 +45,43 @@ def test_schema_diff_calculate():
     ]
 
 
+    "dialect, alter_expression_list",
+    [
+        ("", []),
+        (
+            "mysql",
+            [
+                "ALTER TABLE apply_to_table DROP COLUMN id",
+                "ALTER TABLE apply_to_table ADD COLUMN Id INT",
+            ],
+        ),
+        ("duckdb", []),
+    ],
+)
+def test_schema_diff_case_sensitivity(dialect, alter_expression_list):
+    alter_expressions = SchemaDiffer(
+        **{
+            "dialect": dialect,
+            "array_element_selector": "",
+            "compatible_types": {
+                exp.DataType.build("STRING"): {exp.DataType.build("INT")},
+            },
+        }
+    ).compare_columns(
+        "apply_to_table",
+        {
+            "id": exp.DataType.build("INT"),
+            "name": exp.DataType.build("STRING"),
+        },
+        {
+            "Id": exp.DataType.build("INT"),
+            "name": exp.DataType.build("STRING"),
+        },
+    )
+
+    assert [x.sql() for x in alter_expressions] == alter_expression_list
+
+
 def test_schema_diff_calculate_type_transitions():
     alter_expressions = SchemaDiffer(
         **{


### PR DESCRIPTION
This update aims to take account of case sensitivity of columns by storing the engine's dialect in the `SchemaDiffer` and normalising the column names based on it during the comparison of the schemas.