### PR TITLE
Fix: Add CASCADE modified when dropping columns in Postgres / Redshift

### DIFF
--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -61,6 +61,7 @@ class PostgresEngineAdapter(
                 exp.DataType.build("BPCHAR", dialect=DIALECT).this
             },
         },
+        drop_cascade=True,
     )
 
     def _fetch_native_df(

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -58,6 +58,7 @@ class RedshiftEngineAdapter(
             exp.DataType.build("CHAR", dialect=DIALECT).this: 4096,
             exp.DataType.build("VARCHAR", dialect=DIALECT).this: 65535,
         },
+        drop_cascade=True,
     )
     VARIABLE_LENGTH_DATA_TYPES = {
         "char",

--- a/tests/core/engine_adapter/test_postgres.py
+++ b/tests/core/engine_adapter/test_postgres.py
@@ -141,3 +141,23 @@ def test_merge_version_lt_15(
         'INSERT INTO "target" ("ID", "ts", "val") SELECT DISTINCT ON ("ID") "ID", "ts", "val" FROM "__temp_test_abcdefgh"',
         'DROP TABLE IF EXISTS "__temp_test_abcdefgh"',
     ]
+
+
+def test_alter_table_drop_column_cascade(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(PostgresEngineAdapter)
+
+    current_table_name = "test_table"
+    target_table_name = "target_table"
+
+    def table_columns(table_name: str) -> t.Dict[str, exp.DataType]:
+        if table_name == current_table_name:
+            return {"id": exp.DataType.build("int"), "test_column": exp.DataType.build("int")}
+        else:
+            return {"id": exp.DataType.build("int")}
+
+    adapter.columns = table_columns
+
+    adapter.alter_table(adapter.get_alter_expressions(current_table_name, target_table_name))
+    assert to_sql_calls(adapter) == [
+        'ALTER TABLE "test_table" DROP COLUMN "test_column" CASCADE',
+    ]

--- a/tests/core/engine_adapter/test_redshift.py
+++ b/tests/core/engine_adapter/test_redshift.py
@@ -304,3 +304,21 @@ def test_create_view(adapter: t.Callable):
         'DROP VIEW IF EXISTS "test_view" CASCADE',
         'CREATE VIEW "test_view" ("a", "b") AS SELECT "cola" FROM "table" WITH NO SCHEMA BINDING',
     ]
+
+
+def test_alter_table_drop_column_cascade(adapter: t.Callable):
+    current_table_name = "test_table"
+    target_table_name = "target_table"
+
+    def table_columns(table_name: str) -> t.Dict[str, exp.DataType]:
+        if table_name == current_table_name:
+            return {"id": exp.DataType.build("int"), "test_column": exp.DataType.build("int")}
+        else:
+            return {"id": exp.DataType.build("int")}
+
+    adapter.columns = table_columns
+
+    adapter.alter_table(adapter.get_alter_expressions(current_table_name, target_table_name))
+    assert to_sql_calls(adapter) == [
+        'ALTER TABLE "test_table" DROP COLUMN "test_column" CASCADE',
+    ]

--- a/tests/core/test_schema_diff.py
+++ b/tests/core/test_schema_diff.py
@@ -45,6 +45,32 @@ def test_schema_diff_calculate():
     ]
 
 
+def test_schema_diff_drop_cascade():
+    alter_expressions = SchemaDiffer(
+        **{
+            "support_positional_add": False,
+            "support_nested_operations": False,
+            "array_element_selector": "",
+            "drop_cascade": True,
+        }
+    ).compare_columns(
+        "apply_to_table",
+        {
+            "id": exp.DataType.build("INT"),
+            "name": exp.DataType.build("STRING"),
+            "price": exp.DataType.build("DOUBLE"),
+        },
+        {
+            "id": exp.DataType.build("INT"),
+            "name": exp.DataType.build("STRING"),
+        },
+    )
+
+    assert [x.sql() for x in alter_expressions] == [
+        """ALTER TABLE apply_to_table DROP COLUMN price CASCADE"""
+    ]
+
+
 def test_schema_diff_calculate_type_transitions():
     alter_expressions = SchemaDiffer(
         **{


### PR DESCRIPTION
Otherwise, the schema migration fails because of a view in the virtual layer which still points at the table that is being modified.