### PR TITLE
Feat: Add support for auto-restatements

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1932,6 +1932,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             ignore_cron=ignore_cron,
             circuit_breaker=circuit_breaker,
             selected_snapshots=select_models,
+            auto_restatement_enabled=environment.lower() == c.PROD,
         )
 
     def _apply(self, plan: Plan, circuit_breaker: t.Optional[t.Callable[[], bool]]) -> None:

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -30,12 +30,13 @@ from sqlmesh.core.model.common import (
     parse_dependencies,
     single_value_or_tuple,
 )
-from sqlmesh.core.model.kind import ModelKindName, SeedKind, ModelKind, FullKind, create_model_kind
 from sqlmesh.core.model.meta import ModelMeta, FunctionCall
+from sqlmesh.core.model.kind import ModelKindName, SeedKind, ModelKind, FullKind, create_model_kind
 from sqlmesh.core.model.seed import CsvSeedReader, Seed, create_seed
 from sqlmesh.core.renderer import ExpressionRenderer, QueryRenderer
 from sqlmesh.core.signal import SignalRegistry
 from sqlmesh.utils import columns_to_types_all_known, str_to_bool, UniqueKeyDict
+from sqlmesh.utils.cron import CroniterCache
 from sqlmesh.utils.date import TimeLike, make_inclusive, to_datetime, to_time_column
 from sqlmesh.utils.errors import ConfigError, SQLMeshError, raise_config_error
 from sqlmesh.utils.hashing import hash_data
@@ -769,6 +770,20 @@ class _Model(ModelMeta, frozen=True):
     @property
     def disable_restatement(self) -> bool:
         return getattr(self.kind, "disable_restatement", False)
+
+    @property
+    def auto_restatement_intervals(self) -> t.Optional[int]:
+        return getattr(self.kind, "auto_restatement_intervals", None)
+
+    @property
+    def auto_restatement_cron(self) -> t.Optional[str]:
+        return getattr(self.kind, "auto_restatement_cron", None)
+
+    def auto_restatement_croniter(self, value: TimeLike) -> CroniterCache:
+        cron = self.auto_restatement_cron
+        if cron is None:
+            raise SQLMeshError("Auto restatement cron is not set.")
+        return CroniterCache(cron, value)
 
     @property
     def wap_supported(self) -> bool:

