### PR TITLE
Fix: Add adapters for commands that are not using the snapshot evaluator

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -2023,6 +2023,12 @@ class GenericContext(BaseContext, t.Generic[C]):
             if snapshot.is_model and snapshot.model.gateway
         }
 
+    @cached_property
+    def engine_adapters(self) -> t.Dict[str, EngineAdapter]:
+        """Returns all engine adapters for the gateways defined in the configs."""
+        self._create_engine_adapters()
+        return self._engine_adapters
+
     def _create_engine_adapters(self, gateways: t.Optional[t.Set] = None) -> None:
         """Create engine adapters for the gateways, when none provided include all defined in the configs."""
 
@@ -2037,8 +2043,7 @@ class GenericContext(BaseContext, t.Generic[C]):
 
     def _get_engine_adapter(self, gateway: t.Optional[str] = None) -> EngineAdapter:
         if gateway:
-            self._create_engine_adapters()
-            if adapter := self._engine_adapters.get(gateway):
+            if adapter := self.engine_adapters.get(gateway):
                 return adapter
             raise SQLMeshError(f"Gateway '{gateway}' not found in the available engine adapters.")
         return self.engine_adapter

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -917,6 +917,7 @@ class GenericContext(BaseContext, t.Generic[C]):
 
         expand = self.dag.upstream(model.fqn) if expand is True else expand or []
 
+        self._create_engine_adapters()
         if model.is_seed:
             df = next(
                 model.render(
@@ -1476,6 +1477,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         source_alias, target_alias = source, target
 
         adapter = self.engine_adapter
+        self._create_engine_adapters()
         if model_or_snapshot:
             model = self.get_model(model_or_snapshot, raise_if_missing=True)
             adapter = self._get_engine_adapter(model.gateway)
@@ -1641,6 +1643,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             test_adapter = self._test_connection_config.create_engine_adapter(
                 register_comments_override=False
             )
+            self._create_engine_adapters()
             generate_test(
                 model=model_to_test,
                 input_queries=input_queries,

--- a/tests/core/engine_adapter/integration/__init__.py
+++ b/tests/core/engine_adapter/integration/__init__.py
@@ -470,6 +470,7 @@ class TestContext:
             ],
         )
         if config_mutator:
+            config.gateways = {self.gateway: config.gateways[self.gateway]}
             config_mutator(self.gateway, config)
 
         gateway_config = config.gateways[self.gateway]

--- a/tests/core/engine_adapter/integration/__init__.py
+++ b/tests/core/engine_adapter/integration/__init__.py
@@ -470,8 +470,8 @@ class TestContext:
             ],
         )
         if config_mutator:
-            config.gateways = {self.gateway: config.gateways[self.gateway]}
             config_mutator(self.gateway, config)
+        config.gateways = {self.gateway: config.gateways[self.gateway]}
 
         gateway_config = config.gateways[self.gateway]
         if (

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -1328,6 +1328,8 @@ def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
         personal_paths=[pathlib.Path("~/.sqlmesh/config.yaml").expanduser()],
     )
 
+    # To enable parallelism in integration tests
+    config.gateways = {ctx.gateway: config.gateways[ctx.gateway]}
     current_gateway_config = config.gateways[ctx.gateway]
     current_gateway_config.state_schema = sushi_state_schema
 
@@ -1730,6 +1732,8 @@ def test_init_project(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory
     if config.model_defaults.dialect != ctx.dialect:
         config.model_defaults = config.model_defaults.copy(update={"dialect": ctx.dialect})
 
+    # To enable parallelism in integration tests
+    config.gateways = {ctx.gateway: config.gateways[ctx.gateway]}
     current_gateway_config = config.gateways[ctx.gateway]
 
     if ctx.dialect == "athena":

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -757,10 +757,8 @@ model_defaults:
         new_callable=mocker.PropertyMock(return_value={"snapshot": "athena"}),
     )
 
-    ctx._create_engine_adapters()
-
     assert isinstance(ctx._connection_config, RedshiftConnectionConfig)
-    assert len(ctx._engine_adapters) == 2
-    assert isinstance(ctx._engine_adapters["athena"], AthenaEngineAdapter)
-    assert isinstance(ctx._engine_adapters["redshift"], RedshiftEngineAdapter)
+    assert len(ctx.engine_adapters) == 2
+    assert isinstance(ctx.engine_adapters["athena"], AthenaEngineAdapter)
+    assert isinstance(ctx.engine_adapters["redshift"], RedshiftEngineAdapter)
     assert ctx.engine_adapter == ctx._get_engine_adapter("redshift")

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -341,8 +341,7 @@ def test_gateway_specific_adapters(copy_to_temp_path, mocker):
 
     ctx = Context(paths=path, config="isolated_systems_config")
 
