### PR TITLE
Chore: Address flaky test

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -339,16 +339,16 @@ workflows:
           matrix:
             parameters:
               engine:
-                #- snowflake
-                #- databricks
+                - snowflake
+                - databricks
                 - redshift
-                #- bigquery
-                #- clickhouse-cloud
-                #- athena
-          #filters:
-          # branches:
-          #   only:
-          #     - main
+                - bigquery
+                - clickhouse-cloud
+                - athena
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -339,16 +339,16 @@ workflows:
           matrix:
             parameters:
               engine:
-                - snowflake
-                - databricks
+                #- snowflake
+                #- databricks
                 - redshift
-                - bigquery
-                - clickhouse-cloud
-                - athena
-          filters:
-           branches:
-             only:
-               - main
+                #- bigquery
+                #- clickhouse-cloud
+                #- athena
+          #filters:
+          # branches:
+          #   only:
+          #     - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -1687,9 +1687,11 @@ def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
         ctx._schemas.append(schema)
 
 
-def test_init_project(ctx: TestContext, tmp_path: pathlib.Path):
+def test_init_project(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
     if ctx.test_type != "query":
         pytest.skip("Init example project end-to-end tests only need to run for query")
+
+    tmp_path = tmp_path_factory.mktemp(f"init_project_{ctx.test_id}")
 
     schema_name = ctx.add_test_suffix(TEST_SCHEMA)
     state_schema = ctx.add_test_suffix("sqlmesh_state")


### PR DESCRIPTION
The redshift tests are failing on main for `test_init_project`. However, this is a symptom and doesn't really have anything to do with Redshift per se.

The issue appearts to be that:
 - Redshift throws a transient error, `could not open relation with OID 8199395`
 - This causes the test to fail
 - pytest-retry retries the `test_init_project` test
 - There is an internal failure on teardown related to the `tmp_path` fixture where pytest is expecting some key to exist in its stash that doesnt exist, so raises a KeyError
 - The job fails because the error happens in teardown. If it happened in the test itself, pytest-retry would retry it

I've switched the test to use the `tmp_path_factory` fixture instead, fingers crossed