--- a/sqlmesh/core/node.py
+++ b/sqlmesh/core/node.py
@@ -14,6 +14,7 @@ from sqlmesh.utils.date import TimeLike, to_datetime, validate_date_range
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.pydantic import (
     PydanticModel,
+    SQLGlotCron,
     field_validator,
     model_validator,
     model_validator_v1_args,
@@ -194,7 +195,7 @@ class _Node(PydanticModel):
     owner: t.Optional[str] = None
     start: t.Optional[TimeLike] = None
     end: t.Optional[TimeLike] = None
-    cron: str = "@daily"
+    cron: SQLGlotCron = "@daily"
     interval_unit_: t.Optional[IntervalUnit] = Field(alias="interval_unit", default=None)
     tags: t.List[str] = []
     stamp: t.Optional[str] = None
@@ -239,19 +240,6 @@ class _Node(PydanticModel):
         if v and not to_datetime(v):
             raise ConfigError(f"'{v}' needs to be time-like: https://pypi.org/project/dateparser")
         return v
-
-    @field_validator("cron", mode="before")
-    @classmethod
-    def _cron_validator(cls, v: t.Any) -> t.Optional[str]:
-        cron = str_or_exp_to_str(v)
-        if cron:
-            from croniter import CroniterBadCronError, croniter
-
-            try:
-                croniter(cron)
-            except CroniterBadCronError:
-                raise ConfigError(f"Invalid cron expression '{cron}'")
-        return cron
 
     @field_validator("owner", "description", "stamp", mode="before")
     @classmethod

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -16,13 +16,15 @@ from sqlmesh.core.notification_target import (
 from sqlmesh.core.snapshot import (
     DeployabilityIndex,
     Snapshot,
+    SnapshotId,
     SnapshotEvaluator,
+    apply_auto_restatements,
     earliest_start_date,
     missing_intervals,
+    merge_intervals,
     Intervals,
 )
 from sqlmesh.core.snapshot.definition import Interval, expand_range
-from sqlmesh.core.snapshot.definition import SnapshotId, merge_intervals
 from sqlmesh.core.state_sync import StateSync
 from sqlmesh.utils import format_exception
 from sqlmesh.utils.concurrency import concurrent_apply_to_dag, NodeExecutionFailedError
@@ -116,8 +118,6 @@ class Scheduler:
         validate_date_range(start, end)
 
         snapshots: t.Collection[Snapshot] = self.snapshot_per_version.values()
-        self.state_sync.refresh_snapshot_intervals(snapshots)
-
         snapshots_to_intervals = compute_interval_params(
             snapshots,
             start=start or earliest_start_date(snapshots),
@@ -156,6 +156,7 @@ class Scheduler:
             execution_time: The date/time time reference to use for execution time. Defaults to now.
             deployability_index: Determines snapshots that are deployable in the context of this evaluation.
             batch_index: If the snapshot is part of a batch of related snapshots; which index in the batch is it
+            auto_restatement_enabled: Whether to enable auto restatements.
             kwargs: Additional kwargs to pass to the renderer.
         """
         validate_date_range(start, end)
@@ -225,6 +226,7 @@ class Scheduler:
         selected_snapshots: t.Optional[t.Set[str]] = None,
         circuit_breaker: t.Optional[t.Callable[[], bool]] = None,
         deployability_index: t.Optional[DeployabilityIndex] = None,
+        auto_restatement_enabled: bool = False,
     ) -> bool:
         """Concurrently runs all snapshots in topological order.
 
@@ -243,6 +245,7 @@ class Scheduler:
             selected_snapshots: A set of snapshot names to run. If not provided, all snapshots will be run.
             circuit_breaker: An optional handler which checks if the run should be aborted.
             deployability_index: Determines snapshots that are deployable in the context of this render.
+            auto_restatement_enabled: Whether to enable auto restatements.
 
         Returns:
             True if the execution was successful and False otherwise.
@@ -266,6 +269,15 @@ class Scheduler:
             else DeployabilityIndex.all_deployable()
         )
         execution_time = execution_time or now()
+
+        self.state_sync.refresh_snapshot_intervals(self.snapshots.values())
+        if auto_restatement_enabled:
+            auto_restated_intervals = apply_auto_restatements(self.snapshots, execution_time)
+            self.state_sync.add_snapshots_intervals(auto_restated_intervals)
+            self.state_sync.update_auto_restatements(
+                {s.name_version: s.next_auto_restatement_ts for s in self.snapshots.values()}
+            )
+
         merged_intervals = self.merged_missing_intervals(
             start,
             end,
@@ -288,6 +300,7 @@ class Scheduler:
             circuit_breaker=circuit_breaker,
             start=start,
             end=end,
+            auto_restatement_enabled=auto_restatement_enabled,
         )
 
         self.console.stop_evaluation_progress(success=not errors)
@@ -377,6 +390,7 @@ class Scheduler:
         circuit_breaker: t.Optional[t.Callable[[], bool]] = None,
         start: t.Optional[TimeLike] = None,
         end: t.Optional[TimeLike] = None,
+        auto_restatement_enabled: bool = False,
     ) -> t.Tuple[t.List[NodeExecutionFailedError[SchedulingUnit]], t.List[SchedulingUnit]]:
         """Runs precomputed batches of missing intervals.
 
@@ -388,6 +402,7 @@ class Scheduler:
             circuit_breaker: An optional handler which checks if the run should be aborted.
             start: The start of the run.
             end: The end of the run.
+            auto_restatement_enabled: Whether to enable auto restatements.
 
         Returns:
             A tuple of errors and skipped intervals.

--- a/sqlmesh/core/snapshot/__init__.py
+++ b/sqlmesh/core/snapshot/__init__.py
@@ -15,6 +15,7 @@ from sqlmesh.core.snapshot.definition import (
     SnapshotNameVersionLike as SnapshotNameVersionLike,
     SnapshotTableCleanupTask as SnapshotTableCleanupTask,
     SnapshotTableInfo as SnapshotTableInfo,
+    apply_auto_restatements as apply_auto_restatements,
     earliest_start_date as earliest_start_date,
     fingerprint_from_node as fingerprint_from_node,
     has_paused_forward_only as has_paused_forward_only,

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -17,6 +17,7 @@ from sqlmesh.core.snapshot import (
     SnapshotInfoLike,
     SnapshotTableCleanupTask,
     SnapshotTableInfo,
+    SnapshotNameVersion,
 )
 from sqlmesh.core.snapshot.definition import Interval, SnapshotIntervals
 from sqlmesh.utils import major_minor
@@ -170,6 +171,16 @@ class StateReader(abc.ABC):
     @abc.abstractmethod
     def state_type(self) -> str:
         """Returns the type of state sync."""
+
+    @abc.abstractmethod
+    def update_auto_restatements(
+        self, next_auto_restatement_ts: t.Dict[SnapshotNameVersion, t.Optional[int]]
+    ) -> None:
+        """Updates the next auto restatement timestamp for the snapshots.
+
+        Args:
+            next_auto_restatement_ts: A dictionary of snapshot name / version pairs to the next auto restatement timestamp.
+        """
 
     def get_versions(self, validate: bool = True) -> Versions:
         """Get the current versions of the SQLMesh schema and libraries.

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -124,6 +124,7 @@ class EngineAdapterStateSync(StateSync):
         self.environments_table = exp.table_("_environments", db=self.schema)
         self.intervals_table = exp.table_("_intervals", db=self.schema)
         self.plan_dags_table = exp.table_("_plan_dags", db=self.schema)
+        self.auto_restatements_table = exp.table_("_auto_restatements", db=self.schema)
         self.versions_table = exp.table_("_versions", db=self.schema)
 
         index_type = index_text_type(engine_adapter.dialect)
@@ -168,6 +169,13 @@ class EngineAdapterStateSync(StateSync):
             "is_dev": exp.DataType.build("boolean"),
             "is_removed": exp.DataType.build("boolean"),
             "is_compacted": exp.DataType.build("boolean"),
+            "is_pending_restatement": exp.DataType.build("boolean"),
+        }
+
+        self._auto_restatement_columns_to_types = {
+            "snapshot_name": exp.DataType.build(index_type),
+            "snapshot_version": exp.DataType.build(index_type),
+            "next_auto_restatement_ts": exp.DataType.build("bigint"),
         }
 
         self._version_columns_to_types = {
@@ -645,6 +653,27 @@ class EngineAdapterStateSync(StateSync):
         self._snapshot_cache.clear()
         self.migrate(default_catalog)
 
+    @transactional()
+    def update_auto_restatements(
+        self, next_auto_restatement_ts: t.Dict[SnapshotNameVersion, t.Optional[int]]
+    ) -> None:
+        for where in self._snapshot_name_version_filter(
+            next_auto_restatement_ts, column_prefix="snapshot", alias=None
+        ):
+            self.engine_adapter.delete_from(self.auto_restatements_table, where=where)
+
+        next_auto_restatement_ts_filtered = {
+            k: v for k, v in next_auto_restatement_ts.items() if v is not None
+        }
+        if not next_auto_restatement_ts_filtered:
+            return
+
+        self.engine_adapter.insert_append(
+            self.auto_restatements_table,
+            _auto_restatements_to_df(next_auto_restatement_ts_filtered),
+            columns_to_types=self._auto_restatement_columns_to_types,
+        )
+
     def _update_environment(self, environment: Environment) -> None:
         self.engine_adapter.delete_from(
             self.environments_table,
@@ -742,12 +771,14 @@ class EngineAdapterStateSync(StateSync):
                     updated_ts,
                     unpaused_ts,
                     unrestorable,
+                    next_auto_restatement_ts,
                 ) in self._fetchall(query):
                     snapshot = parse_snapshot(
                         serialized_snapshot=serialized_snapshot,
                         updated_ts=updated_ts,
                         unpaused_ts=unpaused_ts,
                         unrestorable=unrestorable,
+                        next_auto_restatement_ts=next_auto_restatement_ts,
                     )
                     snapshot_id = snapshot.snapshot_id
                     if snapshot_id in fetched_snapshots:
@@ -768,20 +799,46 @@ class EngineAdapterStateSync(StateSync):
             cached_snapshots_in_state: t.Set[SnapshotId] = set()
             for where in self._snapshot_id_filter(cached_snapshots):
                 query = (
-                    exp.select("name", "identifier", "updated_ts", "unpaused_ts", "unrestorable")
-                    .from_(exp.to_table(self.snapshots_table))
+                    exp.select(
+                        "name",
+                        "identifier",
+                        "updated_ts",
+                        "unpaused_ts",
+                        "unrestorable",
+                        "next_auto_restatement_ts",
+                    )
+                    .from_(exp.to_table(self.snapshots_table).as_("snapshots"))
+                    .join(
+                        exp.to_table(self.auto_restatements_table).as_("auto_restatements"),
+                        on=exp.and_(
+                            exp.column("name", table="snapshots").eq(
+                                exp.column("snapshot_name", table="auto_restatements")
+                            ),
+                            exp.column("version", table="snapshots").eq(
+                                exp.column("snapshot_version", table="auto_restatements")
+                            ),
+                        ),
+                        join_type="left",
+                        copy=False,
+                    )
                     .where(where)
                 )
                 if lock_for_update:
                     query = query.lock(copy=False)
-                for name, identifier, updated_ts, unpaused_ts, unrestorable in self._fetchall(
-                    query
-                ):
+                for (
+                    name,
+                    identifier,
+                    updated_ts,
+                    unpaused_ts,
+                    unrestorable,
+                    next_auto_restatement_ts,
+                ) in self._fetchall(query):
                     snapshot_id = SnapshotId(name=name, identifier=identifier)
                     snapshot = snapshots[snapshot_id]
                     snapshot.updated_ts = updated_ts
                     snapshot.unpaused_ts = unpaused_ts
                     snapshot.unrestorable = unrestorable
+                    snapshot.next_auto_restatement_ts = next_auto_restatement_ts
                     cached_snapshots_in_state.add(snapshot_id)
 
             missing_cached_snapshots = cached_snapshots - cached_snapshots_in_state
@@ -816,8 +873,22 @@ class EngineAdapterStateSync(StateSync):
                     "snapshots.updated_ts",
                     "snapshots.unpaused_ts",
                     "snapshots.unrestorable",
+                    "auto_restatements.next_auto_restatement_ts",
                 )
                 .from_(exp.to_table(self.snapshots_table).as_("snapshots"))
