### PR TITLE
Fix(athena): Drop partitions in batches of 25

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -339,16 +339,16 @@ workflows:
           matrix:
             parameters:
               engine:
-                #- snowflake
-                #- databricks
-                #- redshift
-                #- bigquery
-                #- clickhouse-cloud
+                - snowflake
+                - databricks
+                - redshift
+                - bigquery
+                - clickhouse-cloud
                 - athena
-          #filters:
-          # branches:
-          #   only:
-          #     - main
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -339,16 +339,16 @@ workflows:
           matrix:
             parameters:
               engine:
-                - snowflake
-                - databricks
-                - redshift
-                - bigquery
-                - clickhouse-cloud
+                #- snowflake
+                #- databricks
+                #- redshift
+                #- bigquery
+                #- clickhouse-cloud
                 - athena
-          filters:
-           branches:
-             only:
-               - main
+          #filters:
+          # branches:
+          #   only:
+          #     - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests


### PR DESCRIPTION
Prior to this change, if the Athena adapter needed to replace more than 25 partitions in a partitioned model, the following boto3 error would occur:
```
'partitionsToDelete' failed to satisfy constraint: Member must have length less than or
equal to 25
```

This PR changes the adapter to call `batch_delete_partition` in batches of 25, which is the [maximum number](https://docs.aws.amazon.com/glue/latest/webapi/API_BatchDeletePartition.html#API_BatchDeletePartition_RequestParameters) allowed at once.

Note that it's just a dumb loop, technically it could be called in parallel from multiple worker threads to reduce latency if there are a lot of partitions to drop but we could add that later if it turns out to be a problem