### PR TITLE
Fix: Show diff for metadata changes in the plan output

### DIFF
--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -108,7 +108,7 @@ class Plan(PydanticModel, frozen=True):
         """Returns the already categorized snapshots."""
         return [
             self.context_diff.snapshots[s_id]
-            for s_id in sorted(self.directly_modified)
+            for s_id in sorted({*self.directly_modified, *self.metadata_updated})
             if self.context_diff.snapshots[s_id].version
         ]
 
@@ -136,6 +136,15 @@ class Plan(PydanticModel, frozen=True):
                 for s_id in sorted(downstream_s_ids)
             },
             **self.context_diff.removed_snapshots,
+            **{s_id: self.context_diff.snapshots[s_id] for s_id in sorted(self.metadata_updated)},
+        }
+
+    @cached_property
+    def metadata_updated(self) -> t.Set[SnapshotId]:
+        return {
+            snapshot.snapshot_id
+            for snapshot, _ in self.context_diff.modified_snapshots.values()
+            if self.context_diff.metadata_updated(snapshot.name)
         }
 
     @property


### PR DESCRIPTION
Previously, the diff for metadata changes wasn't printed in the plan output. This updates makes it so that diff is printed unless the --no-diff flag was provided.