### PR TITLE
Fix: ensure strict defaults dont break all the models to which they a…

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2087,6 +2087,9 @@ def _create_model(
         kwargs["kind"] = create_model_kind(raw_kind, dialect, defaults or {})
 
     defaults = {k: v for k, v in (defaults or {}).items() if k in klass.all_fields()}
+    if not issubclass(klass, SqlModel):
+        defaults.pop("optimize_query", None)
+        defaults.pop("validate_query", None)
 
     statements = []
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -7032,6 +7032,17 @@ col_a,col_b,col_c
     context.upsert_model(model)
     context.plan(auto_apply=True, no_prompts=True)
 
+    # Ensure strict defaults don't break all non SQL models to which they weren't applicable in the first place
+    seed_strict_defaults = create_seed_model(
+        "test_db.test_seed_model", model_kind, defaults=strict_default
+    )
+    external_strict_defaults = create_external_model(
+        "test_db.test_external_model", columns={"a": "int", "limit": "int"}, defaults=strict_default
+    )
+    context.upsert_model(seed_strict_defaults)
+    context.upsert_model(external_strict_defaults)
+    context.plan(auto_apply=True, no_prompts=True)
+
 
 def test_partition_interval_unit():
     expressions = d.parse(


### PR DESCRIPTION
…re not applicable.

Currently using a basic setting like this: 

```py
config = sqlmesh.Config(
    gateways={"prod": prod, "dev": dev},
    default_gateway="dev",
    model_defaults=ModelDefaultsConfig(
        dialect="bigquery",
        start="2020-01-01",
        validate_query=True,  # NOTE: it is bugged -- it is applying itself to SEEDs and 100s of EXTERNAL models indiscriminately and the throwing error in `validate_definition`
    )
)
```

Causes a project to be un-loadable as all models including seeds and external models would receive this default argument, then raise an error in the [validate_definition](https://github.com/z3z1ma/sqlmesh/blob/fb943d25ef387dc4c0358e010e7e5e86eb4779db/sqlmesh/core/model/definition.py#L919-L929). Considering folks can have many seeds and hundreds of external models, explicitly setting validate_query false on them when you set a project wide setting seems suboptimal compared to fixing it here. :) 

I ensured the test case I added fails without this change and passes with it.