### PR TITLE
Fix(clickhouse): specify DateTime64 precision for model partitioning expression

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2290,7 +2290,7 @@ def clickhouse_partition_func(
     if col_type.is_type(exp.DataType.Type.UNKNOWN):
         return exp.func(
             "toMonday",
-            exp.cast(column, exp.DataType.build("DateTime64('UTC')", dialect="clickhouse")),
+            exp.cast(column, exp.DataType.build("DateTime64(9, 'UTC')", dialect="clickhouse")),
             dialect="clickhouse",
         )
 
@@ -2298,7 +2298,7 @@ def clickhouse_partition_func(
     return exp.cast(
         exp.func(
             "toMonday",
-            exp.cast(column, exp.DataType.build("DateTime64('UTC')", dialect="clickhouse")),
+            exp.cast(column, exp.DataType.build("DateTime64(9, 'UTC')", dialect="clickhouse")),
             dialect="clickhouse",
         ),
         col_type,

--- a/tests/core/engine_adapter/test_clickhouse.py
+++ b/tests/core/engine_adapter/test_clickhouse.py
@@ -371,7 +371,8 @@ def test_partitioned_by_expr(make_mocked_engine_adapter: t.Callable):
     )
 
     assert (
-        model.partitioned_by[0].sql("clickhouse") == """toMonday(CAST("ds" AS DateTime64('UTC')))"""
+        model.partitioned_by[0].sql("clickhouse")
+        == """toMonday(CAST("ds" AS DateTime64(9, 'UTC')))"""
     )
 
     # user specifies without time column, unknown time column type
@@ -396,7 +397,7 @@ def test_partitioned_by_expr(make_mocked_engine_adapter: t.Callable):
     )
 
     assert [p.sql("clickhouse") for p in model.partitioned_by] == [
-        """toMonday(CAST("ds" AS DateTime64('UTC')))""",
+        """toMonday(CAST("ds" AS DateTime64(9, 'UTC')))""",
         '"x"',
     ]
 
@@ -444,7 +445,7 @@ def test_partitioned_by_expr(make_mocked_engine_adapter: t.Callable):
 
     assert (
         model.partitioned_by[0].sql("clickhouse")
-        == """CAST(toMonday(CAST("ds" AS DateTime64('UTC'))) AS String)"""
+        == """CAST(toMonday(CAST("ds" AS DateTime64(9, 'UTC'))) AS String)"""
     )
 
     # user specifies partitioned_by with time column


### PR DESCRIPTION
SQLMesh automatically partitions Clickhouse incremental by time range models, aggregating timestamps to week. If the timestamp data type is not a datetime variant, SQLMesh automatically casts it to DateTime64 in the aggregation expression.

In Clickhouse, casting to DateTime64 type requires specifying a numeric precision.

This PR specifies a precision of 9/nanoseconds (using max precision to prevent accidental truncation of timestamp digits). 