### PR TITLE
feat(cli): ability to set config CLI params via env vars

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -40,11 +40,13 @@ def _sqlmesh_version() -> str:
     "--gateway",
     type=str,
     help="The name of the gateway.",
+    envvar="SQLMESH_GATEWAY",
 )
 @click.option(
     "--ignore-warnings",
     is_flag=True,
     help="Ignore warnings.",
+    envvar="SQLMESH_IGNORE_WARNINGS",
 )
 @click.option(
     "--debug",


### PR DESCRIPTION
Allows `SQLMESH_GATEWAY`, `SQLMESH_IGNORE_WARNINGS` and `SQLMESH_DEBUG` global options to be set via environment variables.