-    ctx._create_engine_adapters({"test"})
-    assert len(ctx._engine_adapters) == 2
+    assert len(ctx.engine_adapters) == 3
     assert ctx.engine_adapter == ctx._get_engine_adapter()
     assert ctx._get_engine_adapter("test") == ctx._engine_adapters["test"]
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -322,8 +322,12 @@ def test_gateway_specific_adapters(copy_to_temp_path, mocker):
     ctx = Context(paths=path, config="isolated_systems_config", gateway="prod")
     assert len(ctx._engine_adapters) == 1
     assert ctx.engine_adapter == ctx._engine_adapters["prod"]
+
     with pytest.raises(SQLMeshError):
-        assert ctx._get_engine_adapter("dev")
+        assert ctx._get_engine_adapter("non_existing")
+
+    # This will create the requested engine adapter
+    assert ctx._get_engine_adapter("dev") == ctx._engine_adapters["dev"]
 
     ctx = Context(paths=path, config="isolated_systems_config")
     assert len(ctx._engine_adapters) == 1

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -6635,10 +6635,7 @@ def test_gateway_specific_render(assert_exp_eq) -> None:
     )
     context = Context(config=config)
     assert context.engine_adapter == context._engine_adapters["main"]
-    with pytest.raises(
-        SQLMeshError, match=r"Gateway 'duckdb' not found in the available engine adapters."
-    ):
-        context._get_engine_adapter("duckdb")
+    assert len(context._engine_adapters) == 1
 
     @model(
         name="dummy_model",

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -6635,7 +6635,6 @@ def test_gateway_specific_render(assert_exp_eq) -> None:
     )
     context = Context(config=config)
     assert context.engine_adapter == context._engine_adapters["main"]
