### PR TITLE
Fix(athena): Fix error replacing partitions in Hive tables where the partition column is a date / timestamp type

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -340,16 +340,16 @@ workflows:
           matrix:
             parameters:
               engine:
-                - snowflake
-                - databricks
-                - redshift
-                - bigquery
-                - clickhouse-cloud
+                #- snowflake
+                #- databricks
+                #- redshift
+                #- bigquery
+                #- clickhouse-cloud
                 - athena
-          filters:
-           branches:
-             only:
-               - main
+          #filters:
+          # branches:
+          #   only:
+          #     - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -340,16 +340,16 @@ workflows:
           matrix:
             parameters:
               engine:
-                #- snowflake
-                #- databricks
-                #- redshift
-                #- bigquery
-                #- clickhouse-cloud
+                - snowflake
+                - databricks
+                - redshift
+                - bigquery
+                - clickhouse-cloud
                 - athena
-          #filters:
-          # branches:
-          #   only:
-          #     - main
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/sqlmesh/core/engine_adapter/athena.py
+++ b/sqlmesh/core/engine_adapter/athena.py
@@ -509,7 +509,7 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
             response = self._glue_client.batch_get_partition(
                 DatabaseName=table.db,
                 TableName=table.name,
-                PartitionsToGet=[{"Values": v} for v in partition_values],
+                PartitionsToGet=[{"Values": [str(v) for v in lst]} for lst in partition_values],
             )
             return sorted(
                 [(p["Values"], p["StorageDescriptor"]["Location"]) for p in response["Partitions"]]


### PR DESCRIPTION
Prior to this PR, replacing an existing partition in a Hive table where the partition column was defined as `DATE` or `TIMESTAMP` resulted in the following error:

```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter PartitionsToGet[0].Values[0], value: 2024-11-21, type: <class 'datetime.date'>, valid types: <class 'str'>
```

The cause was the query to lookup partition values was returning typed python objects but the boto3 method to delete partitions from the metastore needs strings. This PR converts the values to strings adds some tests to show it works

Note that Iceberg tables are unaffected