### PR TITLE
feat: add multiple catalogs functionality to MotherDuck connection 

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -214,7 +214,7 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
 
             return _factory
 
-        return super()._connection_factory
+        return duckdb.connect
 
     @property
     def _cursor_init(self) -> t.Optional[t.Callable[[t.Any], None]]:

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -183,6 +183,10 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
         return engine_adapter.DuckDBEngineAdapter
 
     @property
+    def _connection_kwargs_keys(self) -> t.Set[str]:
+        return {"database"}
+
+    @property
     def _connection_factory(self) -> t.Callable:
         import duckdb
 
@@ -295,7 +299,8 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
         if self.database:
             if isinstance(self, MotherDuckConnectionConfig):
                 data_files.add(
-                    f"md:{self.database}" + f"?motherduck_token={self.token}" if self.token else ""
+                    f"md:{self.database}"
+                    + (f"?motherduck_token={self.token}" if self.token else "")
                 )
             else:
                 data_files.add(self.database)
@@ -379,10 +384,6 @@ class DuckDBConnectionConfig(BaseDuckDBConnectionConfig):
     """Configuration for the DuckDB connection."""
 
     type_: t.Literal["duckdb"] = Field(alias="type", default="duckdb")
-
-    @property
-    def _connection_kwargs_keys(self) -> t.Set[str]:
-        return {"database"}
 
 
 class SnowflakeConnectionConfig(ConnectionConfig):

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -343,7 +343,8 @@ class DuckDBAttachOptions(BaseConfig):
     type: str
     path: str
     read_only: bool = False
-    schema_name: t.Optional[str] = None  # Only used for postgres
+    token: t.Optional[str] = None
+    # schema: t.Optional[str] = None  # Only used for postgres
 
     def to_sql(self, alias: str) -> str:
         options = []
@@ -353,14 +354,16 @@ class DuckDBAttachOptions(BaseConfig):
             options.append(f"TYPE {self.type.upper()}")
         if self.read_only:
             options.append("READ_ONLY")
-        if self.schema_name and self.type == "postgres":
-            options.append(f"SCHEMA '{self.schema_name}'")
+        # TODO: Add support for Postgres schema. Currently adding it blocks access to the information_schema
+        # if self.schema_name and self.type == "postgres":
+        #     options.append(f"SCHEMA '{self.schema_name}'")
         alias_sql = (
             # MotherDuck does not support aliasing
             f" AS {alias}" if not (self.type == "motherduck" or self.path.startswith("md:")) else ""
         )
         options_sql = f" ({', '.join(options)})" if options else ""
-        return f"ATTACH '{self.path}'{alias_sql}{options_sql}"
+        token_sql = "?" + self.token if self.token else ""
+        return f"ATTACH '{self.path}{token_sql}'{alias_sql}{options_sql}"
 
 
 class DuckDBConnectionConfig(BaseDuckDBConnectionConfig):

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -174,7 +174,7 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
             )
         if isinstance(db_path, str) and db_path.startswith("md:"):
             raise ConfigError(
-                "Please use the MotherDuckConnectionConfig without the `md:` prefix if you want to use a MotherDuck database as the single `database`."
+                "Please use connection type 'motherduck' without the `md:` prefix if you want to use a MotherDuck database as the single `database`."
             )
         return values
 
@@ -358,7 +358,6 @@ class DuckDBAttachOptions(BaseConfig):
     path: str
     read_only: bool = False
     token: t.Optional[str] = None
-    # schema: t.Optional[str] = None  # Only used for postgres
 
     def to_sql(self, alias: str) -> str:
         options = []
@@ -369,8 +368,6 @@ class DuckDBAttachOptions(BaseConfig):
         if self.read_only:
             options.append("READ_ONLY")
         # TODO: Add support for Postgres schema. Currently adding it blocks access to the information_schema
