### PR TITLE
Feat!: Support pinning of the physical table version for forward-only models

### DIFF
--- a/docs/concepts/models/overview.md
+++ b/docs/concepts/models/overview.md
@@ -344,6 +344,11 @@ Learn more about these properties and their default values in the [model configu
 ### enabled
 :   Whether the model is enabled. This attribute is `true` by default. Setting it to `false` causes SQLMesh to ignore this model when loading the project.
 
+### physical_version
+:   Pins the version of this model's physical table to the given value.
+
+    NOTE: This can only be set for forward-only models.
+
 ## Incremental Model Properties
 
 These properties can be specified in an incremental model's `kind` definition.

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -798,8 +798,15 @@ class _Model(ModelMeta, frozen=True):
             # TODO: would this sort of logic be better off moved into the Kind?
             if self.dialect == "snowflake" and "target_lag" not in self.physical_properties:
                 raise_config_error(
-                    "Snowflake managed tables must specify the 'target_lag' physical property"
+                    "Snowflake managed tables must specify the 'target_lag' physical property",
+                    self._path,
                 )
+
+        if self.physical_version is not None and not self.forward_only:
+            raise_config_error(
+                "Pinning a physical version is only supported for forward only models",
+                self._path,
+            )
 
     def is_breaking_change(self, previous: Model) -> t.Optional[bool]:
         """Determines whether this model is a breaking change in relation to the `previous` model.
@@ -839,6 +846,7 @@ class _Model(ModelMeta, frozen=True):
             *(gen(expr) for expr in (self.clustered_by or [])),
             self.stamp,
             self.physical_schema,
+            self.physical_version,
             self.interval_unit.value if self.interval_unit is not None else None,
         ]
 

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -77,6 +77,7 @@ class ModelMeta(_Node):
     allow_partials: bool = False
     signals: t.List[exp.Tuple] = []
     enabled: bool = True
+    physical_version: t.Optional[str] = None
 
     _bool_validator = bool_validator
     _model_kind_validator = model_kind_validator
@@ -160,6 +161,12 @@ class ModelMeta(_Node):
         # so this ensures they'll be stored as lowercase
         dialect = str_or_exp_to_str(v)
         return dialect and dialect.lower()
+
+    @field_validator("physical_version", mode="before")
+    def _physical_version_validator(cls, v: t.Any) -> t.Optional[str]:
+        if v is None:
+            return v
+        return str_or_exp_to_str(v)
 
     @field_validator("partitioned_by_", "clustered_by_", mode="before")
     @field_validator_v1_args

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -79,6 +79,7 @@ class ModelConfig(BaseModelConfig):
     forward_only: bool = True
     disable_restatement: t.Optional[bool] = None
     allow_partials: t.Optional[bool] = None
+    physical_version: t.Optional[str] = None
 
     # DBT configuration fields
     cluster_by: t.Optional[t.List[str]] = None
@@ -399,7 +400,12 @@ class ModelConfig(BaseModelConfig):
 
     @property
     def sqlmesh_config_fields(self) -> t.Set[str]:
-        return super().sqlmesh_config_fields | {"cron", "interval_unit", "allow_partials"}
+        return super().sqlmesh_config_fields | {
+            "cron",
+            "interval_unit",
+            "allow_partials",
+            "physical_version",
+        }
 
     def to_sqlmesh(self, context: DbtContext) -> Model:
         """Converts the dbt model into a SQLMesh model."""

--- a/sqlmesh/migrations/v0059_add_physical_version.py
+++ b/sqlmesh/migrations/v0059_add_physical_version.py
@@ -1,0 +1,5 @@
+"""Add the physical_version model attribute."""
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    pass

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -372,7 +372,7 @@ def test_override_builtin_audit_blocking_mode():
             call(
                 "Audit 'not_null' for model 'db.x' failed.\n"
                 "Got 1 results, expected 0.\n"
-                'SELECT * FROM (SELECT * FROM "sqlmesh__db"."db__x__829001280" AS "db__x__829001280") AS "_q_0" WHERE "c" IS NULL AND TRUE\n'
+                'SELECT * FROM (SELECT * FROM "sqlmesh__db"."db__x__2457047842" AS "db__x__2457047842") AS "_q_0" WHERE "c" IS NULL AND TRUE\n'
                 "Audit is warn only so proceeding with execution."
             )
         ]

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -2526,7 +2526,7 @@ def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
     ) = get_default_catalog_and_non_tables(metadata, context.default_catalog)
     assert len(prod_views) == 13
     assert len(dev_views) == 0
-    assert len(user_default_tables) == 12
+    assert len(user_default_tables) == 13
     assert state_metadata.schemas == ["sqlmesh"]
     assert {x.sql() for x in state_metadata.qualified_tables}.issuperset(
         {
@@ -2545,7 +2545,7 @@ def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
     ) = get_default_catalog_and_non_tables(metadata, context.default_catalog)
     assert len(prod_views) == 13
     assert len(dev_views) == 13
-    assert len(user_default_tables) == 12
+    assert len(user_default_tables) == 13
     assert len(non_default_tables) == 0
     assert state_metadata.schemas == ["sqlmesh"]
     assert {x.sql() for x in state_metadata.qualified_tables}.issuperset(
@@ -2565,7 +2565,7 @@ def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
     ) = get_default_catalog_and_non_tables(metadata, context.default_catalog)
     assert len(prod_views) == 13
     assert len(dev_views) == 26
-    assert len(user_default_tables) == 12
+    assert len(user_default_tables) == 13
     assert len(non_default_tables) == 0
     assert state_metadata.schemas == ["sqlmesh"]
     assert {x.sql() for x in state_metadata.qualified_tables}.issuperset(
@@ -2586,7 +2586,7 @@ def test_environment_catalog_mapping(init_and_plan_context: t.Callable):
     ) = get_default_catalog_and_non_tables(metadata, context.default_catalog)
     assert len(prod_views) == 13
     assert len(dev_views) == 13
-    assert len(user_default_tables) == 12
+    assert len(user_default_tables) == 13
     assert len(non_default_tables) == 0
     assert state_metadata.schemas == ["sqlmesh"]
     assert {x.sql() for x in state_metadata.qualified_tables}.issuperset(

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -1646,10 +1646,19 @@ def test_create_scd_type_2_by_time(adapter_mock, make_snapshot):
         table_description=None,
     )
 
-    adapter_mock.create_table.assert_called_once_with(
-        snapshot.table_name(),
-        column_descriptions={},
-        **common_kwargs,
+    adapter_mock.create_table.assert_has_calls(
+        [
+            call(
+                snapshot.table_name(is_deployable=False),
+                column_descriptions=None,
+                **common_kwargs,
+            ),
+            call(
+                snapshot.table_name(),
+                column_descriptions={},
+                **common_kwargs,
+            ),
+        ]
     )
 
 
@@ -1692,8 +1701,17 @@ def test_create_ctas_scd_type_2_by_time(adapter_mock, make_snapshot):
         table_description=None,
     )
 
-    adapter_mock.ctas.assert_called_once_with(
-        snapshot.table_name(), query, None, column_descriptions={}, **common_kwargs
+    adapter_mock.ctas.assert_has_calls(
+        [
+            call(
+                snapshot.table_name(is_deployable=False),
+                query,
+                None,
+                column_descriptions=None,
+                **common_kwargs,
+            ),
+            call(snapshot.table_name(), query, None, column_descriptions={}, **common_kwargs),
+        ]
     )
 
 
@@ -1800,8 +1818,14 @@ def test_create_scd_type_2_by_column(adapter_mock, make_snapshot):
         table_description=None,
     )
 
-    adapter_mock.create_table.assert_called_once_with(
-        snapshot.table_name(), **{**common_kwargs, "column_descriptions": {}}
+    adapter_mock.create_table.assert_has_calls(
+        [
+            call(
+                snapshot.table_name(is_deployable=False),
+                **{**common_kwargs, "column_descriptions": None},
+            ),
+            call(snapshot.table_name(), **{**common_kwargs, "column_descriptions": {}}),
+        ]
     )
 
 
@@ -1843,8 +1867,18 @@ def test_create_ctas_scd_type_2_by_column(adapter_mock, make_snapshot):
         table_description=None,
     )
 
-    adapter_mock.ctas.assert_called_once_with(
-        snapshot.table_name(), query, None, **{**common_kwargs, "column_descriptions": {}}
+    adapter_mock.ctas.assert_has_calls(
+        [
+            call(
+                snapshot.table_name(is_deployable=False),
+                query,
+                None,
+                **{**common_kwargs, "column_descriptions": None},
+            ),
+            call(
+                snapshot.table_name(), query, None, **{**common_kwargs, "column_descriptions": {}}
+            ),
+        ]
     )
 
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -538,7 +538,7 @@ def test_evaluate_materialized_view_with_partitioned_by_cluster_by(
         [
             call("CREATE SCHEMA IF NOT EXISTS `sqlmesh__test_schema`"),
             call(
-                "CREATE MATERIALIZED VIEW `sqlmesh__test_schema`.`test_schema__test_model__1984886695` PARTITION BY `a` CLUSTER BY `b` AS SELECT `a` AS `a`, `b` AS `b` FROM `tbl` AS `tbl`"
+                "CREATE MATERIALIZED VIEW `sqlmesh__test_schema`.`test_schema__test_model__3414391032` PARTITION BY `a` CLUSTER BY `b` AS SELECT `a` AS `a`, `b` AS `b` FROM `tbl` AS `tbl`"
             ),
         ]
     )
@@ -2773,10 +2773,10 @@ def test_cleanup_managed(adapter_mock, make_snapshot, mocker: MockerFixture):
     evaluator.cleanup(target_snapshots=[cleanup_task])
 
     adapter_mock.drop_table.assert_called_once_with(
-        "sqlmesh__test_schema.test_schema__test_model__2898537538__temp"
+        "sqlmesh__test_schema.test_schema__test_model__2319802374__temp"
     )
     adapter_mock.drop_managed_table.assert_called_once_with(
-        "sqlmesh__test_schema.test_schema__test_model__2898537538"
+        "sqlmesh__test_schema.test_schema__test_model__2319802374"
     )
 
 

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -2225,12 +2225,12 @@ def test_snapshot_batching(state_sync, mocker, make_snapshot):
         call(
             exp.to_table("sqlmesh._snapshots"),
             where=parse_one(
-                f"(name, identifier) in (('\"a\"', '{snapshot_a.identifier}'), ('\"a\"', '{snapshot_b.identifier}'))"
+                f"(name, identifier) in (('\"a\"', '{snapshot_b.identifier}'), ('\"a\"', '{snapshot_c.identifier}'))"
             ),
         ),
         call(
             exp.to_table("sqlmesh._snapshots"),
-            where=parse_one(f"(name, identifier) in (('\"a\"', '{snapshot_c.identifier}'))"),
+            where=parse_one(f"(name, identifier) in (('\"a\"', '{snapshot_a.identifier}'))"),
         ),
     ]
 

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -184,7 +184,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
             "models_to_backfill": ['"test_model"'],
             "end_bounded": False,
             "ensure_finalized_snapshots": False,
-            "directly_modified_snapshots": [{"identifier": "4011362914", "name": '"test_model"'}],
+            "directly_modified_snapshots": [{"identifier": "3403909186", "name": '"test_model"'}],
             "indirectly_modified_snapshots": {},
             "removed_snapshots": [],
             "restatements": {


### PR DESCRIPTION
This update introduces the following improvements:
* When a new forward-only model is added, and multiple versions of it are created concurrently without either being promoted to production, we ensure that both versions share the same physical table. This ensures that the name of the physical table remains deterministic and predictable, which is especially important when the model's data is manually backfilled outside of SQLMesh.
* Added the ability to override and pin the version of the physical table, but only for forward-only models. This is the ultimate way for users to ensure that a model's physical table remains unchanged.