### PR TITLE
fix: remove top level pyspark imports

### DIFF
--- a/sqlmesh/engines/spark/db_api/spark_session.py
+++ b/sqlmesh/engines/spark/db_api/spark_session.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
 import logging
 import typing as t
 from threading import get_ident
 
-from pyspark.errors import PySparkAttributeError
-from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.types import Row
-
 from sqlmesh.engines.spark.db_api.errors import NotSupportedError, ProgrammingError
+
+if t.TYPE_CHECKING:
+    from pyspark.sql import DataFrame, SparkSession
+    from pyspark.sql.types import Row
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +90,8 @@ class SparkSessionConnection:
             )
 
     def cursor(self) -> SparkSessionCursor:
+        from pyspark.errors import PySparkAttributeError
+
         try:
             self.spark.sparkContext.setLocalProperty("spark.scheduler.pool", f"pool_{get_ident()}")
             self.spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")


### PR DESCRIPTION
Databricks could hit this when the user doesn't have pyspark installed locally: https://github.com/TobikoData/sqlmesh/blob/016ab9867d2b02eb7362b32e4e31dffe20e5b76b/sqlmesh/core/engine_adapter/databricks.py#L107-L111