### PR TITLE
fix: update default value for `invalidate_hard_deletes` to match docs

### DIFF
--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -659,7 +659,7 @@ class _SCDType2Kind(_Incremental):
     unique_key: SQLGlotListOfFields
     valid_from_name: SQLGlotColumn = Field(exp.column("valid_from"), validate_default=True)
     valid_to_name: SQLGlotColumn = Field(exp.column("valid_to"), validate_default=True)
-    invalidate_hard_deletes: SQLGlotBool = False
+    invalidate_hard_deletes: SQLGlotBool = True
     time_data_type: exp.DataType = Field(exp.DataType.build("TIMESTAMP"), validate_default=True)
 
     forward_only: SQLGlotBool = True


### PR DESCRIPTION
https://sqlmesh.readthedocs.io/en/stable/concepts/models/model_kinds/?h=invalidate+hard+deletes#deletes

> If invalidate_hard_deletes is set to true (default):
>  - valid_to column will be set to the time when the SQLMesh run started that detected the missing record (called execution_time).
>  - If the record is added back, then the valid_to column will remain unchanged.