### PR TITLE
Fix(mysql): Use LONGTEXT data type when storing large blobs of text

### DIFF
--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -72,6 +72,7 @@ from sqlmesh.utils import major_minor, random_id, unique
 from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.date import TimeLike, now, now_timestamp, time_like_to_str, to_timestamp
 from sqlmesh.utils.errors import ConflictingPlanError, SQLMeshError
+from sqlmesh.utils.migration import blob_text_type, index_text_type
 
 logger = logging.getLogger(__name__)
 
@@ -125,10 +126,12 @@ class EngineAdapterStateSync(StateSync):
         self.plan_dags_table = exp.table_("_plan_dags", db=self.schema)
         self.versions_table = exp.table_("_versions", db=self.schema)
 
+        index_type = index_text_type(engine_adapter.dialect)
+        blob_type = blob_text_type(engine_adapter.dialect)
         self._snapshot_columns_to_types = {
-            "name": exp.DataType.build("text"),
-            "identifier": exp.DataType.build("text"),
-            "version": exp.DataType.build("text"),
+            "name": exp.DataType.build(index_type),
+            "identifier": exp.DataType.build(index_type),
+            "version": exp.DataType.build(index_type),
             "snapshot": exp.DataType.build("text"),
             "kind_name": exp.DataType.build("text"),
             "updated_ts": exp.DataType.build("bigint"),
@@ -138,8 +141,8 @@ class EngineAdapterStateSync(StateSync):
         }
 
         self._environment_columns_to_types = {
-            "name": exp.DataType.build("text"),
-            "snapshots": exp.DataType.build("text"),
+            "name": exp.DataType.build(index_type),
+            "snapshots": exp.DataType.build(blob_type),
             "start_at": exp.DataType.build("text"),
             "end_at": exp.DataType.build("text"),
             "plan_id": exp.DataType.build("text"),
@@ -149,15 +152,15 @@ class EngineAdapterStateSync(StateSync):
             "promoted_snapshot_ids": exp.DataType.build("text"),
             "suffix_target": exp.DataType.build("text"),
             "catalog_name_override": exp.DataType.build("text"),
-            "previous_finalized_snapshots": exp.DataType.build("text"),
+            "previous_finalized_snapshots": exp.DataType.build(blob_type),
             "normalize_name": exp.DataType.build("boolean"),
-            "requirements": exp.DataType.build("text"),
+            "requirements": exp.DataType.build(blob_type),
         }
 
         self._interval_columns_to_types = {
-            "id": exp.DataType.build("text"),
+            "id": exp.DataType.build(index_type),
             "created_ts": exp.DataType.build("bigint"),
-            "name": exp.DataType.build("text"),
+            "name": exp.DataType.build(index_type),
             "identifier": exp.DataType.build("text"),
             "version": exp.DataType.build("text"),
             "start_ts": exp.DataType.build("bigint"),
@@ -169,8 +172,8 @@ class EngineAdapterStateSync(StateSync):
 
         self._version_columns_to_types = {
             "schema_version": exp.DataType.build("int"),
-            "sqlglot_version": exp.DataType.build("text"),
-            "sqlmesh_version": exp.DataType.build("text"),
+            "sqlglot_version": exp.DataType.build(index_type),
+            "sqlmesh_version": exp.DataType.build(index_type),
         }
 
         self._snapshot_cache = SnapshotCache(context_path / c.CACHE)

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -149,7 +149,7 @@ class EngineAdapterStateSync(StateSync):
             "previous_plan_id": exp.DataType.build("text"),
             "expiration_ts": exp.DataType.build("bigint"),
             "finalized_ts": exp.DataType.build("bigint"),
-            "promoted_snapshot_ids": exp.DataType.build("text"),
+            "promoted_snapshot_ids": exp.DataType.build(blob_type),
             "suffix_target": exp.DataType.build("text"),
             "catalog_name_override": exp.DataType.build("text"),
             "previous_finalized_snapshots": exp.DataType.build(blob_type),

--- a/sqlmesh/migrations/v0015_environment_add_promoted_snapshot_ids.py
+++ b/sqlmesh/migrations/v0015_environment_add_promoted_snapshot_ids.py
@@ -1,6 +1,7 @@
 """Include a set of snapshot IDs filtered for promotion."""
 
 from sqlglot import exp
+from sqlmesh.utils.migration import blob_text_type
 
 
 def migrate(state_sync, **kwargs):  # type: ignore
@@ -9,13 +10,15 @@ def migrate(state_sync, **kwargs):  # type: ignore
     if state_sync.schema:
         environments_table = f"{state_sync.schema}.{environments_table}"
 
+    blob_type = blob_text_type(engine_adapter.dialect)
+
     alter_table_exp = exp.Alter(
         this=exp.to_table(environments_table),
         kind="TABLE",
         actions=[
             exp.ColumnDef(
                 this=exp.to_column("promoted_snapshot_ids"),
-                kind=exp.DataType.build("text"),
+                kind=exp.DataType.build(blob_type),
             )
         ],
     )

--- a/sqlmesh/migrations/v0032_add_sqlmesh_version.py
+++ b/sqlmesh/migrations/v0032_add_sqlmesh_version.py
@@ -2,20 +2,22 @@
 
 from sqlglot import exp
 
+from sqlmesh.utils.migration import index_text_type
+
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     versions_table = "_versions"
     if state_sync.schema:
         versions_table = f"{state_sync.schema}.{versions_table}"
-
+    index_type = index_text_type(engine_adapter.dialect)
     alter_table_exp = exp.Alter(
         this=exp.to_table(versions_table),
         kind="TABLE",
         actions=[
             exp.ColumnDef(
                 this=exp.to_column("sqlmesh_version"),
-                kind=exp.DataType.build("text"),
+                kind=exp.DataType.build(index_type),
             )
         ],
     )

--- a/sqlmesh/migrations/v0034_add_default_catalog.py
+++ b/sqlmesh/migrations/v0034_add_default_catalog.py
@@ -12,6 +12,7 @@ from sqlglot.helper import dict_depth, seq_get
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
 from sqlmesh.utils.migration import index_text_type
+from sqlmesh.utils.migration import blob_text_type
 
 
 def set_default_catalog(
@@ -80,6 +81,7 @@ def migrate(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ig
     new_snapshots = []
     snapshot_to_dialect = {}
     index_type = index_text_type(engine_adapter.dialect)
+    blob_type = blob_text_type(engine_adapter.dialect)
 
     for name, identifier, version, snapshot, kind_name in engine_adapter.fetchall(
         exp.select("name", "identifier", "version", "snapshot", "kind_name").from_(snapshots_table),
@@ -162,7 +164,7 @@ def migrate(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ig
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),
-                "snapshot": exp.DataType.build("text"),
+                "snapshot": exp.DataType.build(blob_type),
                 "kind_name": exp.DataType.build(index_type),
             },
         )
@@ -240,7 +242,7 @@ def migrate(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ig
             pd.DataFrame(new_environments),
             columns_to_types={
                 "name": exp.DataType.build(index_type),
-                "snapshots": exp.DataType.build("text"),
+                "snapshots": exp.DataType.build(blob_type),
                 "start_at": exp.DataType.build("text"),
                 "end_at": exp.DataType.build("text"),
                 "plan_id": exp.DataType.build("text"),

--- a/sqlmesh/migrations/v0034_add_default_catalog.py
+++ b/sqlmesh/migrations/v0034_add_default_catalog.py
@@ -249,7 +249,7 @@ def migrate(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ig
                 "previous_plan_id": exp.DataType.build("text"),
                 "expiration_ts": exp.DataType.build("bigint"),
                 "finalized_ts": exp.DataType.build("bigint"),
-                "promoted_snapshot_ids": exp.DataType.build("text"),
+                "promoted_snapshot_ids": exp.DataType.build(blob_type),
                 "suffix_target": exp.DataType.build("text"),
             },
         )

--- a/sqlmesh/migrations/v0037_remove_dbt_is_incremental_macro.py
+++ b/sqlmesh/migrations/v0037_remove_dbt_is_incremental_macro.py
@@ -6,6 +6,7 @@ import pandas as pd
 from sqlglot import exp
 
 from sqlmesh.utils.migration import index_text_type
+from sqlmesh.utils.migration import blob_text_type
 
 
 def migrate(state_sync, **kwargs):  # type: ignore
@@ -15,6 +16,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 
+    blob_type = blob_text_type(engine_adapter.dialect)
     new_snapshots = []
     found_dbt_package = False
     for name, identifier, version, snapshot, kind_name in engine_adapter.fetchall(
@@ -52,7 +54,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),
-                "snapshot": exp.DataType.build("text"),
+                "snapshot": exp.DataType.build(blob_type),
                 "kind_name": exp.DataType.build(index_type),
             },
         )

--- a/sqlmesh/migrations/v0038_add_expiration_ts_to_snapshot.py
+++ b/sqlmesh/migrations/v0038_add_expiration_ts_to_snapshot.py
@@ -7,6 +7,7 @@ from sqlglot import exp
 
 from sqlmesh.utils.date import to_datetime, to_timestamp
 from sqlmesh.utils.migration import index_text_type
+from sqlmesh.utils.migration import blob_text_type
 
 
 def migrate(state_sync, **kwargs):  # type: ignore
@@ -17,6 +18,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         snapshots_table = f"{schema}.{snapshots_table}"
 
     index_type = index_text_type(engine_adapter.dialect)
+    blob_type = blob_text_type(engine_adapter.dialect)
 
     alter_table_exp = exp.Alter(
         this=exp.to_table(snapshots_table),
@@ -63,7 +65,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),
-                "snapshot": exp.DataType.build("text"),
+                "snapshot": exp.DataType.build(blob_type),
                 "kind_name": exp.DataType.build(index_type),
                 "expiration_ts": exp.DataType.build("bigint"),
             },

