### PR TITLE
Fix: no models ready to run message shouldn't error 

### DIFF
--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -313,13 +313,17 @@ class Scheduler:
         )
 
         if not merged_intervals:
-            next_ready_interval_start = get_next_model_interval_start(self.snapshots.values())
+            next_run_ready_msg = ""
 
-            utc_time = format_tz_datetime(next_ready_interval_start)
-            local_time = format_tz_datetime(next_ready_interval_start, use_local_timezone=True)
+            next_ready_interval_start = get_next_model_interval_start(self.snapshots.values())
+            if next_ready_interval_start:
+                utc_time = format_tz_datetime(next_ready_interval_start)
+                local_time = format_tz_datetime(next_ready_interval_start, use_local_timezone=True)
+                time_msg = local_time if local_time == utc_time else f"{local_time} ({utc_time})"
+                next_run_ready_msg = f"\n\nNext run will be ready at {time_msg}."
 
             self.console.log_status_update(
-                f"No models are ready to run. Please wait until a model `cron` interval has elapsed.\n\nNext run will be ready at {local_time} ({utc_time})."
+                f"No models are ready to run. Please wait until a model `cron` interval has elapsed.{next_run_ready_msg}"
             )
             return CompletionStatus.NOTHING_TO_DO
 

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -2087,12 +2087,13 @@ def _check_ready_intervals(
     return checked_intervals
 
 
-def get_next_model_interval_start(snapshots: t.Iterable[Snapshot]) -> datetime:
+def get_next_model_interval_start(snapshots: t.Iterable[Snapshot]) -> t.Optional[datetime]:
     now_dt = now()
-    return min(
-        [
-            snap.node.cron_next(now_dt)
-            for snap in snapshots
-            if snap.is_model and not snap.is_symbolic and not snap.is_seed
-        ]
-    )
+
+    starts = [
+        snap.node.cron_next(now_dt)
+        for snap in snapshots
+        if snap.is_model and not snap.is_symbolic and not snap.is_seed
+    ]
+
+    return min(starts) if starts else None


### PR DESCRIPTION
When no models are ready to run, the `sqlmesh run` command issues a message stating when the next model will be ready to run.

Some model kinds, like `seed` and `symbolic`, do not have a "ready" time. Currently, we error if a project only contains these kinds of models.

This PR updates the code to handle this situation, omitting the time when next model ready from the message if it cannot be calculated.