### PR TITLE
Fix: parse python model column types with dialect

### DIFF
--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -71,7 +71,9 @@ class model(registry_decorator):
             column_name: (
                 column_type
                 if isinstance(column_type, exp.DataType)
-                else exp.DataType.build(str(column_type))
+                else exp.DataType.build(
+                    str(column_type), dialect=self.kwargs.get("dialect", self._dialect)
+                )
             )
             for column_name, column_type in self.kwargs.pop("columns", {}).items()
         }


### PR DESCRIPTION
Currently, python model column data types are parsed with the default sqlglot dialect instead of the explicit model dialect or project default dialect. 

This PR updates it to use the explicit model dialect when present and default project dialect when not.