### PR TITLE
Feat(dlt): Add support for generation of nested dlt tables

### DIFF
--- a/examples/sushi_dlt/sushi_pipeline.py
+++ b/examples/sushi_dlt/sushi_pipeline.py
@@ -30,6 +30,39 @@ def waiters() -> t.Iterator[t.Dict[str, t.Any]]:
     ]
 
 
+# Example menu table with nested fillings table
+@dlt.resource(name="sushi_menu", primary_key="id", write_disposition="merge")
+def sushi_menu() -> t.Iterator[t.Dict[str, t.Any]]:
+    yield from [
+        {
+            "id": 0,
+            "name": "Tobiko",
+            "fillings": ["Red Tobiko", "Black Tobiko", "Wasabi Tobiko", "Green Tobiko"],
+        },
+        {
+            "id": 1,
+            "name": "Sashimi",
+            "fillings": [
+                "Tuna Sashimi",
+                "Salmon Sashimi",
+                "Yellowtail Sashimi",
+                "Octopus Sashimi",
+                "Scallop Sashimi",
+            ],
+        },
+        {
+            "id": 2,
+            "name": "Maki",
+            "fillings": ["Cucumber", "Tuna", "Salmon", "Avocado", "Tempura Shrimp"],
+        },
+        {
+            "id": 3,
+            "name": "Temaki",
+            "fillings": ["Tuna Temaki", "Salmon Temaki", "Vegetable Temaki", "Ebi Temaki"],
+        },
+    ]
+
+
 # Run the pipeline
 p = dlt.pipeline(pipeline_name="sushi", destination="duckdb")
-info = p.run([sushi_types(), waiters()])
+info = p.run([sushi_types(), waiters(), sushi_menu()])

--- a/examples/sushi_dlt/sushi_pipeline.py
+++ b/examples/sushi_dlt/sushi_pipeline.py
@@ -30,7 +30,7 @@ def waiters() -> t.Iterator[t.Dict[str, t.Any]]:
     ]
 
 
-# Example menu table with nested fillings table
+# Example sushi menu table with extra one and two levels of nesting tables
 @dlt.resource(name="sushi_menu", primary_key="id", write_disposition="merge")
 def sushi_menu() -> t.Iterator[t.Dict[str, t.Any]]:
     yield from [
@@ -38,6 +38,12 @@ def sushi_menu() -> t.Iterator[t.Dict[str, t.Any]]:
             "id": 0,
             "name": "Tobiko",
             "fillings": ["Red Tobiko", "Black Tobiko", "Wasabi Tobiko", "Green Tobiko"],
+            "details": {
+                "preparation": "Raw",
+                "ingredients": ["Seaweed", "Rice", "Tobiko"],
+                "price": 12.99,
+                "spicy": False,
+            },
         },
         {
             "id": 1,
@@ -49,16 +55,34 @@ def sushi_menu() -> t.Iterator[t.Dict[str, t.Any]]:
                 "Octopus Sashimi",
                 "Scallop Sashimi",
             ],