+                .join(
+                    exp.to_table(self.auto_restatements_table).as_("auto_restatements"),
+                    on=exp.and_(
+                        exp.column("name", table="snapshots").eq(
+                            exp.column("snapshot_name", table="auto_restatements")
+                        ),
+                        exp.column("version", table="snapshots").eq(
+                            exp.column("snapshot_version", table="auto_restatements")
+                        ),
+                    ),
+                    join_type="left",
+                    copy=False,
+                )
                 .where(where)
             )
             if lock_for_update:
@@ -935,8 +1006,8 @@ class EngineAdapterStateSync(StateSync):
                     logger.info(
                         "Adding %s (%s, %s) for snapshot %s",
                         "dev interval" if is_dev else "interval",
-                        start_ts,
-                        end_ts,
+                        time_like_to_str(start_ts),
+                        time_like_to_str(end_ts),
                         snapshot_id,
                     )
                     results.append((start_ts, end_ts))
@@ -963,7 +1034,11 @@ class EngineAdapterStateSync(StateSync):
                     ),
                 }
             )
-            if snapshot_intervals.intervals or snapshot_intervals.dev_intervals:
+            if (
+                snapshot_intervals.intervals
+                or snapshot_intervals.dev_intervals
+                or snapshot_intervals.pending_restatement_intervals
+            ):
                 intervals_to_insert.append(snapshot_intervals)
 
         if intervals_to_insert:
@@ -1104,24 +1179,26 @@ class EngineAdapterStateSync(StateSync):
                 "id",
                 exp.column("name", table="intervals"),
                 exp.column("identifier", table="intervals"),
-                "version",
+                exp.column("version", table="intervals"),
                 "start_ts",
                 "end_ts",
                 "is_dev",
                 "is_removed",
+                "is_pending_restatement",
             )
             .from_(exp.to_table(self.intervals_table).as_("intervals"))
             .order_by(
                 exp.column("name", table="intervals"),
-                exp.column("identifier", table="intervals"),
+                exp.column("version", table="intervals"),
                 "created_ts",
                 "is_removed",
+                "is_pending_restatement",
             )
         )
 
         if uncompacted_only:
             query.join(
-                exp.select("name", "identifier")
+                exp.select("name", "version")
                 .from_(exp.to_table(self.intervals_table).as_("intervals"))
                 .where(exp.column("is_compacted").not_())
                 .distinct()
@@ -1130,8 +1207,8 @@ class EngineAdapterStateSync(StateSync):
                     exp.column("name", table="intervals").eq(
                         exp.column("name", table="uncompacted")
                     ),
-                    exp.column("identifier", table="intervals").eq(
-                        exp.column("identifier", table="uncompacted")
+                    exp.column("version", table="intervals").eq(
+                        exp.column("version", table="uncompacted")
                     ),
                 ),
                 copy=False,
@@ -1149,22 +1226,54 @@ class EngineAdapterStateSync(StateSync):
             rows = self._fetchall(query.where(where))
             interval_ids.update(row[0] for row in rows)
 
+            # Pending restatement intervals are aggregated per (name, version) as opposed to snapshot ID
+            pending_restatement_intervals: t.Dict[t.Tuple[str, str], Intervals] = defaultdict(list)
+            last_seen_identifier_per_version: t.Dict[t.Tuple[str, str], str] = {}
+
             intervals: t.Dict[t.Tuple[str, str, str], Intervals] = defaultdict(list)
             dev_intervals: t.Dict[t.Tuple[str, str, str], Intervals] = defaultdict(list)
             for row in rows:
-                _, name, identifier, version, start, end, is_dev, is_removed = row
+                (
+                    _,
+                    name,
+                    identifier,
+                    version,
+                    start,
+                    end,
+                    is_dev,
+                    is_removed,
+                    is_pending_restatement,
+                ) = row
                 intervals_key = (name, identifier, version)
                 target_intervals = intervals if not is_dev else dev_intervals
                 if is_removed:
                     target_intervals[intervals_key] = remove_interval(
                         target_intervals[intervals_key], start, end
                     )
+                elif is_pending_restatement:
+                    pending_restatement_intervals[(name, version)] = merge_intervals(
+                        [*pending_restatement_intervals[(name, version)], (start, end)]
+                    )
+                    last_seen_identifier_per_version[(name, version)] = identifier
                 else:
                     target_intervals[intervals_key] = merge_intervals(
                         [*target_intervals[intervals_key], (start, end)]
                     )
+                    if not is_dev:
+                        # Remove all pending restatement intervals recorded before the current interval has been added
+                        pending_restatement_intervals[(name, version)] = remove_interval(
+                            pending_restatement_intervals[(name, version)], start, end
+                        )
+                        last_seen_identifier_per_version[(name, version)] = identifier
 
             for name, identifier, version in {**intervals, **dev_intervals}:
+                # Only set the pending restatement intervals for the last seen snapshot per version
+                # FIXME: Remove this logic once intervals are stored per (name, version)
+                pending_restatement_intervals_for_snapshot = (
+                    pending_restatement_intervals.get((name, version), [])
+                    if last_seen_identifier_per_version.get((name, version)) == identifier
+                    else []
+                )
                 snapshot_intervals.append(
                     SnapshotIntervals(
                         name=name,
@@ -1172,6 +1281,7 @@ class EngineAdapterStateSync(StateSync):
                         version=version,
                         intervals=intervals.get((name, identifier, version), []),
                         dev_intervals=dev_intervals.get((name, identifier, version), []),
+                        pending_restatement_intervals=pending_restatement_intervals_for_snapshot,
                     )
                 )
 
@@ -1190,6 +1300,17 @@ class EngineAdapterStateSync(StateSync):
             for start_ts, end_ts in snapshot.dev_intervals:
                 new_intervals.append(
                     _interval_to_df(snapshot, start_ts, end_ts, is_dev=True, is_compacted=True)
+                )
+            for start_ts, end_ts in snapshot.pending_restatement_intervals:
+                new_intervals.append(
+                    _interval_to_df(
+                        snapshot,
+                        start_ts,
+                        end_ts,
+                        is_dev=False,
+                        is_compacted=True,
+                        is_pending_restatement=True,
+                    )
                 )
 
         if new_intervals:
@@ -1262,7 +1383,7 @@ class EngineAdapterStateSync(StateSync):
         """Rollback to the previous migration."""
         logger.info("Starting migration rollback.")
         tables = (self.snapshots_table, self.environments_table, self.versions_table)
-        optional_tables = (self.intervals_table, self.plan_dags_table)
+        optional_tables = (self.intervals_table, self.plan_dags_table, self.auto_restatements_table)
         versions = self.get_versions(validate=False)
         if versions.schema_version == 0:
             # Clean up state tables
@@ -1293,6 +1414,7 @@ class EngineAdapterStateSync(StateSync):
             self.versions_table,
             self.intervals_table,
             self.plan_dags_table,
+            self.auto_restatements_table,
         ):
             if self.engine_adapter.table_exists(table):
                 backup_name = _backup_table_name(table)
@@ -1579,9 +1701,19 @@ class EngineAdapterStateSync(StateSync):
         self,
         snapshot_name_versions: t.Iterable[SnapshotNameVersionLike],
         alias: t.Optional[str] = "snapshots",
+        column_prefix: t.Optional[str] = None,
     ) -> t.Iterator[exp.Condition]:
         name_versions = sorted({(s.name, s.version) for s in snapshot_name_versions})
         batches = self._batches(name_versions)
