### PR TITLE
Feat!: Add support for merge_filter and dbt incremental_predicates for Incremental By Unique Key

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -1264,7 +1264,7 @@ def is_meta_expression(v: t.Any) -> bool:
     return isinstance(v, (Audit, Metric, Model))
 
 
-def replace_table_references(expression: exp.Expression) -> exp.Expression:
+def replace_merge_table_aliases(expression: exp.Expression) -> exp.Expression:
     """
     Resolves references from the "source" and "target" tables (or their DBT equivalents)
     with the corresponding SQLMesh merge aliases (MERGE_SOURCE_ALIAS and MERGE_TARGET_ALIAS)

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -429,10 +429,8 @@ def _parse_props(self: Parser) -> t.Optional[exp.Expression]:
             lambda: _parse_macro_or_clause(self, self._parse_when_matched),
             optional=True,
         )
-    elif name == "merge_filters":
-        value = self._parse_wrapped(
-            lambda: _parse_macro_or_clause(self, self._parse_conjunction), optional=True
-        )
+    elif name == "merge_filter":
+        value = self._parse_conjunction()
     elif self._match(TokenType.L_PAREN):
         value = self.expression(exp.Tuple, expressions=self._parse_csv(self._parse_equality))
         self._match_r_paren()

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -429,7 +429,7 @@ def _parse_props(self: Parser) -> t.Optional[exp.Expression]:
             lambda: _parse_macro_or_clause(self, self._parse_when_matched),
             optional=True,
         )
-    elif name == "incremental_predicates":
+    elif name == "merge_filters":
         value = self._parse_wrapped(
             lambda: _parse_macro_or_clause(self, self._parse_conjunction), optional=True
         )

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1804,6 +1804,7 @@ class EngineAdapter:
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
+        incremental_predicates: t.Optional[exp.Expression] = None,
     ) -> None:
         source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
             source_table, columns_to_types, target_table=target_table
@@ -1815,6 +1816,9 @@ class EngineAdapter:
                 for part in unique_key
             )
         )
+        if incremental_predicates:
+            on = exp.and_(incremental_predicates, on)
+
         if not when_matched:
             when_matched = exp.Whens()
             when_matched.append(

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1804,7 +1804,7 @@ class EngineAdapter:
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
-        incremental_predicates: t.Optional[exp.Expression] = None,
+        merge_filters: t.Optional[exp.Expression] = None,
     ) -> None:
         source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
             source_table, columns_to_types, target_table=target_table
@@ -1816,8 +1816,8 @@ class EngineAdapter:
                 for part in unique_key
             )
         )
-        if incremental_predicates:
-            on = exp.and_(incremental_predicates, on)
+        if merge_filters:
+            on = exp.and_(merge_filters, on)
 
         if not when_matched:
             when_matched = exp.Whens()

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1804,7 +1804,7 @@ class EngineAdapter:
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
-        merge_filters: t.Optional[exp.Expression] = None,
+        merge_filter: t.Optional[exp.Expression] = None,
     ) -> None:
         source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
             source_table, columns_to_types, target_table=target_table
@@ -1816,8 +1816,8 @@ class EngineAdapter:
                 for part in unique_key
             )
         )
-        if merge_filters:
-            on = exp.and_(merge_filters, on)
+        if merge_filter:
+            on = exp.and_(merge_filter, on)
 
         if not when_matched:
             when_matched = exp.Whens()

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -31,6 +31,7 @@ class LogicalMergeMixin(EngineAdapter):
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
+        incremental_predicates: t.Optional[exp.Expression] = None,
     ) -> None:
         logical_merge(
             self,
@@ -39,6 +40,7 @@ class LogicalMergeMixin(EngineAdapter):
             columns_to_types,
             unique_key,
             when_matched=when_matched,
+            incremental_predicates=incremental_predicates,
         )
 
 
@@ -409,6 +411,7 @@ def logical_merge(
     columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
     unique_key: t.Sequence[exp.Expression],
     when_matched: t.Optional[exp.Whens] = None,
+    incremental_predicates: t.Optional[exp.Expression] = None,
 ) -> None:
     """
     Merge implementation for engine adapters that do not support merge natively.
