### PR TITLE
Fix: The inference of the default plan start

### DIFF
--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -852,7 +852,7 @@ def test_plan_default_end(sushi_context_pre_scheduling: Context):
     ).build()
     assert forward_only_dev_plan.end is not None
     assert to_date(make_inclusive_end(forward_only_dev_plan.end)) == plan_end
-    assert forward_only_dev_plan.start == plan_end
+    assert to_timestamp(forward_only_dev_plan.start) == to_timestamp(plan_end)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
The previous logic was overly simplistic and worked well only for daily models, while yielding poor results for models with a coarser cadence (weekly, monthly).

The new logic is based on interval units of models that constitute a plan.