### PR TITLE
chore: bump fastapi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ setup(
             "trino",
         ],
         "web": [
-            "fastapi==0.110.2",
+            "fastapi==0.115.5",
             "watchfiles>=0.19.0",
             "uvicorn[standard]==0.22.0",
             "sse-starlette>=0.2.2",


### PR DESCRIPTION
Allows users to use more recent versions of starlette. I tested by opening up SQLMesh UI and running plan/apply and clicking around a bit and confirming things were working. 