### PR TITLE
Chore!: remove pydantic v1 validator arg helpers

### DIFF
--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -4,6 +4,7 @@ import pathlib
 import typing as t
 from functools import cached_property
 from pathlib import Path
+from typing_extensions import Self
 
 from pydantic import Field
 from sqlglot import exp
@@ -28,12 +29,7 @@ from sqlmesh.utils.jinja import (
     extract_macro_references_and_variables,
 )
 from sqlmesh.utils.metaprogramming import Executable
-from sqlmesh.utils.pydantic import (
-    PydanticModel,
-    field_validator,
-    model_validator,
-    model_validator_v1_args,
-)
+from sqlmesh.utils.pydantic import PydanticModel, field_validator, model_validator
 
 if t.TYPE_CHECKING:
     from sqlmesh.core.snapshot import DeployabilityIndex, Node, Snapshot
@@ -175,12 +171,10 @@ class StandaloneAudit(_Node, AuditMixin):
     _depends_on_validator = depends_on_validator
 
     @model_validator(mode="after")
-    @model_validator_v1_args
-    def _node_root_validator(cls, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
-        if values.get("blocking"):
-            name = values.get("name")
-            raise AuditConfigError(f"Standalone audits cannot be blocking: '{name}'.")
-        return values
+    def _node_root_validator(self) -> Self:
+        if self.blocking:
+            raise AuditConfigError(f"Standalone audits cannot be blocking: '{self.name}'.")
+        return self
 
     def render_audit_query(
         self,

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -5,6 +5,7 @@ import re
 import typing as t
 import zlib
 import logging
+from typing_extensions import Self
 
 from pydantic import Field
 from sqlglot import exp
@@ -40,11 +41,7 @@ from sqlmesh.core.loader import Loader, SqlMeshLoader
 from sqlmesh.core.notification_target import NotificationTarget
 from sqlmesh.core.user import User
 from sqlmesh.utils.errors import ConfigError
-from sqlmesh.utils.pydantic import (
-    field_validator,
-    model_validator,
-    model_validator_v1_args,
-)
+from sqlmesh.utils.pydantic import field_validator, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +141,7 @@ class Config(BaseConfig):
     _scheduler_config_validator = scheduler_config_validator
     _variables_validator = variables_validator
 
-    @field_validator("gateways", mode="before", always=True)
+    @field_validator("gateways", mode="before")
     @classmethod
     def _gateways_ensure_dict(cls, value: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
         try:
@@ -168,50 +165,53 @@ class Config(BaseConfig):
         return compiled_regexes
 
     @model_validator(mode="before")
-    @model_validator_v1_args
-    def _normalize_and_validate_fields(cls, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
-        if "gateways" not in values and "gateway" in values:
-            values["gateways"] = values.pop("gateway")
+    def _normalize_and_validate_fields(cls, data: t.Any) -> t.Any:
+        if isinstance(data, dict):
+            if "gateways" not in data and "gateway" in data:
+                data["gateways"] = data.pop("gateway")
 
-        for plan_deprecated in ("auto_categorize_changes", "include_unmodified"):
-            if plan_deprecated in values:
-                raise ConfigError(
-                    f"The `{plan_deprecated}` config is deprecated. Please use the `plan.{plan_deprecated}` config instead."
+            for plan_deprecated in ("auto_categorize_changes", "include_unmodified"):
+                if plan_deprecated in data:
+                    raise ConfigError(
+                        f"The `{plan_deprecated}` config is deprecated. Please use the `plan.{plan_deprecated}` config instead."
+                    )
+
+            if "physical_schema_override" in data:
+                logger.warning(
+                    "`physical_schema_override` is deprecated. Please use `physical_schema_mapping` instead"
                 )
 
-        if "physical_schema_override" in values:
-            logger.warning(
-                "`physical_schema_override` is deprecated. Please use `physical_schema_mapping` instead"
-            )
+                if "physical_schema_mapping" in data:
+                    raise ConfigError(
+                        "Only one of `physical_schema_override` and `physical_schema_mapping` can be specified"
+                    )
 
-            if "physical_schema_mapping" in values:
-                raise ConfigError(
-                    "Only one of `physical_schema_override` and `physical_schema_mapping` can be specified"
-                )
+                physical_schema_override: t.Dict[str, str] = data.pop("physical_schema_override")
+                # translate physical_schema_override to physical_schema_mapping
+                data["physical_schema_mapping"] = {
+                    f"^{k}$": v for k, v in physical_schema_override.items()
+                }
 
-            physical_schema_override: t.Dict[str, str] = values.pop("physical_schema_override")
-            # translate physical_schema_override to physical_schema_mapping
-            values["physical_schema_mapping"] = {
-                f"^{k}$": v for k, v in physical_schema_override.items()
-            }
-
-        return values
+        return data
 
     @model_validator(mode="after")
-    @model_validator_v1_args
-    def _normalize_fields_after(cls, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
-        dialect = values["model_defaults"].dialect
+    def _normalize_fields_after(self) -> Self:
+        dialect = self.model_defaults.dialect
 
         def _normalize_identifiers(key: str) -> None:
-            values[key] = {
-                k: normalize_identifiers(v, dialect=dialect).name
-                for k, v in values.get(key, {}).items()
-            }
+            setattr(
+                self,
+                key,
+                {
+                    k: normalize_identifiers(v, dialect=dialect).name
+                    for k, v in getattr(self, key, {}).items()
+                },
+            )
 
         _normalize_identifiers("environment_catalog_mapping")
         _normalize_identifiers("physical_schema_mapping")
 
-        return values
+        return self
 
     def get_default_test_connection(
         self,

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -23,7 +23,7 @@ from sqlmesh.schedulers.airflow.client import AirflowClient
 from sqlmesh.schedulers.airflow.mwaa_client import MWAAClient
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.hashing import md5
-from sqlmesh.utils.pydantic import model_validator, model_validator_v1_args, field_validator
+from sqlmesh.utils.pydantic import model_validator, field_validator
 
 if t.TYPE_CHECKING:
     from google.auth.transport.requests import AuthorizedSession
@@ -381,15 +381,18 @@ class CloudComposerSchedulerConfig(_BaseAirflowSchedulerConfig, BaseConfig, extr
         )
 
     @model_validator(mode="before")
-    @model_validator_v1_args
-    def check_supported_fields(cls, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
-        allowed_field_names = {field.alias or name for name, field in cls.all_field_infos().items()}
-        allowed_field_names.add("session")
+    def check_supported_fields(cls, data: t.Any) -> t.Any:
+        if isinstance(data, dict):
+            allowed_field_names = {
+                field.alias or name for name, field in cls.all_field_infos().items()
+            }
+            allowed_field_names.add("session")
 
-        for field_name in values:
-            if field_name not in allowed_field_names:
-                raise ValueError(f"Unsupported Field: {field_name}")
-        return values
+            for field_name in data:
+                if field_name not in allowed_field_names:
+                    raise ValueError(f"Unsupported Field: {field_name}")
+
+        return data
 
 
 class MWAASchedulerConfig(_EngineAdapterStateSyncSchedulerConfig, BaseConfig):

--- a/sqlmesh/core/metric/definition.py
+++ b/sqlmesh/core/metric/definition.py
@@ -10,11 +10,7 @@ from sqlmesh.core import dialect as d
 from sqlmesh.core.node import str_or_exp_to_str
 from sqlmesh.utils import UniqueKeyDict
 from sqlmesh.utils.errors import ConfigError
-from sqlmesh.utils.pydantic import (
-    PydanticModel,
-    field_validator,
-    field_validator_v1_args,
-)
+from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator
 
 MeasureAndDimTables = t.Tuple[str, t.Tuple[str, ...]]
 
@@ -83,7 +79,7 @@ class MetricMeta(PydanticModel, frozen=True):
     @field_validator("name", mode="before")
     @classmethod
     def _name_validator(cls, v: t.Any) -> str:
-        return cls._string_validator(v).lower()
+        return (cls._string_validator(v) or "").lower()
 
     @field_validator("dialect", "owner", "description", mode="before")
     @classmethod
@@ -91,14 +87,9 @@ class MetricMeta(PydanticModel, frozen=True):
         return str_or_exp_to_str(v)
 
     @field_validator("expression", mode="before")
-    @field_validator_v1_args
-    def _validate_expression(
-        cls,
-        v: t.Any,
-        values: t.Dict[str, t.Any],
-    ) -> exp.Expression:
+    def _validate_expression(cls, v: t.Any, info: ValidationInfo) -> exp.Expression:
         if isinstance(v, str):
-            dialect = values.get("dialect")
+            dialect = info.data.get("dialect")
             return d.parse_one(v, dialect=dialect)
         if isinstance(v, exp.Expression):
             return v

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
 import types
 import re
 import typing as t
 from functools import cached_property
 from pathlib import Path
+from typing_extensions import Self
 
 import pandas as pd
 import numpy as np
@@ -59,10 +59,6 @@ if t.TYPE_CHECKING:
     from sqlmesh.core.snapshot import DeployabilityIndex, Node, Snapshot
     from sqlmesh.utils.jinja import MacroReference
 
-    if sys.version_info >= (3, 11):
-        from typing import Self
-    else:
-        from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -23,9 +23,9 @@ from sqlmesh.utils.pydantic import (
     SQLGlotPositiveInt,
     SQLGlotString,
     SQLGlotCron,
+    ValidationInfo,
     column_validator,
     field_validator,
-    field_validator_v1_args,
     get_dialect,
     validate_string,
 )
@@ -235,49 +235,6 @@ class TimeColumn(PydanticModel):
     column: exp.Expression
     format: t.Optional[str] = None
 
-    @classmethod
-    def validator(cls) -> classmethod:
-        def _time_column_validator(v: t.Any, values: t.Any) -> TimeColumn:
-            dialect = get_dialect(values)
-
-            if isinstance(v, exp.Tuple):
-                column_expr = v.expressions[0]
-                column = (
-                    exp.column(column_expr)
-                    if isinstance(column_expr, exp.Identifier)
-                    else column_expr
-                )
-                format = v.expressions[1].name if len(v.expressions) > 1 else None
-            elif isinstance(v, exp.Expression):
-                column = exp.column(v) if isinstance(v, exp.Identifier) else v
-                format = None
-            elif isinstance(v, str):
-                column = d.parse_one(v, dialect=dialect)
-                column.meta.pop("sql")
-                format = None
-            elif isinstance(v, dict):
-                column_raw = v["column"]
-                column = (
-                    d.parse_one(column_raw, dialect=dialect)
-                    if isinstance(column_raw, str)
-                    else column_raw
-                )
-                format = v.get("format")
-            elif isinstance(v, TimeColumn):
-                column = v.column
-                format = v.format
-            else:
-                raise ConfigError(f"Invalid time_column: '{v}'.")
-
-            column = quote_identifiers(
-                normalize_identifiers(column, dialect=dialect), dialect=dialect
-            )
-            column.meta["dialect"] = dialect
-
-            return TimeColumn(column=column, format=format)
-
-        return field_validator("time_column", mode="before")(_time_column_validator)
-
     @field_validator("column", mode="before")
     @classmethod
     def _column_validator(cls, v: t.Union[str, exp.Expression]) -> exp.Expression:
@@ -319,9 +276,7 @@ def _kind_dialect_validator(cls: t.Type, v: t.Optional[str]) -> str:
     return v
 
 
-kind_dialect_validator = field_validator("dialect", mode="before", always=True)(
-    _kind_dialect_validator
-)
+kind_dialect_validator = field_validator("dialect", mode="before")(_kind_dialect_validator)
 
 
 class _Incremental(_ModelKind):
@@ -407,7 +362,42 @@ class IncrementalByTimeRangeKind(_IncrementalBy):
     time_column: TimeColumn
     auto_restatement_intervals: t.Optional[SQLGlotPositiveInt] = None
 
-    _time_column_validator = TimeColumn.validator()
+    @field_validator("time_column", mode="before")
+    @classmethod
+    def _time_column_validator(cls, v: t.Any, values: t.Any) -> TimeColumn:
+        dialect = get_dialect(values)
+
+        if isinstance(v, exp.Tuple):
+            column_expr = v.expressions[0]
+            column = (
+                exp.column(column_expr) if isinstance(column_expr, exp.Identifier) else column_expr
+            )
+            format = v.expressions[1].name if len(v.expressions) > 1 else None
+        elif isinstance(v, exp.Expression):
+            column = exp.column(v) if isinstance(v, exp.Identifier) else v
+            format = None
+        elif isinstance(v, str):
+            column = d.parse_one(v, dialect=dialect)
+            column.meta.pop("sql")
+            format = None
+        elif isinstance(v, dict):
+            column_raw = v["column"]
+            column = (
+                d.parse_one(column_raw, dialect=dialect)
+                if isinstance(column_raw, str)
+                else column_raw
+            )
+            format = v.get("format")
+        elif isinstance(v, TimeColumn):
+            column = v.column
+            format = v.format
+        else:
+            raise ConfigError(f"Invalid time_column: '{v}'.")
+
+        column = quote_identifiers(normalize_identifiers(column, dialect=dialect), dialect=dialect)
+        column.meta["dialect"] = dialect
+
+        return TimeColumn(column=column, format=format)
 
     def to_expression(
         self, expressions: t.Optional[t.List[exp.Expression]] = None, **kwargs: t.Any
@@ -448,11 +438,10 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
     batch_concurrency: t.Literal[1] = 1
 
     @field_validator("when_matched", mode="before")
-    @field_validator_v1_args
     def _when_matched_validator(
         cls,
         v: t.Optional[t.Union[str, exp.Whens]],
-        values: t.Dict[str, t.Any],
+        info: ValidationInfo,
     ) -> t.Optional[exp.Whens]:
         if v is None:
             return v
@@ -462,22 +451,21 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
             if v.startswith("("):
                 v = v[1:-1]
 
-            return t.cast(exp.Whens, d.parse_one(v, into=exp.Whens, dialect=get_dialect(values)))
+            return t.cast(exp.Whens, d.parse_one(v, into=exp.Whens, dialect=get_dialect(info.data)))
 
         return t.cast(exp.Whens, v.transform(d.replace_merge_table_aliases))
 
     @field_validator("merge_filter", mode="before")
-    @field_validator_v1_args
     def _merge_filter_validator(
         cls,
         v: t.Optional[exp.Expression],
-        values: t.Dict[str, t.Any],
+        info: ValidationInfo,
     ) -> t.Optional[exp.Expression]:
         if v is None:
             return v
         if isinstance(v, str):
             v = v.strip()
-            return d.parse_one(v, dialect=get_dialect(values))
+            return d.parse_one(v, dialect=get_dialect(info.data))
 
         return v.transform(d.replace_merge_table_aliases)
 
@@ -614,7 +602,7 @@ class SeedKind(_ModelKind):
         if v is None or isinstance(v, CsvSettings):
             return v
         if isinstance(v, exp.Expression):
-            tuple_exp = parse_properties(cls, v, {})
+            tuple_exp = parse_properties(cls, v)
             if not tuple_exp:
                 return None
             return CsvSettings(**{e.left.name: e.right for e in tuple_exp.expressions})
@@ -667,13 +655,11 @@ class _SCDType2Kind(_Incremental):
 
     _dialect_validator = kind_dialect_validator
 
-    # Remove once Pydantic 1 is deprecated
-    _always_validate_column = field_validator(
-        "valid_from_name", "valid_to_name", mode="before", always=True
-    )(column_validator)
+    _always_validate_column = field_validator("valid_from_name", "valid_to_name", mode="before")(
+        column_validator
+    )
 
-    # always=True can be removed once Pydantic 1 is deprecated
-    @field_validator("time_data_type", mode="before", always=True)
+    @field_validator("time_data_type", mode="before")
     @classmethod
     def _time_data_type_validator(
         cls, v: t.Union[str, exp.Expression], values: t.Any
@@ -740,8 +726,7 @@ class SCDType2ByTimeKind(_SCDType2Kind):
     updated_at_name: SQLGlotColumn = Field(exp.column("updated_at"), validate_default=True)
     updated_at_as_valid_from: SQLGlotBool = False
 
-    # Remove once Pydantic 1 is deprecated
-    _always_validate_updated_at = field_validator("updated_at_name", mode="before", always=True)(
+    _always_validate_updated_at = field_validator("updated_at_name", mode="before")(
         column_validator
     )
 
@@ -984,9 +969,10 @@ def create_model_kind(v: t.Any, dialect: str, defaults: t.Dict[str, t.Any]) -> M
     return model_kind_type_from_name(name)(name=name)  # type: ignore
 
 
-@field_validator_v1_args
-def _model_kind_validator(cls: t.Type, v: t.Any, values: t.Dict[str, t.Any]) -> ModelKind:
-    dialect = get_dialect(values)
+def _model_kind_validator(
+    cls: t.Type, v: t.Any, info: t.Optional[ValidationInfo] = None
+) -> ModelKind:
+    dialect = get_dialect(info.data) if info else ""
     return create_model_kind(v, dialect, {})
 
 

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import typing as t
 from functools import cached_property
+from typing_extensions import Self
 
 from pydantic import Field
 from sqlglot import Dialect, exp
@@ -34,11 +35,10 @@ from sqlmesh.core.reference import Reference
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.pydantic import (
+    ValidationInfo,
     field_validator,
-    field_validator_v1_args,
     list_of_fields_validator,
     model_validator,
-    model_validator_v1_args,
 )
 
 if t.TYPE_CHECKING:
@@ -123,15 +123,14 @@ class ModelMeta(_Node):
         return v or []
 
     @field_validator("tags", mode="before")
-    @field_validator_v1_args
-    def _value_or_tuple_validator(cls, v: t.Any, values: t.Dict[str, t.Any]) -> t.Any:
-        return ensure_list(cls._validate_value_or_tuple(v, values))
+    def _value_or_tuple_validator(cls, v: t.Any, info: ValidationInfo) -> t.Any:
+        return ensure_list(cls._validate_value_or_tuple(v, info.data))
 
     @classmethod
     def _validate_value_or_tuple(
-        cls, v: t.Dict[str, t.Any], values: t.Dict[str, t.Any], normalize: bool = False
+        cls, v: t.Dict[str, t.Any], data: t.Dict[str, t.Any], normalize: bool = False
     ) -> t.Any:
-        dialect = values.get("dialect")
+        dialect = data.get("dialect")
 
         def _normalize(value: t.Any) -> t.Any:
             return normalize_identifiers(value, dialect=dialect) if normalize else value
@@ -147,15 +146,14 @@ class ModelMeta(_Node):
             value = _normalize(v)
             return value.name if isinstance(value, exp.Expression) else value
         if isinstance(v, (list, tuple)):
-            return [cls._validate_value_or_tuple(elm, values, normalize=normalize) for elm in v]
+            return [cls._validate_value_or_tuple(elm, data, normalize=normalize) for elm in v]
 
         return v
 
     @field_validator("table_format", "storage_format", mode="before")
-    @field_validator_v1_args
-    def _format_validator(cls, v: t.Any, values: t.Dict[str, t.Any]) -> t.Optional[str]:
+    def _format_validator(cls, v: t.Any, info: ValidationInfo) -> t.Optional[str]:
         if isinstance(v, exp.Expression) and not (isinstance(v, (exp.Literal, exp.Identifier))):
-            return v.sql(values.get("dialect"))
+            return v.sql(info.data.get("dialect"))
         return str_or_exp_to_str(v)
 
     @field_validator("dialect", mode="before")
@@ -179,11 +177,10 @@ class ModelMeta(_Node):
         return gateway and gateway.lower()
 
     @field_validator("partitioned_by_", "clustered_by", mode="before")
-    @field_validator_v1_args
     def _partition_and_cluster_validator(
-        cls, v: t.Any, values: t.Dict[str, t.Any]
+        cls, v: t.Any, info: ValidationInfo
     ) -> t.List[exp.Expression]:
-        expressions = list_of_fields_validator(v, values)
+        expressions = list_of_fields_validator(v, info.data)
 
         for expression in expressions:
             num_cols = len(list(expression.find_all(exp.Column)))
@@ -202,12 +199,11 @@ class ModelMeta(_Node):
     @field_validator(
         "columns_to_types_", "derived_columns_to_types", mode="before", check_fields=False
     )
-    @field_validator_v1_args
     def _columns_validator(
-        cls, v: t.Any, values: t.Dict[str, t.Any]
+        cls, v: t.Any, info: ValidationInfo
     ) -> t.Optional[t.Dict[str, exp.DataType]]:
         columns_to_types = {}
-        dialect = values.get("dialect")
+        dialect = info.data.get("dialect")
 
         if isinstance(v, exp.Schema):
             for column in v.expressions:
@@ -229,11 +225,10 @@ class ModelMeta(_Node):
         return v
 
     @field_validator("column_descriptions_", mode="before")
-    @field_validator_v1_args
     def _column_descriptions_validator(
-        cls, vs: t.Any, values: t.Dict[str, t.Any]
+        cls, vs: t.Any, info: ValidationInfo
     ) -> t.Optional[t.Dict[str, str]]:
-        dialect = values.get("dialect")
+        dialect = info.data.get("dialect")
 
         if vs is None:
             return None
@@ -253,20 +248,19 @@ class ModelMeta(_Node):
             for k, v in raw_col_descriptions.items()
         }
 
-        columns_to_types = values.get("columns_to_types_")
+        columns_to_types = info.data.get("columns_to_types_")
         if columns_to_types:
             for column_name in col_descriptions:
                 if column_name not in columns_to_types:
                     raise ConfigError(
-                        f"In model '{values['name']}', a description is provided for column '{column_name}' but it is not a column in the model."
+                        f"In model '{info.data['name']}', a description is provided for column '{column_name}' but it is not a column in the model."
                     )
 
         return col_descriptions
 
     @field_validator("grains", "references", mode="before")
-    @field_validator_v1_args
-    def _refs_validator(cls, vs: t.Any, values: t.Dict[str, t.Any]) -> t.List[exp.Expression]:
-        dialect = values.get("dialect")
+    def _refs_validator(cls, vs: t.Any, info: ValidationInfo) -> t.List[exp.Expression]:
+        dialect = info.data.get("dialect")
 
         if isinstance(vs, exp.Paren):
             vs = vs.unnest()
@@ -289,66 +283,63 @@ class ModelMeta(_Node):
         return refs
 
     @model_validator(mode="before")
-    @model_validator_v1_args
-    def _pre_root_validator(cls, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
-        grain = values.pop("grain", None)
-        if grain:
-            grains = values.get("grains")
-            if grains:
-                raise ConfigError(
-                    f"Cannot use argument 'grain' ({grain}) with 'grains' ({grains}), use only grains"
-                )
-            values["grains"] = ensure_list(grain)
+    def _pre_root_validator(cls, data: t.Any) -> t.Any:
+        if isinstance(data, dict):
+            grain = data.pop("grain", None)
+            if grain:
+                grains = data.get("grains")
+                if grains:
+                    raise ConfigError(
+                        f"Cannot use argument 'grain' ({grain}) with 'grains' ({grains}), use only grains"
+                    )
+                data["grains"] = ensure_list(grain)
 
-        table_properties = values.pop("table_properties", None)
-        if table_properties:
-            if not isinstance(table_properties, str):
-                # Do not warn when deserializing from the state.
-                model_name = values["name"]
-                logger.warning(
-                    f"Model '{model_name}' is using the `table_properties` attribute which is deprecated. Please use `physical_properties` instead."
-                )
-            physical_properties = values.get("physical_properties")
-            if physical_properties:
-                raise ConfigError(
-                    f"Cannot use argument 'table_properties' ({table_properties}) with 'physical_properties' ({physical_properties}), use only physical_properties."
-                )
-            values["physical_properties"] = table_properties
-        return values
+            table_properties = data.pop("table_properties", None)
+            if table_properties:
+                if not isinstance(table_properties, str):
+                    # Do not warn when deserializing from the state.
+                    model_name = data["name"]
+                    logger.warning(
+                        f"Model '{model_name}' is using the `table_properties` attribute which is deprecated. Please use `physical_properties` instead."
+                    )
+                physical_properties = data.get("physical_properties")
+                if physical_properties:
+                    raise ConfigError(
+                        f"Cannot use argument 'table_properties' ({table_properties}) with 'physical_properties' ({physical_properties}), use only physical_properties."
+                    )
+                data["physical_properties"] = table_properties
+
+        return data
 
     @model_validator(mode="after")
-    @model_validator_v1_args
-    def _root_validator(cls, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
-        values = cls._kind_validator(values)
+    def _root_validator(self) -> Self:
+        self._kind_validator(self.kind, self.dict())
 
         # needs to be in a mode=after model validator so that the field validators have run to convert from Expression -> str
-        if (storage_format := values.get("storage_format")) and storage_format.lower() in {
+        if (storage_format := self.storage_format) and storage_format.lower() in {
             "iceberg",
             "hive",
             "hudi",
             "delta",
         }:
             logger.warning(
-                f"Model {values['name']} has `storage_format` set to a table format '{storage_format}' which is deprecated. Please use the `table_format` property instead"
+                f"Model {self.name} has `storage_format` set to a table format '{storage_format}' which is deprecated. Please use the `table_format` property instead"
             )
 
-        return values
+        return self
 
     @classmethod
-    def _kind_validator(cls, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
-        kind = values.get("kind")
-        if kind:
-            for field in ("partitioned_by_", "clustered_by"):
-                if (
-                    values.get(field)
-                    and not kind.is_materialized
-                    and not (kind.is_view and kind.materialized)
-                ):
-                    name = field[:-1] if field.endswith("_") else field
-                    raise ValueError(f"{name} field cannot be set for {kind} models")
-            if kind.is_incremental_by_partition and not values.get("partitioned_by_"):
-                raise ValueError(f"partitioned_by field is required for {kind.name} models")
-        return values
+    def _kind_validator(cls, kind: t.Any, values: t.Dict[str, t.Any]) -> None:
+        for field in ("partitioned_by_", "clustered_by"):
+            if (
+                values.get(field)
+                and not kind.is_materialized
+                and not (kind.is_view and kind.materialized)
+            ):
+                name = field[:-1] if field.endswith("_") else field
+                raise ValueError(f"{name} field cannot be set for {kind} models")
+        if kind.is_incremental_by_partition and not values.get("partitioned_by_"):
+            raise ValueError(f"partitioned_by field is required for {kind.name} models")
 
     @property
     def time_column(self) -> t.Optional[TimeColumn]:

--- a/sqlmesh/core/node.py
+++ b/sqlmesh/core/node.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
+from typing_extensions import Self
 
 from pydantic import Field
 from sqlglot import exp
@@ -17,17 +17,11 @@ from sqlmesh.utils.pydantic import (
     SQLGlotCron,
     field_validator,
     model_validator,
-    model_validator_v1_args,
     PRIVATE_FIELDS,
 )
 
 if t.TYPE_CHECKING:
     from sqlmesh.core.snapshot import Node
-
-    if sys.version_info >= (3, 11):
-        from typing import Self
-    else:
-        from typing_extensions import Self
 
 
 class IntervalUnit(str, Enum):
@@ -257,22 +251,24 @@ class _Node(PydanticModel):
         return v
 
     @model_validator(mode="after")
-    @model_validator_v1_args
-    def _node_root_validator(cls, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
-        interval_unit = values.get("interval_unit_")
-        if interval_unit and not values.get("allow_partials"):
-            cron = values["cron"]
+    def _node_root_validator(self) -> Self:
+        interval_unit = self.interval_unit_
+        if interval_unit and not hasattr(self, "allow_partials"):
+            cron = self.cron
             max_interval_unit = IntervalUnit.from_cron(cron)
             if interval_unit.seconds > max_interval_unit.seconds:
                 raise ConfigError(
-                    f"Cron '{cron}' cannot be more frequent than interval unit '{interval_unit.value}'. If this is intentional, set allow_partials to True."
+                    f"Cron '{cron}' cannot be more frequent than interval unit '{interval_unit.value}'. "
+                    "If this is intentional, set allow_partials to True."
                 )
-        start = values.get("start")
-        end = values.get("end")
+
+        start = self.start
+        end = self.end
+
         if end is not None and start is None:
             raise ConfigError("Must define a start date if an end date is defined.")
         validate_date_range(start, end)
-        return values
+        return self
 
     @property
     def batch_size(self) -> t.Optional[int]:

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -23,11 +23,7 @@ from sqlmesh.core.snapshot.definition import Interval, SnapshotIntervals
 from sqlmesh.utils import major_minor
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.errors import SQLMeshError
-from sqlmesh.utils.pydantic import (
-    PydanticModel,
-    field_validator,
-    field_validator_v1_args,
-)
+from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -71,11 +67,10 @@ class PromotionResult(PydanticModel):
     removed_environment_naming_info: t.Optional[EnvironmentNamingInfo]
 
     @field_validator("removed_environment_naming_info")
-    @field_validator_v1_args
     def _validate_removed_environment_naming_info(
-        cls, v: t.Optional[EnvironmentNamingInfo], values: t.Any
+        cls, v: t.Optional[EnvironmentNamingInfo], info: ValidationInfo
     ) -> t.Optional[EnvironmentNamingInfo]:
-        if v and not values["removed"]:
+        if v and not info.data.get("removed"):
             raise ValueError("removed_environment_naming_info must be None if removed is empty")
         return v
 

--- a/sqlmesh/core/user.py
+++ b/sqlmesh/core/user.py
@@ -1,15 +1,8 @@
 import typing as t
 from enum import Enum
 
-from sqlmesh.core.notification_target import (
-    BasicSMTPNotificationTarget,
-    NotificationTarget,
-)
-from sqlmesh.utils.pydantic import (
-    PydanticModel,
-    field_validator,
-    field_validator_v1_args,
-)
+from sqlmesh.core.notification_target import BasicSMTPNotificationTarget, NotificationTarget
+from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator
 
 
 class UserRole(str, Enum):
@@ -44,13 +37,12 @@ class User(PydanticModel):
         return UserRole.REQUIRED_APPROVER in self.roles
 
     @field_validator("notification_targets")
-    @field_validator_v1_args
     def validate_notification_targets(
         cls,
         v: t.List[NotificationTarget],
-        values: t.Dict[str, t.Any],
+        info: ValidationInfo,
     ) -> t.List[NotificationTarget]:
-        email = values["email"]
+        email = info.data["email"]
         for target in v:
             if isinstance(target, BasicSMTPNotificationTarget) and target.recipients != {email}:
                 raise ValueError("Recipient emails do not match user email")

--- a/sqlmesh/dbt/target.py
+++ b/sqlmesh/dbt/target.py
@@ -34,11 +34,7 @@ from sqlmesh.dbt.relation import Policy
 from sqlmesh.dbt.util import DBT_VERSION
 from sqlmesh.utils import AttributeDict, classproperty
 from sqlmesh.utils.errors import ConfigError
-from sqlmesh.utils.pydantic import (
-    field_validator,
-    model_validator,
-    model_validator_v1_args,
-)
+from sqlmesh.utils.pydantic import field_validator, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -167,20 +163,20 @@ class DuckDbConfig(TargetConfig):
     settings: t.Optional[t.Dict[str, t.Any]] = None
 
     @model_validator(mode="before")
-    @model_validator_v1_args
-    def validate_authentication(
-        cls, values: t.Dict[str, t.Union[t.Tuple[str, ...], t.Optional[str], t.Dict[str, t.Any]]]
-    ) -> t.Dict[str, t.Union[t.Tuple[str, ...], t.Optional[str], t.Dict[str, t.Any]]]:
-        if "database" not in values and DBT_VERSION >= (1, 5):
-            path = values.get("path")
-            values["database"] = (
-                "memory"
-                if path is None or path == DUCKDB_IN_MEMORY
-                else Path(t.cast(str, path)).stem
-            )
-        if "threads" in values and t.cast(int, values["threads"]) > 1:
-            logger.warning("DuckDB does not support concurrency - setting threads to 1.")
-        return values
+    @classmethod
+    def validate_authentication(cls, data: t.Any) -> t.Any:
+        if isinstance(data, dict):
+            if "database" not in data and DBT_VERSION >= (1, 5):
+                path = data.get("path")
+                data["database"] = (
+                    "memory"
+                    if path is None or path == DUCKDB_IN_MEMORY
+                    else Path(t.cast(str, path)).stem
+                )
+            if "threads" in data and t.cast(int, data["threads"]) > 1:
+                logger.warning("DuckDB does not support concurrency - setting threads to 1.")
+
+        return data
 
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "delete+insert"
@@ -257,17 +253,17 @@ class SnowflakeConfig(TargetConfig):
     retry_all: bool = False
 
     @model_validator(mode="before")
-    @model_validator_v1_args
-    def validate_authentication(
-        cls, values: t.Dict[str, t.Union[t.Tuple[str, ...], t.Optional[str], t.Dict[str, t.Any]]]
-    ) -> t.Dict[str, t.Union[t.Tuple[str, ...], t.Optional[str], t.Dict[str, t.Any]]]:
-        if (
-            values.get("password")
-            or values.get("authenticator")
-            or values.get("private_key")
-            or values.get("private_key_path")
-        ):
-            return values
+    @classmethod
+    def validate_authentication(cls, data: t.Any) -> t.Any:
+        if isinstance(data, dict):
+            if (
+                data.get("password")
+                or data.get("authenticator")
+                or data.get("private_key")
+                or data.get("private_key_path")
+            ):
+                return data
+
         raise ConfigError("No supported Snowflake authentication method found in target profile.")
 
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
@@ -339,14 +335,13 @@ class PostgresConfig(TargetConfig):
     sslmode: t.Optional[str] = None
 
     @model_validator(mode="before")
-    @model_validator_v1_args
-    def validate_database(
-        cls, values: t.Dict[str, t.Union[t.Tuple[str, ...], t.Optional[str], t.Dict[str, t.Any]]]
-    ) -> t.Dict[str, t.Union[t.Tuple[str, ...], t.Optional[str], t.Dict[str, t.Any]]]:
-        values["database"] = values.get("database") or values.get("dbname")
-        if not values["database"]:
-            raise ConfigError("Either database or dbname must be set")
-        return values
+    @classmethod
+    def validate_database(cls, data: t.Any) -> t.Any:
+        if isinstance(data, dict):
+            data["database"] = data.get("database") or data.get("dbname")
+            if not data["database"]:
+                raise ConfigError("Either database or dbname must be set")
+        return data
 
     @field_validator("port")
     @classmethod
@@ -401,14 +396,13 @@ class RedshiftConfig(TargetConfig):
     sslmode: t.Optional[str] = None
 
     @model_validator(mode="before")
-    @model_validator_v1_args
-    def validate_database(
-        cls, values: t.Dict[str, t.Union[t.Tuple[str, ...], t.Optional[str], t.Dict[str, t.Any]]]
-    ) -> t.Dict[str, t.Union[t.Tuple[str, ...], t.Optional[str], t.Dict[str, t.Any]]]:
-        values["database"] = values.get("database") or values.get("dbname")
-        if not values["database"]:
-            raise ConfigError("Either database or dbname must be set")
-        return values
+    @classmethod
+    def validate_database(cls, data: t.Any) -> t.Any:
+        if isinstance(data, dict):
+            data["database"] = data.get("database") or data.get("dbname")
+            if not data["database"]:
+                raise ConfigError("Either database or dbname must be set")
+        return data
 
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "append"
@@ -546,17 +540,17 @@ class BigQueryConfig(TargetConfig):
     maximum_bytes_billed: t.Optional[int] = None
 
     @model_validator(mode="before")
-    @model_validator_v1_args
-    def validate_fields(
-        cls, values: t.Dict[str, t.Union[t.Tuple[str, ...], t.Optional[str], t.Dict[str, t.Any]]]
-    ) -> t.Dict[str, t.Union[t.Tuple[str, ...], t.Optional[str], t.Dict[str, t.Any]]]:
-        values["schema"] = values.get("schema") or values.get("dataset")
-        if not values["schema"]:
-            raise ConfigError("Either schema or dataset must be set")
-        values["database"] = values.get("database") or values.get("project")
-        if not values["database"]:
-            raise ConfigError("Either database or project must be set")
-        return values
+    @classmethod
+    def validate_fields(cls, data: t.Any) -> t.Any:
+        if isinstance(data, dict):
+            data["schema"] = data.get("schema") or data.get("dataset")
+            if not data["schema"]:
+                raise ConfigError("Either schema or dataset must be set")
+            data["database"] = data.get("database") or data.get("project")
+            if not data["database"]:
+                raise ConfigError("Either database or project must be set")
+
+        return data
 
     def default_incremental_strategy(self, kind: IncrementalKind) -> str:
         return "merge"
@@ -661,23 +655,22 @@ class MSSQLConfig(TargetConfig):
     client_secret: t.Optional[str] = None  # Azure Active Directory auth
 
     @model_validator(mode="before")
-    @model_validator_v1_args
-    def validate_alias_fields(
-        cls, values: t.Dict[str, t.Union[t.Tuple[str, ...], t.Optional[str], t.Dict[str, t.Any]]]
-    ) -> t.Dict[str, t.Union[t.Tuple[str, ...], t.Optional[str], t.Dict[str, t.Any]]]:
-        values["host"] = values.get("host") or values.get("server")
-        if not values["host"]:
-            raise ConfigError("Either host or server must be set")
+    @classmethod
+    def validate_alias_fields(cls, data: t.Any) -> t.Any:
+        if isinstance(data, dict):
+            data["host"] = data.get("host") or data.get("server")
+            if not data["host"]:
+                raise ConfigError("Either host or server must be set")
 
-        values["user"] = values.get("user") or values.get("username") or values.get("UID")
-        if not values["user"]:
-            raise ConfigError("One of user, username, or UID must be set")
+            data["user"] = data.get("user") or data.get("username") or data.get("UID")
+            if not data["user"]:
+                raise ConfigError("One of user, username, or UID must be set")
 
-        values["password"] = values.get("password") or values.get("PWD")
-        if not values["password"]:
-            raise ConfigError("Either password or PWD must be set")
+            data["password"] = data.get("password") or data.get("PWD")
+            if not data["password"]:
+                raise ConfigError("Either password or PWD must be set")
 
-        return values
+        return data
 
     @field_validator("authentication")
     @classmethod

--- a/sqlmesh/integrations/github/cicd/config.py
+++ b/sqlmesh/integrations/github/cicd/config.py
@@ -6,7 +6,7 @@ from pydantic import Field
 from sqlmesh.core.config import CategorizerConfig
 from sqlmesh.core.config.base import BaseConfig
 from sqlmesh.utils.date import TimeLike
-from sqlmesh.utils.pydantic import model_validator, model_validator_v1_args
+from sqlmesh.utils.pydantic import model_validator
 
 
 class MergeMethod(str, Enum):
@@ -30,13 +30,15 @@ class GithubCICDBotConfig(BaseConfig):
     pr_environment_name: t.Optional[str] = None
 
     @model_validator(mode="before")
-    @model_validator_v1_args
-    def _validate(cls, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
-        if values.get("enable_deploy_command") and not values.get("merge_method"):
-            raise ValueError("merge_method must be set if enable_deploy_command is True")
-        if values.get("command_namespace") and not values.get("enable_deploy_command"):
-            raise ValueError("enable_deploy_command must be set if command_namespace is set")
-        return values
+    @classmethod
+    def _validate(cls, data: t.Any) -> t.Any:
+        if isinstance(data, dict):
+            if data.get("enable_deploy_command") and not data.get("merge_method"):
+                raise ValueError("merge_method must be set if enable_deploy_command is True")
+            if data.get("command_namespace") and not data.get("enable_deploy_command"):
+                raise ValueError("enable_deploy_command must be set if command_namespace is set")
+
+        return data
 
     FIELDS_FOR_ANALYTICS: t.ClassVar[t.Set[str]] = {
         "invalidate_environment_after_deploy",

--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import json
 import typing as t
-from functools import wraps
 
 import pydantic
+from pydantic import ValidationInfo as ValidationInfo
 from pydantic.fields import FieldInfo
 from sqlglot import exp, parse_one
 from sqlglot.helper import ensure_list
@@ -27,14 +27,10 @@ PYDANTIC_MAJOR_VERSION, PYDANTIC_MINOR_VERSION = [int(p) for p in pydantic.__ver
 
 
 def field_validator(*args: t.Any, **kwargs: t.Any) -> t.Callable[[t.Any], t.Any]:
-    # Pydantic v2 doesn't support "always" argument. The validator behaves as if "always" is True.
-    kwargs.pop("always", None)
     return pydantic.field_validator(*args, **kwargs)
 
 
 def model_validator(*args: t.Any, **kwargs: t.Any) -> t.Callable[[t.Any], t.Any]:
-    # Pydantic v2 doesn't support "always" argument. The validator behaves as if "always" is True.
-    kwargs.pop("always", None)
     return pydantic.model_validator(*args, **kwargs)
 
 
@@ -179,30 +175,6 @@ class PydanticModel(pydantic.BaseModel):
 
     def __repr__(self) -> str:
         return str(self)
-
-
-def model_validator_v1_args(func: t.Callable[..., t.Any]) -> t.Callable[..., t.Any]:
-    @wraps(func)
-    def wrapper(cls: t.Type, values: t.Any, *args: t.Any, **kwargs: t.Any) -> t.Any:
-        is_values_dict = isinstance(values, dict)
-        values_dict = values if is_values_dict else values.__dict__
-        result = func(cls, values_dict, *args, **kwargs)
-        if is_values_dict:
-            return result
-        else:
-            values.__dict__.update(result)
-            return values
-
-    return wrapper
-
-
-def field_validator_v1_args(func: t.Callable[..., t.Any]) -> t.Callable[..., t.Any]:
-    @wraps(func)
-    def wrapper(cls: t.Type, v: t.Any, values: t.Any, *args: t.Any, **kwargs: t.Any) -> t.Any:
-        values_dict = values if isinstance(values, dict) else values.data
-        return func(cls, v, values_dict, *args, **kwargs)
-
-    return wrapper
 
 
 def validate_list_of_strings(v: t.Any) -> t.List[str]:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2568,7 +2568,7 @@ def test_parse_expression_list_with_jinja():
         "JINJA_STATEMENT_BEGIN;\n{{ log('log message') }}\nJINJA_END;",
         "GRANT SELECT ON TABLE foo TO DEV",
     ]
-    assert input == [val.sql() for val in parse_expression(SqlModel, input, {})]
+    assert input == [val.sql() for val in parse_expression(SqlModel, input)]
 
 
 def test_no_depends_on_runtime_jinja_query():
@@ -3660,7 +3660,7 @@ def test_scd_type_2_by_time_overrides():
     assert not scd_type_2_model.kind.disable_restatement
 
     model_kind_dict = scd_type_2_model.kind.dict()
-    assert scd_type_2_model.kind == _model_kind_validator(None, model_kind_dict, {})
+    assert scd_type_2_model.kind == _model_kind_validator(None, model_kind_dict)
 
 
 def test_scd_type_2_by_column_defaults():
@@ -3749,7 +3749,7 @@ def test_scd_type_2_by_column_overrides():
     assert not scd_type_2_model.kind.disable_restatement
 
     model_kind_dict = scd_type_2_model.kind.dict()
-    assert scd_type_2_model.kind == _model_kind_validator(None, model_kind_dict, {})
+    assert scd_type_2_model.kind == _model_kind_validator(None, model_kind_dict)
 
 
 def test_scd_type_2_python_model() -> None:

--- a/web/server/models.py
+++ b/web/server/models.py
@@ -19,11 +19,7 @@ from sqlmesh.core.snapshot.definition import (
     SnapshotId,
 )
 from sqlmesh.utils.date import TimeLike, now_timestamp
-from sqlmesh.utils.pydantic import (
-    PydanticModel,
-    field_validator,
-    field_validator_v1_args,
-)
+from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator
 
 SUPPORTED_EXTENSIONS = {".py", ".sql", ".yaml", ".yml", ".csv"}
 
@@ -119,11 +115,10 @@ class File(PydanticModel):
     content: t.Optional[str] = None
     model_config = pydantic.ConfigDict(validate_default=True)  # type: ignore
 
-    @field_validator("extension", always=True, mode="before")
-    @field_validator_v1_args
-    def default_extension(cls, v: str, values: t.Dict[str, t.Any]) -> str:
-        if "name" in values:
-            return pathlib.Path(values["name"]).suffix
+    @field_validator("extension", mode="before")
+    def default_extension(cls, v: str, info: ValidationInfo) -> str:
+        if "name" in info.data:
+            return pathlib.Path(info.data["name"]).suffix
         return v
 
 


### PR DESCRIPTION
Fixes #3566

This PR mainly aims to remove `model_validator_v1_args` and `field_validator_v1_args`. It's a WIP, I'm not sure yet if this is the right way to do it, just wanted some first feedback.