### PR TITLE
Refactor!: make when_matched syntax compatible with merge syntax

### DIFF
--- a/docs/concepts/models/model_kinds.md
+++ b/docs/concepts/models/model_kinds.md
@@ -320,7 +320,9 @@ MODEL (
   name db.employees,
   kind INCREMENTAL_BY_UNIQUE_KEY (
     unique_key name,
-    when_matched WHEN MATCHED THEN UPDATE SET target.salary = COALESCE(source.salary, target.salary)
+    when_matched (
+      WHEN MATCHED THEN UPDATE SET target.salary = COALESCE(source.salary, target.salary)
+    )
   )
 );
 ```
@@ -334,8 +336,10 @@ MODEL (
   name db.employees,
   kind INCREMENTAL_BY_UNIQUE_KEY (
     unique_key name,
-    when_matched WHEN MATCHED AND source.value IS NULL THEN UPDATE SET target.salary = COALESCE(source.salary, target.salary),
-    WHEN MATCHED THEN UPDATE SET target.title = COALESCE(source.title, target.title)
+    when_matched (
+      WHEN MATCHED AND source.value IS NULL THEN UPDATE SET target.salary = COALESCE(source.salary, target.salary)
+      WHEN MATCHED THEN UPDATE SET target.title = COALESCE(source.title, target.title)
+    )
   )
 );
 ```

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "rich[jupyter]",
         "ruamel.yaml",
         "setuptools; python_version>='3.12'",
-        "sqlglot[rs]~=25.34.1",
+        "sqlglot[rs]~=26.0.0",
         "tenacity",
     ],
     extras_require={

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -30,7 +30,7 @@ class LogicalMergeMixin(EngineAdapter):
         source_table: QueryOrDF,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
-        when_matched: t.Optional[t.Union[exp.When, t.List[exp.When]]] = None,
+        when_matched: t.Optional[exp.Whens] = None,
     ) -> None:
         logical_merge(
             self,
@@ -105,7 +105,9 @@ class InsertOverwriteWithMergeMixin(EngineAdapter):
                     target_table=table_name,
                     query=query,
                     on=exp.false(),
-                    match_expressions=[when_not_matched_by_source, when_not_matched_by_target],
+                    whens=exp.Whens(
+                        expressions=[when_not_matched_by_source, when_not_matched_by_target]
+                    ),
                 )
 
 
