### PR TITLE
Fix: no_prompts flag not considered when creating plan

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -794,15 +794,15 @@ class TerminalConsole(Console):
 
             if not no_prompts:
                 self._prompt_backfill(plan_builder, auto_apply, default_catalog)
+                backfill_or_preview = "preview" if plan.is_dev and plan.forward_only else "backfill"
+                if not auto_apply and self._confirm(
+                    f"Apply - {backfill_or_preview.capitalize()} Tables"
+                ):
+                    plan_builder.apply()
 
-            backfill_or_preview = "preview" if plan.is_dev and plan.forward_only else "backfill"
-            if not auto_apply and self._confirm(
-                f"Apply - {backfill_or_preview.capitalize()} Tables"
-            ):
-                plan_builder.apply()
-        elif plan.has_changes and not auto_apply:
+        elif not no_prompts and plan.has_changes and not auto_apply:
             self._prompt_promote(plan_builder)
-        elif plan.has_unmodified_unpromoted and not auto_apply:
+        elif not no_prompts and plan.has_unmodified_unpromoted and not auto_apply:
             self.log_status_update("\n[bold]Virtually updating unmodified models\n")
             self._prompt_promote(plan_builder)
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -445,14 +445,24 @@ def test_plan_dev_bad_create_from(runner, tmp_path):
 def test_plan_dev_no_prompts(runner, tmp_path):
     create_example_project(tmp_path)
 
-    # plan for non-prod environment doesn't prompt for dates but prompts to apply
+    # plan for non-prod environment doesn't prompt for dates but prompts to apply when there is no --no-prompts flag
     result = runner.invoke(
         cli, ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "dev", "--no-prompts"]
     )
-    assert "Apply - Backfill Tables [y/n]: " in result.output
+    assert "Apply - Backfill Tables [y/n]: " not in result.output
     assert "Model versions created successfully" not in result.output
     assert "Model batches executed successfully" not in result.output
     assert "The target environment has been updated successfully" not in result.output
+
+
+def test_plan_dev_no_auto_apply(runner, tmp_path):
+    create_example_project(tmp_path)
+
+    # plan for non-prod environment doesn't prompt for dates but prompts to apply when there is no --no-prompts flag
+    result = runner.invoke(
+        cli, ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "dev"], input="\n\n"
+    )
+    assert "Apply - Backfill Tables [y/n]: " in result.output
 
 
 def test_plan_dev_auto_apply(runner, tmp_path):


### PR DESCRIPTION
When I tried to create a plan using python script with below settings, I ran into a problem because the plan method expects us to confirm whether we want to apply the plan or not which doesn't respect the no_prompts flag clearly. I believe that the no_prompts flag is used to disable any interactive prompts, so I made this change. I'd really appreciate any suggestions and feedbacks, thanks :)

```
plan = context.plan(
            environment=environment,
            no_prompts=True,
            auto_apply=False,
            no_gaps=True,
           )
```

Error:

 

```
File "/home/.local/lib/python3.11/site-packages/sqlmesh/core/analytics/__init__.py", line 110, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/.local/lib/python3.11/site-packages/sqlmesh/core/context.py", line 1136, in plan
    self.console.plan(
  File "/home/.local/lib/python3.11/site-packages/sqlmesh/core/console.py", line 695, in plan
    self._show_options_after_categorization(
  File "/home/.local/lib/python3.11/site-packages/sqlmesh/core/console.py", line 799, in _show_options_after_categorization
    if not auto_apply and self._confirm(
                          ^^^^^^^^^^^^^^
  File "/home/.local/lib/python3.11/site-packages/sqlmesh/core/console.py", line 334, in _confirm
    return Confirm.ask(message, console=self.console, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/.local/lib/python3.11/site-packages/rich/prompt.py", line 149, in ask
    return _prompt(default=default, stream=stream)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/.local/lib/python3.11/site-packages/rich/prompt.py", line 292, in __call__
    value = self.get_input(self.console, prompt, self.password, stream=stream)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/.local/lib/python3.11/site-packages/rich/prompt.py", line 211, in get_input
    return console.input(prompt, password=password, stream=stream)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/.local/lib/python3.11/site-packages/rich/console.py", line 2156, in input
    result = input()
```