### PR TITLE
Chore: Simplify the output of the info command

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -669,16 +669,17 @@ def fetchdf(ctx: click.Context, sql: str) -> None:
     is_flag=True,
     help="Skip the connection test.",
 )
+@opt.verbose
 @click.pass_obj
 @error_handler
 @cli_analytics
-def info(obj: Context, skip_connection: bool) -> None:
+def info(obj: Context, skip_connection: bool, verbose: bool) -> None:
     """
     Print information about a SQLMesh project.
 
     Includes counts of project models and macros and connection tests for the data warehouse.
     """
-    obj.print_info(skip_connection=skip_connection)
+    obj.print_info(skip_connection=skip_connection, verbose=verbose)
 
 
 @cli.command("ui")

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1846,21 +1846,25 @@ class GenericContext(BaseContext, t.Generic[C]):
             )
 
     @python_api_analytics
-    def print_info(self, skip_connection: bool = False) -> None:
+    def print_info(self, skip_connection: bool = False, verbose: bool = False) -> None:
         """Prints information about connections, models, macros, etc. to the console."""
         self.console.log_status_update(f"Models: {len(self.models)}")
         self.console.log_status_update(f"Macros: {len(self._macros) - len(macro.get_registry())}")
 
-        print_config(self.config.get_connection(self.gateway), self.console, "Connection")
-        print_config(self.config.get_test_connection(self.gateway), self.console, "Test Connection")
-        print_config(
-            self.config.get_state_connection(self.gateway), self.console, "State Connection"
-        )
-        self.console.log_status_update("\n")
         if skip_connection:
             return
-        self._try_connection("data warehouse", self._engine_adapter.ping)
 
+        if verbose:
+            self.console.log_status_update("")
+            print_config(self.config.get_connection(self.gateway), self.console, "Connection")
+            print_config(
+                self.config.get_test_connection(self.gateway), self.console, "Test Connection"
+            )
+            print_config(
+                self.config.get_state_connection(self.gateway), self.console, "State Connection"
+            )
+
+        self._try_connection("data warehouse", self._engine_adapter.ping)
         state_connection = self.config.get_state_connection(self.gateway)
         if state_connection:
             self._try_connection("state backend", state_connection.connection_validator())

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -960,12 +960,13 @@ class SQLMeshMagics(Magics):
         help="Skip the connection test.",
         default=False,
     )
+    @argument("--verbose", "-v", action="store_true", help="Verbose output.")
     @line_magic
     @pass_sqlmesh_context
     def info(self, context: Context, line: str) -> None:
         """Display SQLMesh project information."""
         args = parse_argstring(self.info, line)
-        context.print_info(skip_connection=args.skip_connection)
+        context.print_info(skip_connection=args.skip_connection, verbose=args.verbose)
 
     @magic_arguments()
     @line_magic

--- a/sqlmesh/utils/config.py
+++ b/sqlmesh/utils/config.py
@@ -62,7 +62,6 @@ def print_config(config: Optional[ConnectionConfig], console: Any, title: str) -
         console: Console object with log_status_update method
     """
     if not config:
-        console.log_status_update("No connection configuration found.")
         return
 
     config_dict = config.dict(mode="json")
@@ -74,5 +73,4 @@ def print_config(config: Optional[ConnectionConfig], console: Any, title: str) -
     configWithTitle = {title: config_dict}
     yaml_output = yaml.dump(configWithTitle)
 
-    console.log_status_update("\n\n")
     console.log_status_update(yaml_output)

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -543,20 +543,17 @@ def test_fetchdf(notebook, sushi_context):
 
 def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_html_output):
     with capture_output() as output:
-        notebook.run_line_magic(magic_name="info", line="")
+        notebook.run_line_magic(magic_name="info", line="--verbose")
 
     assert not output.stdout
     assert not output.stderr
-    assert len(output.outputs) == 9
+    assert len(output.outputs) == 6
     assert convert_all_html_output_to_text(output) == [
         "Models: 17",
         "Macros: 6",
         "",
         "Connection:\n  type: duckdb\n  concurrent_tasks: 1\n  register_comments: true\n  pre_ping: false\n  extensions: []\n  connector_config: {}",
-        "",
         "Test Connection:\n  type: duckdb\n  concurrent_tasks: 1\n  register_comments: true\n  pre_ping: false\n  extensions: []\n  connector_config: {}",
-        "No connection configuration found.",
-        "",
         "Data warehouse connection succeeded",
     ]
     assert get_all_html_output(output) == [
@@ -564,10 +561,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
         "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Macros: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">6</span></pre>",
         "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>",
         '<pre style="white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,\'DejaVu Sans Mono\',consolas,\'Courier New\',monospace">Connection:  type: duckdb  concurrent_tasks: <span style="color: #008080; text-decoration-color: #008080; font-weight: bold">1</span>  register_comments: true  pre_ping: false  extensions: <span style="font-weight: bold">[]</span>  connector_config: <span style="font-weight: bold">{}</span></pre>',
-        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>",
         '<pre style="white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,\'DejaVu Sans Mono\',consolas,\'Courier New\',monospace">Test Connection:  type: duckdb  concurrent_tasks: <span style="color: #008080; text-decoration-color: #008080; font-weight: bold">1</span>  register_comments: true  pre_ping: false  extensions: <span style="font-weight: bold">[]</span>  connector_config: <span style="font-weight: bold">{}</span></pre>',
-        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">No connection configuration found.</pre>",
-        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>",
         "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Data warehouse connection <span style=\"color: #008000; text-decoration-color: #008000\">succeeded</span></pre>",
     ]
 


### PR DESCRIPTION
Only print the connection config when in verbose model. 

Default output:
```
$ sqlmesh info
`physical_schema_override` is deprecated. Please use `physical_schema_mapping` instead
Models: 17
Macros: 6
Data warehouse connection succeeded
```

Verbose:
```
$ sqlmesh info -v
Models: 17
Macros: 6

Connection:
  type: duckdb
  concurrent_tasks: 1
  register_comments: true
  pre_ping: false
  extensions: []
  connector_config: {}

Test Connection:
  type: duckdb
  concurrent_tasks: 1
  register_comments: true
  pre_ping: false
  extensions: []
  connector_config: {}

Data warehouse connection succeeded
```

Skip connection:
```
$ sqlmesh info --skip-connection
Models: 17
Macros: 6
```