### PR TITLE
Fix: Physical view not being created when needed for non-deployable indirect non-breaking snapshots

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1329,8 +1329,10 @@ class DeployabilityIndex(PydanticModel, frozen=True):
         )
 
     def is_representative(self, snapshot: SnapshotIdLike) -> bool:
-        """Returns true if the output produced by the given snapshot in a development environment can be reused
-        in (deployed to) production, or if this snapshot already represents what is currently in production.
+        """Returns true if the deployable (non-dev) table of the given snapshot should be used for reading, table mapping, and
+        computing missing intervals.
+
+        Note, that deployable snapshots are also representative, but the reverse is not always true.
 
         Unlike `is_deployable`, this variant also captures FORWARD_ONLY and INDIRECT_NON_BREAKING snapshots that
         are not deployable by their nature but are currently promoted in production. Therefore, it's safe to consider


### PR DESCRIPTION
In very rare scenarios, there might be a snapshot of a view model that is representative but not deployable, while the corresponding physical view has not yet been created for it.

One example of this happening is the following scenario:
Model DAG: A (forward-only) -> B (non-forward-only) -> C (view).
1. Make some change to A in `dev`. Everything categorized as forward-only
2. Make a follow-up breaking change to B in dev. C is now `INDIRECT_BREAKING`. The deployable view hasn't been created at this point*
3. Deploy the 1st change to `prod` without deploying the 2nd change.
4. Make another change to B, this time non-breaking, still in `dev`. C is now `INDIRECT_NON_BREAKING`. Applying this change fails with missing view

*The view hasn't been created at this point due to a different issue which is outlined in this PR: https://github.com/TobikoData/sqlmesh/pull/2899 