### PR TITLE
Fix: Enable concurrency in DuckDB

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -346,10 +346,10 @@ workflows:
                 - bigquery
                 - clickhouse-cloud
                 - athena
-          #filters:
-          # branches:
-          #   only:
-          #     - main
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -346,10 +346,10 @@ workflows:
                 - bigquery
                 - clickhouse-cloud
                 - athena
-          filters:
-           branches:
-             only:
-               - main
+          #filters:
+          # branches:
+          #   only:
+          #     - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -518,7 +518,7 @@ Recommended state engines for production deployments:
 Other state engines with fast and reliable database transactions (less tested than the recommended engines):
 
 * [DuckDB](../integrations/engines/duckdb.md)
-    * Does not support concurrency and may error if the primary connection executes with concurrent tasks (its [connection configuration's `concurrent_tasks`](#connections) is greater than 1)
+    * With the caveat that it's a [single user](https://duckdb.org/docs/connect/concurrency.html#writing-to-duckdb-from-multiple-processes) database so will not scale to production usage
 * [MySQL](../integrations/engines/mysql.md)
 * [MSSQL](../integrations/engines/mssql.md)
 

--- a/docs/integrations/engines/duckdb.md
+++ b/docs/integrations/engines/duckdb.md
@@ -1,9 +1,9 @@
 # DuckDB
 
 !!! warning "DuckDB state connection limitations"
-    DuckDB does not support concurrent connections, so it may "hang" when used as a state database if the primary connection's `concurrent_tasks` value is greater than 1.
+    DuckDB is a [single user](https://duckdb.org/docs/connect/concurrency.html#writing-to-duckdb-from-multiple-processes) database. Using it for a state connection in your SQLMesh project limits you to a single workstation. This means your project cannot be shared amongst your team members or your CI/CD infrastructure. This is usually fine for proof of concept or test projects but it will not scale to production usage.
 
-    For proof-of-concept or test projects, work around this by setting `concurrent_tasks` to 1 in the primary connection. For production projects use a more robust state database such as Postgres.
+    For production projects, use [Tobiko Cloud](https://tobikodata.com/product.html) or a more robust state database such as [Postgres](./postgres.md).
 
 ## Local/Built-in Scheduler
 **Engine Adapter Type**: `duckdb`

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -166,13 +166,6 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
     def _connection_factory(self) -> t.Callable:
         import duckdb
 
-        if self.concurrent_tasks > 1:
-            # ensures a single connection instance is used across threads
-            # rather than a new connection being established per thread
-            # this is in line with https://duckdb.org/docs/guides/python/multiple_threads.html
-            # the important thing is that the *cursor*'s are per thread, but the connection should be shared
-            return lru_cache(duckdb.connect)
-
         return duckdb.connect
 
     @property
@@ -312,6 +305,49 @@ class DuckDBConnectionConfig(BaseDuckDBConnectionConfig):
     @property
     def _connection_kwargs_keys(self) -> t.Set[str]:
         return {"database"}
+
+    @property
+    def _connection_factory(self) -> t.Callable:
+        import duckdb
+
+        if self.concurrent_tasks > 1:
+            # ensures a single connection instance is used across threads rather than a new connection being established per thread
+            # this is in line with https://duckdb.org/docs/guides/python/multiple_threads.html
+            # the important thing is that the *cursor*'s are per thread, but the connection should be shared
+            @lru_cache
+            def _factory(*args: t.Any, **kwargs: t.Any) -> t.Any:
+                class ConnWrapper:
+                    def __init__(self, conn: duckdb.DuckDBPyConnection):
+                        self.conn = conn
+
+                    def __getattr__(self, attr: str) -> t.Any:
+                        return getattr(self.conn, attr)
+
+                    def close(self) -> None:
+                        # This overrides conn.close() to be a no-op to work with ThreadLocalConnectionPool which assumes that a new connection should
+                        # be created per thread. However, DuckDB expects the same connection instance to be shared across threads. There is a pattern
+                        # in the SQLMesh codebase that `EngineAdapter.recycle()` is called after doing things like merging intervals. This in turn causes
+                        # `ThreadLocalConnectionPool.close_all(exclude_calling_thread=True)` to be called.
+                        #
+                        # The problem with sharing a connection across threads and then allowing it to be closed for every thread except the current one
+                        # is that it gets closed for the current one too because its shared. This causes any ":memory:" databases to be discarded.
+                        # ":memory:" databases are convienient and are used heavily in our test suite amongst other things.
+                        #
+                        # Ok, so why not have a connection per thread as is the default for ThreadLocalConnectionPool? Two reasons:
+                        # - It makes any ":memory:" databases unique to that thread. So if one thread creates tables, another thread cant see them
+                        # - If you use local files instead (eg point each connection to the same db file) then all the connection instances
+                        #   fight over locks to the same file and performance tanks heavily
+                        #
+                        # From what I can tell, DuckDB expects the single process reading / writing the database from multiple
+                        # threads to /share the same connection/ and just use thread-local cursors. In order to support ":memory:" databases
+                        # and remove lock contention, the connection needs to live for the life of the application and not be closed
+                        pass
+
+                return ConnWrapper(duckdb.connect(*args, **kwargs))
+
+            return _factory
+
+        return super()._connection_factory
 
     def create_engine_adapter(self, register_comments_override: bool = False) -> EngineAdapter:
         """Checks if another engine adapter has already been created that shares a catalog that points to the same data

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -86,19 +86,20 @@ class _EngineAdapterStateSyncSchedulerConfig(SchedulerConfig):
             context.config.get_state_connection(context.gateway) or context._connection_config
         )
 
+        warehouse_connection = context.config.get_connection(context.gateway)
+
         if (
             isinstance(state_connection, DuckDBConnectionConfig)
             and state_connection.concurrent_tasks <= 1
         ):
             # If we are using DuckDB, ensure that multithreaded mode gets enabled if necessary
-            warehouse_connection = context.config.get_connection(context.gateway)
             if warehouse_connection.concurrent_tasks > 1:
                 logger.warning(
                     "The duckdb state connection is configured for single threaded mode but the warehouse connection is configured for "
                     + f"multi threaded mode with {warehouse_connection.concurrent_tasks} concurrent tasks."
                     + " This can cause SQLMesh to hang. Overriding the duckdb state connection config to use multi threaded mode"
                 )
-                # this triggers multithreaded mode
+                # this triggers multithreaded mode and has to happen before the engine adapter is created below
                 state_connection.concurrent_tasks = warehouse_connection.concurrent_tasks
 
         engine_adapter = state_connection.create_engine_adapter()
@@ -107,11 +108,17 @@ class _EngineAdapterStateSyncSchedulerConfig(SchedulerConfig):
                 f"The {engine_adapter.DIALECT.upper()} engine cannot be used to store SQLMesh state - please specify a different `state_connection` engine."
                 + " See https://sqlmesh.readthedocs.io/en/stable/reference/configuration/#gateways for more information."
             )
-        if not state_connection.is_recommended_for_state_sync:
-            logger.warning(
-                f"The {state_connection.type_} engine is not recommended for storing SQLMesh state in production deployments. Please see"
-                + " https://sqlmesh.readthedocs.io/en/stable/guides/configuration/#state-connection for a list of recommended engines and more information."
-            )
+
+        # If the user is using DuckDB for both the state and the warehouse connection, they are most likely running an example project
+        # or POC. To reduce friction, we wont log a warning about DuckDB being used for state until they change to a proper warehouse
+        if not isinstance(state_connection, DuckDBConnectionConfig) or not isinstance(
+            warehouse_connection, DuckDBConnectionConfig
+        ):
+            if not state_connection.is_recommended_for_state_sync:
+                logger.warning(
+                    f"The {state_connection.type_} engine is not recommended for storing SQLMesh state in production deployments. Please see"
+                    + " https://sqlmesh.readthedocs.io/en/stable/guides/configuration/#state-connection for a list of recommended engines and more information."
+                )
 
         schema = context.config.get_state_schema(context.gateway)
         return EngineAdapterStateSync(

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -85,17 +85,6 @@ class _EngineAdapterStateSyncSchedulerConfig(SchedulerConfig):
         state_connection = (
             context.config.get_state_connection(context.gateway) or context._connection_config
         )
-        engine_adapter = state_connection.create_engine_adapter()
-        if state_connection.is_forbidden_for_state_sync:
-            raise ConfigError(
-                f"The {engine_adapter.DIALECT.upper()} engine cannot be used to store SQLMesh state - please specify a different `state_connection` engine."
-                + " See https://sqlmesh.readthedocs.io/en/stable/reference/configuration/#gateways for more information."
-            )
-        if not state_connection.is_recommended_for_state_sync:
-            logger.warning(
-                f"The {state_connection.type_} engine is not recommended for storing SQLMesh state in production deployments. Please see"
-                + " https://sqlmesh.readthedocs.io/en/stable/guides/configuration/#state-connection for a list of recommended engines and more information."
-            )
 
         if (
             isinstance(state_connection, DuckDBConnectionConfig)
@@ -111,6 +100,18 @@ class _EngineAdapterStateSyncSchedulerConfig(SchedulerConfig):
                 )
                 # this triggers multithreaded mode
                 state_connection.concurrent_tasks = warehouse_connection.concurrent_tasks
+
+        engine_adapter = state_connection.create_engine_adapter()
+        if state_connection.is_forbidden_for_state_sync:
+            raise ConfigError(
+                f"The {engine_adapter.DIALECT.upper()} engine cannot be used to store SQLMesh state - please specify a different `state_connection` engine."
+                + " See https://sqlmesh.readthedocs.io/en/stable/reference/configuration/#gateways for more information."
+            )
+        if not state_connection.is_recommended_for_state_sync:
+            logger.warning(
+                f"The {state_connection.type_} engine is not recommended for storing SQLMesh state in production deployments. Please see"
+                + " https://sqlmesh.readthedocs.io/en/stable/guides/configuration/#state-connection for a list of recommended engines and more information."
+            )
 
         schema = context.config.get_state_schema(context.gateway)
         return EngineAdapterStateSync(

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -109,8 +109,7 @@ class _EngineAdapterStateSyncSchedulerConfig(SchedulerConfig):
                     + f"multi threaded mode with {warehouse_connection.concurrent_tasks} concurrent tasks."
                     + " This can cause SQLMesh to hang. Overriding the duckdb state connection config to use multi threaded mode"
                 )
-                # this triggers multithreaded mode and will raise an error if the user hasnt set a local DB file
-                # (since multithreaded mode doesnt work on in-memory DuckDB databases)
+                # this triggers multithreaded mode
                 state_connection.concurrent_tasks = warehouse_connection.concurrent_tasks
 
         schema = context.config.get_state_schema(context.gateway)

--- a/tests/core/engine_adapter/integration/__init__.py
+++ b/tests/core/engine_adapter/integration/__init__.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import sys
 import typing as t
+import time
 
 import pandas as pd
 import pytest
@@ -540,3 +541,15 @@ class TestContext:
         assert isinstance(model, SqlModel)
         self._context.upsert_model(model)
         return self._context, model
+
+
+def wait_until(fn: t.Callable[..., bool], attempts=3, wait=5) -> None:
+    current_attempt = 0
+    while current_attempt < attempts:
+        current_attempt += 1
+        result = fn()
+        if result:
+            return
+        time.sleep(wait)
+
+    raise Exception(f"Wait function did not return True after {attempts} attempts")

--- a/tests/core/engine_adapter/integration/docker/compose.trino.yaml
+++ b/tests/core/engine_adapter/integration/docker/compose.trino.yaml
@@ -28,7 +28,7 @@ services:
 
   # Trino Stack
   trino:
-    image: 'trinodb/trino:460'
+    image: 'trinodb/trino:465'
     ports:
       - '8080:8080'
     volumes:

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -87,7 +87,7 @@ def test_type(request):
                 pytest.mark.duckdb,
                 pytest.mark.engine,
                 pytest.mark.slow,
-                # duckdb does not support concurrency so we run the tests sequentially
+                # duckdb does not support concurrency against its ':memory:' catalog so we run the tests sequentially
                 pytest.mark.xdist_group("engine_integration_duckdb"),
             ],
         ),
@@ -1314,8 +1314,6 @@ def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
 
     current_gateway_config = config.gateways[ctx.gateway]
     current_gateway_config.state_schema = sushi_state_schema
-    if (sc := current_gateway_config.state_connection) and sc.type_ == "duckdb":
-        current_gateway_config.connection.concurrent_tasks = 1  # duckdb cant handle parallelism
 
     if ctx.dialect == "athena":
         # Ensure that this test is using the same s3_warehouse_location as TestContext (which includes the testrun_id)
@@ -1716,8 +1714,6 @@ def test_init_project(ctx: TestContext, tmp_path: pathlib.Path):
         config.model_defaults = config.model_defaults.copy(update={"dialect": ctx.dialect})
 
     current_gateway_config = config.gateways[ctx.gateway]
-    if (sc := current_gateway_config.state_connection) and sc.type_ == "duckdb":
-        current_gateway_config.connection.concurrent_tasks = 1  # duckdb cant handle parallelism
 
     if ctx.dialect == "athena":
         # Ensure that this test is using the same s3_warehouse_location as TestContext (which includes the testrun_id)

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -87,7 +87,9 @@ def test_type(request):
                 pytest.mark.duckdb,
                 pytest.mark.engine,
                 pytest.mark.slow,
-                # duckdb does not support concurrency against its ':memory:' catalog so we run the tests sequentially
+                # the duckdb tests cannot run concurrently because many of them point at the same files
+                # and duckdb does not support multi process read/write on the same files
+                # ref: https://duckdb.org/docs/connect/concurrency.html#writing-to-duckdb-from-multiple-processes
                 pytest.mark.xdist_group("engine_integration_duckdb"),
             ],
         ),

--- a/tests/core/engine_adapter/integration/test_integration_duckdb.py
+++ b/tests/core/engine_adapter/integration/test_integration_duckdb.py
@@ -1,0 +1,72 @@
+import typing as t
+import pytest
+from threading import current_thread, Thread
+import random
+from sqlglot import exp
+
+from sqlmesh.core.config.connection import DuckDBConnectionConfig
+from sqlmesh.utils.connection_pool import ThreadLocalConnectionPool
+
+pytestmark = [pytest.mark.duckdb, pytest.mark.engine, pytest.mark.slow]
+
+
+@pytest.mark.parametrize("database", [None, "db.db"])
+def test_multithread_concurrency(tmp_path, database: t.Optional[str]):
+    if database:
+        database = str(tmp_path / database)
+
+    config = DuckDBConnectionConfig(concurrent_tasks=8, database=database)
+
+    adapter = config.create_engine_adapter()
+
+    assert isinstance(adapter._connection_pool, ThreadLocalConnectionPool)
+
+    # this test loosely follows this example: https://duckdb.org/docs/guides/python/multiple_threads.html
+    adapter.execute(
+        "create table tbl (thread_name varchar, insert_time timestamp default current_timestamp)"
+    )
+
+    # list.append() is threadsafe
+    write_results = []
+    read_results = []
+
+    def write_from_thread():
+        thread_name = str(current_thread().name)
+        query = exp.insert(
+            exp.values([(exp.Literal.string(thread_name),)]), "tbl", columns=["thread_name"]
+        )
+        adapter.execute(query)
+        adapter.execute(f"CREATE TABLE thread_{thread_name} (id int)")
+        write_results.append(thread_name)
+
+    def read_from_thread():
+        thread_name = str(current_thread().name)
+        query = exp.select(
+            exp.Literal.string(thread_name).as_("thread_name"),
+            exp.Count(this="*").as_("row_counter"),
+            exp.CurrentTimestamp(),
+        ).from_("tbl")
+        results = adapter.fetchall(query)
+        assert len(results) == 1
+        read_results.append(results[0])
+
+    threads = []
+
+    for i in range(50):
+        threads.append(Thread(target=write_from_thread, name=f"write_thread_{i}"))
+        threads.append(Thread(target=read_from_thread, name=f"read_thread_{i}"))
+
+    random.seed(6)
+    random.shuffle(threads)
+
+    for thread in threads:
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    assert len(read_results) == 50
+    assert len(write_results) == 50
+
+    tables = adapter.fetchall("show tables")
+    assert len(tables) == 51

--- a/tests/core/engine_adapter/integration/test_integration_duckdb.py
+++ b/tests/core/engine_adapter/integration/test_integration_duckdb.py
@@ -12,6 +12,8 @@ pytestmark = [pytest.mark.duckdb, pytest.mark.engine, pytest.mark.slow]
 
 @pytest.mark.parametrize("database", [None, "db.db"])
 def test_multithread_concurrency(tmp_path, database: t.Optional[str]):
+    num_threads = 100
+
     if database:
         database = str(tmp_path / database)
 
@@ -52,7 +54,7 @@ def test_multithread_concurrency(tmp_path, database: t.Optional[str]):
 
     threads = []
 
-    for i in range(50):
+    for i in range(num_threads):
         threads.append(Thread(target=write_from_thread, name=f"write_thread_{i}"))
         threads.append(Thread(target=read_from_thread, name=f"read_thread_{i}"))
 
@@ -65,8 +67,8 @@ def test_multithread_concurrency(tmp_path, database: t.Optional[str]):
     for thread in threads:
         thread.join()
 
-    assert len(read_results) == 50
-    assert len(write_results) == 50
+    assert len(read_results) == num_threads
+    assert len(write_results) == num_threads
 
     tables = adapter.fetchall("show tables")
-    assert len(tables) == 51
+    assert len(tables) == num_threads + 1

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -395,7 +395,7 @@ def test_duckdb(make_config):
         connector_config={"foo": "bar"},
     )
     assert isinstance(config, DuckDBConnectionConfig)
-    assert config.is_recommended_for_state_sync is True
+    assert not config.is_recommended_for_state_sync
 
 
 @pytest.mark.parametrize(
@@ -556,7 +556,7 @@ def test_duckdb_attach_catalog(make_config):
 
     assert config.catalogs.get("test2").read_only is False
     assert config.catalogs.get("test2").path == "test2.duckdb"
-    assert config.is_recommended_for_state_sync is True
+    assert not config.is_recommended_for_state_sync
 
 
 def test_duckdb_attach_options():
@@ -572,6 +572,42 @@ def test_duckdb_attach_options():
     options = DuckDBAttachOptions(type="duckdb", path="test.db", read_only=False)
 
     assert options.to_sql(alias="db") == "ATTACH 'test.db' AS db"
+
+
+def test_duckdb_multithreaded_connection_factory(make_config):
+    from sqlmesh.core.engine_adapter import DuckDBEngineAdapter
+    from sqlmesh.utils.connection_pool import ThreadLocalConnectionPool
+    from threading import Thread
+
+    config = make_config(type="duckdb")
+
+    # defaults to 1, no issue
+    assert config.concurrent_tasks == 1
+
+    # check that the connection factory always returns the same connection in multithreaded mode
+    # this sounds counter-intuitive but that's what DuckDB recommends here: https://duckdb.org/docs/guides/python/multiple_threads.html
+    config = make_config(type="duckdb", concurrent_tasks=8)
+    adapter: DuckDBEngineAdapter = config.create_engine_adapter()
+
+    assert isinstance(adapter._connection_pool, ThreadLocalConnectionPool)
+
+    threads = []
+    connection_objects = []
+
+    def _thread_connection():
+        connection_objects.append(adapter.connection)
+
+    for _ in range(8):
+        threads.append(Thread(target=_thread_connection))
+
+    for thread in threads:
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    assert len(connection_objects) == 8
+    assert len(set(connection_objects)) == 1  # they should all be the same object
 
 
 def test_bigquery(make_config):

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -587,8 +587,8 @@ def test_duckdb_multithreaded_connection_factory(make_config):
     # check that the connection factory always returns the same connection in multithreaded mode
     # this sounds counter-intuitive but that's what DuckDB recommends here: https://duckdb.org/docs/guides/python/multiple_threads.html
     config = make_config(type="duckdb", concurrent_tasks=8)
-    adapter: DuckDBEngineAdapter = config.create_engine_adapter()
-
+    adapter = config.create_engine_adapter()
+    assert isinstance(adapter, DuckDBEngineAdapter)
     assert isinstance(adapter._connection_pool, ThreadLocalConnectionPool)
 
     threads = []
@@ -608,6 +608,11 @@ def test_duckdb_multithreaded_connection_factory(make_config):
 
     assert len(connection_objects) == 8
     assert len(set(connection_objects)) == 1  # they should all be the same object
+
+    # test that recycling the pool means we dont end up with unusable connections (eg check we havent cached a closed connection)
+    assert adapter.fetchone("select 1") == (1,)
+    adapter.recycle()
+    assert adapter.fetchone("select 1") == (1,)
 
 
 def test_bigquery(make_config):


### PR DESCRIPTION
The motivation for this PR is to help prevent people from getting tripped up when using DuckDB for state. The most common problem is related to SQLMesh freezing.

Prior to this PR:
 - DuckDB `concurrent_tasks` was hardcoded to 1
 - This ensured that its connection pool was always in single threaded mode
 - If the main warehouse connection had `concurrent_tasks: 8` or something set, this causes those threads to hit the single DuckDB cursor
 - DuckDB deadlocks

In the time since DuckDB support was originally added, support for [multiple thread concurrency](https://duckdb.org/docs/guides/python/multiple_threads.html) has been made available. This is based on using threadlocal cursors, which our multithreaded connection pool already does.

So this PR:
 - Removes the hardcoding on `concurrent_tasks` (but still defaults to `1`)
 - Automatically sets `concurrent_tasks` based on the warehouse connection `concurrent_tasks` to ensure that the DuckDB connection pool runs in multithreaded mode when required
 - Removes DuckDB from the list of recommended production state sync engines since at the end of the day its still single user / flat file and there is no path to production usage