### PR TITLE
Feat: add AzureSQL engine adapter

### DIFF
--- a/docs/integrations/engines/azuresql.md
+++ b/docs/integrations/engines/azuresql.md
@@ -1,0 +1,30 @@
+# Azure SQL
+
+[Azure SQL](https://azure.microsoft.com/en-us/products/azure-sql) is "a family of managed, secure, and intelligent products that use the SQL Server database engine in the Azure cloud."
+
+The Azure SQL adapter only supports authentication with a username and password. It does not support authentication with Microsoft Entra or Azure Active Directory.
+
+## Local/Built-in Scheduler
+**Engine Adapter Type**: `azuresql`
+
+### Installation
+```
+pip install "sqlmesh[azuresql]"
+```
+
+### Connection options
+
+| Option            | Description                                                      |     Type     | Required |
+| ----------------- | ---------------------------------------------------------------- | :----------: | :------: |
+| `type`            | Engine type name - must be `azuresql`                            |    string    |    Y     |
+| `host`            | The hostname of the Azure SQL server                             |    string    |    Y     |
+| `user`            | The username to use for authentication with the Azure SQL server |    string    |    N     |
+| `password`        | The password to use for authentication with the Azure SQL server |    string    |    N     |
+| `port`            | The port number of the Azure SQL server                          |     int      |    N     |
+| `database`        | The target database                                              |    string    |    N     |
+| `charset`         | The character set used for the connection                        |    string    |    N     |
+| `timeout`         | The query timeout in seconds. Default: no timeout                |     int      |    N     |
+| `login_timeout`   | The timeout for connection and login in seconds. Default: 60     |     int      |    N     |
+| `appname`         | The application name to use for the connection                   |    string    |    N     |
+| `conn_properties` | The list of connection properties                                | list[string] |    N     |
+| `autocommit`      | Is autocommit mode enabled. Default: false                       |     bool     |    N     |

--- a/docs/integrations/overview.md
+++ b/docs/integrations/overview.md
@@ -13,6 +13,7 @@ SQLMesh supports integrations with the following tools:
 SQLMesh supports the following execution engines for running SQLMesh projects:
 
 * [Athena](./engines/athena.md)
+* [Azure SQL](./engines/azuresql.md)
 * [BigQuery](./engines/bigquery.md)
 * [ClickHouse](./engines/clickhouse.md)
 * [Databricks](./engines/databricks.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
       - integrations/github.md
     - Execution engines:
       - integrations/engines/athena.md
+      - integrations/engines/azuresql.md
       - integrations/engines/bigquery.md
       - integrations/engines/clickhouse.md
       - integrations/engines/databricks.md

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     ],
     extras_require={
         "athena": ["PyAthena[Pandas]"],
+        "azuresql": ["pymssql"],
         "bigquery": [
             "google-cloud-bigquery[pandas]",
             "google-cloud-bigquery-storage",

--- a/sqlmesh/core/config/__init__.py
+++ b/sqlmesh/core/config/__init__.py
@@ -4,6 +4,8 @@ from sqlmesh.core.config.categorizer import (
 )
 from sqlmesh.core.config.common import EnvironmentSuffixTarget as EnvironmentSuffixTarget
 from sqlmesh.core.config.connection import (
+    AthenaConnectionConfig as AthenaConnectionConfig,
+    AzureSQLConnectionConfig as AzureSQLConnectionConfig,
     BaseDuckDBConnectionConfig as BaseDuckDBConnectionConfig,
     BigQueryConnectionConfig as BigQueryConnectionConfig,
     ConnectionConfig as ConnectionConfig,

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -1290,6 +1290,14 @@ class MSSQLConnectionConfig(ConnectionConfig):
         return pymssql.connect
 
 
+class AzureSQLConnectionConfig(MSSQLConnectionConfig):
+    type_: t.Literal["azuresql"] = Field(alias="type", default="azuresql")  # type: ignore
+
+    @property
+    def _engine_adapter(self) -> t.Type[EngineAdapter]:
+        return engine_adapter.AzureSQLEngineAdapter
+
+
 class SparkConnectionConfig(ConnectionConfig):
     """
     Vanilla Spark Connection Configuration. Use `DatabricksConnectionConfig` for Databricks.

--- a/sqlmesh/core/engine_adapter/__init__.py
+++ b/sqlmesh/core/engine_adapter/__init__.py
@@ -6,6 +6,8 @@ from sqlmesh.core.engine_adapter.base import (
     EngineAdapter,
     EngineAdapterWithIndexSupport,
 )
+from sqlmesh.core.engine_adapter.athena import AthenaEngineAdapter
+from sqlmesh.core.engine_adapter.azuresql import AzureSQLEngineAdapter  # noqa: F401
 from sqlmesh.core.engine_adapter.bigquery import BigQueryEngineAdapter
 from sqlmesh.core.engine_adapter.clickhouse import ClickhouseEngineAdapter
 from sqlmesh.core.engine_adapter.databricks import DatabricksEngineAdapter
@@ -17,7 +19,6 @@ from sqlmesh.core.engine_adapter.redshift import RedshiftEngineAdapter
 from sqlmesh.core.engine_adapter.snowflake import SnowflakeEngineAdapter
 from sqlmesh.core.engine_adapter.spark import SparkEngineAdapter
 from sqlmesh.core.engine_adapter.trino import TrinoEngineAdapter
-from sqlmesh.core.engine_adapter.athena import AthenaEngineAdapter
 
 DIALECT_TO_ENGINE_ADAPTER = {
     "hive": SparkEngineAdapter,

--- a/sqlmesh/core/engine_adapter/azuresql.py
+++ b/sqlmesh/core/engine_adapter/azuresql.py
@@ -1,0 +1,8 @@
+"""Contains AzureSQLEngineAdapter."""
+
+from sqlmesh.core.engine_adapter.mssql import MSSQLEngineAdapter
+from sqlmesh.core.engine_adapter.shared import CatalogSupport
+
+
+class AzureSQLEngineAdapter(MSSQLEngineAdapter):
+    CATALOG_SUPPORT = CatalogSupport.SINGLE_CATALOG_ONLY


### PR DESCRIPTION
[Azure SQL](https://azure.microsoft.com/en-us/products/azure-sql) is Azure's suite of hosted SQL Server databases.

Azure SQL DBs are generally compatible with MSSQL, with the significant exception that they only support a single catalog (so you can't do something like `USE my_catalog;`).

This PR adds an Azure SQL engine adapter that sub-classes the MSSQL adapter and removes multi-catalog support.

Known limitation: the underlying `pymssql` library only supports username/password authentication.

Follow-up task: add AzureSQL CI/CD