### PR TITLE
Fix: Prevent unintentional table schema changes during evaluation

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -1139,10 +1139,15 @@ class EvaluationStrategy(abc.ABC):
             name: The name of the target table.
             query_or_df: The query or DataFrame to replace the target table with.
         """
+        # Source columns from the underlying table to prevent unintentional table schema changes during restatement of incremental models.
+        columns_to_types = (
+            model.columns_to_types
+            if (model.is_seed or model.kind.is_full) and model.annotated
+            else self.adapter.columns(name)
+        )
         self.adapter.replace_query(
             name,
             query_or_df,
-            columns_to_types=model.columns_to_types if model.annotated else None,
             table_format=model.table_format,
             storage_format=model.storage_format,
             partitioned_by=model.partitioned_by,
@@ -1151,6 +1156,7 @@ class EvaluationStrategy(abc.ABC):
             table_properties=model.physical_properties,
             table_description=model.description,
             column_descriptions=model.column_descriptions,
+            columns_to_types=columns_to_types,
         )
 
 
@@ -1532,6 +1538,8 @@ class SCDType2Strategy(MaterializableStrategy):
         is_first_insert: bool,
         **kwargs: t.Any,
     ) -> None:
+        # Source columns from the underlying table to prevent unintentional table schema changes during the insert.
+        columns_to_types = self.adapter.columns(table_name)
         if isinstance(model.kind, SCDType2ByTimeKind):
             self.adapter.scd_type_2_by_time(
                 target_table=table_name,
@@ -1543,7 +1551,7 @@ class SCDType2Strategy(MaterializableStrategy):
                 updated_at_col=model.kind.updated_at_name,
                 invalidate_hard_deletes=model.kind.invalidate_hard_deletes,
                 updated_at_as_valid_from=model.kind.updated_at_as_valid_from,
-                columns_to_types=model.columns_to_types,
+                columns_to_types=columns_to_types,
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
                 truncate=is_first_insert,
@@ -1559,7 +1567,7 @@ class SCDType2Strategy(MaterializableStrategy):
                 check_columns=model.kind.columns,
                 invalidate_hard_deletes=model.kind.invalidate_hard_deletes,
                 execution_time_as_valid_from=model.kind.execution_time_as_valid_from,
-                columns_to_types=model.columns_to_types,
+                columns_to_types=columns_to_types,
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
                 truncate=is_first_insert,
@@ -1576,6 +1584,8 @@ class SCDType2Strategy(MaterializableStrategy):
         model: Model,
         **kwargs: t.Any,
     ) -> None:
+        # Source columns from the underlying table to prevent unintentional table schema changes during the insert.
+        columns_to_types = self.adapter.columns(table_name)
         if isinstance(model.kind, SCDType2ByTimeKind):
             self.adapter.scd_type_2_by_time(
                 target_table=table_name,
@@ -1586,7 +1596,7 @@ class SCDType2Strategy(MaterializableStrategy):
                 updated_at_col=model.kind.updated_at_name,
                 invalidate_hard_deletes=model.kind.invalidate_hard_deletes,
                 updated_at_as_valid_from=model.kind.updated_at_as_valid_from,
-                columns_to_types=model.columns_to_types,
+                columns_to_types=columns_to_types,
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
                 **kwargs,
@@ -1599,7 +1609,7 @@ class SCDType2Strategy(MaterializableStrategy):
                 valid_from_col=model.kind.valid_from_name,
                 valid_to_col=model.kind.valid_to_name,
                 check_columns=model.kind.columns,
-                columns_to_types=model.columns_to_types,
+                columns_to_types=columns_to_types,
                 invalidate_hard_deletes=model.kind.invalidate_hard_deletes,
                 execution_time_as_valid_from=model.kind.execution_time_as_valid_from,
                 table_description=model.description,

--- a/sqlmesh/utils/pandas.py
+++ b/sqlmesh/utils/pandas.py
@@ -34,7 +34,11 @@ PANDAS_TYPE_MAPPINGS = {
 def columns_to_types_from_df(df: pd.DataFrame) -> t.Dict[str, exp.DataType]:
     result = {}
     for column_name, column_type in df.dtypes.items():
-        exp_type = PANDAS_TYPE_MAPPINGS.get(column_type)
+        exp_type: t.Optional[exp.DataType] = None
+        if hasattr(pd, "DatetimeTZDtype") and isinstance(column_type, pd.DatetimeTZDtype):
+            exp_type = exp.DataType.build("timestamp")
+        else:
+            exp_type = PANDAS_TYPE_MAPPINGS.get(column_type)
         if not exp_type:
             raise ValueError(f"Unsupported pandas type '{column_type}'")
         result[str(column_name)] = exp_type

--- a/sqlmesh/utils/pandas.py
+++ b/sqlmesh/utils/pandas.py
@@ -36,7 +36,7 @@ def columns_to_types_from_df(df: pd.DataFrame) -> t.Dict[str, exp.DataType]:
     for column_name, column_type in df.dtypes.items():
         exp_type: t.Optional[exp.DataType] = None
         if hasattr(pd, "DatetimeTZDtype") and isinstance(column_type, pd.DatetimeTZDtype):
-            exp_type = exp.DataType.build("timestamp")
+            exp_type = exp.DataType.build("timestamptz")
         else:
             exp_type = PANDAS_TYPE_MAPPINGS.get(column_type)
         if not exp_type:


### PR DESCRIPTION
When restating forward-only models, SQLMesh uses the `CREATE OR REPLACE TABLE` semantics to recreate the underlying table. 

While performing this operation, SQLMesh used `columns_to_types` mapping provided by the user, if the user explicitly mapped all columns and their types in their model definition.

However, in case of forward-only models, the order of columns supplied by the user may not match the actual order of columns in the underlying table after applying schema changes. This is because very few engines support positional column alterations.

As a result, the schema of the table after restatement can be different from what it was before. This behavior is problematic because of the following reason:
1. The restatement only suppose to change rows but not the schema, which makes this behavior counterintuitive to users.
2. These unintentional schema changes are not reflected in the virtual layer, making the existing views outdated. This can result in subsequent failures when querying the views downstream. 