--- a/sqlmesh/migrations/v0039_include_environment_in_plan_dag_spec.py
+++ b/sqlmesh/migrations/v0039_include_environment_in_plan_dag_spec.py
@@ -6,6 +6,7 @@ import pandas as pd
 from sqlglot import exp
 
 from sqlmesh.utils.migration import index_text_type
+from sqlmesh.utils.migration import blob_text_type
 
 
 def migrate(state_sync, **kwargs):  # type: ignore
@@ -53,6 +54,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.delete_from(plan_dags_table, "TRUE")
 
         index_type = index_text_type(engine_adapter.dialect)
+        blob_type = blob_text_type(engine_adapter.dialect)
 
         engine_adapter.insert_append(
             plan_dags_table,
@@ -60,6 +62,6 @@ def migrate(state_sync, **kwargs):  # type: ignore
             columns_to_types={
                 "request_id": exp.DataType.build(index_type),
                 "dag_id": exp.DataType.build(index_type),
-                "dag_spec": exp.DataType.build("text"),
+                "dag_spec": exp.DataType.build(blob_type),
             },
         )

--- a/sqlmesh/migrations/v0040_add_previous_finalized_snapshots.py
+++ b/sqlmesh/migrations/v0040_add_previous_finalized_snapshots.py
@@ -2,6 +2,8 @@
 
 from sqlglot import exp
 
