### PR TITLE
Fix: Unpaused snapshots that are downstream of snapshots with enabled auto-restatement can still be representative

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1436,7 +1436,10 @@ class DeployabilityIndex(PydanticModel, frozen=True):
                 )
             else:
                 this_deployable, children_deployable = False, False
-                representative_shared_version_ids.discard(node)
+                if node in snapshots and not snapshots[node].is_paused:
+                    representative_shared_version_ids.add(node)
+                else:
+                    representative_shared_version_ids.discard(node)
 
             deployability_mapping[node] = deployability_mapping.get(node, True) and this_deployable
             for child in reversed_dag[node]:


### PR DESCRIPTION
I've noticed that our deployability strategy for auto-restated models was a bit too aggressive. Snapshots that are downstream of snapshots with auto-restatement enabled were always classified as neither deployable nor representative. 
However, if such a child is currently promoted in production, it can be perfectly suitable for reading in dev, assuming that the snapshot consuming this data remains non-deployable.