### PR TITLE
Fix: Support coercion of BIGNUMERIC values into FLOAT64 for BigQuery

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -78,6 +78,11 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
                 exp.DataType.build("DATETIME", dialect=DIALECT),
             },
         },
+        coerceable_types={
+            exp.DataType.build("FLOAT64", dialect=DIALECT): {
+                exp.DataType.build("BIGNUMERIC", dialect=DIALECT),
+            },
+        },
         support_coercing_compatible_types=True,
         parameterized_type_defaults={
             exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(38, 9), (0,)],

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -565,6 +565,26 @@ def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture)
         ),
         (
             {
+                "coerceable_types": {
+                    exp.DataType.build("FLOAT"): {exp.DataType.build("INT")},
+                },
+            },
+            {
+                "a": "FLOAT",
+                "b": "TEXT",
+            },
+            {
+                "a": "INT",
+                "b": "TEXT",
+            },
+            {
+                "a": "FLOAT",
+                "b": "TEXT",
+            },
+            [],
+        ),
+        (
+            {
                 "support_nested_operations": True,
                 "array_element_selector": "element",
             },
@@ -865,6 +885,8 @@ def test_alter_table(
         current_struct: exp.DataType, new_struct: exp.DataType
     ) -> t.List[TableAlterOperation]:
         operations = original_from_structs(current_struct, new_struct)
+        if not operations:
+            return operations
         assert (
             operations[-1].expected_table_struct.sql()
             == columns_to_types_to_struct(expected_final_structure).sql()

--- a/tests/core/test_schema_diff.py
+++ b/tests/core/test_schema_diff.py
@@ -1108,6 +1108,34 @@ def test_schema_diff_calculate_type_transitions():
                 },
             ),
         ),
+        (
+            "STRUCT<id INT, name STRING, revenue FLOAT>",
+            "STRUCT<id INT, name STRING, revenue INT>",
+            [],
+            dict(
+                support_positional_add=True,
+                support_nested_operations=True,
+                coerceable_types={
+                    exp.DataType.build("FLOAT"): {exp.DataType.build("INT")},
+                },
+            ),
+        ),
+        (
+            "STRUCT<id INT, name STRING, revenue FLOAT>",
+            "STRUCT<id INT, name INT, revenue INT>",
+            [],
+            dict(
+                support_positional_add=True,
+                support_nested_operations=True,
+                support_coercing_compatible_types=True,
+                compatible_types={
+                    exp.DataType.build("INT"): {exp.DataType.build("FLOAT")},
+                },
+                coerceable_types={
+                    exp.DataType.build("STRING"): {exp.DataType.build("INT")},
+                },
+            ),
+        ),
         # Coercion with an alter results in a single alter
         (
             "STRUCT<id INT, name STRING, revenue FLOAT, total INT>",


### PR DESCRIPTION
Even though `BIGNUMERIC` is not compatible with `FLOAT64` when it comes to column alteration, `BIGNUMERIC` values can still be safely inserted into `FLOAT64` columns. This update ensures that SQLMesh can do this without needing to drop and recreate a column.