+from sqlmesh.utils.migration import blob_text_type
+
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
@@ -9,13 +11,15 @@ def migrate(state_sync, **kwargs):  # type: ignore
     if state_sync.schema:
         environments_table = f"{state_sync.schema}.{environments_table}"
 
+    blob_type = blob_text_type(engine_adapter.dialect)
+
     alter_table_exp = exp.Alter(
         this=exp.to_table(environments_table),
         kind="TABLE",
         actions=[
             exp.ColumnDef(
                 this=exp.to_column("previous_finalized_snapshots"),
-                kind=exp.DataType.build("text"),
+                kind=exp.DataType.build(blob_type),
             )
         ],
     )

--- a/sqlmesh/migrations/v0041_remove_hash_raw_query_attribute.py
+++ b/sqlmesh/migrations/v0041_remove_hash_raw_query_attribute.py
@@ -6,6 +6,7 @@ import pandas as pd
 from sqlglot import exp
 
 from sqlmesh.utils.migration import index_text_type
+from sqlmesh.utils.migration import blob_text_type
 
 
 def migrate(state_sync, **kwargs):  # type: ignore
@@ -41,6 +42,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.delete_from(snapshots_table, "TRUE")
 
         index_type = index_text_type(engine_adapter.dialect)
+        blob_type = blob_text_type(engine_adapter.dialect)
 
         engine_adapter.insert_append(
             snapshots_table,
@@ -49,7 +51,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),
-                "snapshot": exp.DataType.build("text"),
+                "snapshot": exp.DataType.build(blob_type),
                 "kind_name": exp.DataType.build(index_type),
                 "expiration_ts": exp.DataType.build("bigint"),
             },

