### PR TITLE
Fix: quote the table produced by _resolve_table

### DIFF
--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -240,7 +240,7 @@ class BaseExpressionRenderer:
         table_mapping: t.Optional[t.Dict[str, str]] = None,
         deployability_index: t.Optional[DeployabilityIndex] = None,
     ) -> exp.Table:
-        return exp.replace_tables(
+        table = exp.replace_tables(
             exp.maybe_parse(table_name, into=exp.Table, dialect=self._dialect),
             {
                 **self._to_table_mapping((snapshots or {}).values(), deployability_index),
@@ -248,6 +248,11 @@ class BaseExpressionRenderer:
             },
             dialect=self._dialect,
             copy=False,
+        )
+        # We quote the table here to mimic the behavior of _resolve_tables, otherwise we may end
+        # up normalizing twice, because _to_table_mapping returns the mapped names unquoted.
+        return (
+            d.quote_identifiers(table, dialect=self._dialect) if self._quote_identifiers else table
         )
 
     def _resolve_tables(


### PR DESCRIPTION
During the recent refactor, where `this_model` changed from a `str` into a `Table` instance, I missed the fact that we were previously [quoting](https://github.com/TobikoData/sqlmesh/commit/b00d7d40b42ff759243b161567a81547c1002486#diff-fddedea4eda285dbd51b83821f3cd54dc42d3946c0056760acdc29efc3e565afL242) it, so I didn't match that behavior.

We discovered that this led to an issue where the resolved table for `this_model` would be normalized twice, if e.g. it was interpolated in a string, and hence generated as a table with unquoted identifiers.

This PR fixes the above issue by having `_resolve_table` quote the table after resolving it, to match the semantics of `_resolve_tables`.