@@ -420,10 +423,12 @@ def logical_merge(
        within the temporary table are ommitted.
     4. Drop the temporary table.
     """
-    if when_matched:
+    if when_matched or incremental_predicates:
+        prop = "when_matched" if when_matched else "incremental_predicates"
         raise SQLMeshError(
-            "This engine does not support MERGE expressions and therefore `when_matched` is not supported."
+            f"This engine does not support MERGE expressions and therefore `{prop}` is not supported."
         )
+
     engine_adapter._replace_by_key(
         target_table, source_table, columns_to_types, unique_key, is_unique_key=True
     )

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -31,7 +31,7 @@ class LogicalMergeMixin(EngineAdapter):
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
-        merge_filters: t.Optional[exp.Expression] = None,
+        merge_filter: t.Optional[exp.Expression] = None,
     ) -> None:
         logical_merge(
             self,
@@ -40,7 +40,7 @@ class LogicalMergeMixin(EngineAdapter):
             columns_to_types,
             unique_key,
             when_matched=when_matched,
-            merge_filters=merge_filters,
+            merge_filter=merge_filter,
         )
 
 
@@ -411,7 +411,7 @@ def logical_merge(
     columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
     unique_key: t.Sequence[exp.Expression],
     when_matched: t.Optional[exp.Whens] = None,
-    merge_filters: t.Optional[exp.Expression] = None,
+    merge_filter: t.Optional[exp.Expression] = None,
 ) -> None:
     """
     Merge implementation for engine adapters that do not support merge natively.
@@ -423,8 +423,8 @@ def logical_merge(
        within the temporary table are ommitted.
     4. Drop the temporary table.
     """
-    if when_matched or merge_filters:
-        prop = "when_matched" if when_matched else "merge_filters"
+    if when_matched or merge_filter:
+        prop = "when_matched" if when_matched else "merge_filter"
         raise SQLMeshError(
             f"This engine does not support MERGE expressions and therefore `{prop}` is not supported."
         )

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -31,7 +31,7 @@ class LogicalMergeMixin(EngineAdapter):
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
-        incremental_predicates: t.Optional[exp.Expression] = None,
+        merge_filters: t.Optional[exp.Expression] = None,
     ) -> None:
         logical_merge(
             self,
@@ -40,7 +40,7 @@ class LogicalMergeMixin(EngineAdapter):
             columns_to_types,
             unique_key,
             when_matched=when_matched,
-            incremental_predicates=incremental_predicates,
+            merge_filters=merge_filters,
         )
 
 
@@ -411,7 +411,7 @@ def logical_merge(
     columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
     unique_key: t.Sequence[exp.Expression],
     when_matched: t.Optional[exp.Whens] = None,
-    incremental_predicates: t.Optional[exp.Expression] = None,
+    merge_filters: t.Optional[exp.Expression] = None,
 ) -> None:
     """
     Merge implementation for engine adapters that do not support merge natively.
@@ -423,8 +423,8 @@ def logical_merge(
        within the temporary table are ommitted.
     4. Drop the temporary table.
     """
-    if when_matched or incremental_predicates:
-        prop = "when_matched" if when_matched else "incremental_predicates"
+    if when_matched or merge_filters:
+        prop = "when_matched" if when_matched else "merge_filters"
         raise SQLMeshError(
             f"This engine does not support MERGE expressions and therefore `{prop}` is not supported."
         )

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -107,7 +107,7 @@ class PostgresEngineAdapter(
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
-        incremental_predicates: t.Optional[exp.Expression] = None,
+        merge_filters: t.Optional[exp.Expression] = None,
     ) -> None:
         # Merge isn't supported until Postgres 15
         merge_impl = (
@@ -121,5 +121,5 @@ class PostgresEngineAdapter(
             columns_to_types,
             unique_key,
             when_matched=when_matched,
-            incremental_predicates=incremental_predicates,
+            merge_filters=merge_filters,
         )

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -107,7 +107,7 @@ class PostgresEngineAdapter(
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
-        merge_filters: t.Optional[exp.Expression] = None,
+        merge_filter: t.Optional[exp.Expression] = None,
     ) -> None:
         # Merge isn't supported until Postgres 15
         merge_impl = (
@@ -121,5 +121,5 @@ class PostgresEngineAdapter(
             columns_to_types,
             unique_key,
             when_matched=when_matched,
-            merge_filters=merge_filters,
+            merge_filter=merge_filter,
         )

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -107,6 +107,7 @@ class PostgresEngineAdapter(
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
+        incremental_predicates: t.Optional[exp.Expression] = None,
     ) -> None:
         # Merge isn't supported until Postgres 15
         merge_impl = (
@@ -120,4 +121,5 @@ class PostgresEngineAdapter(
             columns_to_types,
             unique_key,
             when_matched=when_matched,
+            incremental_predicates=incremental_predicates,
         )

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -444,7 +444,7 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
     )
     unique_key: SQLGlotListOfFields
     when_matched: t.Optional[exp.Whens] = None
-    merge_filters: t.Optional[exp.Expression] = None
+    merge_filter: t.Optional[exp.Expression] = None
     batch_concurrency: t.Literal[1] = 1
 
     @field_validator("when_matched", mode="before")
@@ -466,9 +466,9 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
 
         return t.cast(exp.Whens, v.transform(d.replace_table_references))
 
-    @field_validator("merge_filters", mode="before")
+    @field_validator("merge_filter", mode="before")
     @field_validator_v1_args
-    def _merge_filters_validator(
+    def _merge_filter_validator(
         cls,
         v: t.Optional[exp.Expression],
         values: t.Dict[str, t.Any],
@@ -477,9 +477,7 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
             return v
         if isinstance(v, str):
             v = v.strip()
-            if v.startswith("("):
-                v = v[1:-1]
-            return d.parse_one(v, into=exp.Expression, dialect=get_dialect(values))
+            return d.parse_one(v, dialect=get_dialect(values))
 
         return v.transform(d.replace_table_references)
 
@@ -489,7 +487,7 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
             *super().data_hash_values,
             *(gen(k) for k in self.unique_key),
             gen(self.when_matched) if self.when_matched is not None else None,
-            gen(self.merge_filters) if self.merge_filters is not None else None,
+            gen(self.merge_filter) if self.merge_filter is not None else None,
         ]
 
     def to_expression(
@@ -502,7 +500,7 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
                     {
                         "unique_key": exp.Tuple(expressions=self.unique_key),
                         "when_matched": self.when_matched,
-                        "merge_filters": self.merge_filters,
+                        "merge_filter": self.merge_filter,
                     }
                 ),
             ],

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -464,7 +464,7 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
 
             return t.cast(exp.Whens, d.parse_one(v, into=exp.Whens, dialect=get_dialect(values)))
 
-        return t.cast(exp.Whens, v.transform(d.replace_table_references))
+        return t.cast(exp.Whens, v.transform(d.replace_merge_table_aliases))
 
     @field_validator("merge_filter", mode="before")
     @field_validator_v1_args
@@ -479,7 +479,7 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
             v = v.strip()
             return d.parse_one(v, dialect=get_dialect(values))
 
-        return v.transform(d.replace_table_references)
+        return v.transform(d.replace_merge_table_aliases)
 
     @property
     def data_hash_values(self) -> t.List[t.Optional[str]]:

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -444,7 +444,7 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
     )
     unique_key: SQLGlotListOfFields
     when_matched: t.Optional[exp.Whens] = None
-    incremental_predicates: t.Optional[exp.Expression] = None
+    merge_filters: t.Optional[exp.Expression] = None
     batch_concurrency: t.Literal[1] = 1
 
     @field_validator("when_matched", mode="before")
@@ -466,9 +466,9 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
 
         return t.cast(exp.Whens, v.transform(d.replace_table_references))
 
-    @field_validator("incremental_predicates", mode="before")
+    @field_validator("merge_filters", mode="before")
     @field_validator_v1_args
-    def _incremental_predicates_validator(
+    def _merge_filters_validator(
         cls,
         v: t.Optional[exp.Expression],
         values: t.Dict[str, t.Any],
@@ -489,7 +489,7 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
             *super().data_hash_values,
             *(gen(k) for k in self.unique_key),
             gen(self.when_matched) if self.when_matched is not None else None,
-            gen(self.incremental_predicates) if self.incremental_predicates is not None else None,
+            gen(self.merge_filters) if self.merge_filters is not None else None,
         ]
 
     def to_expression(
@@ -502,7 +502,7 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
                     {
                         "unique_key": exp.Tuple(expressions=self.unique_key),
                         "when_matched": self.when_matched,
-                        "incremental_predicates": self.incremental_predicates,
+                        "merge_filters": self.merge_filters,
                     }
                 ),
             ],

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -444,6 +444,7 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
     )
     unique_key: SQLGlotListOfFields
     when_matched: t.Optional[exp.Whens] = None
+    incremental_predicates: t.Optional[exp.Expression] = None
     batch_concurrency: t.Literal[1] = 1
 
     @field_validator("when_matched", mode="before")
@@ -453,17 +454,6 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
         v: t.Optional[t.Union[str, exp.Whens]],
         values: t.Dict[str, t.Any],
     ) -> t.Optional[exp.Whens]:
-        def replace_table_references(expression: exp.Expression) -> exp.Expression:
-            from sqlmesh.core.engine_adapter.base import MERGE_SOURCE_ALIAS, MERGE_TARGET_ALIAS
-
-            if isinstance(expression, exp.Column):
-                if expression.table.lower() == "target":
-                    expression.set("table", exp.to_identifier(MERGE_TARGET_ALIAS))
-                elif expression.table.lower() == "source":
-                    expression.set("table", exp.to_identifier(MERGE_SOURCE_ALIAS))
-
-            return expression
-
         if v is None:
             return v
         if isinstance(v, str):
@@ -474,7 +464,24 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
 
             return t.cast(exp.Whens, d.parse_one(v, into=exp.Whens, dialect=get_dialect(values)))
 
-        return t.cast(exp.Whens, v.transform(replace_table_references))
+        return t.cast(exp.Whens, v.transform(d.replace_table_references))
+
+    @field_validator("incremental_predicates", mode="before")
+    @field_validator_v1_args
+    def _incremental_predicates_validator(
+        cls,
+        v: t.Optional[exp.Expression],
+        values: t.Dict[str, t.Any],
+    ) -> t.Optional[exp.Expression]:
+        if v is None:
+            return v
+        if isinstance(v, str):
+            v = v.strip()
+            if v.startswith("("):
+                v = v[1:-1]
+            return d.parse_one(v, into=exp.Expression, dialect=get_dialect(values))
+
+        return v.transform(d.replace_table_references)
 
     @property
     def data_hash_values(self) -> t.List[t.Optional[str]]:
@@ -482,6 +489,7 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
             *super().data_hash_values,
             *(gen(k) for k in self.unique_key),
             gen(self.when_matched) if self.when_matched is not None else None,
+            gen(self.incremental_predicates) if self.incremental_predicates is not None else None,
         ]
 
     def to_expression(
@@ -494,6 +502,7 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
                     {
                         "unique_key": exp.Tuple(expressions=self.unique_key),
                         "when_matched": self.when_matched,
+                        "incremental_predicates": self.incremental_predicates,
                     }
                 ),
             ],

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -437,9 +437,9 @@ class ModelMeta(_Node):
         return None
 
     @property
-    def incremental_predicates(self) -> t.Optional[exp.Expression]:
+    def merge_filters(self) -> t.Optional[exp.Expression]:
         if isinstance(self.kind, IncrementalByUniqueKeyKind):
-            return self.kind.incremental_predicates
+            return self.kind.merge_filters
         return None
 
     @property

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -437,6 +437,12 @@ class ModelMeta(_Node):
         return None
 
     @property
+    def incremental_predicates(self) -> t.Optional[exp.Expression]:
+        if isinstance(self.kind, IncrementalByUniqueKeyKind):
+            return self.kind.incremental_predicates
+        return None
+
+    @property
     def catalog(self) -> t.Optional[str]:
         """Returns the catalog of a model."""
         return self.fully_qualified_table.catalog

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -437,9 +437,9 @@ class ModelMeta(_Node):
         return None
 
     @property
-    def merge_filters(self) -> t.Optional[exp.Expression]:
+    def merge_filter(self) -> t.Optional[exp.Expression]:
         if isinstance(self.kind, IncrementalByUniqueKeyKind):
-            return self.kind.merge_filters
+            return self.kind.merge_filter
         return None
 
     @property

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -1392,6 +1392,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
                 columns_to_types=model.columns_to_types,
                 unique_key=model.unique_key,
                 when_matched=model.when_matched,
+                incremental_predicates=model.incremental_predicates,
             )
 
     def append(
@@ -1407,6 +1408,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
             columns_to_types=model.columns_to_types,
             unique_key=model.unique_key,
             when_matched=model.when_matched,
+            incremental_predicates=model.incremental_predicates,
         )
 
 

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -1392,7 +1392,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
                 columns_to_types=model.columns_to_types,
                 unique_key=model.unique_key,
                 when_matched=model.when_matched,
-                merge_filters=model.merge_filters,
+                merge_filter=model.merge_filter,
             )
 
     def append(
@@ -1408,7 +1408,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
             columns_to_types=model.columns_to_types,
             unique_key=model.unique_key,
             when_matched=model.when_matched,
-            merge_filters=model.merge_filters,
+            merge_filter=model.merge_filter,
         )
 
 

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -1392,7 +1392,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
                 columns_to_types=model.columns_to_types,
                 unique_key=model.unique_key,
                 when_matched=model.when_matched,
-                incremental_predicates=model.incremental_predicates,
+                merge_filters=model.merge_filters,
             )
 
     def append(
@@ -1408,7 +1408,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
             columns_to_types=model.columns_to_types,
             unique_key=model.unique_key,
             when_matched=model.when_matched,
-            incremental_predicates=model.incremental_predicates,
+            merge_filters=model.merge_filters,
         )
 
 

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -294,6 +294,17 @@ class ModelConfig(BaseModelConfig):
                         f"{self.canonical_name(context)}: SQLMesh incremental by unique key strategy is not compatible with '{strategy}'"
                         f" incremental strategy. Supported strategies include {collection_to_str(INCREMENTAL_BY_UNIQUE_KEY_STRATEGIES)}."
                     )
+
+                if self.incremental_predicates:
+                    dialect = self.dialect(context)
+                    incremental_kind_kwargs["incremental_predicates"] = exp.and_(
+                        *[
+                            d.parse_one(predicate, dialect=dialect)
+                            for predicate in self.incremental_predicates
+                        ],
+                        dialect=dialect,
+                    ).transform(d.replace_table_references)
+
                 return IncrementalByUniqueKeyKind(
                     unique_key=self.unique_key,
                     disable_restatement=disable_restatement,

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -303,7 +303,7 @@ class ModelConfig(BaseModelConfig):
                             for predicate in self.incremental_predicates
                         ],
                         dialect=dialect,
-                    ).transform(d.replace_table_references)
+                    ).transform(d.replace_merge_table_aliases)
 
                 return IncrementalByUniqueKeyKind(
                     unique_key=self.unique_key,

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -297,7 +297,7 @@ class ModelConfig(BaseModelConfig):
 
                 if self.incremental_predicates:
                     dialect = self.dialect(context)
-                    incremental_kind_kwargs["incremental_predicates"] = exp.and_(
+                    incremental_kind_kwargs["merge_filters"] = exp.and_(
                         *[
                             d.parse_one(predicate, dialect=dialect)
                             for predicate in self.incremental_predicates

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -297,7 +297,7 @@ class ModelConfig(BaseModelConfig):
 
                 if self.incremental_predicates:
                     dialect = self.dialect(context)
-                    incremental_kind_kwargs["merge_filters"] = exp.and_(
+                    incremental_kind_kwargs["merge_filter"] = exp.and_(
                         *[
                             d.parse_one(predicate, dialect=dialect)
                             for predicate in self.incremental_predicates

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -1126,7 +1126,7 @@ MERGE INTO "target" AS "__MERGE_TARGET__" USING (
     )
 
 
-def test_merge_incremental_predicates(make_mocked_engine_adapter: t.Callable, assert_exp_eq):
+def test_merge_filters(make_mocked_engine_adapter: t.Callable, assert_exp_eq):
     adapter = make_mocked_engine_adapter(EngineAdapter)
 
     adapter.merge(
@@ -1159,7 +1159,7 @@ def test_merge_incremental_predicates(make_mocked_engine_adapter: t.Callable, as
                 )
             ]
         ),
-        incremental_predicates=exp.And(
+        merge_filters=exp.And(
             this=exp.GT(
                 this=exp.column("ID", "__MERGE_SOURCE__"),
                 expression=exp.Literal(this="0", is_string=False),

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -1126,7 +1126,7 @@ MERGE INTO "target" AS "__MERGE_TARGET__" USING (
     )
 
 
-def test_merge_filters(make_mocked_engine_adapter: t.Callable, assert_exp_eq):
+def test_merge_filter(make_mocked_engine_adapter: t.Callable, assert_exp_eq):
     adapter = make_mocked_engine_adapter(EngineAdapter)
 
     adapter.merge(
@@ -1159,7 +1159,7 @@ def test_merge_filters(make_mocked_engine_adapter: t.Callable, assert_exp_eq):
                 )
             ]
         ),
-        merge_filters=exp.And(
+        merge_filter=exp.And(
             this=exp.GT(
                 this=exp.column("ID", "__MERGE_SOURCE__"),
                 expression=exp.Literal(this="0", is_string=False),

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -2018,7 +2018,7 @@ def test_create_incremental_by_unique_key_updated_at_exp(adapter_mock, make_snap
             "updated_at": exp.DataType.build("TIMESTAMP"),
         },
         unique_key=[exp.to_column("id", quoted=True)],
-        incremental_predicates=None,
+        merge_filters=None,
         when_matched=exp.Whens(
             expressions=[
                 exp.When(
@@ -2083,7 +2083,7 @@ def test_create_incremental_by_unique_key_multiple_updated_at_exp(adapter_mock, 
             "updated_at": exp.DataType.build("TIMESTAMP"),
         },
         unique_key=[exp.to_column("id", quoted=True)],
-        incremental_predicates=None,
+        merge_filters=None,
         when_matched=exp.Whens(
             expressions=[
                 exp.When(
@@ -2176,7 +2176,7 @@ def test_create_incremental_by_unique_no_intervals(adapter_mock, make_snapshot):
     adapter_mock.columns.assert_called_once_with(snapshot.table_name())
 
 
-def test_create_incremental_by_unique_key_incremental_predicates(adapter_mock, make_snapshot):
+def test_create_incremental_by_unique_key_merge_filters(adapter_mock, make_snapshot):
     evaluator = SnapshotEvaluator(adapter_mock)
     model = load_sql_based_model(
         d.parse(
@@ -2185,7 +2185,7 @@ def test_create_incremental_by_unique_key_incremental_predicates(adapter_mock, m
                 name test_schema.test_model,
                 kind INCREMENTAL_BY_UNIQUE_KEY (
                     unique_key [id],
-                    incremental_predicates source.id > 0 and target.updated_at < TIMESTAMP("2020-02-05"),
+                    merge_filters source.id > 0 and target.updated_at < TIMESTAMP("2020-02-05"),
                     when_matched WHEN MATCHED THEN UPDATE SET target.updated_at = COALESCE(source.updated_at, target.updated_at),
                 )
             );
@@ -2232,7 +2232,7 @@ def test_create_incremental_by_unique_key_incremental_predicates(adapter_mock, m
                 )
             ]
         ),
-        incremental_predicates=exp.And(
+        merge_filters=exp.And(
             this=exp.GT(
                 this=exp.column("id", MERGE_SOURCE_ALIAS),
                 expression=exp.Literal(this="0", is_string=False),

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -2018,7 +2018,7 @@ def test_create_incremental_by_unique_key_updated_at_exp(adapter_mock, make_snap
             "updated_at": exp.DataType.build("TIMESTAMP"),
         },
         unique_key=[exp.to_column("id", quoted=True)],
-        merge_filters=None,
+        merge_filter=None,
         when_matched=exp.Whens(
             expressions=[
                 exp.When(
@@ -2083,7 +2083,7 @@ def test_create_incremental_by_unique_key_multiple_updated_at_exp(adapter_mock, 
             "updated_at": exp.DataType.build("TIMESTAMP"),
         },
         unique_key=[exp.to_column("id", quoted=True)],
-        merge_filters=None,
+        merge_filter=None,
         when_matched=exp.Whens(
             expressions=[
                 exp.When(
@@ -2176,7 +2176,7 @@ def test_create_incremental_by_unique_no_intervals(adapter_mock, make_snapshot):
     adapter_mock.columns.assert_called_once_with(snapshot.table_name())
 
 
-def test_create_incremental_by_unique_key_merge_filters(adapter_mock, make_snapshot):
+def test_create_incremental_by_unique_key_merge_filter(adapter_mock, make_snapshot):
     evaluator = SnapshotEvaluator(adapter_mock)
     model = load_sql_based_model(
         d.parse(
@@ -2185,7 +2185,7 @@ def test_create_incremental_by_unique_key_merge_filters(adapter_mock, make_snaps
                 name test_schema.test_model,
                 kind INCREMENTAL_BY_UNIQUE_KEY (
                     unique_key [id],
-                    merge_filters source.id > 0 and target.updated_at < TIMESTAMP("2020-02-05"),
+                    merge_filter source.id > 0 and target.updated_at < TIMESTAMP("2020-02-05"),
                     when_matched WHEN MATCHED THEN UPDATE SET target.updated_at = COALESCE(source.updated_at, target.updated_at),
                 )
             );
@@ -2232,7 +2232,7 @@ def test_create_incremental_by_unique_key_merge_filters(adapter_mock, make_snaps
                 )
             ]
         ),
-        merge_filters=exp.And(
+        merge_filter=exp.And(
             this=exp.GT(
                 this=exp.column("id", MERGE_SOURCE_ALIAS),
                 expression=exp.Literal(this="0", is_string=False),

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -134,7 +134,7 @@ def test_model_to_sqlmesh_fields():
     assert kind.lookback == 3
     assert kind.on_destructive_change == OnDestructiveChange.ALLOW
     assert (
-        kind.incremental_predicates.sql()
+        kind.merge_filters.sql()
         == "55 > __MERGE_SOURCE__.b AND __MERGE_TARGET__.session_start > DATEADD(day, -7, CURRENT_DATE)"
     )
 

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -134,7 +134,7 @@ def test_model_to_sqlmesh_fields():
     assert kind.lookback == 3
     assert kind.on_destructive_change == OnDestructiveChange.ALLOW
     assert (
-        kind.merge_filters.sql()
+        kind.merge_filter.sql()
         == "55 > __MERGE_SOURCE__.b AND __MERGE_TARGET__.session_start > DATEADD(day, -7, CURRENT_DATE)"
     )
 

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -94,6 +94,10 @@ def test_model_to_sqlmesh_fields():
         start="Jan 1 2023",
         partition_by=["a"],
         cluster_by=["a", '"b"'],
+        incremental_predicates=[
+            "55 > DBT_INTERNAL_SOURCE.b",
+            "DBT_INTERNAL_DEST.session_start > dateadd(day, -7, current_date)",
+        ],
         cron="@hourly",
         interval_unit="FIVE_MINUTE",
         batch_size=5,
@@ -129,6 +133,10 @@ def test_model_to_sqlmesh_fields():
     assert kind.batch_size == 5
     assert kind.lookback == 3
     assert kind.on_destructive_change == OnDestructiveChange.ALLOW
+    assert (
+        kind.incremental_predicates.sql()
+        == "55 > __MERGE_SOURCE__.b AND __MERGE_TARGET__.session_start > DATEADD(day, -7, CURRENT_DATE)"
+    )
 
     model = model_config.update_with({"dialect": "snowflake"}).to_sqlmesh(context)
     assert model.dialect == "snowflake"

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -179,13 +179,13 @@ def test_model_kind():
         unique_key=["bar"],
         incremental_strategy="merge",
         dialect="postgres",
-        incremental_predicates=[dbt_incremental_predicate],
+        merge_filters=[dbt_incremental_predicate],
     ).model_kind(context) == IncrementalByUniqueKeyKind(
         unique_key=["bar"],
         dialect="postgres",
         forward_only=True,
         disable_restatement=False,
-        incremental_predicates=expected_sqlmesh_predicate,
+        merge_filters=expected_sqlmesh_predicate,
     )
 
     assert ModelConfig(materialized=Materialization.INCREMENTAL, unique_key=["bar"]).model_kind(

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -179,13 +179,13 @@ def test_model_kind():
         unique_key=["bar"],
         incremental_strategy="merge",
         dialect="postgres",
-        merge_filters=[dbt_incremental_predicate],
+        merge_filter=[dbt_incremental_predicate],
     ).model_kind(context) == IncrementalByUniqueKeyKind(
         unique_key=["bar"],
         dialect="postgres",
         forward_only=True,
         disable_restatement=False,
-        merge_filters=expected_sqlmesh_predicate,
+        merge_filter=expected_sqlmesh_predicate,
     )
 
     assert ModelConfig(materialized=Materialization.INCREMENTAL, unique_key=["bar"]).model_kind(


### PR DESCRIPTION
This update introduces `merge_filters` in `INCREMENTAL_BY_UNIQUE_KEY` kind models and also adds support for dbt projects with `incremental_predicates`. It updates the incremental logic for engines that support the `MERGE` strategy, by incorporating ability to filter data during the merge operation.

When using this feature, both **source** and **target** aliases can be used to distinguish between the source and target columns similar to `WHEN MATCHED`.

### Example Model

```sql
MODEL (
    name db.test,
    kind INCREMENTAL_BY_UNIQUE_KEY (
        unique_key [purchase_order_id],
        merge_filters (
            source._operation <> 1 AND 
            target.start_date > DATEADD(day, -7, CURRENT_DATE)
        )
    )
);
```

The above predicates are then used into SQLMesh’s `MERGE` statements:

```sql
MERGE INTO <existing_table> AS "__MERGE_TARGET__"
    USING <temp_table> AS "__MERGE_SOURCE__"
    ON
        -- Unique key condition
        "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id"
        -- Custom incremental predicates to limit the data scan
        AND "__MERGE_SOURCE__"._operation <> 1
        AND "__MERGE_TARGET__".start_date > DATEADD(day, -7, CURRENT_DATE)
    WHEN MATCHED THEN 
        UPDATE ...
    WHEN NOT MATCHED THEN 
        INSERT ...
```

This support extends to an existing dbt project to be converted to the equivalent sqlmesh INCREMENTAL_BY_UNIQUE_KEY model, as it aligns with dbt’s **incremental predicates**.