### PR TITLE
Fix: this_model macro usage in the on_virtual_update statements

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -433,6 +433,8 @@ class _Model(ModelMeta, frozen=True):
         engine_adapter: t.Optional[EngineAdapter] = None,
         **kwargs: t.Any,
     ) -> t.List[exp.Expression]:
+        if "this_model" not in kwargs:
+            kwargs["this_model"] = self.fully_qualified_table
         return self._render_statements(
             self.on_virtual_update,
             start=start,


### PR DESCRIPTION
Without this fix `this_model` is resolved to the physical table name when rendering `on_virtual_update` statements.