### PR TITLE
Chore: fix typing and imports for ci/cd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
-        "setuptools",
+        "setuptools; python_version>='3.12'",
         "sqlglot[rs]~=25.32.1",
         "tenacity",
     ],

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "requests",
         "rich[jupyter]",
         "ruamel.yaml",
+        "setuptools",
         "sqlglot[rs]~=25.32.1",
         "tenacity",
     ],

--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -363,7 +363,7 @@ def test_plan_test_failures(
 @pytest.mark.asyncio
 async def test_cancel(client: TestClient) -> None:
     client.app.state.circuit_breaker = threading.Event()  # type: ignore
-    transport = ASGITransport(client.app)
+    transport = ASGITransport(client.app)  # type: ignore
     async with AsyncClient(transport=transport, base_url="http://testserver") as _client:
         await _client.post("/api/plan", json={"environment": "dev"})
         response = await _client.post("/api/plan/cancel")


### PR DESCRIPTION
This PR fixes two CI/CD issues:
1. Adds a new `type ignore` to web test `test_main.py::test_cancel` (new mypy version now flagging this)
2. Adds `setuptools` to the import requirements list for python >=3.12

The second item was added because:
- Python 3.12 no longer includes the `distutils` package
- `pyspark` imports `distutils.version`, which errors on py >=3.12
- Manually **INSTALLING** `setuptools` in a new py3.12 environment will enable importing from distutils (we can't just import, must install)

From the Python 3.12 [release notes](https://docs.python.org/3.12/whatsnew/3.12.html#summary-release-highlights):
> [gh-95299](https://github.com/python/cpython/issues/95299): Do not pre-install setuptools in virtual environments created with [venv](https://docs.python.org/3.12/library/venv.html#module-venv). This means that distutils, setuptools, pkg_resources, and easy_install will no longer available by default; to access these run pip install setuptools in the [activated](https://docs.python.org/3.12/library/venv.html#venv-explanation) virtual environment.