### PR TITLE
Fix!: Make `create_external_models` behave like other SQLMesh commands with respect to `--gateway`

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1830,6 +1830,14 @@ class GenericContext(BaseContext, t.Generic[C]):
             external_models_yaml = (
                 path / c.EXTERNAL_MODELS_YAML if not deprecated_yaml.exists() else deprecated_yaml
             )
+
+            external_models_gateway: t.Optional[str] = self.gateway or self.config.default_gateway
+            if not external_models_gateway:
+                # can happen if there was no --gateway defined and the default_gateway is ''
+                # which means that the single gateway syntax is being used which means there is
+                # no named gateway which means we shuld not put `gateway: ` on the external models
+                external_models_gateway = None
+
             create_external_models_file(
                 path=external_models_yaml,
                 models=UniqueKeyDict(
@@ -1843,7 +1851,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 adapter=self._engine_adapter,
                 state_reader=self.state_reader,
                 dialect=config.model_defaults.dialect,
-                gateway=self.gateway,
+                gateway=external_models_gateway,
                 max_workers=self.concurrent_tasks,
                 strict=strict,
             )

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1835,7 +1835,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             if not external_models_gateway:
                 # can happen if there was no --gateway defined and the default_gateway is ''
                 # which means that the single gateway syntax is being used which means there is
-                # no named gateway which means we shuld not put `gateway: ` on the external models
+                # no named gateway which means we should not stamp `gateway:` on the external models
                 external_models_gateway = None
 
             create_external_models_file(

--- a/tests/core/test_schema_loader.py
+++ b/tests/core/test_schema_loader.py
@@ -16,13 +16,13 @@ from sqlmesh.core.model import SqlModel, create_external_model, load_sql_based_m
 from sqlmesh.core.model.definition import ExternalModel
 from sqlmesh.core.schema_loader import create_external_models_file
 from sqlmesh.core.snapshot import SnapshotChangeCategory
-from sqlmesh.utils.yaml import YAML
+from sqlmesh.utils import yaml
 from sqlmesh.utils.errors import SQLMeshError
 
 
-def test_create_external_models(tmpdir, assert_exp_eq):
+def test_create_external_models(tmp_path, assert_exp_eq):
     config = Config(gateways=GatewayConfig(connection=DuckDBConnectionConfig()))
-    context = Context(paths=[tmpdir], config=config)
+    context = Context(paths=[tmp_path], config=config)
 
     # `fruits` is used by DuckDB in the upcoming select query
     fruits = pd.DataFrame(
@@ -107,7 +107,7 @@ def test_create_external_models(tmpdir, assert_exp_eq):
     assert context.models['"memory"."sushi"."raw_fruits"'].gateway is None
 
 
-def test_gateway_specific_external_models(tmpdir: Path):
+def test_gateway_specific_external_models(tmp_path: Path):
     gateways = {
         "dev": GatewayConfig(connection=DuckDBConnectionConfig()),
         "prod": GatewayConfig(connection=DuckDBConnectionConfig()),
@@ -115,12 +115,12 @@ def test_gateway_specific_external_models(tmpdir: Path):
 
     config = Config(gateways=gateways, default_gateway="dev")
 
-    dev_context = Context(paths=[tmpdir], config=config, gateway="dev")
+    dev_context = Context(paths=[tmp_path], config=config, gateway="dev")
     dev_context.engine_adapter.execute("create schema landing")
     dev_context.engine_adapter.execute("create table landing.dev_source as select 1")
     dev_context.engine_adapter.execute("create schema lake")
 
-    prod_context = Context(paths=[tmpdir], config=config, gateway="prod")
+    prod_context = Context(paths=[tmp_path], config=config, gateway="prod")
     prod_context.engine_adapter.execute("create schema landing")
     prod_context.engine_adapter.execute("create table landing.prod_source as select 1")
     prod_context.engine_adapter.execute("create schema lake")
@@ -160,23 +160,23 @@ def test_gateway_specific_external_models(tmpdir: Path):
 
     # each context can only see models for its own gateway
     # check that models from both gateways present in the file, to show that prod_context.create_external_models() didnt clobber the dev ones
-    external_models_filename = tmpdir / c.EXTERNAL_MODELS_YAML
-    with open(external_models_filename, "r", encoding="utf8") as fd:
-        contents = YAML().load(fd)
+    contents = yaml.load(tmp_path / c.EXTERNAL_MODELS_YAML)
 
-        assert len(contents) == 2
-        assert len([c for c in contents if c["name"] == '"memory"."landing"."dev_source"']) == 1
-        assert len([c for c in contents if c["name"] == '"memory"."landing"."prod_source"']) == 1
+    assert len(contents) == 2
+    assert len([c for c in contents if c["name"] == '"memory"."landing"."dev_source"']) == 1
+    assert len([c for c in contents if c["name"] == '"memory"."landing"."prod_source"']) == 1
 
 
-def test_gateway_specific_external_models_mixed_with_others(tmpdir):
+def test_gateway_specific_external_models_mixed_with_others(tmp_path: Path):
     gateways = {
         "dev": GatewayConfig(connection=DuckDBConnectionConfig()),
+        "prod": GatewayConfig(connection=DuckDBConnectionConfig()),
     }
 
     config = Config(gateways=gateways, default_gateway="dev")
 
-    model_dir = (tmpdir / c.MODELS).mkdir()
+    model_dir = tmp_path / c.MODELS
+    model_dir.mkdir()
 
     with open(model_dir / "table.sql", "w", encoding="utf8") as fd:
         fd.write(
@@ -190,7 +190,7 @@ def test_gateway_specific_external_models_mixed_with_others(tmpdir):
         """,
         )
 
-    ctx = Context(paths=[tmpdir], config=config)  # note: No explicitly defined gateway
+    ctx = Context(paths=[tmp_path], config=config)  # note: No explicitly defined gateway
     assert ctx.gateway is None
 
     ctx.engine_adapter.execute("create schema landing")
@@ -203,28 +203,25 @@ def test_gateway_specific_external_models_mixed_with_others(tmpdir):
 
     ctx.create_external_models()
 
-    # no gateway was specifically chosen; external models should be created without a gateway
-    external_models_filename = tmpdir / c.EXTERNAL_MODELS_YAML
-    with open(external_models_filename, "r", encoding="utf8") as fd:
-        contents = YAML().load(fd)
-        assert len(contents) == 1
-        assert "gateway" not in contents[0]
+    # no gateway was specifically chosen; external models should be created against the default gateway
+    external_models_filename = tmp_path / c.EXTERNAL_MODELS_YAML
+    contents = yaml.load(external_models_filename)
+    assert len(contents) == 1
+    assert contents[0]["gateway"] == "dev"
 
     ctx.load()
     assert len(ctx.models) == 2
     assert '"memory"."landing"."source_table"' in ctx.models
     assert '"memory"."lake"."table"' in ctx.models
 
-    ctx.gateway = "dev"  # explicitly set gateway=dev
+    ctx.gateway = "prod"  # explicitly set --gateway prod
     ctx.create_external_models()
 
-    # there should now be 2 external models with the same name - one with a gateway and one without
-    with open(external_models_filename, "r", encoding="utf8") as fd:
-        contents = YAML().load(fd)
-        assert len(contents) == 2
-        assert "gateway" not in contents[0]
-        assert "gateway" in contents[1]
-        assert contents[0]["name"] == contents[1]["name"]
+    # there should now be 2 external models with the same name - one with a gateway=dev and one with gateway=prod
+    contents = yaml.load(external_models_filename)
+    assert len(contents) == 2
+    assert sorted([contents[0]["gateway"], contents[1]["gateway"]]) == ["dev", "prod"]
+    assert contents[0]["name"] == contents[1]["name"]
 
     # check that this doesnt present a problem on load
     ctx.load()
@@ -232,17 +229,18 @@ def test_gateway_specific_external_models_mixed_with_others(tmpdir):
     external_models = [m for _, m in ctx.models.items() if type(m) == ExternalModel]
     assert len(external_models) == 1
     assert external_models[0].name == '"memory"."landing"."source_table"'
+    assert external_models[0].gateway == "prod"
 
 
-def test_gateway_specific_external_models_default_gateway(tmpdir: Path):
+def test_gateway_specific_external_models_default_gateway(tmp_path: Path):
     model_0 = {"name": "db.model0", "columns": {"a": "int"}}
 
     model_1 = {"name": "db.model1", "gateway": "dev", "columns": {"a": "int"}}
 
     model_2 = {"name": "db.model2", "gateway": "prod", "columns": {"a": "int"}}
 
-    with open(tmpdir / c.EXTERNAL_MODELS_YAML, "w", encoding="utf8") as fd:
-        YAML().dump([model_0, model_1, model_2], fd)
+    with open(tmp_path / c.EXTERNAL_MODELS_YAML, "w", encoding="utf8") as fd:
+        yaml.dump([model_0, model_1, model_2], fd)
 
     gateways = {
         "dev": GatewayConfig(connection=DuckDBConnectionConfig()),
@@ -250,7 +248,7 @@ def test_gateway_specific_external_models_default_gateway(tmpdir: Path):
     }
 
     config = Config(gateways=gateways, default_gateway="prod")
-    ctx = Context(paths=[tmpdir], config=config)
+    ctx = Context(paths=[tmp_path], config=config)
 
     ctx.load()
 
@@ -260,10 +258,11 @@ def test_gateway_specific_external_models_default_gateway(tmpdir: Path):
     assert '"memory"."db"."model2"' in model_names
 
 
-def test_create_external_models_no_duplicates(tmpdir):
+def test_create_external_models_no_duplicates(tmp_path: Path):
     config = Config(gateways={"": GatewayConfig(connection=DuckDBConnectionConfig())})
 
-    model_dir = (tmpdir / c.MODELS).mkdir()
+    model_dir = tmp_path / c.MODELS
+    model_dir.mkdir()
 
     with open(model_dir / "table.sql", "w", encoding="utf8") as fd:
         fd.write(
@@ -277,15 +276,14 @@ def test_create_external_models_no_duplicates(tmpdir):
         """,
         )
 
-    ctx = Context(paths=[tmpdir], config=config)
+    ctx = Context(paths=[tmp_path], config=config)
     assert ctx.gateway is None
     ctx.engine_adapter.execute("create schema landing")
     ctx.engine_adapter.execute("create table landing.source_table as select 1")
     ctx.engine_adapter.execute("create schema lake")
 
     def _load_external_models():
-        with open(tmpdir / c.EXTERNAL_MODELS_YAML, "r", encoding="utf8") as fd:
-            return YAML().load(fd)
+        return yaml.load(tmp_path / c.EXTERNAL_MODELS_YAML)
 
     ctx.create_external_models()
 
@@ -298,7 +296,7 @@ def test_create_external_models_no_duplicates(tmpdir):
     assert len(_load_external_models()) == 1
 
 
-def test_no_internal_model_conversion(tmp_path: Path, make_snapshot, mocker: MockerFixture):
+def test_no_internal_model_conversion(tmp_path: Path, mocker: MockerFixture):
     engine_adapter_mock = mocker.Mock()
     engine_adapter_mock.columns.return_value = {
         "b": exp.DataType.build("text"),
@@ -323,8 +321,7 @@ def test_no_internal_model_conversion(tmp_path: Path, make_snapshot, mocker: Moc
         "bigquery",
     )
 
-    with open(filename, "r", encoding="utf8") as fd:
-        schema = YAML().load(fd)
+    schema = yaml.load(filename)
 
     assert len(schema) == 2
     assert schema[0]["name"] == "`tbl-d`"
@@ -353,8 +350,7 @@ def test_missing_table(tmp_path: Path):
         )
     assert """Unable to get schema for '"tbl_source"'""" in mock_logger.call_args[0][0]
 
-    with open(filename, "r", encoding="utf8") as fd:
-        schema = YAML().load(fd)
+    schema = yaml.load(filename)
     assert len(schema) == 0
 
     with pytest.raises(SQLMeshError, match=r"""Unable to get schema for '"tbl_source"'.*"""):

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -622,6 +622,7 @@ def test_create_external_models(notebook, loaded_sushi_context):
   columns:
     customer_id: INT
     zip: TEXT
+  gateway: duckdb
 """
     )
 


### PR DESCRIPTION
Addresses #3443 

Prior to this PR, assuming a config with:
```
gateways:
  local:
     connection:
        type: duckdb
default_gateway: local
```

Running `sqlmesh create_external_models` would produce different results than `sqlmesh --gateway local create_external_models`.

The first command, `sqlmesh create_external_models` would produce model definitions that looked like:
```
- name: foo
  columns: ..etc
- name: bar
  columns: ...etc
```

Whereas the second command, `sqlmesh --gateway local create_external_models` would produce:
```
- name: foo
  columns: ...etc
  gateway: local
- name: bar
  columns: ...etc
  gateway: local
```

That is, it would stamp the `gateway:` key on each model. The problem is that you can get into a situation where you have a file that looks like:

```
- name: foo
  columns: { "col_a": "int }
- name: foo
  columns: { "col_a": "int", "col_b": "string" }
  gateway: local
```

That is, the same model defined differently, one with a `gateway:` set and one without. 
- `sqlmesh create_external_models` would operate on the first entry because it assumes no explicit gateway means `sqlmesh --gateway None create_external_models`
- but `sqlmesh plan` would operate on the second entry because `sqlmesh plan` with `default_gateway: local` is the same as `sqlmesh --gateway local plan`.

So after this PR:
 - `sqlmesh create_external_models` behaves the same as `sqlmesh --gateway local create_external_models`
 - This means that the `gateway:` will be stamped on the external model entries next time users run the command
 - The existing load order remains for compatibility. That is, models with no `gateway:` defined are loaded first, overlayed with models for the current gateway
 - If the wrong model is getting loaded because it has two versions (one with a gateway and one without), users will need to **manually edit the file** to remove the conflicting entry. We cant do it automatically because we cant assume that the model with no `gateway:` set is the one that should be removed, it's perhaps still relevant on other gateways
 - There is no need for a migration because running `create_external_models` is a manual action and the user can decide afterwards if they want to run a forward-only plan or just a normal plan (because there may have been legitimate upstream changes, not just the addition of the `gateway:` flag)

