### PR TITLE
Fix: Always create views in the virtual layer for expired environments

### DIFF
--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -325,7 +325,11 @@ class EngineAdapterStateSync(StateSync):
         }
 
         added_table_infos = set(table_infos.values())
-        if existing_environment and existing_environment.finalized_ts:
+        if (
+            existing_environment
+            and existing_environment.finalized_ts
+            and not existing_environment.expiration_ts
+        ):
             # Only promote new snapshots.
             added_table_infos -= set(existing_environment.promoted_snapshots)
 

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -870,6 +870,7 @@ def test_promote_environment_expired(state_sync: EngineAdapterStateSync, make_sn
 
     state_sync.push_snapshots([snapshot])
     promote_snapshots(state_sync, [snapshot], "dev")
+    state_sync.finalize(state_sync.get_environment("dev"))
     state_sync.invalidate_environment("dev")
 
     new_environment = Environment(
@@ -882,7 +883,10 @@ def test_promote_environment_expired(state_sync: EngineAdapterStateSync, make_sn
     )
 
     # This call shouldn't fail.
-    state_sync.promote(new_environment)
+    promotion_result = state_sync.promote(new_environment)
+    assert promotion_result.added == [snapshot.table_info]
+    assert promotion_result.removed == []
+    assert promotion_result.removed_environment_naming_info is None
 
 
 def test_promote_snapshots_no_gaps(state_sync: EngineAdapterStateSync, make_snapshot: t.Callable):


### PR DESCRIPTION
This ensures that SQLMesh always recreates views for environments that have been invalidated (soft delete) but which haven't been garbage collected by the janitor process.