### PR TITLE
Fix: Move rendering for merge_filter to evaluation time

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -1277,9 +1277,9 @@ def replace_merge_table_aliases(expression: exp.Expression) -> exp.Expression:
     from sqlmesh.core.engine_adapter.base import MERGE_SOURCE_ALIAS, MERGE_TARGET_ALIAS
 
     if isinstance(expression, exp.Column):
-        if expression.table.lower() in ("target", "dbt_internal_dest"):
+        if expression.table.lower() in ("target", "dbt_internal_dest", "__merge_target__"):
             expression.set("table", exp.to_identifier(MERGE_TARGET_ALIAS))
-        elif expression.table.lower() in ("source", "dbt_internal_source"):
+        elif expression.table.lower() in ("source", "dbt_internal_source", "__merge_source__"):
             expression.set("table", exp.to_identifier(MERGE_SOURCE_ALIAS))
 
     return expression

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -1394,7 +1394,11 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
                 columns_to_types=model.columns_to_types,
                 unique_key=model.unique_key,
                 when_matched=model.when_matched,
-                merge_filter=model.merge_filter,
+                merge_filter=model.render_merge_filter(
+                    start=kwargs.get("start"),
+                    end=kwargs.get("end"),
+                    execution_time=kwargs.get("execution_time"),
+                ),
             )
 
     def append(
@@ -1410,7 +1414,11 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
             columns_to_types=model.columns_to_types,
             unique_key=model.unique_key,
             when_matched=model.when_matched,
-            merge_filter=model.merge_filter,
+            merge_filter=model.render_merge_filter(
+                start=kwargs.get("start"),
+                end=kwargs.get("end"),
+                execution_time=kwargs.get("execution_time"),
+            ),
         )
 
 


### PR DESCRIPTION
This update moves the rendering of `merge_filter` to evaluation time instead of load time, ensuring that any temporal macros (e.g. `@start_ds`) are resolved based on the evaluation time objects.