+
+        name_column_name = "name"
+        version_column_name = "version"
+        if column_prefix:
+            name_column_name = f"{column_prefix}_{name_column_name}"
+            version_column_name = f"{column_prefix}_{version_column_name}"
+
+        name_column = exp.column(name_column_name, table=alias)
+        version_column = exp.column(version_column_name, table=alias)
 
         if not name_versions:
             yield exp.false()
@@ -1591,8 +1723,8 @@ class EngineAdapterStateSync(StateSync):
                     exp.Tuple,
                     exp.convert(
                         (
-                            exp.column("name", table=alias),
-                            exp.column("version", table=alias),
+                            name_column,
+                            version_column,
                         )
                     ),
                 ).isin(*versions)
@@ -1601,8 +1733,8 @@ class EngineAdapterStateSync(StateSync):
                 yield exp.or_(
                     *[
                         exp.and_(
-                            exp.column("name", table=alias).eq(name),
-                            exp.column("version", table=alias).eq(version),
+                            name_column.eq(name),
+                            version_column.eq(version),
                         )
                         for name, version in versions
                     ]
@@ -1640,22 +1772,23 @@ def _snapshots_intervals_to_df(
     snapshots_intervals: t.Sequence[SnapshotIntervals],
     is_removed: bool = False,
 ) -> pd.DataFrame:
-    return pd.DataFrame(
-        [
-            _interval_to_df(
-                snapshot_intervals,
-                start_ts,
-                end_ts,
-                is_dev=is_dev,
-                is_removed=is_removed,
-            )
-            for snapshot_intervals in snapshots_intervals
-            for is_dev in (False, True)
-            for start_ts, end_ts in getattr(
-                snapshot_intervals, "dev_intervals" if is_dev else "intervals"
-            )
-        ]
-    )
+    interval_dicts = []
+    for snapshot_intervals in snapshots_intervals:
+        for interval_attr in ("dev_intervals", "intervals", "pending_restatement_intervals"):
+            is_pending_restatement = interval_attr == "pending_restatement_intervals"
+            is_dev = interval_attr == "dev_intervals"
+            for start_ts, end_ts in getattr(snapshot_intervals, interval_attr):
+                interval_dicts.append(
+                    _interval_to_df(
+                        snapshot_intervals,
+                        start_ts,
+                        end_ts,
+                        is_dev=is_dev,
+                        is_removed=is_removed,
+                        is_pending_restatement=is_pending_restatement,
+                    )
+                )
+    return pd.DataFrame(interval_dicts)
 
 
 def _interval_to_df(
@@ -1665,6 +1798,7 @@ def _interval_to_df(
     is_dev: bool = False,
     is_removed: bool = False,
     is_compacted: bool = False,
+    is_pending_restatement: bool = False,
 ) -> t.Dict[str, t.Any]:
     return {
         "id": random_id(),
@@ -1677,6 +1811,7 @@ def _interval_to_df(
         "is_dev": is_dev,
         "is_removed": is_removed,
         "is_compacted": is_compacted,
+        "is_pending_restatement": is_pending_restatement,
     }
 
 
@@ -1730,6 +1865,19 @@ def _environment_to_df(environment: Environment) -> pd.DataFrame:
     )
 
 
+def _auto_restatements_to_df(auto_restatements: t.Dict[SnapshotNameVersion, int]) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "snapshot_name": name_version.name,
+                "snapshot_version": name_version.version,
+                "next_auto_restatement_ts": ts,
+            }
+            for name_version, ts in auto_restatements.items()
+        ]
+    )
+
+
 def _backup_table_name(table_name: TableName) -> exp.Table:
     table = exp.to_table(table_name).copy()
     table.set("this", exp.to_identifier(table.name + "_backup"))
@@ -1738,7 +1886,15 @@ def _backup_table_name(table_name: TableName) -> exp.Table:
 
 def _snapshot_to_json(snapshot: Snapshot) -> str:
     return snapshot.json(
-        exclude={"intervals", "dev_intervals", "updated_ts", "unpaused_ts", "unrestorable"}
+        exclude={
+            "intervals",
+            "dev_intervals",
+            "pending_restatement_intervals",
+            "updated_ts",
+            "unpaused_ts",
+            "unrestorable",
+            "next_auto_restatement_ts",
+        }
     )
 
 
@@ -1747,6 +1903,7 @@ def parse_snapshot(
     updated_ts: int,
     unpaused_ts: t.Optional[int],
     unrestorable: bool,
+    next_auto_restatement_ts: t.Optional[int],
 ) -> Snapshot:
     return Snapshot(
         **{
@@ -1754,6 +1911,7 @@ def parse_snapshot(
             "updated_ts": updated_ts,
             "unpaused_ts": unpaused_ts,
             "unrestorable": unrestorable,
+            "next_auto_restatement_ts": next_auto_restatement_ts,
         }
     )
 

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -81,6 +81,8 @@ class ModelConfig(BaseModelConfig):
     disable_restatement: t.Optional[bool] = None
     allow_partials: t.Optional[bool] = None
     physical_version: t.Optional[str] = None
+    auto_restatement_cron: t.Optional[str] = None
+    auto_restatement_intervals: t.Optional[int] = None
 
     # DBT configuration fields
     cluster_by: t.Optional[t.List[str]] = None
@@ -235,18 +237,21 @@ class ModelConfig(BaseModelConfig):
 
             incremental_kind_kwargs["on_destructive_change"] = on_destructive_change
 
+        for field in ("forward_only", "auto_restatement_cron"):
+            field_val = getattr(self, field, None) or self.meta.get(field, None)
+            if field_val:
+                incremental_kind_kwargs[field] = field_val
+
         if materialization == Materialization.TABLE:
             return FullKind()
         if materialization == Materialization.VIEW:
             return ViewKind()
         if materialization == Materialization.INCREMENTAL:
-            incremental_materialization_kwargs: t.Dict[str, t.Any] = {
-                "dialect": self.dialect(context)
-            }
-            for field in ("batch_size", "batch_concurrency", "lookback", "forward_only"):
+            incremental_by_kind_kwargs: t.Dict[str, t.Any] = {"dialect": self.dialect(context)}
+            for field in ("batch_size", "batch_concurrency", "lookback"):
                 field_val = getattr(self, field, None) or self.meta.get(field, None)
                 if field_val:
-                    incremental_materialization_kwargs[field] = field_val
+                    incremental_by_kind_kwargs[field] = field_val
 
             if self.time_column:
                 strategy = self.incremental_strategy or target.default_incremental_strategy(
@@ -266,8 +271,9 @@ class ModelConfig(BaseModelConfig):
                     disable_restatement=(
                         self.disable_restatement if self.disable_restatement is not None else False
                     ),
+                    auto_restatement_intervals=self.auto_restatement_intervals,
                     **incremental_kind_kwargs,
-                    **incremental_materialization_kwargs,
+                    **incremental_by_kind_kwargs,
                 )
 
             disable_restatement = self.disable_restatement
@@ -292,7 +298,7 @@ class ModelConfig(BaseModelConfig):
                     unique_key=self.unique_key,
                     disable_restatement=disable_restatement,
                     **incremental_kind_kwargs,
-                    **incremental_materialization_kwargs,
+                    **incremental_by_kind_kwargs,
                 )
 
             logger.warning(
@@ -306,7 +312,6 @@ class ModelConfig(BaseModelConfig):
             )
             return IncrementalUnmanagedKind(
                 insert_overwrite=strategy in INCREMENTAL_BY_TIME_STRATEGIES,
-                forward_only=incremental_materialization_kwargs.get("forward_only", True),
                 disable_restatement=disable_restatement,
                 **incremental_kind_kwargs,
             )

