### PR TITLE
Check that test_adapter exist before closing

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1653,7 +1653,8 @@ class GenericContext(BaseContext, t.Generic[C]):
                 include_ctes=include_ctes,
             )
         finally:
-            test_adapter.close()
+            if test_adapter:
+                test_adapter.close()
 
     @python_api_analytics
     def test(


### PR DESCRIPTION
It looks like that
```
model_to_test = self.get_model(model, raise_if_missing=True)
```

got introduced https://github.com/TobikoData/sqlmesh/pull/3394 but it might fail and result in an exception that would prevent the creation of the `test_adapter` that we are trying to close.

(it happened on my end as I was tinkering on my project)