### PR TITLE
Fix: Rename docs to catalog to keep routes consistent

### DIFF
--- a/docs/guides/ui.md
+++ b/docs/guides/ui.md
@@ -56,7 +56,7 @@ The UI modules are:
 
 - [Code editor](#editor-module)
 - [Plan builder](#plan-module)
-- [Project documentation](#docs-module)
+- [Data catalog](#docs-module)
 - [Table and column lineage](#lineage-module)
 
 The screenshots in most examples below use the default `editor` mode.
@@ -75,7 +75,7 @@ The `editor` module will appear by default if the UI is started without specifyi
 
 It also contains nine buttons:
 
-1. Toggle Editor/Docs/Errors/Plan toggles among the editor module (default), docs module, errors view, and plan module. Errors view is only available if an error has occurred.
+1. Toggle Editor/Data Catalog/Errors/Plan toggles among the editor module (default), data catalog module, errors view, and plan module. Errors view is only available if an error has occurred.
 2. History navigation returns to previous views, similar to the back button in a web browser.
 3. Add new tab opens a new code editor window.
 4. Plan opens the plan module.
@@ -194,19 +194,19 @@ Click the blue `Apply Changes And Backfill` button to apply the plan and execute
 
 ![Plan after applying updated plan with modified model](./ui/ui-quickstart_apply-plan-dev-modified.png){ loading=lazy }
 
-### Docs module
+### Data Catalog module
 
-The docs module displays information about all your project's models in one interface.
+The data catalog module displays information about all your project's models in one interface.
 
 A list of all models is displayed in the left-hand pane. You can filter models by name by typing in the field at the top of the pane.
 
 When you choose a model, its query, lineage, and attributes are displayed. This example shows information from the [quickstart project](../quick_start.md) incremental model:
 
-![Docs with incremental model selected](./ui/ui-guide_docs.png){ loading=lazy }
+![Data Catalog with incremental model selected](./ui/ui-guide_docs.png){ loading=lazy }
 
 By default, the model definition source code is displayed. If you toggle to `Compiled Query`, it will display an example of the model query rendered with macro values substituted:
 
-![Docs with compiled incremental model query](./ui/ui-guide_docs-compiled-query.png){ loading=lazy }
+![Data Catalog with compiled incremental model query](./ui/ui-guide_docs-compiled-query.png){ loading=lazy }
 
 ### Lineage module
 
@@ -232,9 +232,10 @@ You may specify the UI mode as an option when you [start the UI on the command l
 
 The UI modes contain these modules:
 
-- `editor`: code editor, plan builder, project documentation, table and column lineage
-- `plan`: plan builder, project documentation, table and column lineage
-- `docs`: project documentation, table and column lineage
+- `editor`: code editor, plan builder, data catalog, table and column lineage
+- `plan`: plan builder, data catalog, table and column lineage
+- `docs`: data catalog, table and column lineage
+- `catalog`: data catalog, table and column lineage
 
 ### Working with an IDE
 

--- a/docs/guides/ui.md
+++ b/docs/guides/ui.md
@@ -56,7 +56,7 @@ The UI modules are:
 
 - [Code editor](#editor-module)
 - [Plan builder](#plan-module)
-- [Data catalog](#docs-module)
+- [Data catalog](#data-catalog-module)
 - [Table and column lineage](#lineage-module)
 
 The screenshots in most examples below use the default `editor` mode.
@@ -234,7 +234,6 @@ The UI modes contain these modules:
 
 - `editor`: code editor, plan builder, data catalog, table and column lineage
 - `plan`: plan builder, data catalog, table and column lineage
-- `docs`: data catalog, table and column lineage
 - `catalog`: data catalog, table and column lineage
 
 ### Working with an IDE

--- a/docs/quickstart/ui.md
+++ b/docs/quickstart/ui.md
@@ -166,7 +166,7 @@ The SQLMesh UI default view contains five panes:
 
 It also contains nine buttons:
 
-1. Toggle Editor/Docs/Errors toggles among the Code Editor (default), Docs, and Errors views. Errors view is only available if an error has occurred.
+1. Toggle Editor/Data Catalog/Errors toggles among the Code Editor (default), Data Catalog, and Errors views. Errors view is only available if an error has occurred.
 2. History navigation returns to previous views, similar to the back button in a web browser.
 3. Add new tab opens a new code editor window.
 4. Run plan command executes the [`sqlmesh plan` command](../reference/cli.md#plan).

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -702,9 +702,9 @@ def info(obj: Context, skip_connection: bool, verbose: bool) -> None:
 )
 @click.option(
     "--mode",
-    type=click.Choice(["ide", "default", "docs", "plan"], case_sensitive=False),
-    default="default",
-    help="Mode to start the UI in. Default: default",
+    type=click.Choice(["ide", "catalog", "docs", "plan"], case_sensitive=False),
+    default="ide",
+    help="Mode to start the UI in. Default: ide",
 )
 @click.pass_context
 @error_handler

--- a/web/client/openapi.json
+++ b/web/client/openapi.json
@@ -762,6 +762,15 @@
             }
           },
           {
+            "name": "temp_schema",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "title": "Temp Schema"
+            }
+          },
+          {
             "name": "limit",
             "in": "query",
             "required": false,
@@ -1583,7 +1592,7 @@
         "enum": [
           "editor",
           "files",
-          "docs",
+          "catalog",
           "plans",
           "tests",
           "audits",

--- a/web/client/openapi.json
+++ b/web/client/openapi.json
@@ -1592,7 +1592,7 @@
         "enum": [
           "editor",
           "files",
-          "catalog",
+          "data-catalog",
           "plans",
           "tests",
           "audits",

--- a/web/client/src/App.tsx
+++ b/web/client/src/App.tsx
@@ -39,7 +39,7 @@ export default function App(): JSX.Element {
     }
   }, [])
 
-  const router = getBrowserRouter(modules.list)
+  const router = getBrowserRouter(modules)
 
   return (
     <>

--- a/web/client/src/api/instance.ts
+++ b/web/client/src/api/instance.ts
@@ -1,5 +1,11 @@
-import { isNil } from '@utils/index'
+import { isNil, isStringEmptyOrNil } from '@utils/index'
 import { tableFromIPC } from 'apache-arrow'
+
+declare global {
+  interface Window {
+    __BASE_URL__?: string
+  }
+}
 
 export interface ResponseWithDetail {
   ok: boolean
@@ -121,7 +127,7 @@ function toRequestBody(obj: unknown): BodyInit {
 }
 
 export function getUrlPrefix(): string {
-  return (window as any).__BASE_URL__ ?? '/'
+  return isStringEmptyOrNil(window.__BASE_URL__) ? '/' : window.__BASE_URL__
 }
 
 export default fetchAPI

--- a/web/client/src/library/components/editor/EditorPreview.tsx
+++ b/web/client/src/library/components/editor/EditorPreview.tsx
@@ -59,7 +59,7 @@ export default function EditorPreview({
   const [activeTabIndex, setActiveTabIndex] = useState(-1)
 
   const modelExtensions = useSQLMeshModelExtensions(tab.file.path, model => {
-    navigate(`${EnumRoutes.DocsModels}/${model.name}`)
+    navigate(`${EnumRoutes.CatalogModels}/${model.name}`)
   })
 
   const model = models.get(tab.file.path)

--- a/web/client/src/library/components/editor/EditorPreview.tsx
+++ b/web/client/src/library/components/editor/EditorPreview.tsx
@@ -59,7 +59,7 @@ export default function EditorPreview({
   const [activeTabIndex, setActiveTabIndex] = useState(-1)
 
   const modelExtensions = useSQLMeshModelExtensions(tab.file.path, model => {
-    navigate(`${EnumRoutes.CatalogModels}/${model.name}`)
+    navigate(`${EnumRoutes.DataCatalogModels}/${model.name}`)
   })
 
   const model = models.get(tab.file.path)

--- a/web/client/src/library/components/editor/EditorTabs.tsx
+++ b/web/client/src/library/components/editor/EditorTabs.tsx
@@ -70,7 +70,7 @@ export default function EditorTabs(): JSX.Element {
     }
 
     selectTab(newTab)
-  }, [selectedFile])
+  }, [selectedFile, modules])
 
   useEffect(() => {
     if (isNil(lastSelectedModel)) return
@@ -132,7 +132,6 @@ function Tab({ tab, title }: { tab: EditorTab; title: string }): JSX.Element {
   const setSelectedFile = useStoreProject(s => s.setSelectedFile)
 
   const activeTab = useStoreEditor(s => s.tab)
-  const selectTab = useStoreEditor(s => s.selectTab)
   const closeTab = useStoreEditor(s => s.closeTab)
 
   useEffect(() => {
@@ -178,7 +177,6 @@ function Tab({ tab, title }: { tab: EditorTab; title: string }): JSX.Element {
       onClick={(e: MouseEvent) => {
         e.stopPropagation()
 
-        selectTab(tab)
         setSelectedFile(tab.file)
       }}
     >

--- a/web/client/src/library/components/moduleNavigation/ModuleNavigation.tsx
+++ b/web/client/src/library/components/moduleNavigation/ModuleNavigation.tsx
@@ -46,10 +46,10 @@ export default function ModuleNavigation({
           iconActive={<FolderIcon className="min-w-6 w-6" />}
         />
       )}
-      {modules.hasDocs && (
+      {modules.hasDataCatalog && (
         <ModuleLink
-          title="Docs"
-          to={EnumRoutes.Catalog}
+          title="Data Catalog"
+          to={EnumRoutes.DataCatalog}
           icon={<OutlineDocumentTextIcon className="min-w-6 w-6" />}
           iconActive={<DocumentTextIcon className="min-w-6 w-6" />}
           className="relative rounded-xl my-1 px-2 py-1 h-10 hover:bg-neutral-5 dark:hover:bg-neutral-10 text-neutral-600 dark:text-neutral-300"

--- a/web/client/src/library/components/moduleNavigation/ModuleNavigation.tsx
+++ b/web/client/src/library/components/moduleNavigation/ModuleNavigation.tsx
@@ -49,7 +49,7 @@ export default function ModuleNavigation({
       {modules.hasDocs && (
         <ModuleLink
           title="Docs"
-          to={EnumRoutes.Docs}
+          to={EnumRoutes.Catalog}
           icon={<OutlineDocumentTextIcon className="min-w-6 w-6" />}
           iconActive={<DocumentTextIcon className="min-w-6 w-6" />}
           className="relative rounded-xl my-1 px-2 py-1 h-10 hover:bg-neutral-5 dark:hover:bg-neutral-10 text-neutral-600 dark:text-neutral-300"

--- a/web/client/src/library/pages/data-catalog/DataCatalog.tsx
+++ b/web/client/src/library/pages/data-catalog/DataCatalog.tsx
@@ -28,7 +28,7 @@ import { useApiModel } from '@api/index'
 import Loading from '@components/loading/Loading'
 import Spinner from '@components/logo/Spinner'
 
-export default function PageDocs(): JSX.Element {
+export default function PageDataCatalog(): JSX.Element {
   const { modelName = '' } = useParams()
 
   const navigate = useNavigate()
@@ -76,7 +76,7 @@ export default function PageDocs(): JSX.Element {
 
     if (isNil(model)) return
 
-    navigate(EnumRoutes.CatalogModels + '/' + model.name)
+    navigate(`${EnumRoutes.DataCatalogModels}/${model.name}`)
   }
 
   function handleError(error: ErrorIDE): void {
@@ -87,11 +87,11 @@ export default function PageDocs(): JSX.Element {
     <div className="flex overflow-auto w-full h-full">
       {isNil(model) ? (
         <NotFound
-          link={EnumRoutes.Catalog}
+          link={EnumRoutes.DataCatalog}
           description={
             isNil(modelName) ? undefined : `Model ${modelName} Does Not Exist`
           }
-          message="Back To Docs"
+          message="Back To Data Catalog"
         />
       ) : (
         <LineageFlowProvider

--- a/web/client/src/library/pages/docs/Docs.tsx
+++ b/web/client/src/library/pages/docs/Docs.tsx
@@ -76,7 +76,7 @@ export default function PageDocs(): JSX.Element {
 
     if (isNil(model)) return
 
-    navigate(EnumRoutes.DocsModels + '/' + model.name)
+    navigate(EnumRoutes.CatalogModels + '/' + model.name)
   }
 
   function handleError(error: ErrorIDE): void {
@@ -87,7 +87,7 @@ export default function PageDocs(): JSX.Element {
     <div className="flex overflow-auto w-full h-full">
       {isNil(model) ? (
         <NotFound
-          link={EnumRoutes.Docs}
+          link={EnumRoutes.Catalog}
           description={
             isNil(modelName) ? undefined : `Model ${modelName} Does Not Exist`
           }

--- a/web/client/src/library/pages/plan/Content.tsx
+++ b/web/client/src/library/pages/plan/Content.tsx
@@ -37,7 +37,7 @@ export default function Content(): JSX.Element {
               ? undefined
               : `Environment ${environmentName} Does Not Exist`
           }
-          message="Back To Docs"
+          message="Back To Data Catalog"
         />
       ) : (
         <Plan />

--- a/web/client/src/library/pages/root/Root.tsx
+++ b/web/client/src/library/pages/root/Root.tsx
@@ -374,7 +374,7 @@ export default function Root({
         cancelRequestFile()
       }
     }
-  }, [])
+  }, [modules])
 
   useEffect(() => {
     const channelPlanApply = channel?.('plan-apply', updatePlanApplyTracker)
@@ -388,7 +388,7 @@ export default function Root({
         channelPlanApply?.unsubscribe()
       }
     }
-  }, [updatePlanApplyTracker])
+  }, [updatePlanApplyTracker, modules])
 
   useEffect(() => {
     const channelPlanOverview = channel?.(
@@ -405,7 +405,7 @@ export default function Root({
         channelPlanOverview?.unsubscribe()
       }
     }
-  }, [updatePlanOverviewTracker])
+  }, [updatePlanOverviewTracker, modules])
 
   useEffect(() => {
     const channelPlanCancel = channel?.('plan-cancel', updatePlanCancelTracker)
@@ -419,7 +419,7 @@ export default function Root({
         channelPlanCancel?.unsubscribe()
       }
     }
-  }, [updatePlanCancelTracker])
+  }, [updatePlanCancelTracker, modules])
 
   useEffect(() => {
     const channelFile = channel?.('file', updateFiles)
@@ -448,7 +448,7 @@ export default function Root({
     ) {
       navigate(modules.defaultNavigationRoute(), { replace: true })
     }
-  }, [location, modules.list])
+  }, [location, modules])
 
   useEffect(() => {
     setShowConfirmation(confirmations.length > 0)

--- a/web/client/src/library/pages/root/Root.tsx
+++ b/web/client/src/library/pages/root/Root.tsx
@@ -54,7 +54,11 @@ import { type EnvironmentName } from '@models/environment'
 import { EnumPlanAction, ModelPlanAction } from '@models/plan-action'
 import { useChannelEvents, type EventSourceChannel } from '@api/channels'
 
-export default function Root(): JSX.Element {
+export default function Root({
+  content,
+}: {
+  content?: React.ReactNode
+}): JSX.Element {
   const location = useLocation()
   const navigate = useNavigate()
 
@@ -73,7 +77,7 @@ export default function Root(): JSX.Element {
   const setEnvironment = useStoreContext(s => s.setEnvironment)
   let channel: EventSourceChannel
 
-  if (isFalse(modules.hasOnlyDocs)) {
+  if (isFalse(modules.hasOnlyDataCatalog)) {
     channel = useChannelEvents()
   }
 
@@ -438,7 +442,7 @@ export default function Root(): JSX.Element {
   }, [formatFile])
 
   useEffect(() => {
-    if (location.pathname === EnumRoutes.Home) {
+    if (location.pathname === EnumRoutes.Home || location.pathname === '') {
       navigate(modules.defaultNavigationRoute(), { replace: true })
     }
   }, [location])
@@ -498,7 +502,7 @@ export default function Root(): JSX.Element {
             <Divider />
           </>
         )}
-        <Outlet />
+        {content ?? <Outlet />}
         <ModalConfirmation
           show={showConfirmation}
           onClose={() => {

--- a/web/client/src/library/pages/root/Root.tsx
+++ b/web/client/src/library/pages/root/Root.tsx
@@ -442,10 +442,13 @@ export default function Root({
   }, [formatFile])
 
   useEffect(() => {
-    if (location.pathname === EnumRoutes.Home || location.pathname === '') {
+    if (
+      (isFalse(modules.isEmpty) && location.pathname === EnumRoutes.Home) ||
+      location.pathname === ''
+    ) {
       navigate(modules.defaultNavigationRoute(), { replace: true })
     }
-  }, [location])
+  }, [location, modules.list])
 
   useEffect(() => {
     setShowConfirmation(confirmations.length > 0)

--- a/web/client/src/models/module-controller.ts
+++ b/web/client/src/models/module-controller.ts
@@ -40,8 +40,8 @@ export class ModelModuleController extends ModelInitial {
     return this.modules.size === 2 && this.hasProjectEditor
   }
 
-  get hasOnlyDocs(): boolean {
-    return this.modules.size === 1 && this.hasDocs
+  get hasOnlyDataCatalog(): boolean {
+    return this.modules.size === 1 && this.hasDataCatalog
   }
 
   get hasProjectEditorAndModule(): boolean {
@@ -52,8 +52,8 @@ export class ModelModuleController extends ModelInitial {
     )
   }
 
-  get hasDocs(): boolean {
-    return this.modules.has(Modules.catalog)
+  get hasDataCatalog(): boolean {
+    return this.modules.has(Modules['data-catalog'])
   }
 
   get hasPlans(): boolean {
@@ -102,7 +102,7 @@ export class ModelModuleController extends ModelInitial {
       this.hasSingleModule ||
       this.hasOnlyProjectEditor ||
       this.hasModuleAndErrors ||
-      this.hasOnlyDocs
+      this.hasOnlyDataCatalog
     )
       return false
     if (this.hasProjectEditorAndModule) return true
@@ -114,10 +114,10 @@ export class ModelModuleController extends ModelInitial {
     if (
       this.hasOnlyProjectEditor ||
       this.hasModuleAndErrors ||
-      this.hasOnlyDocs
+      this.hasOnlyDataCatalog
     )
       return false
-    if (this.hasProjectEditorAndModule || this.hasDocs) return true
+    if (this.hasProjectEditorAndModule || this.hasDataCatalog) return true
 
     return isFalse(this.isEmpty)
   }
@@ -132,8 +132,8 @@ export class ModelModuleController extends ModelInitial {
 
   defaultNavigationRoute(): Routes {
     if (this.hasEditor) return EnumRoutes.Editor
-    if (this.hasDocs) return EnumRoutes.Catalog
     if (this.hasPlans) return EnumRoutes.Plan
+    if (this.hasDataCatalog) return EnumRoutes.DataCatalog
 
     return EnumRoutes.NotFound
   }

--- a/web/client/src/models/module-controller.ts
+++ b/web/client/src/models/module-controller.ts
@@ -53,7 +53,7 @@ export class ModelModuleController extends ModelInitial {
   }
 
   get hasDocs(): boolean {
-    return this.modules.has(Modules.docs)
+    return this.modules.has(Modules.catalog)
   }
 
   get hasPlans(): boolean {
@@ -132,7 +132,7 @@ export class ModelModuleController extends ModelInitial {
 
   defaultNavigationRoute(): Routes {
     if (this.hasEditor) return EnumRoutes.Editor
-    if (this.hasDocs) return EnumRoutes.Docs
+    if (this.hasDocs) return EnumRoutes.Catalog
     if (this.hasPlans) return EnumRoutes.Plan
 
     return EnumRoutes.NotFound

--- a/web/client/src/routes.tsx
+++ b/web/client/src/routes.tsx
@@ -6,12 +6,15 @@ import Spinner from '@components/logo/Spinner'
 import { isArrayNotEmpty, isNil } from './utils'
 import { Modules } from '@api/client'
 import { getUrlPrefix } from '@api/instance'
+import { type ModelModuleController } from '@models/module-controller'
 
 const Root = lazy(() => import('./library/pages/root/Root'))
 const Editor = lazy(() => import('./library/pages/editor/Editor'))
 const Plan = lazy(() => import('./library/pages/plan/Plan'))
 const PlanContent = lazy(() => import('./library/pages/plan/Content'))
-const Docs = lazy(() => import('./library/pages/docs/Docs'))
+const DataCatalog = lazy(
+  () => import('./library/pages/data-catalog/DataCatalog'),
+)
 const Tests = lazy(() => import('./library/pages/tests/Tests'))
 const Audits = lazy(() => import('./library/pages/audits/Audits'))
 const Data = lazy(() => import('./library/pages/data/Data'))
@@ -24,8 +27,8 @@ const Welcome = lazy(() => import('./library/components/banner/Welcome'))
 export const EnumRoutes = {
   Home: '/',
   Editor: '/editor',
-  Catalog: '/catalog',
-  CatalogModels: '/catalog/models',
+  DataCatalog: '/data-catalog',
+  DataCatalogModels: '/data-catalog/models',
   Data: '/data',
   DataModels: '/data/models',
   Lineage: '/lineage',
@@ -34,6 +37,7 @@ export const EnumRoutes = {
   Audits: '/audits',
   Errors: '/errors',
   Plan: '/plan',
+  Models: '/models',
   NotFound: '/not-found',
 } as const
 
@@ -44,379 +48,380 @@ const aliases: Record<string, string[]> = {
 }
 
 export function getBrowserRouter(
-  modules: string[],
+  modules: ModelModuleController,
 ): ReturnType<typeof createBrowserRouter> {
   const routes = [
     {
       path: '*',
-      element: isArrayNotEmpty(modules) ? (
+      element: isArrayNotEmpty(modules.list) ? (
         <NotFound
           link={EnumRoutes.Home}
-          message="Back To Editor"
+          message="Back To Main"
         />
       ) : (
         <NotFound headline="Empty" />
       ),
     },
-    isArrayNotEmpty(modules) && {
-      path: '/',
+    {
+      path: EnumRoutes.Home,
       element: <Root />,
-      children: [
-        {
-          path: 'editor',
-          element: <Editor />,
-        },
-        {
-          path: 'catalog',
-          element: <Models route={EnumRoutes.Catalog} />,
-          children: [
-            {
-              index: true,
-              element: (
-                <Welcome
-                  headline="Welcome to the documentation"
-                  tagline="Here you can find all the information about the models and their fields."
-                />
-              ),
-            },
-            {
-              path: '*',
-              element: (
-                <NotFound
-                  link={EnumRoutes.Catalog}
-                  message="Back To Docs"
-                />
-              ),
-            },
-            {
-              path: 'models',
-              children: [
-                {
-                  index: true,
-                  element: (
-                    <Welcome
-                      headline="Welcome to the documentation"
-                      tagline="Here you can find all the information about the models and their fields."
-                    />
-                  ),
-                },
-                {
-                  path: '*',
-                  element: (
-                    <NotFound
-                      link={EnumRoutes.Catalog}
-                      message="Back To Docs"
-                    />
-                  ),
-                },
-                {
-                  path: ':modelName',
-                  element: (
-                    <Suspense
-                      fallback={
-                        <div className="flex justify-center items-center w-full h-full">
-                          <Loading className="inline-block">
-                            <Spinner className="w-3 h-3 border border-neutral-10 mr-4" />
-                            <h3 className="text-md">Loading Content...</h3>
-                          </Loading>
-                        </div>
-                      }
-                    >
-                      <Docs />
-                    </Suspense>
-                  ),
-                },
-              ],
-            },
-          ],
-        },
-        {
-          path: 'data',
-          element: <Models route={EnumRoutes.Data} />,
-          children: [
-            {
-              index: true,
-              element: (
-                <Welcome
-                  headline="Welcome to the documentation"
-                  tagline="Here you can find all the information about the models and their fields."
-                />
-              ),
-            },
-            {
-              path: '*',
-              element: (
-                <NotFound
-                  link={EnumRoutes.Data}
-                  message="Back To Data"
-                />
-              ),
-            },
-            {
-              path: 'models',
-              children: [
-                {
-                  index: true,
-                  element: (
-                    <Welcome
-                      headline="Welcome to the documentation"
-                      tagline="Here you can find all the information about the models and their fields."
-                    />
-                  ),
-                },
-                {
-                  path: '*',
-                  element: (
-                    <NotFound
-                      link={EnumRoutes.Data}
-                      message="Back To Data"
-                    />
-                  ),
-                },
-                {
-                  path: ':modelName',
-                  element: (
-                    <Suspense
-                      fallback={
-                        <div className="flex justify-center items-center w-full h-full">
-                          <Loading className="inline-block">
-                            <Spinner className="w-3 h-3 border border-neutral-10 mr-4" />
-                            <h3 className="text-md">Loading Content...</h3>
-                          </Loading>
-                        </div>
-                      }
-                    >
-                      <Data />
-                    </Suspense>
-                  ),
-                },
-              ],
-            },
-          ],
-        },
-        {
-          path: 'lineage',
-          element: <Models route={EnumRoutes.Lineage} />,
-          children: [
-            {
-              index: true,
-              element: (
-                <Welcome
-                  headline="Welcome to the documentation"
-                  tagline="Here you can find all the information about the models and their fields."
-                />
-              ),
-            },
-            {
-              path: '*',
-              element: (
-                <NotFound
-                  link={EnumRoutes.Lineage}
-                  message="Back To Lineage"
-                />
-              ),
-            },
-            {
-              path: 'models',
-              children: [
-                {
-                  index: true,
-                  element: (
-                    <Welcome
-                      headline="Welcome to the documentation"
-                      tagline="Here you can find all the information about the models and their fields."
-                    />
-                  ),
-                },
-                {
-                  path: '*',
-                  element: (
-                    <NotFound
-                      link={EnumRoutes.Lineage}
-                      message="Back To Lineage"
-                    />
-                  ),
-                },
-                {
-                  path: ':modelName',
-                  element: (
-                    <Suspense
-                      fallback={
-                        <div className="flex justify-center items-center w-full h-full">
-                          <Loading className="inline-block">
-                            <Spinner className="w-3 h-3 border border-neutral-10 mr-4" />
-                            <h3 className="text-md">Loading Content...</h3>
-                          </Loading>
-                        </div>
-                      }
-                    >
-                      <Lineage />
-                    </Suspense>
-                  ),
-                },
-              ],
-            },
-          ],
-        },
-        {
-          path: 'errors',
-          element: <Errors />,
-          children: [
-            {
-              index: true,
-              element: (
-                <Welcome
-                  headline="Welcome to errors report"
-                  tagline="Here you can see all the errors that occurred."
-                />
-              ),
-            },
-            {
-              path: '*',
-              element: (
-                <NotFound
-                  link={EnumRoutes.Errors}
-                  message="Back To Errors"
-                />
-              ),
-            },
-            {
-              path: ':id',
-              element: (
-                <Suspense
-                  fallback={
-                    <div className="flex justify-center items-center w-full h-full">
-                      <Loading className="inline-block">
-                        <Spinner className="w-3 h-3 border border-neutral-10 mr-4" />
-                        <h3 className="text-md">Loading Content...</h3>
-                      </Loading>
-                    </div>
-                  }
-                >
-                  <ErrorContent />
-                </Suspense>
-              ),
-            },
-          ],
-        },
-        {
-          path: 'plan',
-          element: <Plan />,
-          children: [
-            {
-              index: true,
-              element: (
-                <Welcome
-                  headline="Welcome to plan"
-                  tagline="Here you can run the plan and apply the changes."
-                />
-              ),
-            },
-            {
-              path: '*',
-              element: (
-                <NotFound
-                  link={EnumRoutes.Plan}
-                  message="Back To Plan"
-                />
-              ),
-            },
-            {
-              path: 'environments',
-              children: [
-                {
-                  index: true,
-                  element: (
-                    <Welcome
-                      headline="Welcome to plan"
-                      tagline="Here you can run the plan and apply the changes."
-                    />
-                  ),
-                },
-                {
-                  path: '*',
-                  element: (
-                    <NotFound
-                      link={EnumRoutes.Plan}
-                      message="Back To Plan"
-                    />
-                  ),
-                },
-                {
-                  path: ':environmentName',
-                  element: (
-                    <Suspense
-                      fallback={
-                        <div className="flex justify-center items-center w-full h-full">
-                          <Loading className="inline-block">
-                            <Spinner className="w-3 h-3 border border-neutral-10 mr-4" />
-                            <h3 className="text-md">Loading Content...</h3>
-                          </Loading>
-                        </div>
-                      }
-                    >
-                      <PlanContent />
-                    </Suspense>
-                  ),
-                },
-              ],
-            },
-          ],
-        },
-        {
-          path: 'tests',
-          element: <Tests />,
-          children: [
-            {
-              index: true,
-              element: (
-                <Welcome
-                  headline="Welcome to tests report"
-                  tagline="Here you can run tests and see the results."
-                />
-              ),
-            },
-            {
-              path: '*',
-              element: (
-                <NotFound
-                  link={EnumRoutes.Tests}
-                  message="Back To Tests"
-                />
-              ),
-            },
-          ],
-        },
-        {
-          path: 'audits',
-          element: <Audits />,
-          children: [
-            {
-              index: true,
-              element: (
-                <Welcome
-                  headline="Welcome to audits report"
-                  tagline="Here you can run audits and see the results."
-                />
-              ),
-            },
-            {
-              path: '*',
-              element: (
-                <NotFound
-                  link={EnumRoutes.Audits}
-                  message="Back To Audits"
-                />
-              ),
-            },
-          ],
-        },
-      ].filter(r =>
-        isNil(aliases[r.path])
-          ? modules.includes(r.path)
-          : aliases[r.path]?.some(a => modules.includes(a)),
-      ),
     },
+    ...[
+      {
+        path: EnumRoutes.Editor,
+        element: <Root content={<Editor />} />,
+      },
+      {
+        path: EnumRoutes.DataCatalog,
+        element: <Root content={<Models route={EnumRoutes.DataCatalog} />} />,
+        children: [
+          {
+            index: true,
+            element: (
+              <Welcome
+                headline="Welcome to the Data Catalog"
+                tagline="Here you can find all the information about the models and their fields."
+              />
+            ),
+          },
+          {
+            path: '*',
+            element: (
+              <NotFound
+                link={EnumRoutes.DataCatalog}
+                message="Back To Data Catalog"
+              />
+            ),
+          },
+          {
+            path: 'models',
+            children: [
+              {
+                index: true,
+                element: (
+                  <Welcome
+                    headline="Welcome to the Data Catalog"
+                    tagline="Here you can find all the information about the models and their fields."
+                  />
+                ),
+              },
+              {
+                path: '*',
+                element: (
+                  <NotFound
+                    link={EnumRoutes.DataCatalog}
+                    message="Back To Data Catalog"
+                  />
+                ),
+              },
+              {
+                path: ':modelName',
+                element: (
+                  <Suspense
+                    fallback={
+                      <div className="flex justify-center items-center w-full h-full">
+                        <Loading className="inline-block">
+                          <Spinner className="w-3 h-3 border border-neutral-10 mr-4" />
+                          <h3 className="text-md">Loading Content...</h3>
+                        </Loading>
+                      </div>
+                    }
+                  >
+                    <DataCatalog />
+                  </Suspense>
+                ),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        path: EnumRoutes.Data,
+        element: <Root content={<Models route={EnumRoutes.Data} />} />,
+        children: [
+          {
+            index: true,
+            element: (
+              <Welcome
+                headline="Welcome to the Data"
+                tagline="Here you can find all the information about the models and their fields."
+              />
+            ),
+          },
+          {
+            path: '*',
+            element: (
+              <NotFound
+                link={EnumRoutes.Data}
+                message="Back To Data"
+              />
+            ),
+          },
+          {
+            path: 'models',
+            children: [
+              {
+                index: true,
+                element: (
+                  <Welcome
+                    headline="Welcome to the Data"
+                    tagline="Here you can find all the information about the models and their fields."
+                  />
+                ),
+              },
+              {
+                path: '*',
+                element: (
+                  <NotFound
+                    link={EnumRoutes.Data}
+                    message="Back To Data"
+                  />
+                ),
+              },
+              {
+                path: ':modelName',
+                element: (
+                  <Suspense
+                    fallback={
+                      <div className="flex justify-center items-center w-full h-full">
+                        <Loading className="inline-block">
+                          <Spinner className="w-3 h-3 border border-neutral-10 mr-4" />
+                          <h3 className="text-md">Loading Content...</h3>
+                        </Loading>
+                      </div>
+                    }
+                  >
+                    <Data />
+                  </Suspense>
+                ),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        path: EnumRoutes.Lineage,
+        element: <Root content={<Models route={EnumRoutes.Lineage} />} />,
+        children: [
+          {
+            index: true,
+            element: (
+              <Welcome
+                headline="Welcome to the Lineage"
+                tagline="Here you can find all the information about the models and their fields."
+              />
+            ),
+          },
+          {
+            path: '*',
+            element: (
+              <NotFound
+                link={EnumRoutes.Lineage}
+                message="Back To Lineage"
+              />
+            ),
+          },
+          {
+            path: 'models',
+            children: [
+              {
+                index: true,
+                element: (
+                  <Welcome
+                    headline="Welcome to the Lineage"
+                    tagline="Here you can find all the information about the models and their fields."
+                  />
+                ),
+              },
+              {
+                path: '*',
+                element: (
+                  <NotFound
+                    link={EnumRoutes.Lineage}
+                    message="Back To Lineage"
+                  />
+                ),
+              },
+              {
+                path: ':modelName',
+                element: (
+                  <Suspense
+                    fallback={
+                      <div className="flex justify-center items-center w-full h-full">
+                        <Loading className="inline-block">
+                          <Spinner className="w-3 h-3 border border-neutral-10 mr-4" />
+                          <h3 className="text-md">Loading Content...</h3>
+                        </Loading>
+                      </div>
+                    }
+                  >
+                    <Lineage />
+                  </Suspense>
+                ),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        path: EnumRoutes.Errors,
+        element: <Root content={<Errors />} />,
+        children: [
+          {
+            index: true,
+            element: (
+              <Welcome
+                headline="Welcome to errors report"
+                tagline="Here you can see all the errors that occurred."
+              />
+            ),
+          },
+          {
+            path: '*',
+            element: (
+              <NotFound
+                link={EnumRoutes.Errors}
+                message="Back To Errors"
+              />
+            ),
+          },
+          {
+            path: ':id',
+            element: (
+              <Suspense
+                fallback={
+                  <div className="flex justify-center items-center w-full h-full">
+                    <Loading className="inline-block">
+                      <Spinner className="w-3 h-3 border border-neutral-10 mr-4" />
+                      <h3 className="text-md">Loading Content...</h3>
+                    </Loading>
+                  </div>
+                }
+              >
+                <ErrorContent />
+              </Suspense>
+            ),
+          },
+        ],
+      },
+      {
+        path: EnumRoutes.Plan,
+        element: <Root content={<Plan />} />,
+        children: [
+          {
+            index: true,
+            element: (
+              <Welcome
+                headline="Welcome to plan"
+                tagline="Here you can run the plan and apply the changes."
+              />
+            ),
+          },
+          {
+            path: '*',
+            element: (
+              <NotFound
+                link={EnumRoutes.Plan}
+                message="Back To Plan"
+              />
+            ),
+          },
+          {
+            path: 'environments',
+            children: [
+              {
+                index: true,
+                element: (
+                  <Welcome
+                    headline="Welcome to plan"
+                    tagline="Here you can run the plan and apply the changes."
+                  />
+                ),
+              },
+              {
+                path: '*',
+                element: (
+                  <NotFound
+                    link={EnumRoutes.Plan}
+                    message="Back To Plan"
+                  />
+                ),
+              },
+              {
+                path: ':environmentName',
+                element: (
+                  <Suspense
+                    fallback={
+                      <div className="flex justify-center items-center w-full h-full">
+                        <Loading className="inline-block">
+                          <Spinner className="w-3 h-3 border border-neutral-10 mr-4" />
+                          <h3 className="text-md">Loading Content...</h3>
+                        </Loading>
+                      </div>
+                    }
+                  >
+                    <PlanContent />
+                  </Suspense>
+                ),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        path: EnumRoutes.Tests,
+        element: <Root content={<Tests />} />,
+        children: [
+          {
+            index: true,
+            element: (
+              <Welcome
+                headline="Welcome to tests report"
+                tagline="Here you can run tests and see the results."
+              />
+            ),
+          },
+          {
+            path: '*',
+            element: (
+              <NotFound
+                link={EnumRoutes.Tests}
+                message="Back To Tests"
+              />
+            ),
+          },
+        ],
+      },
+      {
+        path: EnumRoutes.Audits,
+        element: <Root content={<Audits />} />,
+        children: [
+          {
+            index: true,
+            element: (
+              <Welcome
+                headline="Welcome to audits report"
+                tagline="Here you can run audits and see the results."
+              />
+            ),
+          },
+          {
+            path: '*',
+            element: (
+              <NotFound
+                link={EnumRoutes.Audits}
+                message="Back To Audits"
+              />
+            ),
+          },
+        ],
+      },
+    ].filter(r => {
+      const path = r.path.replace('/', '') as Modules
+      return isNil(aliases[path])
+        ? modules.list.includes(path as Modules)
+        : aliases[path]?.some(a => modules.list.includes(a as Modules))
+    }),
   ].filter(Boolean) as RouteObject[]
 
   return createBrowserRouter(routes, { basename: getUrlPrefix() })

--- a/web/client/src/routes.tsx
+++ b/web/client/src/routes.tsx
@@ -419,7 +419,5 @@ export function getBrowserRouter(
     },
   ].filter(Boolean) as RouteObject[]
 
-  console.log('routes', routes, getUrlPrefix())
-
   return createBrowserRouter(routes, { basename: getUrlPrefix() })
 }

--- a/web/client/src/routes.tsx
+++ b/web/client/src/routes.tsx
@@ -24,8 +24,8 @@ const Welcome = lazy(() => import('./library/components/banner/Welcome'))
 export const EnumRoutes = {
   Home: '/',
   Editor: '/editor',
-  Docs: '/docs',
-  DocsModels: '/docs/models',
+  Catalog: '/catalog',
+  CatalogModels: '/catalog/models',
   Data: '/data',
   DataModels: '/data/models',
   Lineage: '/lineage',
@@ -67,8 +67,8 @@ export function getBrowserRouter(
           element: <Editor />,
         },
         {
-          path: 'docs',
-          element: <Models route={EnumRoutes.Docs} />,
+          path: 'catalog',
+          element: <Models route={EnumRoutes.Catalog} />,
           children: [
             {
               index: true,
@@ -83,7 +83,7 @@ export function getBrowserRouter(
               path: '*',
               element: (
                 <NotFound
-                  link={EnumRoutes.Docs}
+                  link={EnumRoutes.Catalog}
                   message="Back To Docs"
                 />
               ),
@@ -104,7 +104,7 @@ export function getBrowserRouter(
                   path: '*',
                   element: (
                     <NotFound
-                      link={EnumRoutes.Docs}
+                      link={EnumRoutes.Catalog}
                       message="Back To Docs"
                     />
                   ),
@@ -418,6 +418,8 @@ export function getBrowserRouter(
       ),
     },
   ].filter(Boolean) as RouteObject[]
+
+  console.log('routes', routes, getUrlPrefix())
 
   return createBrowserRouter(routes, { basename: getUrlPrefix() })
 }

--- a/web/client/vite.config.ts
+++ b/web/client/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react-swc'
 
 const BASE_URL = process.env.BASE_URL ?? ''
-const BASE = BASE_URL ?? '/'
+const BASE = BASE_URL == null || BASE_URL === '' ? '/' : BASE_URL
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -49,7 +49,7 @@ export default defineConfig({
               target: 'http://api:8000',
               rewrite: path => path.replace(`${BASE_URL}/api`, '/api'),
             },
-            [`${BASE_URL}/docs`]: {
+            [`${BASE_URL}/catalog`]: {
               target: 'http://app:8001',
               rewrite: path => BASE,
             },

--- a/web/client/vite.config.ts
+++ b/web/client/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
               target: 'http://api:8000',
               rewrite: path => path.replace(`${BASE_URL}/api`, '/api'),
             },
-            [`${BASE_URL}/catalog`]: {
+            [`${BASE_URL}/data-catalog`]: {
               target: 'http://app:8001',
               rewrite: path => BASE,
             },

--- a/web/server/models.py
+++ b/web/server/models.py
@@ -32,7 +32,7 @@ SUPPORTED_EXTENSIONS = {".py", ".sql", ".yaml", ".yml", ".csv"}
 class Mode(str, enum.Enum):
     IDE = "ide"  # Allow all modules
     DOCS = "docs"  # Only docs module
-    DEFAULT = "default"  # Allow docs and plan
+    CATALOG = "catalog"  # Only docs module
     PLAN = "plan"  # Allow plan
 
 
@@ -54,7 +54,7 @@ class EventName(str, enum.Enum):
 class Modules(str, enum.Enum):
     EDITOR = "editor"  # include ability to edit files and run queries
     FILES = "files"  # include projects files
-    DOCS = "docs"  # include docs
+    CATALOG = "catalog"  # include docs
     PLANS = "plans"  # include ability to run/apply plans
     TESTS = "tests"  # include ability to run tests
     AUDITS = "audits"  # include ability to run audits

--- a/web/server/models.py
+++ b/web/server/models.py
@@ -54,7 +54,7 @@ class EventName(str, enum.Enum):
 class Modules(str, enum.Enum):
     EDITOR = "editor"  # include ability to edit files and run queries
     FILES = "files"  # include projects files
-    CATALOG = "catalog"  # include docs
+    DATA_CATALOG = "data-catalog"  # include data-catalog
     PLANS = "plans"  # include ability to run/apply plans
     TESTS = "tests"  # include ability to run tests
     AUDITS = "audits"  # include ability to run audits

--- a/web/server/settings.py
+++ b/web/server/settings.py
@@ -25,12 +25,17 @@ MODE_TO_MODULES = {
     models.Mode.IDE: {
         models.Modules.EDITOR,
         models.Modules.FILES,
-        models.Modules.CATALOG,
+        models.Modules.DATA_CATALOG,
         models.Modules.ERRORS,
         models.Modules.PLANS,
     },
-    models.Mode.CATALOG: {models.Modules.CATALOG, models.Modules.ERRORS},
-    models.Mode.PLAN: {models.Modules.PLANS, models.Modules.LINEAGE, models.Modules.ERRORS},
+    models.Mode.CATALOG: {models.Modules.DATA_CATALOG},
+    models.Mode.PLAN: {
+        models.Modules.PLANS,
+        models.Modules.DATA_CATALOG,
+        models.Modules.LINEAGE,
+        models.Modules.ERRORS,
+    },
 }
 
 

--- a/web/server/settings.py
+++ b/web/server/settings.py
@@ -25,19 +25,12 @@ MODE_TO_MODULES = {
     models.Mode.IDE: {
         models.Modules.EDITOR,
         models.Modules.FILES,
-        models.Modules.DOCS,
+        models.Modules.CATALOG,
         models.Modules.ERRORS,
         models.Modules.PLANS,
     },
-    models.Mode.DOCS: {models.Modules.DOCS, models.Modules.ERRORS},
+    models.Mode.CATALOG: {models.Modules.CATALOG, models.Modules.ERRORS},
     models.Mode.PLAN: {models.Modules.PLANS, models.Modules.LINEAGE, models.Modules.ERRORS},
-    models.Mode.DEFAULT: {
-        models.Modules.DOCS,
-        models.Modules.PLANS,
-        models.Modules.ERRORS,
-        models.Modules.EDITOR,
-        models.Modules.FILES,
-    },
 }
 
 
@@ -48,12 +41,14 @@ class Settings(PydanticModel):
     config: str = Field(default_factory=lambda: os.getenv("CONFIG", ""))
     gateway: t.Optional[str] = Field(default_factory=lambda: os.getenv("GATEWAY"))
     ui_mode: Mode = Field(
-        default_factory=lambda: Mode[os.getenv("UI_MODE", Mode.DEFAULT.value).upper()]
+        default_factory=lambda: Mode[os.getenv("UI_MODE", Mode.IDE.value).upper()]
     )
 
     @property
     def modules(self) -> t.Set[models.Modules]:
-        return MODE_TO_MODULES[self.ui_mode]
+        return MODE_TO_MODULES[
+            models.Mode.CATALOG if self.ui_mode == models.Mode.DOCS else self.ui_mode
+        ]
 
 
 @lru_cache()

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -96,7 +96,7 @@ async def watch_project() -> None:
         if settings.modules.intersection(
             {
                 models.Modules.FILES,
-                models.Modules.DOCS,
+                models.Modules.CATALOG,
                 models.Modules.PLANS,
                 models.Modules.LINEAGE,
             }

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -96,7 +96,7 @@ async def watch_project() -> None:
         if settings.modules.intersection(
             {
                 models.Modules.FILES,
-                models.Modules.CATALOG,
+                models.Modules.DATA_CATALOG,
                 models.Modules.PLANS,
                 models.Modules.LINEAGE,
             }


### PR DESCRIPTION
- Changing related routes from `docs` to `data-catalog`
- both cli commands `sqlmesh ui --mode docs` and `sqlmesh ui --mode catalog` spin up SQLMesh UI in `docs`/ `catalog` mode but with routing name `data-catalog``
- Changing internal references form `Docs` to `Data Catalog`
