### PR TITLE
Fix: qualify information schema query for duckdb

### DIFF
--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -103,7 +103,7 @@ class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin,
                 )
                 .as_("type"),
             )
-            .from_(exp.to_table("information_schema.tables"))
+            .from_(exp.to_table("system.information_schema.tables"))
             .where(
                 exp.column("table_catalog").eq(catalog), exp.column("table_schema").eq(schema_name)
             )


### PR DESCRIPTION
DuckDB information schema can be qualified with `system` as it is an internal table. When you `ATTACH` a database, its tables and columns also end up in `system.information_schema.*` (part of how the ATTACH feature works is that a `catalog` is necessarily supplied). Hence there is no need for an ambiguous catalog in the `_get_data_objects` method. If the search path is mutated (such as by `USE`?), this method can fail. Such is the case when using multiengine support with Bigquery. 

I venture to reason Postgres avoids this failure (since you were able to do a multiengine model with it) by having information schema in its own catalog. But Postgres' catalog is synced to DuckDB as part of ATTACH so its best to just use a fully qualified duckdb reference.


https://github.com/duckdb/duckdb/blob/v1.0.0/src/include/duckdb/common/constants.hpp#L34
https://github.com/duckdb/duckdb/blob/0024e5d4beba0185733df68642775e3f38e089cb/src/catalog/catalog.cpp#L1024-L1048
https://github.com/duckdb/duckdb/blob/0024e5d4beba0185733df68642775e3f38e089cb/src/main/database_manager.cpp#L207-L213