### PR TITLE
Chore!: bump sqlglot to v25.31.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=25.30.0",
+        "sqlglot[rs]~=25.31.2",
         "tenacity",
     ],
     extras_require={

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -579,17 +579,17 @@ def test_scd_type_2_by_time(
         parse_one(
             """WITH `source` AS (
   SELECT
-    TRUE AS `_exists`,
-    `id`,
-    `name`,
-    `price`,
-    CAST(`test_updated_at` AS TIMESTAMP) AS `test_updated_at`
+    `_exists`,
+    id,
+    name,
+    price,
+    `test_updated_at`
   FROM (
     SELECT
       TRUE AS `_exists`,
-      `id`,
-      `name`,
-      `price`,
+      `id` AS id,
+      `name` AS name,
+      `price` AS price,
       CAST(`test_updated_at` AS TIMESTAMP) AS `test_updated_at`,
       ROW_NUMBER() OVER (PARTITION BY COALESCE(`id`, '') ORDER BY COALESCE(`id`, '')) AS _row_number
     FROM (


### PR DESCRIPTION
@tobymao note the diff in the test, it's due to https://github.com/tobymao/sqlglot/commit/45eef600064ad024b34e32e7acc3aca409fbd9c4.

EDIT: made another fix upstream so the test didn't change significantly after all.