### PR TITLE
Feat: expose physical schema override per model for more granular us…

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2075,12 +2075,13 @@ def _create_model(
 
     physical_schema_mapping = physical_schema_mapping or {}
     model_schema_name = exp.to_table(name, dialect=dialect).db
-    physical_schema_override: t.Optional[str] = None
+    physical_schema_override: t.Optional[str] = kwargs.pop("physical_schema_override", None)
 
-    for re_pattern, override_schema in physical_schema_mapping.items():
-        if re.match(re_pattern, model_schema_name):
-            physical_schema_override = override_schema
-            break
+    if not physical_schema_override:
+        for re_pattern, override_schema in physical_schema_mapping.items():
+            if re.match(re_pattern, model_schema_name):
+                physical_schema_override = override_schema
+                break
 
     raw_kind = kwargs.pop("kind", None)
     if raw_kind:

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -166,8 +166,8 @@ class ModelMeta(_Node):
         dialect = str_or_exp_to_str(v)
         return dialect and dialect.lower()
 
-    @field_validator("physical_version", mode="before")
-    def _physical_version_validator(cls, v: t.Any) -> t.Optional[str]:
+    @field_validator("physical_version", "physical_schema_override", mode="before")
+    def _physical_version_and_schema_validator(cls, v: t.Any) -> t.Optional[str]:
         if v is None:
             return v
         return str_or_exp_to_str(v)

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -6303,6 +6303,27 @@ def test_physical_version():
         ).validate_definition()
 
 
+def test_physical_schema():
+    # in conjunction with physical_version, you can have sqlmesh manage an existing table without moving it
+    # or using a dedicated schema just for the physical_schema_mapping
+    expressions = d.parse(
+        """
+        MODEL (
+            name db.table,
+            kind INCREMENTAL_BY_TIME_RANGE(
+                time_column a
+            ),
+            physical_schema_override db
+        );
+
+        SELECT a, b
+        """
+    )
+
+    model = load_sql_based_model(expressions)
+    assert model.physical_schema == "db"
+
+
 def test_trailing_comments():
     expressions = d.parse(
         """


### PR DESCRIPTION
…er use cases. 

This looked like a low hanging fruit. This allows setting physical schema override on a per model basis for power users who need it. Users are not likely going to start footgunning themselves with this any harder or faster than power users trying to fudge around with physical_schema_mapping for what would otherwise be one-off use cases for a specific model (for whatever the reason may be).


Furthermore, in theory, you can make any one-off physical table in the catalog a sqlmesh managed table with no copying or renaming using this in conjunction physical_version and forward only.


One good example I have are that we have these data marts. In them, only 1 table is a mission critical licensing table that we would like to store separately from the rest. But we would still like the views in one schema. 


```
# say you want all these env views in mart_sales, but for one model, you need to store its physical snapshots somewhere specific
mart_sales.table_A -> sqlmesh__mart_sales
mart_sales.table_B -> sqlmesh__mart_sales
mart_sales.historical_financial_metrics -> physical_schema_override -> mart_sales_historicals_no_delete
mart_sales.table_C -> sqlmesh__mart_sales
```