--- a/sqlmesh/migrations/v0042_trim_indirect_versions.py
+++ b/sqlmesh/migrations/v0042_trim_indirect_versions.py
@@ -6,6 +6,7 @@ import pandas as pd
 from sqlglot import exp
 
 from sqlmesh.utils.migration import index_text_type
+from sqlmesh.utils.migration import blob_text_type
 
 
 def migrate(state_sync, **kwargs):  # type: ignore
@@ -48,6 +49,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.delete_from(snapshots_table, "TRUE")
 
         index_type = index_text_type(engine_adapter.dialect)
+        blob_type = blob_text_type(engine_adapter.dialect)
 
         engine_adapter.insert_append(
             snapshots_table,
@@ -56,7 +58,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),
-                "snapshot": exp.DataType.build("text"),
+                "snapshot": exp.DataType.build(blob_type),
                 "kind_name": exp.DataType.build(index_type),
                 "expiration_ts": exp.DataType.build("bigint"),
             },

--- a/sqlmesh/migrations/v0043_fix_remove_obsolete_attributes_in_plan_dags.py
+++ b/sqlmesh/migrations/v0043_fix_remove_obsolete_attributes_in_plan_dags.py
@@ -6,6 +6,7 @@ import pandas as pd
 from sqlglot import exp
 
 from sqlmesh.utils.migration import index_text_type
+from sqlmesh.utils.migration import blob_text_type
 
 
 def migrate(state_sync, **kwargs):  # type: ignore
@@ -46,6 +47,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.delete_from(plan_dags_table, "TRUE")
 
         index_type = index_text_type(engine_adapter.dialect)
+        blob_type = blob_text_type(engine_adapter.dialect)
 
         engine_adapter.insert_append(
             plan_dags_table,
@@ -53,6 +55,6 @@ def migrate(state_sync, **kwargs):  # type: ignore
             columns_to_types={
                 "request_id": exp.DataType.build(index_type),
                 "dag_id": exp.DataType.build(index_type),
-                "dag_spec": exp.DataType.build("text"),
+                "dag_spec": exp.DataType.build(blob_type),
             },
         )

--- a/sqlmesh/migrations/v0045_move_gateway_variable.py
+++ b/sqlmesh/migrations/v0045_move_gateway_variable.py
@@ -7,6 +7,7 @@ import pandas as pd
 from sqlglot import exp
 
 from sqlmesh.utils.migration import index_text_type
+from sqlmesh.utils.migration import blob_text_type
 
 
 def migrate(state_sync, **kwargs):  # type: ignore
@@ -52,6 +53,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.delete_from(snapshots_table, "TRUE")
 
         index_type = index_text_type(engine_adapter.dialect)
+        blob_type = blob_text_type(engine_adapter.dialect)
 
         engine_adapter.insert_append(
             snapshots_table,
@@ -60,7 +62,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),
-                "snapshot": exp.DataType.build("text"),
+                "snapshot": exp.DataType.build(blob_type),
                 "kind_name": exp.DataType.build(index_type),
                 "expiration_ts": exp.DataType.build("bigint"),
             },

--- a/sqlmesh/migrations/v0048_drop_indirect_versions.py
+++ b/sqlmesh/migrations/v0048_drop_indirect_versions.py
@@ -6,6 +6,7 @@ import pandas as pd
 from sqlglot import exp
 
 from sqlmesh.utils.migration import index_text_type
+from sqlmesh.utils.migration import blob_text_type
 
 
 def migrate(state_sync, **kwargs):  # type: ignore
@@ -41,6 +42,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.delete_from(snapshots_table, "TRUE")
 
         index_type = index_text_type(engine_adapter.dialect)
+        blob_type = blob_text_type(engine_adapter.dialect)
 
         engine_adapter.insert_append(
             snapshots_table,
@@ -49,7 +51,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),
-                "snapshot": exp.DataType.build("text"),
+                "snapshot": exp.DataType.build(blob_type),
                 "kind_name": exp.DataType.build(index_type),
                 "expiration_ts": exp.DataType.build("bigint"),
             },

--- a/sqlmesh/migrations/v0051_rename_column_descriptions.py
+++ b/sqlmesh/migrations/v0051_rename_column_descriptions.py
@@ -6,6 +6,7 @@ import pandas as pd
 from sqlglot import exp
 
 from sqlmesh.utils.migration import index_text_type
+from sqlmesh.utils.migration import blob_text_type
 
 
 def migrate(state_sync, **kwargs):  # type: ignore
