### PR TITLE
Fix!: always control error handling of audits in scheduler

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1747,7 +1747,6 @@ class GenericContext(BaseContext, t.Generic[C]):
                 start=start,
                 end=end,
                 snapshots=self.snapshots,
-                raise_exception=False,
             ):
                 audit_id = f"{audit_result.audit.name}"
                 if audit_result.model:

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import abc
 import logging
-import traceback
 import typing as t
 
 from sqlglot import exp
@@ -245,7 +244,6 @@ class Scheduler:
             start=start,
             end=end,
             execution_time=execution_time,
-            raise_exception=False,
             snapshots=snapshots,
             deployability_index=deployability_index,
             wap_id=wap_id,
@@ -268,9 +266,10 @@ class Scheduler:
                 )
             if audit_result.blocking:
                 audit_error_to_raise = error
+            else:
+                logger.warning(f"{error}\nAudit is warn only so proceeding with execution.")
 
         if audit_error_to_raise:
-            logger.error(f"Audit Failure: {traceback.format_exc()}")
             raise audit_error_to_raise
 
         self.state_sync.add_interval(snapshot, start, end, is_dev=not is_deployable)

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -267,7 +267,7 @@ class Scheduler:
             if audit_result.blocking:
                 audit_error_to_raise = error
             else:
-                logger.warning(f"{error}\nAudit is warn only so proceeding with execution.")
+                logger.warning(f"{error}\nAudit is non-blocking so proceeding with execution.")
 
         if audit_error_to_raise:
             raise audit_error_to_raise

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -456,7 +456,7 @@ def test_override_builtin_audit_blocking_mode():
         )
     )
 
-    logger = logging.getLogger("sqlmesh.core.snapshot.evaluator")
+    logger = logging.getLogger("sqlmesh.core.scheduler")
     with patch.object(logger, "warning") as mock_logger:
         plan = context.plan(auto_apply=True, no_prompts=True)
         new_snapshot = next(iter(plan.context_diff.new_snapshots.values()))

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -467,7 +467,7 @@ def test_override_builtin_audit_blocking_mode():
                 "Audit 'not_null' for model 'db.x' failed.\n"
                 "Got 1 results, expected 0.\n"
                 f'SELECT * FROM (SELECT * FROM "sqlmesh__db"."db__x__{version}" AS "db__x__{version}") AS "_q_0" WHERE "c" IS NULL AND TRUE\n'
-                "Audit is warn only so proceeding with execution."
+                "Audit is non-blocking so proceeding with execution."
             )
         ]
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -51,7 +51,7 @@ from sqlmesh.core.snapshot import (
 from sqlmesh.core.snapshot.evaluator import CustomMaterialization
 from sqlmesh.utils.concurrency import NodeExecutionFailedError
 from sqlmesh.utils.date import to_timestamp
-from sqlmesh.utils.errors import AuditError, ConfigError, SQLMeshError
+from sqlmesh.utils.errors import ConfigError, SQLMeshError
 from sqlmesh.utils.metaprogramming import Executable
 
 
@@ -2468,10 +2468,10 @@ def test_audit_set_blocking_at_use_site(adapter_mock, make_snapshot):
     # Return a non-zero count to indicate audit failure
     adapter_mock.fetchone.return_value = (1,)
 
-    logger = logging.getLogger("sqlmesh.core.snapshot.evaluator")
-    with patch.object(logger, "warning") as mock_logger:
-        evaluator.audit(snapshot, snapshots={})
-        assert "Audit is warn only so proceeding with execution." in mock_logger.call_args[0][0]
+    results = evaluator.audit(snapshot, snapshots={})
+    assert len(results) == 1
+    assert results[0].count == 1
+    assert not results[0].blocking
 
     model = SqlModel(
         name="test_schema.test_table",
@@ -2486,11 +2486,10 @@ def test_audit_set_blocking_at_use_site(adapter_mock, make_snapshot):
     snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
     adapter_mock.fetchone.return_value = (1,)
 
-    with pytest.raises(
-        AuditError,
-        match="Audit 'always_fail' for model 'test_schema.test_table' failed.",
-    ):
-        evaluator.audit(snapshot, snapshots={})
+    results = evaluator.audit(snapshot, snapshots={})
+    assert len(results) == 1
+    assert results[0].count == 1
+    assert results[0].blocking
 
 
 def test_create_post_statements_use_deployable_table(


### PR DESCRIPTION
While working on https://github.com/TobikoData/sqlmesh/issues/3461, I noticed something strange: even though the audit is blocking, after running plan I got this warning:

```
2024-12-04 19:55:59,002 - MainThread - sqlmesh.core.snapshot.evaluator - WARNING - Audit 'is_positive' for model 'test_model' failed.
Got 1 results, expected 0.
SELECT * FROM (SELECT * FROM "db"."sqlmesh__default"."test_model__3395822052" AS "test_model__3395822052") AS "_q_0" WHERE "foobar" < 0
Audit is warn only so proceeding with execution. (evaluator.py:941)
```

After digging a bit, I realized this happened due to the `raise_exception=False` flag blocking a `raise` statement. Then, I noticed that in most execution paths where we reach `_audit`, this flag should be set to `False`.