### PR TITLE
refactor: change evaluator to be directly evaluatable

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1917,8 +1917,8 @@ class GenericContext(BaseContext, t.Generic[C]):
         )
 
     def _apply(self, plan: Plan, circuit_breaker: t.Optional[t.Callable[[], bool]]) -> None:
-        self._scheduler.create_plan_evaluator(self).evaluate(
-            plan.to_evaluatable(), circuit_breaker=circuit_breaker
+        self._scheduler.create_plan_evaluator(self, plan.to_evaluatable()).evaluate(
+            circuit_breaker=circuit_breaker
         )
 
     @python_api_analytics

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,6 +244,7 @@ def push_plan(context: Context, plan: Plan) -> None:
         context.snapshot_evaluator,
         context.create_scheduler,
         context.default_catalog,
+        plan.to_evaluatable(),
     )
     plan_evaluator._push(plan.to_evaluatable(), plan.snapshots)
     promotion_result = plan_evaluator._promote(plan.to_evaluatable(), plan.snapshots)

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -254,17 +254,18 @@ def test_diff(sushi_context: Context, mocker: MockerFixture):
     yesterday = yesterday_ds()
     success = sushi_context.run(start=yesterday, end=yesterday)
 
+    plan = PlanBuilder(
+        context_diff=sushi_context._context_diff("prod"),
+        engine_schema_differ=sushi_context.engine_adapter.SCHEMA_DIFFER,
+    ).build()
+
     plan_evaluator = BuiltInPlanEvaluator(
         sushi_context.state_sync,
         sushi_context.snapshot_evaluator,
         sushi_context.create_scheduler,
         sushi_context.default_catalog,
+        plan.to_evaluatable(),
     )
-
-    plan = PlanBuilder(
-        context_diff=sushi_context._context_diff("prod"),
-        engine_schema_differ=sushi_context.engine_adapter.SCHEMA_DIFFER,
-    ).build()
 
     # stringify used to trigger an unhashable exception due to
     # https://github.com/pydantic/pydantic/issues/8016


### PR DESCRIPTION
- this slightly changes the defition of a plan evaluator, while as
  before it was sort of engine that could evaluate a plan, now an
  evaluator is both the plan and the engine to be evaluated.
- this was done to simplify the code downstream so that in the abstract
  you can always get an id/the plan.