@@ -47,6 +48,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.delete_from(snapshots_table, "TRUE")
 
         index_type = index_text_type(engine_adapter.dialect)
+        blob_type = blob_text_type(engine_adapter.dialect)
 
         engine_adapter.insert_append(
             snapshots_table,
@@ -55,7 +57,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),
-                "snapshot": exp.DataType.build("text"),
+                "snapshot": exp.DataType.build(blob_type),
                 "kind_name": exp.DataType.build(index_type),
                 "expiration_ts": exp.DataType.build("bigint"),
             },

--- a/sqlmesh/migrations/v0055_add_updated_ts_unpaused_ts_ttl_ms_unrestorable_to_snapshot.py
+++ b/sqlmesh/migrations/v0055_add_updated_ts_unpaused_ts_ttl_ms_unrestorable_to_snapshot.py
@@ -7,6 +7,7 @@ from sqlglot import exp
 
 from sqlmesh.utils.date import to_datetime, to_timestamp
 from sqlmesh.utils.migration import index_text_type
+from sqlmesh.utils.migration import blob_text_type
 
 
 def migrate(state_sync, **kwargs):  # type: ignore
@@ -17,6 +18,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         snapshots_table = f"{schema}.{snapshots_table}"
 
     index_type = index_text_type(engine_adapter.dialect)
