### PR TITLE
Chore!: Disable date prompts by default when running the plan command

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -69,7 +69,7 @@ Configuration for the `sqlmesh plan` command.
 | `forward_only`            | Indicates whether the plan should be [forward-only](../concepts/plans.md#forward-only-plans) (Default: False)                                                                                                                                           |       boolean        |    N     |
 | `enable_preview`          | Indicates whether to enable [data preview](../concepts/plans.md#data-preview) for forward-only models when targeting a development environment (Default: False)                                                                                         |       boolean        |    N     |
 | `no_diff`                 | Don't show diffs for changed models (Default: False)                                                                                                                                                                                                    |       boolean        |    N     |
-| `no_prompts`              | Disables interactive prompts in CLI (Default: False)                                                                                                                                                                                                    |       boolean        |    N     |
+| `no_prompts`              | Disables interactive prompts in CLI (Default: True)                                                                                                                                                                                                    |       boolean        |    N     |
 
 ## Run
 

--- a/sqlmesh/core/config/plan.py
+++ b/sqlmesh/core/config/plan.py
@@ -14,7 +14,7 @@ class PlanConfig(BaseConfig):
         include_unmodified: Whether to include unmodified models in the target development environment.
         enable_preview: Whether to enable preview for forward-only models in development environments.
         no_diff: Hide text differences for changed models.
-        no_prompts: Whether to disable interactive prompts for the backfill time range. Please note that
+        no_prompts: Whether to disable interactive prompts for the backfill time range.
         auto_apply: Whether to automatically apply the new plan after creation.
         use_finalized_state: Whether to compare against the latest finalized environment state, or to use
             whatever state the target environment is currently in.
@@ -25,6 +25,6 @@ class PlanConfig(BaseConfig):
     include_unmodified: bool = False
     enable_preview: bool = False
     no_diff: bool = False
-    no_prompts: bool = False
+    no_prompts: bool = True
     auto_apply: bool = False
     use_finalized_state: bool = False

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -692,10 +692,9 @@ class TerminalConsole(Console):
             default_catalog=default_catalog,
         )
 
-        if not no_prompts:
-            self._show_options_after_categorization(
-                plan_builder, auto_apply, default_catalog=default_catalog
-            )
+        self._show_options_after_categorization(
+            plan_builder, auto_apply, default_catalog=default_catalog, no_prompts=no_prompts
+        )
 
         if auto_apply:
             plan_builder.apply()
@@ -780,15 +779,27 @@ class TerminalConsole(Console):
         self._print(tree)
 
     def _show_options_after_categorization(
-        self, plan_builder: PlanBuilder, auto_apply: bool, default_catalog: t.Optional[str]
+        self,
+        plan_builder: PlanBuilder,
+        auto_apply: bool,
+        default_catalog: t.Optional[str],
+        no_prompts: bool,
     ) -> None:
         plan = plan_builder.build()
-        if plan.forward_only and plan.new_snapshots:
+        if not no_prompts and plan.forward_only and plan.new_snapshots:
             self._prompt_effective_from(plan_builder, auto_apply, default_catalog)
 
         if plan.requires_backfill:
             self._show_missing_dates(plan_builder.build(), default_catalog)
-            self._prompt_backfill(plan_builder, auto_apply, default_catalog)
+
+            if not no_prompts:
+                self._prompt_backfill(plan_builder, auto_apply, default_catalog)
+
+            backfill_or_preview = "preview" if plan.is_dev and plan.forward_only else "backfill"
+            if not auto_apply and self._confirm(
+                f"Apply - {backfill_or_preview.capitalize()} Tables"
+            ):
+                plan_builder.apply()
         elif plan.has_changes and not auto_apply:
             self._prompt_promote(plan_builder)
         elif plan.has_unmodified_unpromoted and not auto_apply:
@@ -933,6 +944,9 @@ class TerminalConsole(Console):
             if not plan_builder.override_end:
                 if plan.provided_end:
                     blank_meaning = f"'{time_like_to_str(plan.provided_end)}'"
+                elif plan.interval_end_per_model:
+                    max_end = max(plan.interval_end_per_model.values())
+                    blank_meaning = f"'{time_like_to_str(max_end)}'"
                 else:
                     blank_meaning = "now"
                 end = self._prompt(
@@ -942,9 +956,6 @@ class TerminalConsole(Console):
                     plan_builder.set_end(end)
 
             plan = plan_builder.build()
-
-        if not auto_apply and self._confirm(f"Apply - {backfill_or_preview.capitalize()} Tables"):
-            plan_builder.apply()
 
     def _prompt_promote(self, plan_builder: PlanBuilder) -> None:
         if self._confirm(
@@ -1286,13 +1297,18 @@ class NotebookMagicConsole(TerminalConsole):
 
         def effective_from_change_callback(change: t.Dict[str, datetime.datetime]) -> None:
             plan_builder.set_effective_from(change["new"])
-            self._show_options_after_categorization(plan_builder, auto_apply, default_catalog)
+            self._show_options_after_categorization(
+                plan_builder, auto_apply, default_catalog, no_prompts=False
+            )
 
         def going_forward_change_callback(change: t.Dict[str, bool]) -> None:
             checked = change["new"]
             plan_builder.set_effective_from(None if checked else yesterday_ds())
             self._show_options_after_categorization(
-                plan_builder, auto_apply=auto_apply, default_catalog=default_catalog
+                plan_builder,
+                auto_apply=auto_apply,
+                default_catalog=default_catalog,
+                no_prompts=False,
             )
 
         date_picker = widgets.DatePicker(
@@ -1350,11 +1366,15 @@ class NotebookMagicConsole(TerminalConsole):
 
         def start_change_callback(change: t.Dict[str, datetime.datetime]) -> None:
             plan_builder.set_start(change["new"])
-            self._show_options_after_categorization(plan_builder, auto_apply, default_catalog)
+            self._show_options_after_categorization(
+                plan_builder, auto_apply, default_catalog, no_prompts=False
+            )
 
         def end_change_callback(change: t.Dict[str, datetime.datetime]) -> None:
             plan_builder.set_end(change["new"])
-            self._show_options_after_categorization(plan_builder, auto_apply, default_catalog)
+            self._show_options_after_categorization(
+                plan_builder, auto_apply, default_catalog, no_prompts=False
+            )
 
         if plan_builder.is_start_and_end_allowed:
             add_to_layout_widget(
@@ -1402,11 +1422,17 @@ class NotebookMagicConsole(TerminalConsole):
             button.output = output
 
     def _show_options_after_categorization(
-        self, plan_builder: PlanBuilder, auto_apply: bool, default_catalog: t.Optional[str]
+        self,
+        plan_builder: PlanBuilder,
+        auto_apply: bool,
+        default_catalog: t.Optional[str],
+        no_prompts: bool,
     ) -> None:
         self.dynamic_options_after_categorization_output.children = ()
         self.display(self.dynamic_options_after_categorization_output)
-        super()._show_options_after_categorization(plan_builder, auto_apply, default_catalog)
+        super()._show_options_after_categorization(
+            plan_builder, auto_apply, default_catalog, no_prompts
+        )
 
     def _add_to_dynamic_options(self, *widgets: widgets.Widget) -> None:
         add_to_layout_widget(self.dynamic_options_after_categorization_output, *widgets)
@@ -1431,7 +1457,9 @@ class NotebookMagicConsole(TerminalConsole):
 
         def radio_button_selected(change: t.Dict[str, t.Any]) -> None:
             plan_builder.set_choice(snapshot, choices[change["owner"].index])
-            self._show_options_after_categorization(plan_builder, auto_apply, default_catalog)
+            self._show_options_after_categorization(
+                plan_builder, auto_apply, default_catalog, no_prompts=False
+            )
 
         radio = widgets.RadioButtons(
             options=choice_mapping.values(),

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -51,6 +51,9 @@ default_gateway: local
 
 model_defaults:
   dialect: duckdb
+
+plan:
+  no_prompts: false
 """
         )
 
@@ -442,13 +445,11 @@ def test_plan_dev_bad_create_from(runner, tmp_path):
 def test_plan_dev_no_prompts(runner, tmp_path):
     create_example_project(tmp_path)
 
-    # plan for non-prod environment doesn't prompt to apply and doesn't
-    # backfill if only `--no-prompts` is passed
+    # plan for non-prod environment doesn't prompt for dates but prompts to apply
     result = runner.invoke(
         cli, ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "dev", "--no-prompts"]
     )
-    assert result.exit_code == 0
-    assert "Apply - Backfill Tables [y/n]: " not in result.output
+    assert "Apply - Backfill Tables [y/n]: " in result.output
     assert "All model versions have been created successfully" not in result.output
     assert "All model batches have been executed successfully" not in result.output
     assert "The target environment has been updated successfully" not in result.output

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -1647,14 +1647,13 @@ def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
         )
 
     # Ensure that the plan has been applied successfully.
-    no_change_plan: Plan = context.plan(
+    no_change_plan: Plan = context.plan_builder(
         environment="test_dev",
         start=start,
         end=end,
         skip_tests=True,
-        no_prompts=True,
         include_unmodified=True,
-    )
+    ).build()
     assert not no_change_plan.requires_backfill
     assert no_change_plan.context_diff.is_new_environment
 
@@ -1769,12 +1768,11 @@ def test_init_project(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory
     assert len(physical_layer_results.tables) == len(physical_layer_results.non_temp_tables) == 3
 
     # make and validate unmodified dev environment
-    no_change_plan: Plan = context.plan(
+    no_change_plan: Plan = context.plan_builder(
         environment="test_dev",
         skip_tests=True,
-        no_prompts=True,
         include_unmodified=True,
-    )
+    ).build()
     assert not no_change_plan.requires_backfill
     assert no_change_plan.context_diff.is_new_environment
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -844,9 +844,9 @@ def test_plan_default_end(sushi_context_pre_scheduling: Context):
     assert dev_plan.end is not None
     assert to_date(make_inclusive_end(dev_plan.end)) == plan_end
 
-    forward_only_dev_plan = sushi_context_pre_scheduling.plan(
-        "test_env_forward_only", no_prompts=True, include_unmodified=True, forward_only=True
-    )
+    forward_only_dev_plan = sushi_context_pre_scheduling.plan_builder(
+        "test_env_forward_only", include_unmodified=True, forward_only=True
+    ).build()
     assert forward_only_dev_plan.end is not None
     assert to_date(make_inclusive_end(forward_only_dev_plan.end)) == plan_end
     assert forward_only_dev_plan.start == plan_end
@@ -1187,6 +1187,6 @@ def test_requirements(copy_to_temp_path: t.Callable):
 
     context._requirements = {"numpy": "2.1.2", "pandas": "2.2.1"}
     context._excluded_requirements = {"ipywidgets", "ruamel.yaml", "ruamel.yaml.clib"}
-    diff = context.plan("dev", no_prompts=True, skip_tests=True, skip_backfill=True).context_diff
+    diff = context.plan_builder("dev", skip_tests=True, skip_backfill=True).build().context_diff
     assert set(diff.previous_requirements) == requirements
     assert set(diff.requirements) == {"numpy", "pandas"}


### PR DESCRIPTION
The default settings for the start and the end date are good enough that it should satisfy the vast majority of use cases. This should simplify the UX since it's one less thing for users to think about.

In addition to being `true` by default, the `no_prompts` flag has the following behavioral changes:
* Change categories are now printed
* Expected backfill dates are now printed
* SQLMesh prompts for confirmation to apply the plan unless the `--auto-apply` flag is specified. Previously, `no_prompts` also suppressed the confirmation prompt