### PR TITLE
Fix(mssql): change mssql conn_properties type to List

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -1211,7 +1211,7 @@ class MSSQLConnectionConfig(ConnectionConfig):
     charset: t.Optional[str] = "UTF-8"
     appname: t.Optional[str] = None
     port: t.Optional[int] = 1433
-    conn_properties: t.Optional[t.Union[t.Iterable[str], str]] = None
+    conn_properties: t.Optional[t.Union[t.List[str], str]] = None
     autocommit: t.Optional[bool] = False
     tds_version: t.Optional[str] = None
 


### PR DESCRIPTION
Pydantic v2 or above errors when a value is passed to the `conn_properties` connection key:

```
TypeError: cannot pickle 'pydantic_core._pydantic_core.SerializationIterator' object
```

This PR updates the type from iterable to list, fixing this issue and matching the [pymssql typing](https://github.com/pymssql/pymssql/blob/eb17b88510d0d897c2f4ef38d17e8da9f59ef5cd/src/pymssql/_pymssql.pyi#L207).