### PR TITLE
Feat: Add an option to not run upstream dependencies when selecting models in the  command

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -458,9 +458,9 @@ def plan(
     help="If set, the command will exit with the specified code if the run is interrupted by an update to the target environment.",
 )
 @click.option(
-    "--no-force-upstream",
+    "--no-auto-upstream",
     is_flag=True,
-    help="Do not force upstream models to run. Only applicable when --select-model is used. Note: this may result in missing / invalid data for the selected models.",
+    help="Do not automatically include upstream models. Only applicable when --select-model is used. Note: this may result in missing / invalid data for the selected models.",
 )
 @click.pass_context
 @error_handler

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -457,6 +457,11 @@ def plan(
     type=int,
     help="If set, the command will exit with the specified code if the run is interrupted by an update to the target environment.",
 )
+@click.option(
+    "--no-force-upstream",
+    is_flag=True,
+    help="Do not force upstream models to run. Only applicable when --select-model is used. Note: this may result in missing / invalid data for the selected models.",
+)
 @click.pass_context
 @error_handler
 @cli_analytics

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -597,7 +597,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         ignore_cron: bool = False,
         select_models: t.Optional[t.Collection[str]] = None,
         exit_on_env_update: t.Optional[int] = None,
-        no_force_upstream: bool = False,
+        no_auto_upstream: bool = False,
     ) -> bool:
         """Run the entire dag through the scheduler.
 
@@ -612,7 +612,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 upstream dependencies of selected models will also be evaluated.
             exit_on_env_update: If set, exits with the provided code if the run is interrupted by an update
                 to the target environment.
-            no_force_upstream: Whether to not force upstream models to run. Only applicable when using `select_models`.
+            no_auto_upstream: Whether to not force upstream models to run. Only applicable when using `select_models`.
 
         Returns:
             True if the run was successful, False otherwise.
@@ -681,7 +681,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                     ignore_cron=ignore_cron,
                     select_models=select_models,
                     circuit_breaker=_has_environment_changed,
-                    no_force_upstream=no_force_upstream,
+                    no_auto_upstream=no_auto_upstream,
                 )
                 done = True
             except CircuitBreakerError:
@@ -1889,7 +1889,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         ignore_cron: bool,
         select_models: t.Optional[t.Collection[str]],
         circuit_breaker: t.Optional[t.Callable[[], bool]],
-        no_force_upstream: bool,
+        no_auto_upstream: bool,
     ) -> bool:
         scheduler = self.scheduler(environment=environment)
         snapshots = scheduler.snapshots
@@ -1903,7 +1903,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 dag.add(fqn, model.depends_on)
             model_selector = self._new_selector(models=models, dag=dag)
             select_models = set(model_selector.expand_model_selections(select_models))
-            if not no_force_upstream:
+            if not no_auto_upstream:
                 select_models = set(dag.subdag(*select_models))
 
         return scheduler.run(

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -462,6 +462,11 @@ class SQLMeshMagics(Magics):
         type=int,
         help="If set, the command will exit with the specified code if the run is interrupted by an update to the target environment.",
     )
+    @argument(
+        "--no-force-upstream",
+        action="store_true",
+        help="Do not force upstream models to run. Only applicable when --select-model is used. Note: this may result in missing / invalid data for the selected models.",
+    )
     @line_magic
     @pass_sqlmesh_context
     def run_dag(self, context: Context, line: str) -> None:
@@ -476,6 +481,7 @@ class SQLMeshMagics(Magics):
             ignore_cron=args.ignore_cron,
             select_models=args.select_model,
             exit_on_env_update=args.exit_on_env_update,
+            no_force_upstream=args.no_force_upstream,
         )
         if not success:
             raise SQLMeshError("Error Running DAG. Check logs for details.")

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -463,9 +463,9 @@ class SQLMeshMagics(Magics):
         help="If set, the command will exit with the specified code if the run is interrupted by an update to the target environment.",
     )
     @argument(
-        "--no-force-upstream",
+        "--no-auto-upstream",
         action="store_true",
-        help="Do not force upstream models to run. Only applicable when --select-model is used. Note: this may result in missing / invalid data for the selected models.",
+        help="Do not automatically include upstream models. Only applicable when --select-model is used. Note: this may result in missing / invalid data for the selected models.",
     )
     @line_magic
     @pass_sqlmesh_context
@@ -481,7 +481,7 @@ class SQLMeshMagics(Magics):
             ignore_cron=args.ignore_cron,
             select_models=args.select_model,
             exit_on_env_update=args.exit_on_env_update,
-            no_force_upstream=args.no_force_upstream,
+            no_auto_upstream=args.no_auto_upstream,
         )
         if not success:
             raise SQLMeshError("Error Running DAG. Check logs for details.")

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -1160,7 +1160,7 @@ def test_run_with_select_models(
 
 
 @freeze_time("2023-01-08 15:00:00")
-def test_run_with_select_models_no_force_upstream(
+def test_run_with_select_models_no_auto_upstream(
     init_and_plan_context: t.Callable,
 ):
     context, _ = init_and_plan_context("examples/sushi")
@@ -1172,7 +1172,7 @@ def test_run_with_select_models_no_force_upstream(
     context.plan("prod", no_prompts=True, skip_tests=True, auto_apply=True)
 
     with freeze_time("2023-01-09 00:00:00"):
-        assert context.run(select_models=["*waiter_revenue_by_day"], no_force_upstream=True)
+        assert context.run(select_models=["*waiter_revenue_by_day"], no_auto_upstream=True)
 
         snapshots = context.state_sync.state_sync.get_snapshots(context.snapshots.values())
         # Only waiter_revenue_by_day should be backfilled up to 2023-01-09.


### PR DESCRIPTION
The new option allows users to run selected models without waiting for upstream dependencies to catch up.