+            "details": {
+                "preparation": "Raw",
+                "ingredients": ["Fish", "Soy Sauce", "Wasabi"],
+                "price": 19.99,
+                "spicy": False,
+            },
         },
         {
             "id": 2,
             "name": "Maki",
             "fillings": ["Cucumber", "Tuna", "Salmon", "Avocado", "Tempura Shrimp"],
+            "details": {
+                "preparation": "Rolled",
+                "ingredients": ["Seaweed", "Rice", "Fish", "Vegetables"],
+                "price": 14.99,
+                "spicy": True,
+            },
         },
         {
             "id": 3,
             "name": "Temaki",
             "fillings": ["Tuna Temaki", "Salmon Temaki", "Vegetable Temaki", "Ebi Temaki"],
+            "details": {
+                "preparation": "Hand Roll",
+                "ingredients": ["Seaweed", "Rice", "Fish", "Vegetables"],
+                "price": 10.99,
+                "spicy": True,
+            },
         },
     ]
 

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -958,6 +958,6 @@ def dlt_refresh(
     sqlmesh_models = generate_dlt_models(ctx.obj, pipeline, list(table or []), force)
     if sqlmesh_models:
         model_names = "\n".join([f"- {model_name}" for model_name in sqlmesh_models])
-        ctx.obj.console.log_success(f"Updatde SQLMesh project with models:\n{model_names}")
+        ctx.obj.console.log_success(f"Updated SQLMesh project with models:\n{model_names}")
     else:
         ctx.obj.console.log_success("All SQLMesh models are up to date.")

--- a/sqlmesh/integrations/dlt.py
+++ b/sqlmesh/integrations/dlt.py
@@ -61,8 +61,13 @@ def generate_dlt_models_and_settings(
             if col.get("primary_key"):
                 primary_key.append(str(col["name"]))
 
+        load_id = next(
+            (col for col in ["_dlt_load_id", "load_id", "_dlt_parent_id"] if col in dlt_columns),
+            None,
+        )
+
         column_types = [
-            exp.cast(column, data_type, dialect=dialect).as_(column).sql(dialect=dialect)
+            exp.cast("c." + column, data_type, dialect=dialect).as_(column).sql(dialect=dialect)
             for column, data_type in dlt_columns.items()
             if isinstance(column, str)
         ]
@@ -73,15 +78,32 @@ def generate_dlt_models_and_settings(
         grain = f"\n  grain ({', '.join(primary_key)})," if primary_key else ""
         incremental_model_name = f"{dataset}_sqlmesh.incremental_{table_name}"
 
-        incremental_model_sql = generate_incremental_model(
-            incremental_model_name,
-            select_columns,
-            grain,
-            dataset + "." + table_name,
-            dialect,
-        )
+        if load_id:
+            load_key = "c." + load_id
+            parent_table = None
 
-        sqlmesh_models.add((incremental_model_name, incremental_model_sql))
+            # Handling for nested tables: https://dlthub.com/docs/general-usage/destination-tables#nested-tables
+            if load_id == "_dlt_parent_id" and "_dlt_parent_id" in dlt_columns:
+                if parent_table := table["parent"]:
+                    if (
+                        parent_table in dlt_tables
+                        and "_dlt_id" in dlt_tables[parent_table]["columns"]
+                    ):
+                        load_key = "p._dlt_load_id"
+                        parent_table = dataset + "." + parent_table
+                    else:
+                        break
+
+            incremental_model_sql = generate_incremental_model(
+                incremental_model_name,
+                select_columns,
+                grain,
+                dataset + "." + table_name,
+                dialect,
+                load_key,
+                parent_table,
+            )
+            sqlmesh_models.add((incremental_model_name, incremental_model_sql))
 
     return sqlmesh_models, format_config(configs, db_type), get_start_date(storage_ids)
 
@@ -113,11 +135,21 @@ def generate_incremental_model(
     grain: str,
     from_table: str,
     dialect: str,
+    load_id: str,
+    parent_table: t.Optional[str] = None,
 ) -> str:
     """Generate the SQL definition for an incremental model."""
 
-    load_id = "load_id" if from_table.endswith("_dlt_loads") else "_dlt_load_id"
     time_column = parse_one(f"to_timestamp(CAST({load_id} AS DOUBLE))").sql(dialect=dialect)
+
+    join = (
+        f"""\nJOIN
+  {parent_table} as p
+ON
+  c._dlt_parent_id = p._dlt_id"""
+        if parent_table
+        else ""
+    )
 
     return f"""MODEL (
   name {model_name},
@@ -130,7 +162,7 @@ SELECT
 {select_columns},
   {time_column} as _dlt_load_time
 FROM
-  {from_table}
+  {from_table} as c{join}
 WHERE
   {time_column} BETWEEN @start_ds AND @end_ds
 """

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -812,20 +812,21 @@ model_defaults:
 );
 
 SELECT
-  CAST(id AS BIGINT) AS id,
-  CAST(name AS TEXT) AS name,
-  CAST(_dlt_load_id AS TEXT) AS _dlt_load_id,
-  CAST(_dlt_id AS TEXT) AS _dlt_id,
-  TO_TIMESTAMP(CAST(_dlt_load_id AS DOUBLE)) as _dlt_load_time
+  CAST(c.id AS BIGINT) AS id,
+  CAST(c.name AS TEXT) AS name,
+  CAST(c._dlt_load_id AS TEXT) AS _dlt_load_id,
+  CAST(c._dlt_id AS TEXT) AS _dlt_id,
+  TO_TIMESTAMP(CAST(c._dlt_load_id AS DOUBLE)) as _dlt_load_time
 FROM
-  sushi_dataset.sushi_types
+  sushi_dataset.sushi_types as c
 WHERE
-  TO_TIMESTAMP(CAST(_dlt_load_id AS DOUBLE)) BETWEEN @start_ds AND @end_ds
+  TO_TIMESTAMP(CAST(c._dlt_load_id AS DOUBLE)) BETWEEN @start_ds AND @end_ds
 """
 
     dlt_sushi_types_model_path = tmp_path / "models/incremental_sushi_types.sql"
     dlt_loads_model_path = tmp_path / "models/incremental__dlt_loads.sql"
     dlt_waiters_model_path = tmp_path / "models/incremental_waiters.sql"
+    dlt_sushi_fillings_model_path = tmp_path / "models/incremental_sushi_menu__fillings.sql"
 
     with open(dlt_sushi_types_model_path) as file:
         incremental_model = file.read()
@@ -838,20 +839,47 @@ WHERE
 );
 
 SELECT
-  CAST(load_id AS TEXT) AS load_id,
-  CAST(schema_name AS TEXT) AS schema_name,
-  CAST(status AS BIGINT) AS status,
-  CAST(inserted_at AS TIMESTAMP) AS inserted_at,
-  CAST(schema_version_hash AS TEXT) AS schema_version_hash,
-  TO_TIMESTAMP(CAST(load_id AS DOUBLE)) as _dlt_load_time
+  CAST(c.load_id AS TEXT) AS load_id,
+  CAST(c.schema_name AS TEXT) AS schema_name,
+  CAST(c.status AS BIGINT) AS status,
+  CAST(c.inserted_at AS TIMESTAMP) AS inserted_at,
+  CAST(c.schema_version_hash AS TEXT) AS schema_version_hash,
+  TO_TIMESTAMP(CAST(c.load_id AS DOUBLE)) as _dlt_load_time
 FROM
-  sushi_dataset._dlt_loads
+  sushi_dataset._dlt_loads as c
 WHERE
-  TO_TIMESTAMP(CAST(load_id AS DOUBLE)) BETWEEN @start_ds AND @end_ds
+  TO_TIMESTAMP(CAST(c.load_id AS DOUBLE)) BETWEEN @start_ds AND @end_ds
 """
 
     with open(dlt_loads_model_path) as file:
         dlt_loads_model = file.read()
+
+    expected_nested_fillings_model = """MODEL (
+  name sushi_dataset_sqlmesh.incremental_sushi_menu__fillings,
+  kind INCREMENTAL_BY_TIME_RANGE (
+    time_column _dlt_load_time,
+  ),
+);
+
+SELECT
+  CAST(c.value AS TEXT) AS value,
+  CAST(c._dlt_root_id AS TEXT) AS _dlt_root_id,
+  CAST(c._dlt_parent_id AS TEXT) AS _dlt_parent_id,
+  CAST(c._dlt_list_idx AS BIGINT) AS _dlt_list_idx,
+  CAST(c._dlt_id AS TEXT) AS _dlt_id,
+  TO_TIMESTAMP(CAST(p._dlt_load_id AS DOUBLE)) as _dlt_load_time
+FROM
+  sushi_dataset.sushi_menu__fillings as c
+JOIN
+  sushi_dataset.sushi_menu as p
+ON
+  c._dlt_parent_id = p._dlt_id
+WHERE
+  TO_TIMESTAMP(CAST(p._dlt_load_id AS DOUBLE)) BETWEEN @start_ds AND @end_ds
+"""
+
+    with open(dlt_sushi_fillings_model_path) as file:
+        nested_model = file.read()
 
     # Validate generated config and models
     assert config == expected_config
@@ -860,6 +888,7 @@ WHERE
     assert dlt_waiters_model_path.exists()
     assert dlt_loads_model == expected_dlt_loads_model
     assert incremental_model == expected_incremental_model
+    assert nested_model == expected_nested_fillings_model
 
     # Plan prod and backfill
     result = runner.invoke(
@@ -884,6 +913,7 @@ WHERE
     remove(dlt_waiters_model_path)
     remove(dlt_loads_model_path)
     remove(dlt_sushi_types_model_path)
+    remove(dlt_sushi_fillings_model_path)
 
     # Update to generate a specific model: sushi_types
     assert generate_dlt_models(context, "sushi", ["sushi_types"], False) == [
@@ -893,6 +923,7 @@ WHERE
     # Only the sushi_types should be generated now
     assert not dlt_waiters_model_path.exists()
     assert not dlt_loads_model_path.exists()
+    assert not dlt_sushi_fillings_model_path.exists()
     assert dlt_sushi_types_model_path.exists()
 
     # Update with force = True will generate all models and overwrite existing ones
@@ -900,5 +931,6 @@ WHERE
     assert dlt_loads_model_path.exists()
     assert dlt_sushi_types_model_path.exists()
     assert dlt_waiters_model_path.exists()
+    assert dlt_sushi_fillings_model_path.exists()
 
     remove(dataset_path)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -827,6 +827,9 @@ WHERE
     dlt_loads_model_path = tmp_path / "models/incremental__dlt_loads.sql"
     dlt_waiters_model_path = tmp_path / "models/incremental_waiters.sql"
     dlt_sushi_fillings_model_path = tmp_path / "models/incremental_sushi_menu__fillings.sql"
+    dlt_sushi_twice_nested_model_path = (
+        tmp_path / "models/incremental_sushi_menu__details__ingredients.sql"
+    )
 
     with open(dlt_sushi_types_model_path) as file:
         incremental_model = file.read()
@@ -886,6 +889,8 @@ WHERE
     assert dlt_loads_model_path.exists()
     assert dlt_sushi_types_model_path.exists()
     assert dlt_waiters_model_path.exists()
+    assert dlt_sushi_fillings_model_path.exists()
+    assert dlt_sushi_twice_nested_model_path.exists()
     assert dlt_loads_model == expected_dlt_loads_model
     assert incremental_model == expected_incremental_model
     assert nested_model == expected_nested_fillings_model
@@ -914,6 +919,7 @@ WHERE
     remove(dlt_loads_model_path)
     remove(dlt_sushi_types_model_path)
     remove(dlt_sushi_fillings_model_path)
+    remove(dlt_sushi_twice_nested_model_path)
 
     # Update to generate a specific model: sushi_types
     assert generate_dlt_models(context, "sushi", ["sushi_types"], False) == [
@@ -924,6 +930,7 @@ WHERE
     assert not dlt_waiters_model_path.exists()
     assert not dlt_loads_model_path.exists()
     assert not dlt_sushi_fillings_model_path.exists()
+    assert not dlt_sushi_twice_nested_model_path.exists()
     assert dlt_sushi_types_model_path.exists()
 
     # Update with force = True will generate all models and overwrite existing ones
@@ -932,5 +939,6 @@ WHERE
     assert dlt_sushi_types_model_path.exists()
     assert dlt_waiters_model_path.exists()
     assert dlt_sushi_fillings_model_path.exists()
+    assert dlt_sushi_twice_nested_model_path.exists()
 
     remove(dataset_path)


### PR DESCRIPTION
This is an update to the dlt integration and adds support for [nested DLT tables](https://dlthub.com/docs/general-usage/destination-tables#nested-tables), fixes: #3545 

- Each row in all (root and nested) data tables created by dlt contains a unique column named _dlt_id (row key), but only parent tables contain the `_dlt_load_id`. 
- Since each dlt nested table contains a column named `_dlt_parent_id` referencing a particular row (`_dlt_id`) of a parent table (parent key), this is used to join and get the parent `_dlt_load_id` to be used for the incremental model.