### PR TITLE
Fix: use model dialect as fallback for audits

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -464,7 +464,7 @@ class _Model(ModelMeta, frozen=True):
 
         query_renderer = QueryRenderer(
             audit.query,
-            audit.dialect,
+            audit.dialect or self.dialect,
             audit.macro_definitions,
             path=audit._path or Path(),
             jinja_macro_registry=audit.jinja_macros,


### PR DESCRIPTION
Fixes a regression [caused](https://github.com/TobikoData/sqlmesh/blob/main/sqlmesh/core/audit/definition.py#L216) by the recent [audit refactor](https://github.com/TobikoData/sqlmesh/commit/944283bd760f67d9c2c06a1c394ef18d97567ade). Additional context can be found in [this](https://tobiko-data.slack.com/archives/C044BRE5W4S/p1732365420003479) thread.