### PR TITLE
Feat: implement support for bigframes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -101,3 +101,6 @@ ignore_missing_imports = True
 
 [mypy-dlt.*]
 ignore_missing_imports = True
+
+[mypy-bigframes.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
             "google-cloud-bigquery[pandas]",
             "google-cloud-bigquery-storage",
         ],
+        "bigframes": ["bigframes>=1.32.0"],
         "clickhouse": ["clickhouse-connect"],
         "databricks": ["databricks-sql-connector"],
         "dev": [

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -126,6 +126,7 @@ if t.TYPE_CHECKING:
     from typing_extensions import Literal
 
     from sqlmesh.core.engine_adapter._typing import (
+        BigframeSession,
         DF,
         PySparkDataFrame,
         PySparkSession,
@@ -166,6 +167,11 @@ class BaseContext(abc.ABC):
     def snowpark(self) -> t.Optional[SnowparkSession]:
         """Returns the snowpark session if it exists."""
         return self.engine_adapter.snowpark
+
+    @property
+    def bigframe(self) -> t.Optional[BigframeSession]:
+        """Returns the bigframe session if it exists."""
+        return self.engine_adapter.bigframe
 
     @property
     def default_catalog(self) -> t.Optional[str]:

--- a/sqlmesh/core/engine_adapter/_typing.py
+++ b/sqlmesh/core/engine_adapter/_typing.py
@@ -8,6 +8,8 @@ from sqlmesh.utils import optional_import
 if t.TYPE_CHECKING:
     import pyspark
     import pyspark.sql.connect.dataframe
+    from bigframes.session import Session as BigframeSession  # noqa
+    from bigframes.dataframe import DataFrame as BigframeDataFrame
 
     snowpark = optional_import("snowflake.snowpark")
 
@@ -23,6 +25,7 @@ if t.TYPE_CHECKING:
         pd.DataFrame,
         pyspark.sql.DataFrame,
         pyspark.sql.connect.dataframe.DataFrame,
+        BigframeDataFrame,
         SnowparkDataFrame,
     ]
 

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -49,6 +49,7 @@ from sqlmesh.utils.pandas import columns_to_types_from_df
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import SchemaName, SessionProperties, TableName
     from sqlmesh.core.engine_adapter._typing import (
+        BigframeSession,
         DF,
         PySparkDataFrame,
         PySparkSession,
@@ -158,6 +159,10 @@ class EngineAdapter:
 
     @property
     def snowpark(self) -> t.Optional[SnowparkSession]:
+        return None
+
+    @property
+    def bigframe(self) -> t.Optional[BigframeSession]:
         return None
 
     @property

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -673,7 +673,7 @@ class SnapshotEvaluator:
                 if isinstance(query_or_df, pd.DataFrame):
                     return query_or_df.head(limit)
                 if not isinstance(query_or_df, exp.Expression):
-                    # We assume that if this branch is reached, `query_or_df` is a pyspark / snowpark dataframe,
+                    # We assume that if this branch is reached, `query_or_df` is a pyspark / snowpark / bigframe dataframe,
                     # so we use `limit` instead of `head` to get back a dataframe instead of List[Row]
                     # https://spark.apache.org/docs/3.1.1/api/python/reference/api/pyspark.sql.DataFrame.head.html#pyspark.sql.DataFrame.head
                     return query_or_df.limit(limit)


### PR DESCRIPTION
I PR'ed the upstream lib so that they have no upper bound on their SQLGlot pin. This means the library is now fully compatible with SQLMesh. This PR adds support. Instead of bundling the extra with bigquery, I have temporarily added it to its own extra so it is opt-in. Once they cut a version release, we can add it with a proper `>=` version specifier. 

This enables many novel uses such as using Gemini / LLM capabilities at scale more effectively, using ML models (training , predicting, etc), and so on leveraging BigQuery's compute through a dataframe interface wrapped intuitively by `sqlmesh`'s python model system.

https://cloud.google.com/bigquery/docs/use-bigquery-dataframes#pandas-examples

https://github.com/googleapis/python-bigquery-dataframes/blob/main/notebooks/getting_started/ml_fundamentals_bq_dataframes.ipynb

I have tested this locally. I was able to crunch through 35G in 15 seconds with no local computation. Its very nice.

The following example requires no seeds or pre-loaded data as it leverages BQ's open datasets. You can run this with or without the remote function. 

```python
"""Working example to get your feet wet"""
import typing as t
from datetime import datetime

from bigframes.pandas import DataFrame

from sqlmesh import ExecutionContext, model


def get_bucket(num: int):
    if not num:
        return "NA"
    boundary = 10
    return "at_or_above_10" if num >= boundary else "below_10"


@model(
    "mart.wiki",
    columns={
        "title": "text",
        "views": "int",
        "bucket": "text",
    },
)
def execute(
    context: ExecutionContext,
    start: datetime,
    end: datetime,
    execution_time: datetime,
    **kwargs: t.Any,
) -> DataFrame:
    # Create a remote function to be used in the Bigframe DataFrame
    remote_get_bucket = context.bigframe.remote_function([int], str)(get_bucket)

    # Returns the Bigframe DataFrame handle, no data is computed locally
    df = context.bigframe.read_gbq("bigquery-samples.wikipedia_pageviews.200809h")

    df = (
        # This runs entirely on the BigQuery engine lazily
        df[df.title.str.contains(r"[Gg]oogle")]
        .groupby(["title"], as_index=False)["views"]
        .sum(numeric_only=True)
        .sort_values("views", ascending=False)
    )

    return df.assign(bucket=df["views"].apply(remote_get_bucket))
```


Support was simple given the way the `query_factory` works and similar art with Snowpark. Very straightforward. Good work on that.


You can even do interesting things like include a read from a gcs bucket in BQ engine:

```python
filepath_or_buffer = "gs://cloud-samples-data/bigquery/us-states/us-states.csv"
df_from_gcs = bpd.read_csv(filepath_or_buffer)
```