### PR TITLE
Fix: Reduce parsing overhead and improve performance when unpausing snapshots deployed to prod

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -940,16 +940,6 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
 
         self.change_category = category
 
-    def set_unpaused_ts(self, unpaused_dt: t.Optional[TimeLike]) -> None:
-        """Sets the timestamp for when this snapshot was unpaused.
-
-        Args:
-            unpaused_dt: The datetime object of when this snapshot was unpaused.
-        """
-        self.unpaused_ts = (
-            to_timestamp(self.node.interval_unit.cron_floor(unpaused_dt)) if unpaused_dt else None
-        )
-
     def table_name(self, is_deployable: bool = True) -> str:
         """Full table name pointing to the materialized location of the snapshot.
 

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -1400,7 +1400,7 @@ def test_has_paused_forward_only(snapshot: Snapshot):
     snapshot.categorize_as(SnapshotChangeCategory.FORWARD_ONLY)
     assert has_paused_forward_only([snapshot], [snapshot])
 
-    snapshot.set_unpaused_ts("2023-01-01")
+    snapshot.unpaused_ts = to_timestamp("2023-01-01")
     assert not has_paused_forward_only([snapshot], [snapshot])
 
 

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -1429,6 +1429,50 @@ def test_unpause_snapshots(state_sync: EngineAdapterStateSync, make_snapshot: t.
     assert not actual_snapshots[new_snapshot.snapshot_id].unrestorable
 
 
+def test_unpause_snapshots_hourly(state_sync: EngineAdapterStateSync, make_snapshot: t.Callable):
+    snapshot = make_snapshot(
+        SqlModel(
+            name="test_snapshot",
+            query=parse_one("select 1, ds"),
+            cron="@hourly",
+        ),
+    )
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+    snapshot.version = "a"
+
+    assert not snapshot.unpaused_ts
+    state_sync.push_snapshots([snapshot])
+
+    # Unpaused timestamp not aligned with cron
+    unpaused_dt = "2022-01-01 01:22:33"
+    state_sync.unpause_snapshots([snapshot], unpaused_dt)
+
+    actual_snapshot = state_sync.get_snapshots([snapshot])[snapshot.snapshot_id]
+    assert actual_snapshot.unpaused_ts
+    assert actual_snapshot.unpaused_ts == to_timestamp("2022-01-01 01:00:00")
+
+    new_snapshot = make_snapshot(
+        SqlModel(
+            name="test_snapshot",
+            query=parse_one("select 2, ds"),
+            cron="@daily",
+            interval_unit="hour",
+        )
+    )
+    new_snapshot.categorize_as(SnapshotChangeCategory.FORWARD_ONLY)
+    new_snapshot.version = "a"
+
+    assert not new_snapshot.unpaused_ts
+    state_sync.push_snapshots([new_snapshot])
+    state_sync.unpause_snapshots([new_snapshot], unpaused_dt)
+
+    actual_snapshots = state_sync.get_snapshots([snapshot, new_snapshot])
+    assert not actual_snapshots[snapshot.snapshot_id].unpaused_ts
+    assert actual_snapshots[new_snapshot.snapshot_id].unpaused_ts == to_timestamp(
+        "2022-01-01 01:00:00"
+    )
+
+
 def test_unrestorable_snapshot(state_sync: EngineAdapterStateSync, make_snapshot: t.Callable):
     snapshot = make_snapshot(
         SqlModel(
@@ -1526,6 +1570,45 @@ def test_unpause_snapshots_remove_intervals(
     ]
     assert actual_snapshots[snapshot.snapshot_id].intervals == [
         (to_timestamp("2023-01-01"), to_timestamp("2023-01-03")),
+    ]
+
+
+def test_unpause_snapshots_remove_intervals_disabled_restatement(
+    state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
+):
+    kind = dict(name="INCREMENTAL_BY_TIME_RANGE", time_column="ds", disable_restatement=True)
+    snapshot = make_snapshot(
+        SqlModel(
+            name="test_snapshot",
+            query=parse_one("select 1, ds"),
+            cron="@daily",
+            kind=kind,
+        ),
+        version="a",
+    )
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+    snapshot.version = "a"
+    state_sync.push_snapshots([snapshot])
+    state_sync.add_interval(snapshot, "2023-01-01", "2023-01-05")
+
+    new_snapshot = make_snapshot(
+        SqlModel(name="test_snapshot", query=parse_one("select 2, ds"), cron="@daily", kind=kind),
+        version="a",
+    )
+    new_snapshot.categorize_as(SnapshotChangeCategory.FORWARD_ONLY)
+    new_snapshot.version = "a"
+    new_snapshot.effective_from = "2023-01-03"
+    state_sync.push_snapshots([new_snapshot])
+    state_sync.add_interval(snapshot, "2023-01-06", "2023-01-06")
+    state_sync.unpause_snapshots([new_snapshot], "2023-01-06")
+
+    actual_snapshots = state_sync.get_snapshots([snapshot, new_snapshot])
+    assert actual_snapshots[new_snapshot.snapshot_id].intervals == [
+        (to_timestamp("2023-01-01"), to_timestamp("2023-01-03")),
+    ]
+    # The intervals shouldn't have been removed because restatement is disabled
+    assert actual_snapshots[snapshot.snapshot_id].intervals == [
+        (to_timestamp("2023-01-01"), to_timestamp("2023-01-07")),
     ]
 
 


### PR DESCRIPTION
Unpausing snapshots that are deployed to prod involves fetching all snapshots that share the same version as the ones being deployed. 

Before this change, fetching snapshots with the same versions involved full parsing of snapshot objects, including their models and queries. This caused a significant performance issue for projects with a high number of models, especially forward-only models.

With this update, SQLMesh will perform only a partial parsing when fetching snapshots with the same version, falling back to parsing the full snapshot only when absolutely necessary (which should be rare).

Additionally, this should also improve the performance of deleting expired snapshots, which relies on the same method to fetch snapshots with the same version.