### PR TITLE
Fix: Support nested variables in dbt projects

### DIFF
--- a/sqlmesh/dbt/project.py
+++ b/sqlmesh/dbt/project.py
@@ -56,9 +56,6 @@ class Project:
 
         variable_overrides = variables
         variables = {**project_yaml.get("vars", {}), **(variables or {})}
-        global_variables = {
-            name: var for name, var in variables.items() if not isinstance(var, dict)
-        }
 
         project_name = context.render(project_yaml.get("name", ""))
         context.project_name = project_name
@@ -107,7 +104,7 @@ class Project:
             if isinstance(package_vars, dict):
                 package.variables.update(package_vars)
 
-            package.variables.update(global_variables)
+            package.variables.update(variables)
 
         return Project(context, profile, packages)
 

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -354,6 +354,18 @@ def test_variables(assert_exp_eq, sushi_test_project):
         "top_waiters:limit": 10,
         "top_waiters:revenue": "revenue",
         "customers:boo": ["a", "b"],
+        "nested_vars": {
+            "some_nested_var": 2,
+        },
+        "list_var": [
+            {"name": "item1", "value": 1},
+            {"name": "item2", "value": 2},
+        ],
+        "customers": {
+            "customers:bla": False,
+            "customers:customer_id": "customer_id",
+            "some_var": ["foo", "bar"],
+        },
     }
     expected_customer_variables = {
         "some_var": ["foo", "bar"],
@@ -365,10 +377,32 @@ def test_variables(assert_exp_eq, sushi_test_project):
         "top_waiters:limit": 10,
         "top_waiters:revenue": "revenue",
         "customers:boo": ["a", "b"],
+        "nested_vars": {
+            "some_nested_var": 2,
+        },
+        "list_var": [
+            {"name": "item1", "value": 1},
+            {"name": "item2", "value": 2},
+        ],
+        "customers": {
+            "customers:bla": False,
+            "customers:customer_id": "customer_id",
+            "some_var": ["foo", "bar"],
+        },
     }
 
     assert sushi_test_project.packages["sushi"].variables == expected_sushi_variables
     assert sushi_test_project.packages["customers"].variables == expected_customer_variables
+
+
+def test_nested_variables(sushi_test_project):
+    model_config = ModelConfig(
+        alias="sushi.test_nested",
+        sql="SELECT {{ var('nested_vars')['some_nested_var'] }}",
+        dependencies=Dependencies(variables=["nested_vars"]),
+    )
+    sqlmesh_model = model_config.to_sqlmesh(sushi_test_project.context)
+    assert sqlmesh_model.jinja_macros.global_objs["vars"]["nested_vars"] == {"some_nested_var": 2}
 
 
 def test_source_config(sushi_test_project: Project):

--- a/tests/dbt/test_manifest.py
+++ b/tests/dbt/test_manifest.py
@@ -85,7 +85,7 @@ def test_manifest_helper(caplog):
             MacroReference(name="source"),
         },
         sources={"streaming.items", "streaming.orders", "streaming.order_items"},
-        variables={"yet_another_var"},
+        variables={"yet_another_var", "nested_vars"},
     )
     assert waiter_revenue_by_day_config.materialized == "incremental"
     assert waiter_revenue_by_day_config.incremental_strategy == "delete+insert"

--- a/tests/fixtures/dbt/sushi_test/dbt_project.yml
+++ b/tests/fixtures/dbt/sushi_test/dbt_project.yml
@@ -48,3 +48,12 @@ vars:
     some_var: ["foo", "bar"]
     'customers:bla': false
     'customers:customer_id': "customer_id"
+
+  nested_vars:
+    some_nested_var: 2
+
+  list_var:
+    - name: 'item1'
+      value: 1
+    - name: 'item2'
+      value: 2

--- a/tests/fixtures/dbt/sushi_test/macros/test_dependencies.sql
+++ b/tests/fixtures/dbt/sushi_test/macros/test_dependencies.sql
@@ -4,4 +4,5 @@
 
 {% macro nested_test_dependencies() %}
     {{ log(var("yet_another_var", 2)) }}
+    {{ log(var("nested_vars")['some_nested_var']) }}
 {% endmacro %}


### PR DESCRIPTION
This adds support for nested variables defined as:
```
vars:
  nested_vars:
    some_nested_var: 2
```