### PR TITLE
Fix: Don't drop intervals in state when restating models in a dev environment

### DIFF
--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -357,7 +357,7 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         )
 
     def _restate(self, plan: EvaluatablePlan, snapshots_by_name: t.Dict[str, Snapshot]) -> None:
-        if not plan.restatements:
+        if not plan.restatements or plan.is_dev:
             return
 
         snapshot_intervals_to_restate = {
@@ -365,16 +365,15 @@ class BuiltInPlanEvaluator(PlanEvaluator):
             for name, intervals in plan.restatements.items()
         }
 
-        if plan.is_prod:
-            # Restating intervals on prod plans should mean that the intervals are cleared across
-            # all environments, not just the version currently in prod
-            # This ensures that work done in dev environments can still be promoted to prod
-            # by forcing dev environments to re-run intervals that changed in prod
-            #
-            # Without this rule, its possible that promoting a dev table to prod will introduce old data to prod
-            snapshot_intervals_to_restate.update(
-                self._restatement_intervals_across_all_environments(plan.restatements)
-            )
+        # Restating intervals on prod plans should mean that the intervals are cleared across
+        # all environments, not just the version currently in prod
+        # This ensures that work done in dev environments can still be promoted to prod
+        # by forcing dev environments to re-run intervals that changed in prod
+        #
+        # Without this rule, its possible that promoting a dev table to prod will introduce old data to prod
+        snapshot_intervals_to_restate.update(
+            self._restatement_intervals_across_all_environments(plan.restatements)
+        )
 
         self.state_sync.remove_intervals(
             snapshot_intervals=list(snapshot_intervals_to_restate),

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -293,6 +293,9 @@ class Scheduler:
         execution_time = execution_time or now()
 
         self.state_sync.refresh_snapshot_intervals(self.snapshots.values())
+        for s_id, interval in (restatements or {}).items():
+            self.snapshots[s_id].remove_interval(interval)
+
         if auto_restatement_enabled:
             auto_restated_intervals = apply_auto_restatements(self.snapshots, execution_time)
             self.state_sync.add_snapshots_intervals(auto_restated_intervals)


### PR DESCRIPTION
Otherwise, a user iterating in one dev environment may unintentionally affect other dev environments by dropping shared intervals.

It also appears that we no longer need to modify the state in order to perform restatements in dev correctly within the same plan. 

Restatements are already reflected on in-memory snapshot instances when computing missing intervals here: https://github.com/TobikoData/sqlmesh/blob/v0.141.1/sqlmesh/core/snapshot/definition.py#L1712