### PR TITLE
Feat!: Add multiple engine project support

### DIFF
--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -123,6 +123,7 @@ class BuiltInSchedulerConfig(_EngineAdapterStateSyncSchedulerConfig, BaseConfig)
         return BuiltInPlanEvaluator(
             state_sync=context.state_sync,
             snapshot_evaluator=context.snapshot_evaluator,
+            snapshot_evaluators=context._snapshot_evaluators,
             create_scheduler=context.create_scheduler,
             default_catalog=self.get_default_catalog(context),
             console=context.console,

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -386,23 +386,24 @@ class GenericContext(BaseContext, t.Generic[C]):
             "test_configs"
         )
 
-        for gateway_name in self.config.gateways:
-            connection = self.config.get_connection(gateway_name)
-            adapter = (
-                connection.create_engine_adapter()
-                if gateway_name != self.config.default_gateway
-                else self._engine_adapter
-            )
-            evaluator = SnapshotEvaluator(
-                adapter.with_log_level(logging.INFO),
-                ddl_concurrent_tasks=connection.concurrent_tasks,
-            )
-            self._snapshot_evaluators[gateway_name] = evaluator
-            if self.config.default_gateway == gateway_name:
-                self._default_evaluator = evaluator
-            self._test_connection_configs[gateway_name] = self.config.get_test_connection(
-                gateway_name, adapter.default_catalog, default_catalog_dialect=adapter.DIALECT
-            )
+        if not gateway:
+            for gateway_name in self.config.gateways:
+                connection = self.config.get_connection(gateway_name)
+                adapter = (
+                    connection.create_engine_adapter()
+                    if gateway_name != self.config.default_gateway
+                    else self._engine_adapter
+                )
+                evaluator = SnapshotEvaluator(
+                    adapter.with_log_level(logging.INFO),
+                    ddl_concurrent_tasks=connection.concurrent_tasks,
+                )
+                self._snapshot_evaluators[gateway_name] = evaluator
+                if self.config.default_gateway == gateway_name:
+                    self._default_evaluator = evaluator
+                self._test_connection_configs[gateway_name] = self.config.get_test_connection(
+                    gateway_name, adapter.default_catalog, default_catalog_dialect=adapter.DIALECT
+                )
 
         self.console = console or get_console(dialect=self._engine_adapter.dialect)
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -61,6 +61,7 @@ from sqlmesh.core.config import (
     Config,
     load_configs,
 )
+from sqlmesh.core.config.connection import ConnectionConfig
 from sqlmesh.core.config.loader import C
 from sqlmesh.core.console import Console, get_console
 from sqlmesh.core.context_diff import ContextDiff
@@ -95,6 +96,7 @@ from sqlmesh.core.snapshot import (
     SnapshotFingerprint,
     to_table_mapping,
 )