+    blob_type = blob_text_type(engine_adapter.dialect)
 
     add_column_exps = [
         exp.Alter(
@@ -95,7 +97,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),
-                "snapshot": exp.DataType.build("text"),
+                "snapshot": exp.DataType.build(blob_type),
                 "kind_name": exp.DataType.build(index_type),
                 "updated_ts": exp.DataType.build("bigint"),
                 "unpaused_ts": exp.DataType.build("bigint"),

--- a/sqlmesh/migrations/v0056_restore_table_indexes.py
+++ b/sqlmesh/migrations/v0056_restore_table_indexes.py
@@ -3,6 +3,7 @@
 from sqlglot import exp
 from sqlmesh.utils import random_id
 from sqlmesh.utils.migration import index_text_type
+from sqlmesh.utils.migration import blob_text_type
 
 
 def migrate(state_sync, **kwargs):  # type: ignore
@@ -22,13 +23,14 @@ def migrate(state_sync, **kwargs):  # type: ignore
     table_suffix = random_id(short=True)
 
     index_type = index_text_type(engine_adapter.dialect)
+    blob_type = blob_text_type(engine_adapter.dialect)
 
     new_snapshots_table = f"{snapshots_table}__{table_suffix}"
     snapshots_columns_to_types = {
         "name": exp.DataType.build(index_type),
         "identifier": exp.DataType.build(index_type),
         "version": exp.DataType.build(index_type),
-        "snapshot": exp.DataType.build("text"),
+        "snapshot": exp.DataType.build(blob_type),
         "kind_name": exp.DataType.build(index_type),
         "updated_ts": exp.DataType.build("bigint"),
         "unpaused_ts": exp.DataType.build("bigint"),
@@ -39,7 +41,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
     new_environments_table = f"{environments_table}__{table_suffix}"
     environments_columns_to_types = {
         "name": exp.DataType.build(index_type),
-        "snapshots": exp.DataType.build("text"),
+        "snapshots": exp.DataType.build(blob_type),
         "start_at": exp.DataType.build("text"),
         "end_at": exp.DataType.build("text"),
         "plan_id": exp.DataType.build("text"),
@@ -49,7 +51,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         "promoted_snapshot_ids": exp.DataType.build("text"),
         "suffix_target": exp.DataType.build("text"),
         "catalog_name_override": exp.DataType.build("text"),
-        "previous_finalized_snapshots": exp.DataType.build("text"),
+        "previous_finalized_snapshots": exp.DataType.build(blob_type),
         "normalize_name": exp.DataType.build("boolean"),
     }
 

--- a/sqlmesh/migrations/v0056_restore_table_indexes.py
+++ b/sqlmesh/migrations/v0056_restore_table_indexes.py
@@ -48,7 +48,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         "previous_plan_id": exp.DataType.build("text"),
         "expiration_ts": exp.DataType.build("bigint"),
         "finalized_ts": exp.DataType.build("bigint"),
-        "promoted_snapshot_ids": exp.DataType.build("text"),
+        "promoted_snapshot_ids": exp.DataType.build(blob_type),
         "suffix_target": exp.DataType.build("text"),
         "catalog_name_override": exp.DataType.build("text"),
         "previous_finalized_snapshots": exp.DataType.build(blob_type),

--- a/sqlmesh/migrations/v0058_add_requirements.py
+++ b/sqlmesh/migrations/v0058_add_requirements.py
@@ -2,6 +2,8 @@
 
 from sqlglot import exp
 
+from sqlmesh.utils.migration import blob_text_type
+
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
@@ -9,13 +11,14 @@ def migrate(state_sync, **kwargs):  # type: ignore
     if state_sync.schema:
         environments_table = f"{state_sync.schema}.{environments_table}"
 
+    blob_type = blob_text_type(engine_adapter.dialect)
     alter_table_exp = exp.Alter(
         this=exp.to_table(environments_table),
         kind="TABLE",
         actions=[
             exp.ColumnDef(
                 this=exp.to_column("requirements"),
-                kind=exp.DataType.build("text"),
+                kind=exp.DataType.build(blob_type),
             )
         ],
     )

--- a/sqlmesh/migrations/v0060_mysql_fix_blob_text_type.py
+++ b/sqlmesh/migrations/v0060_mysql_fix_blob_text_type.py
@@ -1,4 +1,4 @@
-"""Use LONGTEXT type for blob fields in MySQL."""
+"""Duplicate of v0033, Use LONGTEXT type for blob fields in MySQL."""
 
 from sqlglot import exp
 
@@ -24,6 +24,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     targets = [
         (environments_table, "snapshots"),
+        (environments_table, "previous_finalized_snapshots"),
+        (environments_table, "requirements"),
         (snapshots_table, "snapshot"),
         (seeds_table, "content"),
         (plan_dags_table, "dag_spec"),

--- a/sqlmesh/migrations/v0060_mysql_fix_blob_text_type.py
+++ b/sqlmesh/migrations/v0060_mysql_fix_blob_text_type.py
@@ -1,4 +1,8 @@
-"""Duplicate of v0033, Use LONGTEXT type for blob fields in MySQL."""
+"""Duplicate of v0033, Use LONGTEXT type for blob fields in MySQL.
+
+Seeds table has since been dropped.
+Environments table now has a requirements column.
+"""
 
 from sqlglot import exp
 
@@ -13,13 +17,11 @@ def migrate(state_sync, **kwargs):  # type: ignore
     schema = state_sync.schema
     environments_table = "_environments"
     snapshots_table = "_snapshots"
-    seeds_table = "_seeds"
     plan_dags_table = "_plan_dags"
 
     if schema:
         environments_table = f"{schema}.{environments_table}"
         snapshots_table = f"{schema}.{snapshots_table}"
-        seeds_table = f"{state_sync.schema}.{seeds_table}"
         plan_dags_table = f"{schema}.{plan_dags_table}"
 
     targets = [
@@ -27,7 +29,6 @@ def migrate(state_sync, **kwargs):  # type: ignore
         (environments_table, "previous_finalized_snapshots"),
         (environments_table, "requirements"),
         (snapshots_table, "snapshot"),
-        (seeds_table, "content"),
         (plan_dags_table, "dag_spec"),
     ]
 

--- a/sqlmesh/migrations/v0060_mysql_fix_blob_text_type.py
+++ b/sqlmesh/migrations/v0060_mysql_fix_blob_text_type.py
@@ -26,6 +26,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     targets = [
         (environments_table, "snapshots"),
+        (environments_table, "promoted_snapshot_ids"),
         (environments_table, "previous_finalized_snapshots"),
         (environments_table, "requirements"),
         (snapshots_table, "snapshot"),


### PR DESCRIPTION
fixes #3438

I found some code that @izeigerman committed [here](https://github.com/TobikoData/sqlmesh/commit/911c745b9e616d3018e08b0de6213a3df7e0a87e) that does what we're looking for.

Since migration v0033 the migration helper `blob_text_type` hasn't been used so I can only assume that this migration was reverted.
See attached integration testing after building the wheel and running `sqlmesh migrate` against a MySQL target.
![Screenshot 2024-11-29 at 12 20 36](https://github.com/user-attachments/assets/7cf3b9bc-e664-4aa4-9b08-959a678f5fc7)

I got a bit lost looking at how to prevent this from happening in the future in unit/integration testing, any recommendations would be welcome.