### PR TITLE
Docs: Minor updates

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,19 +60,6 @@ Other extras are required to use specific SQL engines, like Bigquery or Postgres
 
 Multiple extras can be installed at once, as in `pip install "sqlmesh[web,slack]"`.
 
-## Pydantic v2
-SQLMesh supports Pydantic v2, but since v2 is relatively new, v1 is the version installed by default. If you would like to use Pydantic v2, you can by installing it after installing SQLMesh.
-
-```bash
-pip install --upgrade pydantic
-```
-
-Pip may issue a warning about dependency conflicts, but SQLMesh should still function fine. Furthermore, if you are using the SQLMesh UI, you will also need to install pydantic-settings.
-
-```bash
-pip install --upgrade pydantic-settings
-```
-
 ## Next steps
 
 Now that you've installed SQLMesh, it's time to get started with the SQLMesh example project.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -6,6 +6,7 @@ The example project runs locally on your machine with a DuckDB SQL engine, and S
 
 All you need to do is install SQLMesh on your machine - get started by ensuring your system meets the basic [prerequisites for using SQLMesh](./prerequisites.md).
 
+Head over to the [CLI Quickstart](./quickstart/cli.md) or check out the video below. 
 
 ## Video Quickstart
 
@@ -13,4 +14,4 @@ This video walks through the quickstart installation, setup, and creating your f
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/weJH3eM0rzc?si=C70me05Lv0zUlpIy" title="YouTube video player" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-If you're ready to keep going after your first plan, head over to the [CLI Quickstart](./quickstart/cli.md#3-update-a-model) to start modifying the project's models.
+If you're ready to keep going after your first plan, head over to the [CLI Quickstart Step 3](./quickstart/cli.md#3-update-a-model) to start modifying the project's models.

--- a/docs/quickstart/cli.md
+++ b/docs/quickstart/cli.md
@@ -1,6 +1,6 @@
 # CLI
 
-In this quick start guide, you'll use the SQLMesh command line interface (CLI) to get up and running with SQLMesh's scaffold generator. This example project will run locally on your computer using [DuckDB](https://duckdb.org/) as an embedded SQL engine.
+In this quickstart, you'll use the SQLMesh command line interface (CLI) to get up and running with SQLMesh's scaffold generator. This example project will run locally on your computer using [DuckDB](https://duckdb.org/) as an embedded SQL engine.
 
 Before beginning, ensure that you meet all the [prerequisites](../prerequisites.md) for using SQLMesh.
 

--- a/docs/quickstart/notebook.md
+++ b/docs/quickstart/notebook.md
@@ -1,6 +1,6 @@
 # Notebook
 
-In this quick start guide, you'll use the SQLMesh notebook interface to get up and running with SQLMesh's scaffold generator. This example project will run locally on your computer using [DuckDB](https://duckdb.org/) as an embedded SQL engine.
+In this quickstart, you'll use the SQLMesh notebook interface to get up and running with SQLMesh's scaffold generator. This example project will run locally on your computer using [DuckDB](https://duckdb.org/) as an embedded SQL engine.
 
 Before beginning, ensure that you meet all the [prerequisites](../prerequisites.md) for using SQLMesh.
 

--- a/docs/quickstart/ui.md
+++ b/docs/quickstart/ui.md
@@ -1,6 +1,6 @@
 # Browser UI
 
-In this quick start guide, you'll use the SQLMesh browser user interface to get up and running with SQLMesh's scaffold generator. This example project will run locally on your computer using [DuckDB](https://duckdb.org/) as an embedded SQL engine.
+In this quickstart, you'll use the SQLMesh browser user interface to get up and running with SQLMesh's scaffold generator. This example project will run locally on your computer using [DuckDB](https://duckdb.org/) as an embedded SQL engine.
 
 ??? info "Learn more about the quickstart project structure"
     This project demonstrates key SQLMesh features by walking through the SQLMesh workflow on a simple data pipeline. This section describes the project structure and the SQLMesh concepts you will encounter as you work through it.

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -24,9 +24,9 @@ import sqlmesh
 %context path_to_sqlmesh_project
 ```
 
-### Quick start project
+### Quickstart project
 
-If desired, you can create the [quick start example project](../quick_start.md) with the Python `init_example_project` function. The function requires a default SQL dialect for the project's models; this example uses `snowflake`:
+If desired, you can create the [quickstart example project](../quick_start.md) with the Python `init_example_project` function. The function requires a default SQL dialect for the project's models; this example uses `snowflake`:
 
 ```python
 from sqlmesh.cli.example_project import init_example_project


### PR DESCRIPTION
Minor changes:
- Removes Pydantic V2 information from installation docks, made outdated by #3548 
- Adds a link to go straight to the CLI quickstart instead of watching the video quickstart.
- Quickstart is spelled two different ways. This standardizes it to "Quickstart".