### PR TITLE
Refactor: make resolve_table consistent across evaluation contexts

### DIFF
--- a/docs/concepts/models/python_models.md
+++ b/docs/concepts/models/python_models.md
@@ -165,14 +165,14 @@ def execute(
 ```
 
 ## Dependencies
-In order to fetch data from an upstream model, you first get the table name using `context`'s `table` method. This returns the appropriate table name for the current runtime [environment](../environments.md):
+In order to fetch data from an upstream model, you first get the table name using `context`'s `resolve_table` method. This returns the appropriate table name for the current runtime [environment](../environments.md):
 
 ```python linenums="1"
-table = context.table("docs_example.upstream_model")
+table = context.resolve_table("docs_example.upstream_model")
 df = context.fetchdf(f"SELECT * FROM {table}")
 ```
 
-The `table` method will automatically add the referenced model to the Python model's dependencies.
+The `resolve_table` method will automatically add the referenced model to the Python model's dependencies.
 
 The only other way to set dependencies of models in Python models is to define them explicitly in the `@model` decorator using the keyword `depends_on`. The dependencies defined in the model decorator take precedence over any dynamic references inside the function.
 
@@ -192,7 +192,7 @@ def execute(
 ) -> pd.DataFrame:
 
     # ignored due to @model dependency "upstream_dependency"
-    context.table("docs_example.another_dependency")
+    context.resolve_table("docs_example.another_dependency")
 ```
 
 
@@ -323,7 +323,7 @@ def execute(
     **kwargs: t.Any,
 ) -> pd.DataFrame:
     # get the upstream model's name and register it as a dependency
-    table = context.table("upstream_model")
+    table = context.resolve_table("upstream_model")
 
     # fetch data from the model as a pandas DataFrame
     # if the engine is spark, this returns a spark DataFrame
@@ -362,7 +362,7 @@ def execute(
     **kwargs: t.Any,
 ) -> DataFrame:
     # get the upstream model's name and register it as a dependency
-    table = context.table("upstream_model")
+    table = context.resolve_table("upstream_model")
 
     # use the spark DataFrame api to add the country column
     df = context.spark.table(table).withColumn("country", functions.lit("USA"))
@@ -427,7 +427,7 @@ def execute(
     **kwargs: t.Any,
 ) -> pd.DataFrame:
     # get the upstream model's table name
-    table = context.table("upstream_model")
+    table = context.resolve_table("upstream_model")
 
     for i in range(3):
         # run 3 queries to get chunks of data and not run out of memory

--- a/examples/ibis/models/ibis_full_model_python.py
+++ b/examples/ibis/models/ibis_full_model_python.py
@@ -28,7 +28,7 @@ def execute(
     **kwargs: t.Any,
 ) -> pd.DataFrame:
     # get physical table name
-    upstream_model = exp.to_table(context.table("ibis.incremental_model"))
+    upstream_model = exp.to_table(context.resolve_table("ibis.incremental_model"))
     # connect ibis to database
     con = ibis.duckdb.connect(DB_PATH)
 

--- a/examples/sushi/models/order_items.py
+++ b/examples/sushi/models/order_items.py
@@ -16,7 +16,7 @@ ITEMS = "sushi.items"
 
 
 def get_items_table(context: ExecutionContext) -> str:
-    return context.table(ITEMS)
+    return context.resolve_table(ITEMS)
 
 
 @model(
@@ -49,7 +49,7 @@ def execute(
     execution_time: datetime,
     **kwargs: t.Any,
 ) -> t.Generator[pd.DataFrame, None, None]:
-    orders_table = context.table("sushi.orders")
+    orders_table = context.resolve_table("sushi.orders")
     engine_dialect = context.engine_adapter.dialect
 
     items_table = get_items_table(context)

--- a/examples/sushi/models/raw_marketing.py
+++ b/examples/sushi/models/raw_marketing.py
@@ -35,7 +35,7 @@ def execute(
     **kwargs: t.Any,
 ) -> pd.DataFrame:
     # Generate query with sqlglot dialect/quoting
-    existing_table = context.table("sushi.raw_marketing")
+    existing_table = context.resolve_table("sushi.raw_marketing")
     engine_dialect = context.engine_adapter.dialect
 
     df_existing = context.fetchdf(

--- a/examples/wursthall/models/db/order_f.py
+++ b/examples/wursthall/models/db/order_f.py
@@ -41,8 +41,8 @@ def execute(
     end: datetime,
     **kwargs: t.Any,
 ) -> pd.DataFrame:
-    item_d_table_name = context.table("db.item_d")
-    order_item_f_table_name = context.table("db.order_item_f")
+    item_d_table_name = context.resolve_table("db.item_d")
+    order_item_f_table_name = context.resolve_table("db.order_item_f")
 
     # We use parse_one here instead of a raw string because this is a multi-dialect
     # project and we want to ensure that the resulting query is properly quoted in

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -169,6 +169,13 @@ class BaseContext(abc.ABC):
         raise NotImplementedError
 
     def table(self, model_name: str) -> str:
+        logger.warning(
+            "The SQLMesh context's `table` method is deprecated and will be removed "
+            "in a future release. Please use the `resolve_table` method instead."
+        )
+        return self.resolve_table(model_name)
+
+    def resolve_table(self, model_name: str) -> str:
         """Gets the physical table name for a given model.
 
         Args:

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2306,7 +2306,8 @@ def _parse_dependencies(
                             f"Error resolving dependencies for '{executable.path}'. Argument '{expression.strip()}' must be resolvable at parse time."
                         )
 
-                if func.value.id == "context" and func.attr == "table":
+                # TODO: remove "table" when it is deprecated
+                if func.value.id == "context" and func.attr in ("table", "resolve_table"):
                     depends_on.add(get_first_arg("model_name"))
                 elif func.value.id in ("context", "evaluator") and func.attr == c.VAR:
                     variables.add(get_first_arg("var_name").lower())

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -104,17 +104,12 @@ class BaseExpressionRenderer:
             return self._cache
 
         if self._model_fqn and "this_model" not in kwargs:
-            kwargs["this_model"] = exp.to_table(
-                self._to_table_mapping(
-                    (
-                        [snapshots[self._model_fqn]]
-                        if snapshots and self._model_fqn in snapshots
-                        else []
-                    ),
-                    deployability_index,
-                ).get(self._model_fqn, self._model_fqn),
-                dialect=self._dialect,
-            ).sql(dialect=self._dialect, identify=True)
+            this_snapshot = (snapshots or {}).get(self._model_fqn)
+            kwargs["this_model"] = self._resolve_table(
+                self._model_fqn,
+                snapshots={self._model_fqn: this_snapshot} if this_snapshot else None,
+                deployability_index=deployability_index,
+            )
 
         expressions = [self._expression]
 
@@ -135,15 +130,12 @@ class BaseExpressionRenderer:
             deployability_index=deployability_index,
             default_catalog=self._default_catalog,
             runtime_stage=runtime_stage.value,
-            resolve_table=lambda table_name: exp.replace_tables(
-                exp.maybe_parse(table_name, into=exp.Table, dialect=self._dialect),
-                {
-                    **self._to_table_mapping((snapshots or {}).values(), deployability_index),
-                    **(table_mapping or {}),
-                },
-                dialect=self._dialect,
-                copy=False,
-            ).sql(dialect=self._dialect),
+            resolve_table=lambda table: self._resolve_table(
+                table,
+                snapshots=snapshots,
+                table_mapping=table_mapping,
+                deployability_index=deployability_index,
+            ),
         )
 
         if isinstance(self._expression, d.Jinja):
@@ -168,6 +160,7 @@ class BaseExpressionRenderer:
             jinja_env=jinja_env,
             schema=self.schema,
             runtime_stage=runtime_stage,
+            resolve_table=jinja_env.globals["resolve_table"],  # type: ignore
             resolve_tables=lambda e: self._resolve_tables(
                 e,
                 snapshots=snapshots,
@@ -230,6 +223,23 @@ class BaseExpressionRenderer:
 
     def update_cache(self, expression: t.Optional[exp.Expression]) -> None:
         self._cache = [expression]
+
+    def _resolve_table(
+        self,
+        table_name: str | exp.Expression,
+        snapshots: t.Optional[t.Dict[str, Snapshot]] = None,
+        table_mapping: t.Optional[t.Dict[str, str]] = None,
+        deployability_index: t.Optional[DeployabilityIndex] = None,
+    ) -> str:
+        return exp.replace_tables(
+            exp.maybe_parse(table_name, into=exp.Table, dialect=self._dialect),
+            {
+                **self._to_table_mapping((snapshots or {}).values(), deployability_index),
+                **(table_mapping or {}),
+            },
+            dialect=self._dialect,
+            copy=False,
+        ).sql(dialect=self._dialect, identify=True, comments=False)
 
     def _resolve_tables(
         self,

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -78,7 +78,9 @@ def test_generate_table_name_in_dialect(mocker: MockerFixture):
         "sqlmesh.core.context.GenericContext._model_tables",
         PropertyMock(return_value={'"project-id"."dataset"."table"': '"project-id".dataset.table'}),
     )
-    assert context.table('"project-id"."dataset"."table"') == "`project-id`.`dataset`.`table`"
+    assert (
+        context.resolve_table('"project-id"."dataset"."table"') == "`project-id`.`dataset`.`table`"
+    )
 
 
 def test_config_not_found(copy_to_temp_path: t.Callable):
@@ -900,9 +902,20 @@ def test_load_external_models(copy_to_temp_path):
     assert "prod_raw.model1" not in external_model_names
 
     # get physical table names of external models using table
-    assert context.table("raw.model1") == '"memory"."raw"."model1"'
-    assert context.table("raw.demographics") == '"memory"."raw"."demographics"'
-    assert context.table("raw.model2") == '"memory"."raw"."model2"'
+    assert context.resolve_table("raw.model1") == '"memory"."raw"."model1"'
+    assert context.resolve_table("raw.demographics") == '"memory"."raw"."demographics"'
+    assert context.resolve_table("raw.model2") == '"memory"."raw"."model2"'
+
+    logger = logging.getLogger("sqlmesh.core.context")
+    with patch.object(logger, "warning") as mock_logger:
+        context.table("raw.model1") == '"memory"."raw"."model1"'
+
+        assert mock_logger.mock_calls == [
+            call(
+                "The SQLMesh context's `table` method is deprecated and will be removed "
+                "in a future release. Please use the `resolve_table` method instead."
+            )
+        ]
 
 
 def test_load_gateway_specific_external_models(copy_to_temp_path):


### PR DESCRIPTION
This is a followup to https://github.com/TobikoData/sqlmesh/commit/6a324e7ea3bba49b7e1d7feb7e3814683bb65e47. Until now, we had:

- `ExecutionContext.table` -- resolve a model's name into its physical table
- `MacroEvaluator.resolve_tables` -- same, but this was mostly used to resolved all references within query (it transforms the whole thing)
- A `resolve_table` function registered in the Jinja environment, which can be used on a single table name

This PR exposes the `resolve_table` helper to the macro evaluator and the execution context, so that all of these execution environments support it, while also deprecating `Context.table`.