-        # if self.schema_name and self.type == "postgres":
-        #     options.append(f"SCHEMA '{self.schema_name}'")
         alias_sql = (
             # MotherDuck does not support aliasing
             f" AS {alias}" if not (self.type == "motherduck" or self.path.startswith("md:")) else ""

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -259,6 +259,7 @@ class DuckDBAttachOptions(BaseConfig):
     type: str
     path: str
     read_only: bool = False
+    schema: t.Optional[str] = None  # Only used for postgres
 
     def to_sql(self, alias: str) -> str:
         options = []
@@ -268,6 +269,8 @@ class DuckDBAttachOptions(BaseConfig):
             options.append(f"TYPE {self.type.upper()}")
         if self.read_only:
             options.append("READ_ONLY")
+        if self.schema and self.type == "postgres":
+            options.append(f"SCHEMA '{self.schema}'")
         options_sql = f" ({', '.join(options)})" if options else ""
         return f"ATTACH '{self.path}' AS {alias}{options_sql}"
 
@@ -309,11 +312,12 @@ class DuckDBConnectionConfig(BaseDuckDBConnectionConfig):
         if not self.motherduck_config:
             return super()._static_connection_kwargs
         from sqlmesh import __version__
+
         connection_str = "md:"
 
-        if md_database := self.motherduck_config.get('database'):
+        if md_database := self.motherduck_config.get("database"):
             connection_str += md_database
-        if md_token := self.motherduck_config.get('token'):
+        if md_token := self.motherduck_config.get("token"):
             connection_str += f"?motherduck_token={md_token}"
 
         return {

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -349,13 +349,15 @@ class DuckDBAttachOptions(BaseConfig):
         options = []
         # 'duckdb' is actually not a supported type, but we'd like to allow it for
         # fully qualified attach options or integration testing, similar to duckdb-dbt
-        if self.type != "duckdb":
+        if self.type not in ("duckdb", "motherduck"):
             options.append(f"TYPE {self.type.upper()}")
         if self.read_only:
             options.append("READ_ONLY")
         if self.schema_name and self.type == "postgres":
             options.append(f"SCHEMA '{self.schema_name}'")
-        alias_sql = f" AS {alias}" if self.type != "motherduck" else ""
+        alias_sql = (
+            f" AS {alias}" if not (self.type == "motherduck" or self.type.startswith("md:")) else ""
+        )
         options_sql = f" ({', '.join(options)})" if options else ""
         return f"ATTACH '{self.path}'{alias_sql}{options_sql}"
 

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -316,7 +316,7 @@ class MotherDuckConnectionConfig(BaseDuckDBConnectionConfig):
         token: The optional MotherDuck token. If not specified, the user will be prompted to login with their web browser.
     """
 
-    database: str
+    database: t.Optional[str] = None
     token: t.Optional[str] = None
 
     type_: t.Literal["motherduck"] = Field(alias="type", default="motherduck")
@@ -330,7 +330,7 @@ class MotherDuckConnectionConfig(BaseDuckDBConnectionConfig):
         """kwargs that are for execution config only"""
         from sqlmesh import __version__
 
-        connection_str = f"md:{self.database}"
+        connection_str = f"md:{self.database or ''}"
         if self.token:
             connection_str += f"?motherduck_token={self.token}"
         return {
@@ -356,7 +356,7 @@ class DuckDBAttachOptions(BaseConfig):
         if self.schema_name and self.type == "postgres":
             options.append(f"SCHEMA '{self.schema_name}'")
         alias_sql = (
-            f" AS {alias}" if not (self.type == "motherduck" or self.type.startswith("md:")) else ""
+            f" AS {alias}" if not (self.type == "motherduck" or self.path.startswith("md:")) else ""
         )
         options_sql = f" ({', '.join(options)})" if options else ""
         return f"ATTACH '{self.path}'{alias_sql}{options_sql}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ from sqlglot.dialects.dialect import DialectType
 from sqlglot.helper import ensure_list
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
-from sqlmesh.core.config import DuckDBConnectionConfig
+from sqlmesh.core.config import BaseDuckDBConnectionConfig
 from sqlmesh.core.context import Context
 from sqlmesh.core.engine_adapter import MSSQLEngineAdapter, SparkEngineAdapter
 from sqlmesh.core.engine_adapter.base import EngineAdapter
@@ -218,7 +218,7 @@ def rescope_global_models(request):
 
 @pytest.fixture(scope="function", autouse=True)
 def rescope_duckdb_classvar(request):
-    DuckDBConnectionConfig._data_file_to_adapter = {}
+    BaseDuckDBConnectionConfig._data_file_to_adapter = {}
     yield
 
 


### PR DESCRIPTION
This modifies the `MotherDuckConnectionConfig` to enable using MotherDuck in conjunction with multiple attached catalogs (e.g. postgres, local duckdb, other MotherDuck databases, etc.).  This way you can run models inside MD and join external attached data without injecting the `ATTACH` statements inside Jinja blocks.

Mostly this was done by moving most of the logic inside `DuckDBConnectionConfig` upstream into the base class `BaseDuckDBConnectionConfig` since vanilla DuckDB and MotherDuck are mostly at feature parity at the moment.

So you can configure as follows:

```yaml
gateways:
  local:
    connection:
      type: motherduck
      # token: {{ env_var('MOTHERDUCK_TOKEN') }}
      catalogs:
        my_db:
          type: motherduck
          path: 'md:my_db'
        local_duckdb:
          type: duckdb
          path: 'local.ddb'
        postgres_db:
          type: postgres
          path: 'dbname=postgres user=postgres password=postgres port=5555 host=0.0.0.0'
default_gateway: local
model_defaults:
  dialect: duckdb
  start: 2024-12-08
```


Let me know if this works!