+from sqlmesh.core.snapshot.definition import SnapshotTableCleanupTask
 from sqlmesh.core.state_sync import (
     CachingStateSync,
     StateReader,
@@ -379,22 +381,34 @@ class GenericContext(BaseContext, t.Generic[C]):
         self._snapshot_evaluators: UniqueKeyDict[str, SnapshotEvaluator] = UniqueKeyDict(
             "evaluators"
         )
+        self._default_evaluator: t.Optional[SnapshotEvaluator] = None
+        self._test_connection_configs: UniqueKeyDict[str, ConnectionConfig] = UniqueKeyDict(
+            "test_configs"
+        )
+
         for gateway_name in self.config.gateways:
             connection = self.config.get_connection(gateway_name)
-            adapter = connection.create_engine_adapter()
+            adapter = (
+                connection.create_engine_adapter()
+                if gateway_name != self.config.default_gateway
+                else self._engine_adapter
+            )
             evaluator = SnapshotEvaluator(
                 adapter.with_log_level(logging.INFO),
                 ddl_concurrent_tasks=connection.concurrent_tasks,
             )
             self._snapshot_evaluators[gateway_name] = evaluator
+            if self.config.default_gateway == gateway_name:
+                self._default_evaluator = evaluator
+            self._test_connection_configs[gateway_name] = self.config.get_test_connection(
+                gateway_name, adapter.default_catalog, default_catalog_dialect=adapter.DIALECT
+            )
 
         self.console = console or get_console(dialect=self._engine_adapter.dialect)
 
         self._test_connection_config = self.config.get_test_connection(
             self.gateway, self.default_catalog, default_catalog_dialect=self.engine_adapter.DIALECT
         )
-
-        self._snapshot_evaluator: t.Optional[SnapshotEvaluator] = None
 
         self._provided_state_sync: t.Optional[StateSync] = state_sync
         self._state_sync: t.Optional[StateSync] = None
@@ -427,12 +441,12 @@ class GenericContext(BaseContext, t.Generic[C]):
 
     @property
     def snapshot_evaluator(self) -> SnapshotEvaluator:
-        if not self._snapshot_evaluator:
-            self._snapshot_evaluator = SnapshotEvaluator(
+        if not self._default_evaluator:
+            self._default_evaluator = SnapshotEvaluator(
                 self.engine_adapter.with_log_level(logging.INFO),
                 ddl_concurrent_tasks=self.concurrent_tasks,
             )
-        return self._snapshot_evaluator
+        return self._default_evaluator
 
     def execution_context(
         self, deployability_index: t.Optional[DeployabilityIndex] = None
@@ -973,8 +987,8 @@ class GenericContext(BaseContext, t.Generic[C]):
             limit: A limit applied to the model.
         """
         snapshot = self.get_snapshot(model_or_snapshot, raise_if_missing=True)
-
-        df = self.snapshot_evaluator.evaluate_and_fetch(
+        evaluator = self._snapshot_evaluators.get(snapshot.model.gateway, self.snapshot_evaluator)
+        df = evaluator.evaluate_and_fetch(
             snapshot,
             start=start,
             end=end,
@@ -1642,11 +1656,13 @@ class GenericContext(BaseContext, t.Generic[C]):
         }
 
         try:
-            test_adapter = self._test_connection_config.create_engine_adapter(
-                register_comments_override=False
+            model_to_test = self.get_model(model, raise_if_missing=True)
+            connection_config = self._test_connection_configs.get(
+                model_to_test.gateway, self._test_connection_config
             )
+            test_adapter = connection_config.create_engine_adapter(register_comments_override=False)
             generate_test(
-                model=self.get_model(model, raise_if_missing=True),
+                model=model_to_test,
                 input_queries=input_queries,
                 models=self._models,
                 engine_adapter=self._engine_adapter,
@@ -1748,7 +1764,10 @@ class GenericContext(BaseContext, t.Generic[C]):
         errors = []
         skipped_count = 0
         for snapshot in snapshots:
-            for audit_result in self.snapshot_evaluator.audit(
+            evaluator = self._snapshot_evaluators.get(
+                snapshot.model.gateway, self.snapshot_evaluator
+            )
+            for audit_result in evaluator.audit(
                 snapshot=snapshot,
                 start=start,
                 end=end,
@@ -1893,8 +1912,9 @@ class GenericContext(BaseContext, t.Generic[C]):
 
     def close(self) -> None:
         """Releases all resources allocated by this context."""
-        if self._snapshot_evaluator:
-            self._snapshot_evaluator.close()
+        if self._snapshot_evaluators:
+            for evaluator in self._snapshot_evaluators.values():
+                evaluator.close()
         if self._state_sync:
             self._state_sync.close()
 
@@ -2106,9 +2126,18 @@ class GenericContext(BaseContext, t.Generic[C]):
     def _run_janitor(self, ignore_ttl: bool = False) -> None:
         self._cleanup_environments()
         expired_snapshots = self.state_sync.delete_expired_snapshots(ignore_ttl=ignore_ttl)
-        self.snapshot_evaluator.cleanup(
-            expired_snapshots, on_complete=self.console.update_cleanup_progress
-        )
+
+        gateways: t.Dict[str, t.List[SnapshotTableCleanupTask]] = {}
+        for snapshot_cleanup_task in expired_snapshots:
+            snapshot_name = snapshot_cleanup_task.snapshot.name
+            gateway = self.snapshots[snapshot_name].model.gateway or "default"
+            gateways.setdefault(gateway, []).append(snapshot_cleanup_task)
+
+        for gateway, snapshots_cleanup_tasks in gateways.items():
+            evaluator = self._snapshot_evaluators.get(gateway, self.snapshot_evaluator)
+            evaluator.cleanup(
+                snapshots_cleanup_tasks, on_complete=self.console.update_cleanup_progress
+            )
 
         self.state_sync.compact_intervals()
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -56,7 +56,11 @@ from sqlmesh.core import analytics
 from sqlmesh.core import constants as c
 from sqlmesh.core.analytics import python_api_analytics
 from sqlmesh.core.audit import Audit, ModelAudit, StandaloneAudit
-from sqlmesh.core.config import CategorizerConfig, Config, load_configs
+from sqlmesh.core.config import (
+    CategorizerConfig,
+    Config,
+    load_configs,
+)
 from sqlmesh.core.config.loader import C
 from sqlmesh.core.console import Console, get_console
 from sqlmesh.core.context_diff import ContextDiff
@@ -372,6 +376,18 @@ class GenericContext(BaseContext, t.Generic[C]):
         self.concurrent_tasks = concurrent_tasks or self._connection_config.concurrent_tasks
         self._engine_adapter = engine_adapter or self._connection_config.create_engine_adapter()
 
+        self._snapshot_evaluators: UniqueKeyDict[str, SnapshotEvaluator] = UniqueKeyDict(
+            "evaluators"
+        )
+        for gateway_name in self.config.gateways:
+            connection = self.config.get_connection(gateway_name)
+            adapter = connection.create_engine_adapter()
+            evaluator = SnapshotEvaluator(
+                adapter.with_log_level(logging.INFO),
+                ddl_concurrent_tasks=connection.concurrent_tasks,
+            )
+            self._snapshot_evaluators[gateway_name] = evaluator
+
         self.console = console or get_console(dialect=self._engine_adapter.dialect)
 
         self._test_connection_config = self.config.get_test_connection(
@@ -516,6 +532,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             max_workers=self.concurrent_tasks,
             console=self.console,
             notification_target_manager=self.notification_target_manager,
+            snapshot_evaluators=self._snapshot_evaluators,
         )
 
     @property

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -299,8 +299,12 @@ class VarcharSizeWorkaroundMixin(EngineAdapter):
                 select_or_union.set("where", None)
 
             temp_view_name = self._get_temp_table("ctas")
+
+            # to handle external tables that are not supported in views in Redshift
+            no_schema_binding = True if self.dialect == "redshift" else False
+
             self.create_view(
-                temp_view_name, select_statement, replace=False, no_schema_binding=False
+                temp_view_name, select_statement, replace=False, no_schema_binding=no_schema_binding
             )
             try:
                 columns_to_types_from_view = self._default_precision_to_max(

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1541,7 +1541,6 @@ class ExternalModel(_Model):
     """The model definition which represents an external source/table."""
 
     source_type: Literal["external"] = "external"
-    gateway: t.Optional[str] = None
 
     def is_breaking_change(self, previous: Model) -> t.Optional[bool]:
         if not isinstance(previous, ExternalModel):

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -77,6 +77,7 @@ class ModelMeta(_Node):
     allow_partials: bool = False
     signals: t.List[exp.Tuple] = []
     enabled: bool = True
+    gateway: t.Optional[str] = None
 
     _bool_validator = bool_validator
     _model_kind_validator = model_kind_validator
@@ -160,6 +161,13 @@ class ModelMeta(_Node):
         # so this ensures they'll be stored as lowercase
         dialect = str_or_exp_to_str(v)
         return dialect and dialect.lower()
+
+    @field_validator("gateway", mode="before")
+    def _gateway_validator(cls, v: t.Any) -> t.Optional[str]:
+        if v is None:
+            return None
+        gateway = str_or_exp_to_str(v)
+        return gateway and gateway.lower()
 
     @field_validator("partitioned_by_", "clustered_by_", mode="before")
     @field_validator_v1_args

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -39,6 +39,7 @@ from sqlmesh.core.user import User
 from sqlmesh.schedulers.airflow import common as airflow_common
 from sqlmesh.schedulers.airflow.client import AirflowClient, BaseAirflowClient
 from sqlmesh.schedulers.airflow.mwaa_client import MWAAClient
+from sqlmesh.utils import UniqueKeyDict
 from sqlmesh.utils.errors import SQLMeshError
 
 logger = logging.getLogger(__name__)
@@ -69,9 +70,11 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         create_scheduler: t.Callable[[t.Iterable[Snapshot]], Scheduler],
         default_catalog: t.Optional[str],
         console: t.Optional[Console] = None,
+        snapshot_evaluators: t.Optional[UniqueKeyDict[str, SnapshotEvaluator]] = None,
     ):
         self.state_sync = state_sync
         self.snapshot_evaluator = snapshot_evaluator
+        self.snapshot_evaluators = snapshot_evaluators
         self.create_scheduler = create_scheduler
         self.default_catalog = default_catalog
         self.console = console or get_console()
@@ -227,13 +230,30 @@ class BuiltInPlanEvaluator(PlanEvaluator):
 
         completed = False
         try:
-            self.snapshot_evaluator.create(
-                snapshots_to_create,
-                snapshots,
-                allow_destructive_snapshots=plan.allow_destructive_models,
-                deployability_index=deployability_index,
-                on_complete=self.console.update_creation_progress,
-            )
+            gateways: t.Dict[str, t.List[Snapshot]] = {}
+            for snapshot in snapshots_to_create:
+                gateway = snapshot.model.gateway or "default"
+                gateways.setdefault(gateway, []).append(snapshot)
+
+            if not self.snapshot_evaluators or len(gateways) == 1:
+                self.snapshot_evaluator.create(
+                    snapshots_to_create,
+                    snapshots,
+                    allow_destructive_snapshots=plan.allow_destructive_models,
+                    deployability_index=deployability_index,
+                    on_complete=self.console.update_creation_progress,
+                )
+            else:
+                for gateway, snapshots_to_create_list in gateways.items():
+                    evaluator = self.snapshot_evaluators.get(gateway, self.snapshot_evaluator)
+                    evaluator.create(
+                        snapshots_to_create_list,
+                        snapshots,
+                        allow_destructive_snapshots=plan.allow_destructive_models,
+                        deployability_index=deployability_index,
+                        on_complete=self.console.update_creation_progress,
+                    )
+
             completed = True
         finally:
             self.console.stop_creation_progress(success=completed)

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -235,24 +235,20 @@ class BuiltInPlanEvaluator(PlanEvaluator):
                 gateway = snapshot.model.gateway or "default"
                 gateways.setdefault(gateway, []).append(snapshot)
 
-            if not self.snapshot_evaluators or len(gateways) == 1:
-                self.snapshot_evaluator.create(
-                    snapshots_to_create,
+            evaluators = (
+                self.snapshot_evaluators
+                if self.snapshot_evaluators
+                else {"default": self.snapshot_evaluator}
+            )
+            for gateway, snapshots_to_create_list in gateways.items():
+                evaluator = evaluators.get(gateway, self.snapshot_evaluator)
+                evaluator.create(
+                    snapshots_to_create_list,
                     snapshots,
                     allow_destructive_snapshots=plan.allow_destructive_models,
                     deployability_index=deployability_index,
                     on_complete=self.console.update_creation_progress,
                 )
-            else:
-                for gateway, snapshots_to_create_list in gateways.items():
-                    evaluator = self.snapshot_evaluators.get(gateway, self.snapshot_evaluator)
-                    evaluator.create(
-                        snapshots_to_create_list,
-                        snapshots,
-                        allow_destructive_snapshots=plan.allow_destructive_models,
-                        deployability_index=deployability_index,
-                        on_complete=self.console.update_creation_progress,
-                    )
 
             completed = True
         finally:

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -25,7 +25,7 @@ from sqlmesh.core.snapshot import (
 from sqlmesh.core.snapshot.definition import Interval as SnapshotInterval
 from sqlmesh.core.snapshot.definition import Intervals, SnapshotId, merge_intervals
 from sqlmesh.core.state_sync import StateSync
-from sqlmesh.utils import format_exception
+from sqlmesh.utils import UniqueKeyDict, format_exception
 from sqlmesh.utils.concurrency import concurrent_apply_to_dag, NodeExecutionFailedError
 from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.date import (
@@ -118,11 +118,12 @@ class Scheduler:
 
     Args:
         snapshots: A collection of snapshots.
-        snapshot_evaluator: The snapshot evaluator to execute queries.
+        snapshot_evaluator: The default snapshot evaluator to execute queries.
         state_sync: The state sync to pull saved snapshots.
         max_workers: The maximum number of parallel queries to run.
         console: The rich instance used for printing scheduling information.
         signal_factory: A factory method for building Signal instances from model signal configuration.
+        snapshot_evaluators: The snapshot evaluators to execute queries if multiple are defined.
     """
 
     def __init__(
@@ -135,12 +136,14 @@ class Scheduler:
         console: t.Optional[Console] = None,
         notification_target_manager: t.Optional[NotificationTargetManager] = None,
         signal_factory: t.Optional[SignalFactory] = None,
+        snapshot_evaluators: t.Optional[UniqueKeyDict[str, SnapshotEvaluator]] = None,
     ):
         self.state_sync = state_sync
         self.snapshots = {s.snapshot_id: s for s in snapshots}
         self.snapshot_per_version = _resolve_one_snapshot_per_version(self.snapshots.values())
         self.default_catalog = default_catalog
         self.snapshot_evaluator = snapshot_evaluator
+        self.snapshot_evaluators = snapshot_evaluators
         self.max_workers = max_workers
         self.console = console or get_console()
         self.notification_target_manager = (
@@ -234,7 +237,17 @@ class Scheduler:
 
         is_deployable = deployability_index.is_deployable(snapshot)
 
-        wap_id = self.snapshot_evaluator.evaluate(
+        evaluator = self.snapshot_evaluator
+        if (
+            snapshot.is_model
+            and not snapshot.is_seed
+            and self.snapshot_evaluators
+            and snapshot.model.gateway
+        ):
+            if snapshot_evaluator := self.snapshot_evaluators.get(snapshot.model.gateway):
+                evaluator = snapshot_evaluator
+
+        wap_id = evaluator.evaluate(
             snapshot,
             start=start,
             end=end,
@@ -244,7 +257,7 @@ class Scheduler:
             batch_index=batch_index,
             **kwargs,
         )
-        audit_results = self.snapshot_evaluator.audit(
+        audit_results = evaluator.audit(
             snapshot=snapshot,
             start=start,
             end=end,
@@ -263,7 +276,7 @@ class Scheduler:
                 model=snapshot.model_or_none,
                 count=t.cast(int, audit_result.count),
                 query=t.cast(exp.Query, audit_result.query),
-                adapter_dialect=self.snapshot_evaluator.adapter.dialect,
+                adapter_dialect=evaluator.adapter.dialect,
             )
             self.notification_target_manager.notify(NotificationEvent.AUDIT_FAILURE, error)
             if is_deployable and snapshot.node.owner:

--- a/tests/core/engine_adapter/test_redshift.py
+++ b/tests/core/engine_adapter/test_redshift.py
@@ -74,7 +74,7 @@ def test_varchar_size_workaround(make_mocked_engine_adapter: t.Callable, mocker:
     )
 
     assert to_sql_calls(adapter) == [
-        'CREATE VIEW "__temp_ctas_test_random_id" AS SELECT "char", "char1" + 1 AS "char1", "char2" AS "char2", "varchar", "varchar256", "varchar2" FROM (SELECT * FROM "table")',
+        'CREATE VIEW "__temp_ctas_test_random_id" AS SELECT "char", "char1" + 1 AS "char1", "char2" AS "char2", "varchar", "varchar256", "varchar2" FROM (SELECT * FROM "table") WITH NO SCHEMA BINDING',
         'DROP VIEW IF EXISTS "__temp_ctas_test_random_id" CASCADE',
         'CREATE TABLE "test_schema"."test_table" ("char" CHAR, "char1" CHAR(max), "char2" CHAR(2), "varchar" VARCHAR, "varchar256" VARCHAR(max), "varchar2" VARCHAR(2))',
     ]
@@ -113,7 +113,7 @@ def test_create_table_from_query_exists_no_if_not_exists(
     )
 
     assert to_sql_calls(adapter) == [
-        'CREATE VIEW "__temp_ctas_test_random_id" AS SELECT "a", "b", "x" + 1 AS "c", "d" AS "d", "e" FROM (SELECT * FROM "table")',
+        'CREATE VIEW "__temp_ctas_test_random_id" AS SELECT "a", "b", "x" + 1 AS "c", "d" AS "d", "e" FROM (SELECT * FROM "table") WITH NO SCHEMA BINDING',
         'DROP VIEW IF EXISTS "__temp_ctas_test_random_id" CASCADE',
         'CREATE TABLE "test_schema"."test_table" ("a" VARCHAR(MAX), "b" VARCHAR(60), "c" VARCHAR(MAX), "d" VARCHAR(MAX), "e" TIMESTAMP)',
     ]

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -313,6 +313,15 @@ def test_evaluate_limit():
     assert context.evaluate("without_limit", "2020-01-01", "2020-01-02", "2020-01-02", 2).size == 2
 
 
+def test_gateway_specific_evaluator(copy_to_temp_path):
+    path = copy_to_temp_path("examples/sushi")
+    ctx = Context(paths=path, config="isolated_systems_config", gateway="prod")
+    assert not ctx._snapshot_evaluators
+
+    ctx = Context(paths=path, config="isolated_systems_config")
+    assert len(ctx._snapshot_evaluators) == 3
+
+
 def test_multiple_gateways(tmp_path: Path):
     db_path = str(tmp_path / "db.db")
     gateways = {
@@ -335,9 +344,6 @@ def test_multiple_gateways(tmp_path: Path):
     assert gateway_model.gateway == "staging"
     context.upsert_model(gateway_model)
     assert context.evaluate("staging.stg_model", "2020-01-01", "2020-01-02", "2020-01-02").size == 5
-    assert (
-        context.evaluate("staging.stg_model", "2020-01-01", "2020-01-02", "2020-01-02", 2).size == 2
-    )
 
     default_model = load_sql_based_model(
         parse(

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -14,6 +14,7 @@ from pytest_mock.plugin import MockerFixture
 from sqlglot import exp, parse_one
 from sqlglot.errors import SchemaError
 
+from sqlmesh.core.config.gateway import GatewayConfig
 import sqlmesh.core.constants
 import sqlmesh.core.dialect as d
 from sqlmesh.core.config import (
@@ -310,6 +311,69 @@ def test_evaluate_limit():
     assert context.evaluate("without_limit", "2020-01-01", "2020-01-02", "2020-01-02").size == 5
     assert context.evaluate("without_limit", "2020-01-01", "2020-01-02", "2020-01-02", 4).size == 4
     assert context.evaluate("without_limit", "2020-01-01", "2020-01-02", "2020-01-02", 2).size == 2
+
+
+def test_multiple_gateways(tmp_path: Path):
+    db_path = str(tmp_path / "db.db")
+    gateways = {
+        "staging": GatewayConfig(connection=DuckDBConnectionConfig(database=db_path)),
+        "final": GatewayConfig(connection=DuckDBConnectionConfig(database=db_path)),
+    }
+
+    config = Config(gateways=gateways, default_gateway="final")
+    context = Context(config=config)
+
+    gateway_model = load_sql_based_model(
+        parse(
+            """
+    MODEL(name staging.stg_model, start '2024-01-01',kind FULL, gateway staging);
+    SELECT t.v as v FROM (VALUES (1), (2), (3), (4), (5)) AS t(v)"""
+        ),
+        default_catalog="db",
+    )
+
+    assert gateway_model.gateway == "staging"
+    context.upsert_model(gateway_model)
+    assert context.evaluate("staging.stg_model", "2020-01-01", "2020-01-02", "2020-01-02").size == 5
+    assert (
+        context.evaluate("staging.stg_model", "2020-01-01", "2020-01-02", "2020-01-02", 2).size == 2
+    )
+
+    default_model = load_sql_based_model(
+        parse(
+            """
+    MODEL(name main.final_model, start '2024-01-01',kind FULL);
+    SELECT v FROM staging.stg_model"""
+        ),
+        default_catalog="db",
+    )
+
+    assert not default_model.gateway
+    context.upsert_model(default_model)
+
+    context.plan(
+        execution_time="2024-01-02",
+        auto_apply=True,
+        no_prompts=True,
+    )
+
+    physical_schemas = [snapshot.physical_schema for snapshot in sorted(context.snapshots.values())]
+    view_schemas = [
+        snapshot.qualified_view_name.schema_name for snapshot in sorted(context.snapshots.values())
+    ]
+
+    assert physical_schemas == ["sqlmesh__main", "sqlmesh__staging"]
+    assert view_schemas == ["main", "staging"]
+    assert (
+        str(context.fetchdf("select * from staging.stg_model"))
+        == "   v\n0  1\n1  2\n2  3\n3  4\n4  5"
+    )
+    assert str(context.fetchdf("select * from final_model")) == "   v\n0  1\n1  2\n2  3\n3  4\n4  5"
+    assert (
+        context.snapshots['"db"."main"."final_model"'].parents[0].name
+        == '"db"."staging"."stg_model"'
+    )
+    assert context.dag._sorted == ['"db"."staging"."stg_model"', '"db"."main"."final_model"']
 
 
 def test_plan_execution_time():


### PR DESCRIPTION
**WIP** : This is an update to enable the use of multiple engines within a single SQLMesh project. The engine for each model will be determined by the gateway specified in the model definition:

```sql
MODEL (
  name main_db.sales,
  kind FULL,
  gateway <gateway_name>
);
```

If no gateway is specified the default gateway will be used and the virtual layer will be using the default_gateway for the views.