### PR TITLE
Fix!: Models with allow_partials set to true should respect cron

### DIFF
--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -35,7 +35,6 @@ from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.date import (
     TimeLike,
     format_tz_datetime,
-    now,
     now_timestamp,
     to_timestamp,
     validate_date_range,
@@ -143,9 +142,9 @@ class Scheduler:
         snapshots_to_intervals = compute_interval_params(
             snapshots,
             start=start or earliest_start_date(snapshots),
-            end=end or now(),
+            end=end or now_timestamp(),
             deployability_index=deployability_index,
-            execution_time=execution_time or now(),
+            execution_time=execution_time or now_timestamp(),
             restatements=restatements,
             interval_end_per_model=interval_end_per_model,
             ignore_cron=ignore_cron,
@@ -290,7 +289,7 @@ class Scheduler:
             if environment_naming_info.name != c.PROD
             else DeployabilityIndex.all_deployable()
         )
-        execution_time = execution_time or now()
+        execution_time = execution_time or now_timestamp()
 
         self.state_sync.refresh_snapshot_intervals(self.snapshots.values())
         if auto_restatement_enabled:
@@ -435,7 +434,7 @@ class Scheduler:
         Returns:
             A tuple of errors and skipped intervals.
         """
-        execution_time = execution_time or now()
+        execution_time = execution_time or now_timestamp()
 
         batched_intervals = self.batch_intervals(merged_intervals, start, end, execution_time)
 

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -712,7 +712,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
                 When previewing, we are not actually restating a model, but removing an interval to trigger
                 a run.
         """
-        end = execution_time or now() if self.depends_on_past else end
+        end = execution_time or now_timestamp() if self.depends_on_past else end
         if not is_preview and self.full_history_restatement_only and self.intervals:
             start = self.intervals[0][0]
         return self.inclusive_exclusive(start, end, strict)
@@ -722,7 +722,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         start: TimeLike,
         end: TimeLike,
         strict: bool = True,
-        allow_partial: bool = False,
+        allow_partial: t.Optional[bool] = None,
     ) -> Interval:
         """Transform the inclusive start and end into a [start, end) pair.
 
@@ -735,6 +735,8 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         Returns:
             A [start, end) pair.
         """
+        if allow_partial is None:
+            allow_partial = self.is_model and self.model.allow_partials
         return inclusive_exclusive(
             start,
             end,
@@ -833,7 +835,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         if not self.evaluatable or (self.is_seed and intervals):
             return []
 
-        allow_partials = not end_bounded and self.is_model and self.model.allow_partials
+        allow_partials = self.is_model and self.model.allow_partials
         start_ts, end_ts = (
             to_timestamp(ts)
             for ts in self.inclusive_exclusive(
@@ -845,20 +847,18 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         )
 
         interval_unit = self.node.interval_unit
-        upper_bound_ts = to_timestamp(execution_time or now())
+        execution_time_ts = to_timestamp(execution_time) if execution_time else now_timestamp()
+        upper_bound_ts = (
+            execution_time_ts
+            if ignore_cron
+            else to_timestamp(self.node.cron_floor(execution_time_ts))
+        )
+        if end_bounded:
+            upper_bound_ts = min(upper_bound_ts, end_ts)
+        if not allow_partials:
+            upper_bound_ts = to_timestamp(interval_unit.cron_floor(upper_bound_ts))
 
-        if allow_partials:
-            end_ts = min(end_ts, upper_bound_ts)
-        else:
-            if not ignore_cron:
-                upper_bound_ts = to_timestamp(self.node.cron_floor(upper_bound_ts))
-            if end_bounded:
-                upper_bound_ts = min(upper_bound_ts, end_ts)
-
-            end_ts = min(
-                end_ts,
-                to_timestamp(interval_unit.cron_floor(upper_bound_ts)),
-            )
+        end_ts = min(end_ts, upper_bound_ts)
 
         lookback = 0
         model_end_ts: t.Optional[int] = None
@@ -1684,7 +1684,7 @@ def missing_intervals(
     """Returns all missing intervals given a collection of snapshots."""
     missing = {}
     cache: t.Dict[str, datetime] = {}
-    end_date = end or now()
+    end_date = end or now_timestamp()
     start_dt = (
         to_datetime(start)
         if start

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -1524,7 +1524,9 @@ def test_incremental_by_partition(init_and_plan_context: t.Callable):
         source_name,
         d.parse_one("SELECT 'key_a' AS key, 2 AS value"),
     )
-    context.run(ignore_cron=True)
+    # Run 1 minute later.
+    with time_machine.travel("2023-01-08 15:01:00 UTC"):
+        context.run(ignore_cron=True)
     assert context.engine_adapter.fetchall(f"SELECT * FROM {model_name}") == [
         ("key_b", 1),
         ("key_a", 2),

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -350,7 +350,11 @@ def test_missing_intervals_partial(make_snapshot):
     assert snapshot.missing_intervals(start, end_ts) == [
         (to_timestamp(start), end_ts),
     ]
-    assert snapshot.missing_intervals(start, end_ts, execution_time=end_ts) == [
+    assert snapshot.missing_intervals(start, end_ts, execution_time=end_ts) == []
+    assert snapshot.missing_intervals(start, end_ts, execution_time=end_ts, ignore_cron=True) == [
+        (to_timestamp(start), end_ts)
+    ]
+    assert snapshot.missing_intervals(start, end_ts, execution_time="2023-01-02") == [
         (to_timestamp(start), end_ts)
     ]
     assert snapshot.missing_intervals(start, start) == [
@@ -524,7 +528,7 @@ def test_incremental_time_self_reference(make_snapshot):
     ]
 
 
-def test_lookback(snapshot: Snapshot, make_snapshot):
+def test_lookback(make_snapshot):
     snapshot = make_snapshot(
         SqlModel(
             name="name",

--- a/tests/dbt/test_integration.py
+++ b/tests/dbt/test_integration.py
@@ -399,7 +399,8 @@ test_config = config"""
         time_start_end_mapping = {}
         for time, (starting_source_data, expected_table_data) in time_expected_mapping.items():
             self._replace_source_table(adapter, starting_source_data)
-            with time_machine.travel(time):
+            # Tick when running dbt runtime because it hangs during execution for unknown reasons.
+            with time_machine.travel(time, tick=test_type.is_dbt_runtime):
                 start_time = self._get_duckdb_now(adapter)
                 run()
                 end_time = self._get_duckdb_now(adapter)


### PR DESCRIPTION
This update makes it so that models for which `allow_partials` is set to true still respect their cron schedules. 

When running `sqlmesh run` the model won't run unless its time to run has come even if the `allow_partials` flag is set for it. However, if the `--ignore-cron` flag is specified in the `run` command, the model will run every time.

Additionally, this change has the following implications:
- Execution time is no longer rounded down to a minute
- The previous point also results in the `valid_to` column in SCD2 models being populated with millisecond precision