### PR TITLE
Feat: provide useful error for invalid model kind

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -577,7 +577,12 @@ def _create_parser(parser_type: t.Type[exp.Expression], table_keys: t.List[str])
                 if not field or isinstance(field, (MacroVar, MacroFunc)):
                     value = field
                 else:
-                    kind = ModelKindName[field.name.upper()]
+                    try:
+                        kind = ModelKindName[field.name.upper()]
+                    except KeyError:
+                        raise SQLMeshError(
+                            f"Model kind specified as '{field.name}', but that is not a valid model kind.\n\nPlease specify one of {', '.join(ModelKindName)}."
+                        )
 
                     if kind in (
                         ModelKindName.INCREMENTAL_BY_TIME_RANGE,

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -5910,6 +5910,22 @@ materialized TRUE
     )
 
 
+def test_bad_model_kind():
+    with pytest.raises(
+        SQLMeshError,
+        match=f"Model kind specified as 'BAD_KIND', but that is not a valid model kind.\n\nPlease specify one of {', '.join(ModelKindName)}.",
+    ):
+        d.parse(
+            """
+        MODEL (
+            name db.table,
+            kind BAD_KIND
+        );
+        SELECT a, b
+        """
+        )
+
+
 def test_merge_filter():
     expressions = d.parse(
         """
@@ -5945,7 +5961,7 @@ def test_merge_filter():
             merge_filter (
                 source.ds > (SELECT MAX(ds) FROM db.test) AND
                 source.ds > @start_ds AND
-                source._operation <> 1 AND 
+                source._operation <> 1 AND
                 target.start_date > dateadd(day, -7, current_date)
             )
           )


### PR DESCRIPTION
It is difficult to determine the problem when you pass an invalid model kind, due to the structure of the error.

This PR provides a clear, useful error message when an invalid model kind is passed, including a list of all valid model kinds:

> Error: Model kind specified as 'INCREMENTAL_BY_TIME_RAN', but that is not a valid model kind.
> 
> Please specify one of INCREMENTAL_BY_TIME_RANGE, INCREMENTAL_BY_UNIQUE_KEY, INCREMENTAL_BY_PARTITION, INCREMENTAL_UNMANAGED, FULL, SCD_TYPE_2, SCD_TYPE_2_BY_TIME, SCD_TYPE_2_BY_COLUMN, VIEW, EMBEDDED, SEED, EXTERNAL, CUSTOM, MANAGED.