### PR TITLE
Chore: fix arg name in Node Field definition

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -48,7 +48,7 @@ if t.TYPE_CHECKING:
 Interval = t.Tuple[int, int]
 Intervals = t.List[Interval]
 
-Node = t.Annotated[t.Union[Model, StandaloneAudit], Field(descriminator="source_type")]
+Node = t.Annotated[t.Union[Model, StandaloneAudit], Field(discriminator="source_type")]
 
 
 class SnapshotChangeCategory(IntEnum):


### PR DESCRIPTION
Fix arg name typo:
- `discriminator` is a `Field` arg 
- `"descriminator"` was being consumed as a kwarg and ignored