### PR TITLE
Fix: access SIGUSR1 using fully-qualified path to avoid windows issue

### DIFF
--- a/sqlmesh/__init__.py
+++ b/sqlmesh/__init__.py
@@ -173,13 +173,15 @@ def configure_logging(
             os.remove(path)
 
     if debug:
-        from signal import SIGUSR1
         import faulthandler
 
         enable_debug_mode()
 
         # Enable threadumps.
         faulthandler.enable()
+
         # Windows doesn't support register so we check for it here
         if hasattr(faulthandler, "register"):
+            from signal import SIGUSR1
+
             faulthandler.register(SIGUSR1.value)


### PR DESCRIPTION
Fixes #3603, I think this is what we originally did [here](https://github.com/TobikoData/sqlmesh/commit/ea7b37738c8a14b3c752703f6e810cd1c8b23e7d) for the same reason, but along the line the full path was refactored I guess. Not 100% sure this is the right approach but thought I'd give it a shot.