--- a/sqlmesh/migrations/v0066_add_auto_restatements.py
+++ b/sqlmesh/migrations/v0066_add_auto_restatements.py
@@ -1,0 +1,46 @@
+"""Add the auto restatements table."""
+
+from sqlglot import exp
+
+from sqlmesh.utils.migration import index_text_type
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    auto_restatements_table = "_auto_restatements"
+    intervals_table = "_intervals"
+
+    if schema:
+        auto_restatements_table = f"{schema}.{auto_restatements_table}"
+        intervals_table = f"{schema}.{intervals_table}"
+
+    index_type = index_text_type(engine_adapter.dialect)
+
+    engine_adapter.create_state_table(
+        auto_restatements_table,
+        {
+            "snapshot_name": exp.DataType.build(index_type),
+            "snapshot_version": exp.DataType.build(index_type),
+            "next_auto_restatement_ts": exp.DataType.build("bigint"),
+        },
+        primary_key=("snapshot_name", "snapshot_version"),
+    )
+
+    alter_table_exp = exp.Alter(
+        this=exp.to_table(intervals_table),
+        kind="TABLE",
+        actions=[
+            exp.ColumnDef(
+                this=exp.to_column("is_pending_restatement"),
+                kind=exp.DataType.build("boolean"),
+            )
+        ],
+    )
+    engine_adapter.execute(alter_table_exp)
+
+    engine_adapter.update_table(
+        intervals_table,
+        {"is_pending_restatement": False},
+        where=exp.true(),
+    )

--- a/sqlmesh/schedulers/airflow/state_sync.py
+++ b/sqlmesh/schedulers/airflow/state_sync.py
@@ -11,6 +11,7 @@ from sqlmesh.core.snapshot import (
     SnapshotIdLike,
     SnapshotInfoLike,
     SnapshotTableCleanupTask,
+    SnapshotNameVersion,
 )
 from sqlmesh.core.snapshot.definition import Interval, SnapshotIntervals
 from sqlmesh.core.state_sync import StateSync, Versions