-    assert len(context._engine_adapters) == 1
 
     @model(
         name="dummy_model",
@@ -6652,8 +6651,6 @@ def test_gateway_specific_render(assert_exp_eq) -> None:
     assert isinstance(dummy_model, SqlModel)
     assert dummy_model.gateway == "duckdb"
 
-    # Calling render with a model with a non-default gateway should create
-    # the engine adapters and render with the model specified gateway
     assert_exp_eq(
         context.render("dummy_model"),
         """

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -26,6 +26,7 @@ from sqlmesh.core.config import (
 from sqlmesh.core.context import Context, ExecutionContext
 from sqlmesh.core.dialect import parse
 from sqlmesh.core.engine_adapter.base import MERGE_SOURCE_ALIAS, MERGE_TARGET_ALIAS
+from sqlmesh.core.engine_adapter.duckdb import DuckDBEngineAdapter
 from sqlmesh.core.macros import MacroEvaluator, macro
 from sqlmesh.core.model import (
     CustomKind,
@@ -6620,3 +6621,49 @@ def test_auto_restatement():
     )
     with pytest.raises(ValueError, match="Invalid cron expression '@invalid'.*"):
         load_sql_based_model(parsed_definition)
+
+
+def test_gateway_specific_render(assert_exp_eq) -> None:
+    gateways = {
+        "main": GatewayConfig(connection=DuckDBConnectionConfig()),
+        "duckdb": GatewayConfig(connection=DuckDBConnectionConfig()),
+    }
+    config = Config(
+        gateways=gateways,
+        model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+        default_gateway="main",
+    )
+    context = Context(config=config)
+    assert context.engine_adapter == context._engine_adapters["main"]
+    with pytest.raises(
+        SQLMeshError, match=r"Gateway 'duckdb' not found in the available engine adapters."
+    ):
+        context._get_engine_adapter("duckdb")
+
+    @model(
+        name="dummy_model",
+        is_sql=True,
+        kind="full",
+        gateway="duckdb",
+        grain='"x"',
+    )
+    def dummy_model_entry(evaluator: MacroEvaluator) -> exp.Select:
+        return exp.select("x").from_(exp.values([("1", 2)], "_v", ["x"]))
+
+    dummy_model = model.get_registry()["dummy_model"].model(module_path=Path("."), path=Path("."))
+    context.upsert_model(dummy_model)
+    assert isinstance(dummy_model, SqlModel)
+    assert dummy_model.gateway == "duckdb"
+
+    # Calling render with a model with a non-default gateway should create
+    # the engine adapters and render with the model specified gateway
+    assert_exp_eq(
+        context.render("dummy_model"),
+        """
+        SELECT
+          "_v"."x" AS "x",
+        FROM (VALUES ('1', 2)) AS "_v"("x")
+        """,
+    )
+    assert isinstance(context._get_engine_adapter("duckdb"), DuckDBEngineAdapter)
+    assert len(context._engine_adapters) == 2

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -2021,7 +2021,6 @@ def test_test_with_gateway_specific_model(tmp_path: Path, mocker: MockerFixture)
     )
 
     assert context.engine_adapter == context._engine_adapters["main"]
-    assert len(context._engine_adapters) == 1
     with pytest.raises(
         SQLMeshError, match=r"Gateway 'wrong' not found in the available engine adapters."
     ):

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -2021,14 +2021,16 @@ def test_test_with_gateway_specific_model(tmp_path: Path, mocker: MockerFixture)
     )
 
     assert context.engine_adapter == context._engine_adapters["main"]
+    assert len(context._engine_adapters) == 1
     with pytest.raises(
-        SQLMeshError, match=r"Gateway 'second' not found in the available engine adapters."
+        SQLMeshError, match=r"Gateway 'wrong' not found in the available engine adapters."
     ):
-        context._get_engine_adapter("second")
+        context._get_engine_adapter("wrong")
 
     # Create test should use the gateway specific engine adapter
     context.create_test("sqlmesh_example.gw_model", input_queries=input_queries, overwrite=True)
     assert context._get_engine_adapter("second") == context._engine_adapters["second"]
+    assert len(context._engine_adapters) == 2
 
     test = load_yaml(context.path / c.TESTS / "test_gw_model.yaml")
 

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -25,7 +25,7 @@ from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.macros import MacroEvaluator, macro
 from sqlmesh.core.model import Model, SqlModel, load_sql_based_model, model
 from sqlmesh.core.test.definition import ModelTest, PythonModelTest, SqlModelTest
-from sqlmesh.utils.errors import ConfigError, TestError
+from sqlmesh.utils.errors import ConfigError, SQLMeshError, TestError
 from sqlmesh.utils.yaml import dump as dump_yaml
 from sqlmesh.utils.yaml import load as load_yaml
 
@@ -1989,3 +1989,52 @@ def test_test_generation_with_recursive_ctes(tmp_path: Path) -> None:
     }
 
     _check_successful_or_raise(context.test())
+
+
+def test_test_with_gateway_specific_model(tmp_path: Path, mocker: MockerFixture) -> None:
+    init_example_project(tmp_path, dialect="duckdb")
+
+    config = Config(
+        gateways={
+            "main": GatewayConfig(connection=DuckDBConnectionConfig()),
+            "second": GatewayConfig(connection=DuckDBConnectionConfig()),
+        },
+        default_gateway="main",
+        model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+    )
+    gw_model_sql_file = tmp_path / "models" / "gw_model.sql"
+
+    # The model has a gateway specified which isn't the default
+    gw_model_sql_file.write_text(
+        "MODEL (name sqlmesh_example.gw_model, gateway second); SELECT c FROM sqlmesh_example.input_model;"
+    )
+    input_model_sql_file = tmp_path / "models" / "input_model.sql"
+    input_model_sql_file.write_text(
+        "MODEL (name sqlmesh_example.input_model); SELECT c FROM external_table;"
+    )
+
+    context = Context(paths=tmp_path, config=config)
+    input_queries = {'"memory"."sqlmesh_example"."input_model"': "SELECT 5 AS c"}
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.base.EngineAdapter.fetchdf",
+        return_value=pd.DataFrame({"c": [5]}),
+    )
+
+    assert context.engine_adapter == context._engine_adapters["main"]
+    with pytest.raises(
+        SQLMeshError, match=r"Gateway 'second' not found in the available engine adapters."
+    ):
+        context._get_engine_adapter("second")
+
+    # Create test should use the gateway specific engine adapter
+    context.create_test("sqlmesh_example.gw_model", input_queries=input_queries, overwrite=True)
+    assert context._get_engine_adapter("second") == context._engine_adapters["second"]
+
+    test = load_yaml(context.path / c.TESTS / "test_gw_model.yaml")
+
+    assert len(test) == 1
+    assert "test_gw_model" in test
+    assert test["test_gw_model"]["inputs"] == {
+        '"memory"."sqlmesh_example"."input_model"': [{"c": 5}]
+    }
+    assert test["test_gw_model"]["outputs"] == {"query": [{"c": 5}]}


### PR DESCRIPTION
This fixes an omission on the latest multi-engine feature, to create the engine adapters in cases when they're not generated in the snapshot_evaluator property, ie for the commands `render`, `table_diff` and `create_test`