### PR TITLE
Feat: add this_model property in the macro evaluator to return a string

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -448,6 +448,14 @@ class MacroEvaluator:
         return self.locals["runtime_stage"]
 
     @property
+    def this_model(self) -> str:
+        """Returns the resolved name of the surrounding model."""
+        this_model = self.locals.get("this_model")
+        if not this_model:
+            raise SQLMeshError("Model name is not available in the macro evaluator.")
+        return this_model.sql(dialect=self.dialect, identify=True, comments=False)
+
+    @property
     def engine_adapter(self) -> EngineAdapter:
         engine_adapter = self.locals.get("engine_adapter")
         if not engine_adapter:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -5050,6 +5050,7 @@ def test_this_model() -> None:
         return not this_model or (
             isinstance(this_model, exp.Table)
             and this_model.sql(dialect=evaluator.dialect, comments=False) == expected_name
+            and evaluator.this_model == expected_name
         )
 
     expressions = d.parse(


### PR DESCRIPTION
Provides an easier path to migrate away from old code that used `locals["this_model"]`.