@@ -308,6 +309,13 @@ class HttpStateSync(StateSync):
         """
         raise NotImplementedError(
             "Compacting intervals is not supported by the Airflow state sync."
+        )
+
+    def update_auto_restatements(
+        self, next_auto_restatement_ts: t.Dict[SnapshotNameVersion, t.Optional[int]]
+    ) -> None:
+        raise NotImplementedError(
+            "Updating auto restatements is not supported by the Airflow state sync."
         )
 
     def migrate(

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -30,6 +30,7 @@ from sqlmesh.core.context import Context
 from sqlmesh.core.config.categorizer import CategorizerConfig
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.environment import EnvironmentNamingInfo
+from sqlmesh.core.macros import macro
 from sqlmesh.core.model import (
     IncrementalByTimeRangeKind,
     IncrementalByUniqueKeyKind,
@@ -1838,6 +1839,207 @@ def test_new_forward_only_model_same_dev_environment(init_and_plan_context: t.Ca
 
     df = context.fetchdf("SELECT * FROM memory.sushi__dev.new_model").replace({np.nan: None})
     assert df.to_dict() == {"ds": {0: "2023-01-07"}, "b": {0: 1}}
+
+
+@time_machine.travel("2023-01-08 01:00:00 UTC")
+def test_run_auto_restatement(init_and_plan_context: t.Callable):
+    context, _ = init_and_plan_context("examples/sushi")
+
+    context.engine_adapter.execute(
+        "CREATE TABLE _test_auto_restatement_intervals (name STRING, start_ds STRING, end_ds STRING)"
+    )
+
+    @macro()
+    def record_intervals(
+        evaluator, name: exp.Expression, start: exp.Expression, end: exp.Expression, **kwargs: t.Any
+    ) -> None:
+        if evaluator.runtime_stage == "evaluating":
+            evaluator.engine_adapter.insert_append(
+                "_test_auto_restatement_intervals",
+                pd.DataFrame({"name": [name.name], "start_ds": [start.name], "end_ds": [end.name]}),
+            )
+
+    new_model_expr = d.parse(
+        """
+        MODEL (
+            name memory.sushi.new_model,
+            kind INCREMENTAL_BY_TIME_RANGE (
+                time_column ds,
+                auto_restatement_cron '0 6 * * 7',  -- At 6am every Sunday
+                auto_restatement_intervals 3,
+            ),
+            start '2023-01-01',
+        );
+
+        @record_intervals('new_model', @start_ds, @end_ds);
+
+        SELECT '2023-01-07' AS ds, 1 AS a;
+        """
+    )
+    new_model = load_sql_based_model(new_model_expr)
+    context.upsert_model(new_model)
+
+    new_model_downstream_expr = d.parse(
+        """
+        MODEL (
+            name memory.sushi.new_model_downstream,
+            kind INCREMENTAL_BY_TIME_RANGE (
+                time_column ds,
+            ),
+            cron '@hourly',
+        );
+
+        @record_intervals('new_model_downstream', @start_ts, @end_ts);
+
+        SELECT * FROM memory.sushi.new_model;
+        """
+    )
+    new_model_downstream = load_sql_based_model(new_model_downstream_expr)
+    context.upsert_model(new_model_downstream)
+
+    plan = context.plan("prod", no_prompts=True)
+    context.apply(plan)
+
+    with time_machine.travel("2023-01-08 06:01:00 UTC"):
+        assert context.run()
+
+        recorded_intervals_df = context.engine_adapter.fetchdf(
+            "SELECT start_ds, end_ds FROM _test_auto_restatement_intervals WHERE name = 'new_model'"
+        )
+        # The first interval is the first backfill and the second interval should be the 3 auto restated intervals
+        assert recorded_intervals_df.to_dict() == {
+            "start_ds": {0: "2023-01-01", 1: "2023-01-05"},
+            "end_ds": {0: "2023-01-07", 1: "2023-01-07"},
+        }
+        recorded_intervals_downstream_df = context.engine_adapter.fetchdf(
+            "SELECT start_ds, end_ds FROM _test_auto_restatement_intervals WHERE name = 'new_model_downstream'"
+        )
+        # The first interval is the first backfill, the second interval should be the 3 days of restated intervals, and
+        # the third interval should catch up to the current hour
+        assert recorded_intervals_downstream_df.to_dict() == {
+            "start_ds": {
+                0: "2023-01-01 00:00:00",
+                1: "2023-01-05 00:00:00",
+                2: "2023-01-08 01:00:00",
+            },
+            "end_ds": {
+                0: "2023-01-08 00:59:59.999999",
+                1: "2023-01-07 23:59:59.999999",
+                2: "2023-01-08 05:59:59.999999",
+            },
+        }
+
+        snapshot = context.get_snapshot(new_model.name)
+        snapshot = context.state_sync.state_sync.get_snapshots([snapshot.snapshot_id])[
+            snapshot.snapshot_id
+        ]
+        assert snapshot.next_auto_restatement_ts == to_timestamp("2023-01-15 06:00:00")
+        assert not snapshot.pending_restatement_intervals
+
+        snapshot_downstream = context.get_snapshot(new_model_downstream.name)
+        snapshot_downstream = context.state_sync.state_sync.get_snapshots(
+            [snapshot_downstream.snapshot_id]
+        )[snapshot_downstream.snapshot_id]
+        assert not snapshot_downstream.next_auto_restatement_ts
+        assert not snapshot_downstream.pending_restatement_intervals
+
+
+@time_machine.travel("2023-01-08 01:00:00 UTC")
+def test_run_auto_restatement_plan_preview(init_and_plan_context: t.Callable):
+    context, init_plan = init_and_plan_context("examples/sushi")
+    context.apply(init_plan)
+
+    new_model_expr = d.parse(
+        """
+        MODEL (
+            name memory.sushi.new_model,
+            kind INCREMENTAL_BY_TIME_RANGE (
+                time_column ds,
+                auto_restatement_cron '0 6 * * 7',
+            ),
+            start '2023-01-01',
+        );
+
+        SELECT '2023-01-07' AS ds, 1 AS a;
+        """
+    )
+    new_model = load_sql_based_model(new_model_expr)
+    context.upsert_model(new_model)
+    snapshot = context.get_snapshot(new_model.name)
+
+    plan_dev = context.plan("dev", no_prompts=True)
+    # Make sure that a limited preview is computed by default
+    assert to_timestamp(plan_dev.start) == to_timestamp("2023-01-07")
+    assert plan_dev.missing_intervals == [
+        SnapshotIntervals(
+            snapshot.snapshot_id,
+            [(to_timestamp("2023-01-07"), to_timestamp("2023-01-08"))],
+        )
+    ]
+    assert not plan_dev.deployability_index.is_deployable(snapshot.snapshot_id)
+    context.apply(plan_dev)
+
+    plan_prod = context.plan("prod", no_prompts=True)
+    assert plan_prod.missing_intervals == [
+        SnapshotIntervals(
+            context.get_snapshot(new_model.name).snapshot_id,
+            [
+                (to_timestamp("2023-01-01"), to_timestamp("2023-01-02")),
+                (to_timestamp("2023-01-02"), to_timestamp("2023-01-03")),
+                (to_timestamp("2023-01-03"), to_timestamp("2023-01-04")),
+                (to_timestamp("2023-01-04"), to_timestamp("2023-01-05")),
+                (to_timestamp("2023-01-05"), to_timestamp("2023-01-06")),
+                (to_timestamp("2023-01-06"), to_timestamp("2023-01-07")),
+                (to_timestamp("2023-01-07"), to_timestamp("2023-01-08")),
+            ],
+        )
+    ]
+    context.apply(plan_prod)
+
+
+@time_machine.travel("2023-01-08 01:00:00 UTC")
+def test_run_auto_restatement_failure(init_and_plan_context: t.Callable):
+    context, _ = init_and_plan_context("examples/sushi")
+
+    @macro()
+    def fail_auto_restatement(evaluator, start: exp.Expression, **kwargs: t.Any) -> None:
+        if evaluator.runtime_stage == "evaluating" and start.name != "2023-01-01":
+            raise Exception("Failed")
+
+    new_model_expr = d.parse(
+        """
+        MODEL (
+            name memory.sushi.new_model,
+            kind INCREMENTAL_BY_TIME_RANGE (
+                time_column ds,
+                auto_restatement_cron '0 6 * * 7',  -- At 6am every Sunday
+                auto_restatement_intervals 3,
+            ),
+            start '2023-01-01',
+        );
+
+        @fail_auto_restatement(@start_ds);
+
+        SELECT '2023-01-07' AS ds, 1 AS a;
+        """
+    )
+    new_model = load_sql_based_model(new_model_expr)
+    context.upsert_model(new_model)
+
+    plan = context.plan("prod", no_prompts=True)
+    context.apply(plan)
+
+    with time_machine.travel("2023-01-08 06:01:00 UTC"):
+        assert not context.run()
+
+        snapshot = context.get_snapshot(new_model.name)
+        snapshot = context.state_sync.state_sync.get_snapshots([snapshot.snapshot_id])[
+            snapshot.snapshot_id
+        ]
+        assert snapshot.next_auto_restatement_ts == to_timestamp("2023-01-15 06:00:00")
+        assert snapshot.pending_restatement_intervals == [
+            (to_timestamp("2023-01-05"), to_timestamp("2023-01-08"))
+        ]
 
 
 def test_plan_twice_with_star_macro_yields_no_diff(tmp_path: Path):

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -2549,7 +2549,6 @@ def test_plan_start_when_preview_enabled(make_snapshot, mocker: MockerFixture):
 
     default_start_for_preview = "2024-06-09"
 
-    # When a model is added SQLMesh should not consider the backfill to be a preview.
     plan_builder = PlanBuilder(
         context_diff,
         DuckDBEngineAdapter.SCHEMA_DIFFER,
@@ -2557,7 +2556,7 @@ def test_plan_start_when_preview_enabled(make_snapshot, mocker: MockerFixture):
         is_dev=True,
         enable_preview=True,
     )
-    assert plan_builder.build().start == to_timestamp(model_start)
+    assert plan_builder.build().start == default_start_for_preview
 
     # When a model is modified then the backfill should be a preview.
     snapshot = make_snapshot(model)

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -164,7 +164,6 @@ def test_incremental_by_unique_key_kind_dag(
             ((to_timestamp("2023-01-01"), to_timestamp("2023-01-07")), 0),
         ): set(),
     }
-    mock_state_sync.refresh_snapshot_intervals.assert_called_once()
 
 
 def test_incremental_time_self_reference_dag(

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -39,6 +39,7 @@ from sqlmesh.core.snapshot import (
     SnapshotId,
     SnapshotChangeCategory,
     SnapshotFingerprint,
+    SnapshotIntervals,
     SnapshotTableInfo,
     earliest_start_date,
     fingerprint_from_node,
@@ -48,6 +49,7 @@ from sqlmesh.core.snapshot import (
 from sqlmesh.core.snapshot.cache import SnapshotCache
 from sqlmesh.core.snapshot.categorizer import categorize_change
 from sqlmesh.core.snapshot.definition import (
+    apply_auto_restatements,
     display_name,
     _check_ready_intervals,
     _contiguous_intervals,
@@ -107,6 +109,7 @@ def test_json(snapshot: Snapshot):
         "fingerprint": snapshot.fingerprint.dict(),
         "intervals": [],
         "dev_intervals": [],
+        "pending_restatement_intervals": [],
         "node": {
             "audits": [],
             "audit_definitions": {},
@@ -708,7 +711,7 @@ def test_fingerprint(model: Model, parent_model: Model):
 
     original_fingerprint = SnapshotFingerprint(
         data_hash="1312415267",
-        metadata_hash="2793463216",
+        metadata_hash="2573378960",
     )
 
     assert fingerprint == original_fingerprint
@@ -806,7 +809,7 @@ def test_fingerprint_jinja_macros(model: Model):
     )
     original_fingerprint = SnapshotFingerprint(
         data_hash="923305614",
-        metadata_hash="2793463216",
+        metadata_hash="2573378960",
     )
 
     fingerprint = fingerprint_from_node(model, nodes={})
@@ -1715,6 +1718,35 @@ def test_deployability_index_uncategorized_forward_only_model(make_snapshot):
     assert not deployability_index.is_representative(snapshot_b)
 
 
+def test_deployability_index_auto_restatement_model(make_snapshot):
+    model_a = SqlModel(
+        name="a",
+        query=parse_one("SELECT 1, ds"),
+        kind=IncrementalByTimeRangeKind(
+            time_column="ds", forward_only=False, auto_restatement_cron="@weekly"
+        ),
+    )
+
+    snapshot_a_old = make_snapshot(model_a)
+    snapshot_a_old.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    snapshot_a = make_snapshot(model_a)
+    snapshot_a.previous_versions = snapshot_a_old.all_versions
+
+    snapshot_b = make_snapshot(SqlModel(name="b", query=parse_one("SELECT 1")))
+    snapshot_b.parents = (snapshot_a.snapshot_id,)
+
+    deployability_index = DeployabilityIndex.create(
+        {s.snapshot_id: s for s in [snapshot_a, snapshot_b]}
+    )
+
+    assert not deployability_index.is_deployable(snapshot_a)
+    assert not deployability_index.is_deployable(snapshot_b)
+
+    assert not deployability_index.is_representative(snapshot_a)
+    assert not deployability_index.is_representative(snapshot_b)
+
+
 def test_deployability_index_categorized_forward_only_model(make_snapshot):
     model_a = SqlModel(
         name="a",
@@ -2235,3 +2267,248 @@ def test_check_ready_intervals(mocker: MockerFixture):
         [[(0, 1)], [(3, 4)]],
         [(0, 1), (3, 4)],
     )
+
+
+@pytest.mark.parametrize(
+    "auto_restatement_intervals,expected_auto_restatement_start",
+    [
+        (None, "2020-01-01"),
+        (2, "2020-01-04"),
+    ],
+)
+def test_get_next_auto_restatement_interval(
+    make_snapshot,
+    auto_restatement_intervals: t.Optional[int],
+    expected_auto_restatement_start: str,
+):
+    snapshot = make_snapshot(
+        SqlModel(
+            name="test_model",
+            kind=IncrementalByTimeRangeKind(
+                time_column=TimeColumn(column="ds"),
+                auto_restatement_cron="0 10 * * *",
+                auto_restatement_intervals=auto_restatement_intervals,
+            ),
+            cron="@daily",
+            query=parse_one("SELECT 1, ds FROM name"),
+        )
+    )
+    snapshot.add_interval("2020-01-01", "2020-01-05")
+    snapshot.next_auto_restatement_ts = to_timestamp("2020-01-06 10:00:00")
+
+    assert snapshot.get_next_auto_restatement_interval(to_timestamp("2020-01-06 09:59:00")) is None
+
+    assert snapshot.get_next_auto_restatement_interval(to_timestamp("2020-01-06 10:01:00")) == (
+        to_timestamp(expected_auto_restatement_start),
+        to_timestamp("2020-01-06"),
+    )
+
+
+def test_apply_auto_restatements(make_snapshot):
+    # Hourly upstream model with auto restatement intervals set to 24
+    model_a = SqlModel(
+        name="test_model_a",
+        kind=IncrementalByTimeRangeKind(
+            time_column=TimeColumn(column="ds"),
+            auto_restatement_cron="0 10 * * *",
+            auto_restatement_intervals=24,
+        ),
+        cron="@hourly",
+        query=parse_one("SELECT 1, ds FROM name"),
+    )
+    snapshot_a = make_snapshot(model_a, version="1")
+    snapshot_a.add_interval("2020-01-01", "2020-01-06 09:00:00")
+    snapshot_a.next_auto_restatement_ts = to_timestamp("2020-01-06 10:00:00")
+
+    # Daily downstream model with no auto restatement
+    model_b = SqlModel(
+        name="test_model_b",
+        kind=IncrementalByTimeRangeKind(
+            time_column=TimeColumn(column="ds"),
+        ),
+        cron="@daily",
+        query=parse_one("SELECT ds FROM test_model_a"),
+    )
+    snapshot_b = make_snapshot(model_b, nodes={model_a.fqn: model_a}, version="2")
+    snapshot_b.add_interval("2020-01-01", "2020-01-05")
+    assert snapshot_a.snapshot_id in snapshot_b.parents
+
+    # Daily downstream model with auto restatement intervals of 2
+    model_c = SqlModel(
+        name="test_model_c",
+        kind=IncrementalByTimeRangeKind(
+            time_column=TimeColumn(column="ds"),
+            auto_restatement_cron="0 10 * * *",
+            auto_restatement_intervals=2,
+        ),
+        cron="@daily",
+        query=parse_one("SELECT ds FROM test_model_a"),
+    )
+    snapshot_c = make_snapshot(model_c, nodes={model_a.fqn: model_a}, version="3")
+    snapshot_c.add_interval("2020-01-01", "2020-01-05")
+    snapshot_c.next_auto_restatement_ts = to_timestamp("2020-01-06 10:00:00")
+    assert snapshot_a.snapshot_id in snapshot_c.parents
+
+    # Hourly downstream model with auto restatement intervals of 5
+    model_d = SqlModel(
+        name="test_model_d",
+        kind=IncrementalByTimeRangeKind(
+            time_column=TimeColumn(column="ds"),
+            auto_restatement_cron="0 10 * * *",
+            auto_restatement_intervals=5,
+        ),
+        cron="@hourly",
+        query=parse_one("SELECT ds FROM test_model_a"),
+    )
+    snapshot_d = make_snapshot(model_d, nodes={model_a.fqn: model_a}, version="4")
+    snapshot_d.add_interval("2020-01-01", "2020-01-06 09:00:00")
+    snapshot_d.next_auto_restatement_ts = to_timestamp("2020-01-06 10:00:00")
+    assert snapshot_a.snapshot_id in snapshot_d.parents
+
+    # Hourly upstream model with auto restatement intervals set to 5
+    model_e = SqlModel(
+        name="test_model_e",
+        kind=IncrementalByTimeRangeKind(
+            time_column=TimeColumn(column="ds"),
+            auto_restatement_cron="0 10 * * *",
+            auto_restatement_intervals=5,
+        ),
+        cron="@hourly",
+        query=parse_one("SELECT 1, ds FROM name"),
+    )
+    snapshot_e = make_snapshot(model_e, version="5")
+    snapshot_e.add_interval("2020-01-01", "2020-01-06 09:00:00")
+    snapshot_e.next_auto_restatement_ts = to_timestamp("2020-01-06 10:00:00")
+
+    # Daily model downstream from model_e without auto restatement that should not be impacted by auto restatement
+    # upstream.
+    model_f = SqlModel(
+        name="test_model_f",
+        kind=IncrementalByTimeRangeKind(
+            time_column=TimeColumn(column="ds"),
+        ),
+        cron="@daily",
+        query=parse_one("SELECT ds FROM test_model_e"),
+    )
+    snapshot_f = make_snapshot(model_f, nodes={model_e.fqn: model_e}, version="6")
+    snapshot_f.add_interval("2020-01-01", "2020-01-05")
+    assert snapshot_e.snapshot_id in snapshot_f.parents
+
+    assert snapshot_a.intervals == [
+        (to_timestamp("2020-01-01"), to_timestamp("2020-01-06 09:00:00")),
+    ]
+    assert snapshot_b.intervals == [
+        (to_timestamp("2020-01-01"), to_timestamp("2020-01-06")),
+    ]
+    assert snapshot_c.intervals == [
+        (to_timestamp("2020-01-01"), to_timestamp("2020-01-06")),
+    ]
+    assert snapshot_d.intervals == [
+        (to_timestamp("2020-01-01"), to_timestamp("2020-01-06 09:00:00")),
+    ]
+    assert snapshot_e.intervals == [
+        (to_timestamp("2020-01-01"), to_timestamp("2020-01-06 09:00:00")),
+    ]
+    assert snapshot_f.intervals == [
+        (to_timestamp("2020-01-01"), to_timestamp("2020-01-06")),
+    ]
+
+    restated_intervals = apply_auto_restatements(
+        {
+            snapshot_a.snapshot_id: snapshot_a,
+            snapshot_b.snapshot_id: snapshot_b,
+            snapshot_c.snapshot_id: snapshot_c,
+            snapshot_d.snapshot_id: snapshot_d,
+            snapshot_e.snapshot_id: snapshot_e,
+            snapshot_f.snapshot_id: snapshot_f,
+        },
+        "2020-01-06 10:01:00",
+    )
+    assert sorted(restated_intervals, key=lambda x: x.name) == [
+        SnapshotIntervals(
+            name=snapshot_a.name,
+            identifier=snapshot_a.identifier,
+            version=snapshot_a.version,
+            intervals=[],
+            dev_intervals=[],
+            pending_restatement_intervals=[
+                (to_timestamp("2020-01-05 10:00:00"), to_timestamp("2020-01-06 10:00:00"))
+            ],
+        ),
+        SnapshotIntervals(
+            name=snapshot_b.name,
+            identifier=snapshot_b.identifier,
+            version=snapshot_b.version,
+            intervals=[],
+            dev_intervals=[],
+            pending_restatement_intervals=[
+                (to_timestamp("2020-01-05"), to_timestamp("2020-01-07"))
+            ],
+        ),
+        SnapshotIntervals(
+            name=snapshot_c.name,
+            identifier=snapshot_c.identifier,
+            version=snapshot_c.version,
+            intervals=[],
+            dev_intervals=[],
+            pending_restatement_intervals=[
+                (to_timestamp("2020-01-04"), to_timestamp("2020-01-07"))
+            ],
+        ),
+        SnapshotIntervals(
+            name=snapshot_d.name,
+            identifier=snapshot_d.identifier,
+            version=snapshot_d.version,
+            intervals=[],
+            dev_intervals=[],
+            pending_restatement_intervals=[
+                (to_timestamp("2020-01-05 10:00:00"), to_timestamp("2020-01-06 10:00:00"))
+            ],
+        ),
+        SnapshotIntervals(
+            name=snapshot_e.name,
+            identifier=snapshot_e.identifier,
+            version=snapshot_e.version,
+            intervals=[],
+            dev_intervals=[],
+            pending_restatement_intervals=[
+                (to_timestamp("2020-01-06 05:00:00"), to_timestamp("2020-01-06 10:00:00"))
+            ],
+        ),
+        SnapshotIntervals(
+            name=snapshot_f.name,
+            identifier=snapshot_f.identifier,
+            version=snapshot_f.version,
+            intervals=[],
+            dev_intervals=[],
+            pending_restatement_intervals=[
+                (to_timestamp("2020-01-06"), to_timestamp("2020-01-07"))
+            ],
+        ),
+    ]
+
+    assert snapshot_a.next_auto_restatement_ts == to_timestamp("2020-01-07 10:00:00")
+    assert snapshot_b.next_auto_restatement_ts is None
+    assert snapshot_c.next_auto_restatement_ts == to_timestamp("2020-01-07 10:00:00")
+    assert snapshot_d.next_auto_restatement_ts == to_timestamp("2020-01-07 10:00:00")
+    assert snapshot_e.next_auto_restatement_ts == to_timestamp("2020-01-07 10:00:00")
+    assert snapshot_f.next_auto_restatement_ts is None
+
+    assert snapshot_a.intervals == [
+        (to_timestamp("2020-01-01"), to_timestamp("2020-01-05 10:00:00")),
+    ]
+    assert snapshot_b.intervals == [
+        (to_timestamp("2020-01-01"), to_timestamp("2020-01-05")),
+    ]
+    assert snapshot_c.intervals == [
+        (to_timestamp("2020-01-01"), to_timestamp("2020-01-04")),
+    ]
+    assert snapshot_d.intervals == [
+        (to_timestamp("2020-01-01"), to_timestamp("2020-01-05 10:00:00")),
+    ]
+    assert snapshot_e.intervals == [
+        (to_timestamp("2020-01-01"), to_timestamp("2020-01-06 05:00:00")),
+    ]
+    assert snapshot_f.intervals == [
+        (to_timestamp("2020-01-01"), to_timestamp("2020-01-06")),
+    ]

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -208,8 +208,13 @@ def test_model_kind():
         unique_key=["bar"],
         disable_restatement=True,
         full_refresh=False,
+        auto_restatement_cron="0 0 * * *",
     ).model_kind(context) == IncrementalByUniqueKeyKind(
-        unique_key=["bar"], dialect="duckdb", forward_only=True, disable_restatement=True
+        unique_key=["bar"],
+        dialect="duckdb",
+        forward_only=True,
+        disable_restatement=True,
+        auto_restatement_cron="0 0 * * *",
     )
 
     assert ModelConfig(
@@ -234,6 +239,22 @@ def test_model_kind():
         partition_by={"field": "bar"},
         forward_only=False,
     ).model_kind(context) == IncrementalByTimeRangeKind(time_column="foo", dialect="duckdb")
+
+    assert ModelConfig(
+        materialized=Materialization.INCREMENTAL,
+        time_column="foo",
+        incremental_strategy="insert_overwrite",
+        partition_by={"field": "bar"},
+        forward_only=False,
+        auto_restatement_cron="0 0 * * *",
+        auto_restatement_intervals=3,
+    ).model_kind(context) == IncrementalByTimeRangeKind(
+        time_column="foo",
+        dialect="duckdb",
+        forward_only=False,
+        auto_restatement_cron="0 0 * * *",
+        auto_restatement_intervals=3,
+    )
 
     assert ModelConfig(
         materialized=Materialization.INCREMENTAL,
@@ -289,6 +310,14 @@ def test_model_kind():
         disable_restatement=True,
     ).model_kind(context) == IncrementalUnmanagedKind(
         insert_overwrite=True, disable_restatement=True
+    )
+
+    assert ModelConfig(
+        materialized=Materialization.INCREMENTAL,
+        incremental_strategy="insert_overwrite",
+        auto_restatement_cron="0 0 * * *",
+    ).model_kind(context) == IncrementalUnmanagedKind(
+        insert_overwrite=True, auto_restatement_cron="0 0 * * *", disable_restatement=False
     )
 
     assert (

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -98,6 +98,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
                     "fingerprint": snapshot.fingerprint.dict(),
                     "intervals": [],
                     "dev_intervals": [],
+                    "pending_restatement_intervals": [],
                     "node": {
                         "audits": [],
                         "audit_definitions": {},


### PR DESCRIPTION
It’s prevalent among dbt users to nuke the tables of their incremental models occasionally to ensure correctness as well as to capture late arriving data. This is because dbt models lack an idempotent way to re-process arbitrary intervals of data. 

When transitioning to SQLMesh, these users are forced to use restatement plans in order to replicate workflows they are used to in dbt. However, the restatement plans are highly invasive, as they remove intervals for all versions of the model across all environments. This negatively impacts users iterating in development environments, as they are suddenly forced to rerun models they haven’t modified.

To address this issue, we are introducing first-class support for this use case and call it Auto-Restatements. This allows users to configure a cadence for full (or partial) refreshes of incremental models, which will be automatically applied as part of the `sqlmesh run` command when appropriate.
