### PR TITLE
Chore!: bump sqlglot to v25.32.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "sqlglot[rs]~=25.31.4",
+        "sqlglot[rs]~=25.32.1",
         "tenacity",
     ],
     extras_require={


### PR DESCRIPTION
Includes a SQLGlot fix that's related to `JSON_VALUE` and `JSON_QUERY` for BigQuery.