@@ -406,7 +408,7 @@ def logical_merge(
     source_table: QueryOrDF,
     columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
     unique_key: t.Sequence[exp.Expression],
-    when_matched: t.Optional[t.Union[exp.When, t.List[exp.When]]] = None,
+    when_matched: t.Optional[exp.Whens] = None,
 ) -> None:
     """
     Merge implementation for engine adapters that do not support merge natively.

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -106,7 +106,7 @@ class PostgresEngineAdapter(
         source_table: QueryOrDF,
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
-        when_matched: t.Optional[t.Union[exp.When, t.List[exp.When]]] = None,
+        when_matched: t.Optional[exp.Whens] = None,
     ) -> None:
         # Merge isn't supported until Postgres 15
         merge_impl = (

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -430,7 +430,7 @@ class ModelMeta(_Node):
         return getattr(self.kind, "managed_columns", {})
 
     @property
-    def when_matched(self) -> t.Optional[t.List[exp.When]]:
+    def when_matched(self) -> t.Optional[exp.Whens]:
         if isinstance(self.kind, IncrementalByUniqueKeyKind):
             return self.kind.when_matched
         return None

--- a/sqlmesh/migrations/v0064_join_when_matched_strings.py
+++ b/sqlmesh/migrations/v0064_join_when_matched_strings.py
@@ -1,0 +1,85 @@
+"""Join list of `WHEN [NOT] MATCHED` strings into a single string."""
+
+import json
+
+import pandas as pd
+from sqlglot import exp
+
+from sqlmesh.utils.migration import index_text_type, blob_text_type
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    index_type = index_text_type(engine_adapter.dialect)
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+
+    new_snapshots = []
+
+    for (
+        name,
+        identifier,
+        version,
+        snapshot,
+        kind_name,
+        updated_ts,
+        unpaused_ts,
+        ttl_ms,
+        unrestorable,
+    ) in engine_adapter.fetchall(
+        exp.select(
+            "name",
+            "identifier",
+            "version",
+            "snapshot",
+            "kind_name",
+            "updated_ts",
+            "unpaused_ts",
+            "ttl_ms",
+            "unrestorable",
+        ).from_(snapshots_table),
+        quote_identifiers=True,
+    ):
+        parsed_snapshot = json.loads(snapshot)
+        node = parsed_snapshot["node"]
+
+        if "kind" in node:
+            kind = node["kind"]
+            if isinstance(when_matched := kind.get("when_matched"), list):
+                kind["when_matched"] = " ".join(when_matched)
+
+            new_snapshots.append(
+                {
+                    "name": name,
+                    "identifier": identifier,
+                    "version": version,
+                    "snapshot": json.dumps(parsed_snapshot),
+                    "kind_name": kind_name,
+                    "updated_ts": updated_ts,
+                    "unpaused_ts": unpaused_ts,
+                    "ttl_ms": ttl_ms,
+                    "unrestorable": unrestorable,
+                }
+            )
+
+    if new_snapshots:
+        engine_adapter.delete_from(snapshots_table, "TRUE")
+        blob_type = blob_text_type(engine_adapter.dialect)
+
+        engine_adapter.insert_append(
+            snapshots_table,
+            pd.DataFrame(new_snapshots),
+            columns_to_types={
+                "name": exp.DataType.build(index_type),
+                "identifier": exp.DataType.build(index_type),
+                "version": exp.DataType.build(index_type),
+                "snapshot": exp.DataType.build(blob_type),
+                "kind_name": exp.DataType.build(index_type),
+                "updated_ts": exp.DataType.build("bigint"),
+                "unpaused_ts": exp.DataType.build("bigint"),
+                "ttl_ms": exp.DataType.build("bigint"),
+                "unrestorable": exp.DataType.build("boolean"),
+            },
+        )

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -2334,6 +2334,8 @@ def test_value_normalization(
                     )
                 ],
             )
+    if ctx.dialect == "tsql" and column_type == exp.DataType.Type.DATETIME:
+        full_column_type = exp.DataType.build("DATETIME2", dialect="tsql")
 
     columns_to_types = {
         "_idx": exp.DataType.build(DATA_TYPE.INT),

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -1014,20 +1014,26 @@ def test_merge_when_matched(make_mocked_engine_adapter: t.Callable, assert_exp_e
             "val": exp.DataType.build("int"),
         },
         unique_key=[exp.to_identifier("ID", quoted=True)],
-        when_matched=exp.When(
-            matched=True,
-            source=False,
-            then=exp.Update(
-                expressions=[
-                    exp.column("val", "__MERGE_TARGET__").eq(exp.column("val", "__MERGE_SOURCE__")),
-                    exp.column("ts", "__MERGE_TARGET__").eq(
-                        exp.Coalesce(
-                            this=exp.column("ts", "__MERGE_SOURCE__"),
-                            expressions=[exp.column("ts", "__MERGE_TARGET__")],
-                        )
+        when_matched=exp.Whens(
+            expressions=[
+                exp.When(
+                    matched=True,
+                    source=False,
+                    then=exp.Update(
+                        expressions=[
+                            exp.column("val", "__MERGE_TARGET__").eq(
+                                exp.column("val", "__MERGE_SOURCE__")
+                            ),
+                            exp.column("ts", "__MERGE_TARGET__").eq(
+                                exp.Coalesce(
+                                    this=exp.column("ts", "__MERGE_SOURCE__"),
+                                    expressions=[exp.column("ts", "__MERGE_TARGET__")],
+                                )
+                            ),
+                        ],
                     ),
-                ],
-            ),
+                )
+            ]
         ),
     )
 
@@ -1061,42 +1067,44 @@ def test_merge_when_matched_multiple(make_mocked_engine_adapter: t.Callable, ass
             "val": exp.DataType.build("int"),
         },
         unique_key=[exp.to_identifier("ID", quoted=True)],
-        when_matched=[
-            exp.When(
-                matched=True,
-                condition=exp.column("ID", "__MERGE_SOURCE__").eq(exp.Literal.number(1)),
-                then=exp.Update(
-                    expressions=[
-                        exp.column("val", "__MERGE_TARGET__").eq(
-                            exp.column("val", "__MERGE_SOURCE__")
-                        ),
-                        exp.column("ts", "__MERGE_TARGET__").eq(
-                            exp.Coalesce(
-                                this=exp.column("ts", "__MERGE_SOURCE__"),
-                                expressions=[exp.column("ts", "__MERGE_TARGET__")],
-                            )
-                        ),
-                    ],
+        when_matched=exp.Whens(
+            expressions=[
+                exp.When(
+                    matched=True,
+                    condition=exp.column("ID", "__MERGE_SOURCE__").eq(exp.Literal.number(1)),
+                    then=exp.Update(
+                        expressions=[
+                            exp.column("val", "__MERGE_TARGET__").eq(
+                                exp.column("val", "__MERGE_SOURCE__")
+                            ),
+                            exp.column("ts", "__MERGE_TARGET__").eq(
+                                exp.Coalesce(
+                                    this=exp.column("ts", "__MERGE_SOURCE__"),
+                                    expressions=[exp.column("ts", "__MERGE_TARGET__")],
+                                )
+                            ),
+                        ],
+                    ),
                 ),
-            ),
-            exp.When(
-                matched=True,
-                source=False,
-                then=exp.Update(
-                    expressions=[
-                        exp.column("val", "__MERGE_TARGET__").eq(
-                            exp.column("val", "__MERGE_SOURCE__")
-                        ),
-                        exp.column("ts", "__MERGE_TARGET__").eq(
-                            exp.Coalesce(
-                                this=exp.column("ts", "__MERGE_SOURCE__"),
-                                expressions=[exp.column("ts", "__MERGE_TARGET__")],
-                            )
-                        ),
-                    ],
+                exp.When(
+                    matched=True,
+                    source=False,
+                    then=exp.Update(
+                        expressions=[
+                            exp.column("val", "__MERGE_TARGET__").eq(
+                                exp.column("val", "__MERGE_SOURCE__")
+                            ),
+                            exp.column("ts", "__MERGE_TARGET__").eq(
+                                exp.Coalesce(
+                                    this=exp.column("ts", "__MERGE_SOURCE__"),
+                                    expressions=[exp.column("ts", "__MERGE_TARGET__")],
+                                )
+                            ),
+                        ],
+                    ),
                 ),
-            ),
-        ],
+            ]
+        ),
     )
 
     assert_exp_eq(

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -2018,25 +2018,27 @@ def test_create_incremental_by_unique_key_updated_at_exp(adapter_mock, make_snap
             "updated_at": exp.DataType.build("TIMESTAMP"),
         },
         unique_key=[exp.to_column("id", quoted=True)],
-        when_matched=[
-            exp.When(
-                matched=True,
-                source=False,
-                then=exp.Update(
-                    expressions=[
-                        exp.column("name", MERGE_TARGET_ALIAS).eq(
-                            exp.column("name", MERGE_SOURCE_ALIAS)
-                        ),
-                        exp.column("updated_at", MERGE_TARGET_ALIAS).eq(
-                            exp.Coalesce(
-                                this=exp.column("updated_at", MERGE_SOURCE_ALIAS),
-                                expressions=[exp.column("updated_at", MERGE_TARGET_ALIAS)],
-                            )
-                        ),
-                    ],
-                ),
-            )
-        ],
+        when_matched=exp.Whens(
+            expressions=[
+                exp.When(
+                    matched=True,
+                    source=False,
+                    then=exp.Update(
+                        expressions=[
+                            exp.column("name", MERGE_TARGET_ALIAS).eq(
+                                exp.column("name", MERGE_SOURCE_ALIAS)
+                            ),
+                            exp.column("updated_at", MERGE_TARGET_ALIAS).eq(
+                                exp.Coalesce(
+                                    this=exp.column("updated_at", MERGE_SOURCE_ALIAS),
+                                    expressions=[exp.column("updated_at", MERGE_TARGET_ALIAS)],
+                                )
+                            ),
+                        ],
+                    ),
+                )
+            ]
+        ),
     )
 
 
@@ -2080,42 +2082,44 @@ def test_create_incremental_by_unique_key_multiple_updated_at_exp(adapter_mock, 
             "updated_at": exp.DataType.build("TIMESTAMP"),
         },
         unique_key=[exp.to_column("id", quoted=True)],
-        when_matched=[
-            exp.When(
-                matched=True,
-                condition=exp.column("id", MERGE_SOURCE_ALIAS).eq(exp.Literal.number(1)),
-                then=exp.Update(
-                    expressions=[
-                        exp.column("name", MERGE_TARGET_ALIAS).eq(
-                            exp.column("name", MERGE_SOURCE_ALIAS)
-                        ),
-                        exp.column("updated_at", MERGE_TARGET_ALIAS).eq(
-                            exp.Coalesce(
-                                this=exp.column("updated_at", MERGE_SOURCE_ALIAS),
-                                expressions=[exp.column("updated_at", MERGE_TARGET_ALIAS)],
-                            )
-                        ),
-                    ],
+        when_matched=exp.Whens(
+            expressions=[
+                exp.When(
+                    matched=True,
+                    condition=exp.column("id", MERGE_SOURCE_ALIAS).eq(exp.Literal.number(1)),
+                    then=exp.Update(
+                        expressions=[
+                            exp.column("name", MERGE_TARGET_ALIAS).eq(
+                                exp.column("name", MERGE_SOURCE_ALIAS)
+                            ),
+                            exp.column("updated_at", MERGE_TARGET_ALIAS).eq(
+                                exp.Coalesce(
+                                    this=exp.column("updated_at", MERGE_SOURCE_ALIAS),
+                                    expressions=[exp.column("updated_at", MERGE_TARGET_ALIAS)],
+                                )
+                            ),
+                        ],
+                    ),
                 ),
-            ),
-            exp.When(
-                matched=True,
-                source=False,
-                then=exp.Update(
-                    expressions=[
-                        exp.column("name", MERGE_TARGET_ALIAS).eq(
-                            exp.column("name", MERGE_SOURCE_ALIAS)
-                        ),
-                        exp.column("updated_at", MERGE_TARGET_ALIAS).eq(
-                            exp.Coalesce(
-                                this=exp.column("updated_at", MERGE_SOURCE_ALIAS),
-                                expressions=[exp.column("updated_at", MERGE_TARGET_ALIAS)],
-                            )
-                        ),
-                    ],
+                exp.When(
+                    matched=True,
+                    source=False,
+                    then=exp.Update(
+                        expressions=[
+                            exp.column("name", MERGE_TARGET_ALIAS).eq(
+                                exp.column("name", MERGE_SOURCE_ALIAS)
+                            ),
+                            exp.column("updated_at", MERGE_TARGET_ALIAS).eq(
+                                exp.Coalesce(
+                                    this=exp.column("updated_at", MERGE_SOURCE_ALIAS),
+                                    expressions=[exp.column("updated_at", MERGE_TARGET_ALIAS)],
+                                )
+                            ),
+                        ],
+                    ),
                 ),
-            ),
-        ],
+            ],
+        ),
     )
 
 


### PR DESCRIPTION
Before this PR, the `when_matched` attribute couldn't be parsed consistently. E.g., a user [reported](https://tobiko-data.slack.com/archives/C044BRE5W4S/p1733343291111989) that, even though the following definition worked, switching the two clauses so that `THEN DELETE` is first would result in a parse error.

```sql
MODEL (
  name @{macro_val}.test,
  kind INCREMENTAL_BY_UNIQUE_KEY (
    unique_key purchase_order_id,
    when_matched
    WHEN MATCHED AND source._operation <> 1 THEN UPDATE SET target.purchase_order_id = 1
    WHEN MATCHED AND source._operation = 1 THEN DELETE
  )
);

select purchase_order_id from @{macro_val}.upstream;
```

This happened because we relied on some implicit behavior around how the clauses are consumed ([example](https://github.com/TobikoData/sqlmesh/pull/3497#discussion_r1878883456)).

This PR refactors the `when_matched` syntax, so that parentheses are used as explicit delimiters. It also makes a few changes to the API (triggered by the relevant SQLGlot [changes](https://github.com/tobymao/sqlglot/commit/051c6f085e426dbcdda3fbc324a180ada268355f)), in order to represent multiple `WHEN [NOT] MATCHED` clauses with a single `Whens` expression, instead of a list of `When` expressions.

- [x] Fix MSSQL test related to `DATETIME` and `DATETIME2` ([context](https://github.com/tobymao/sqlglot/commit/ab108518c53173ddf71ac1dfd9e45df6ac621b81))
- [x] Check if there are additional side-effects caused by the above SQLGlot change
- [x] Add migration script