### PR TITLE
Fix: Defer creation of the deploable table for a new forward-only model

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -762,6 +762,8 @@ class SnapshotEvaluator:
                 and adapter.SUPPORTS_CLONING
                 # managed models cannot have their schema mutated because theyre based on queries, so clone + alter wont work
                 and not snapshot.is_managed
+                # If the deployable table is missing we can't clone it
+                and True not in deployability_flags
             ):
                 target_table_name = snapshot.table_name(is_deployable=False)
                 tmp_table_name = f"{target_table_name}__schema_migration_source"
@@ -797,6 +799,19 @@ class SnapshotEvaluator:
             else:
                 dry_run = len(deployability_flags) == 1
                 for is_table_deployable in deployability_flags:
+                    if (
+                        is_table_deployable
+                        and snapshot.model.forward_only
+                        and not is_snapshot_representative
+                    ):
+                        logger.info(
+                            "Skipping creation of the deployable table '%s' for the forward-only model %s. "
+                            "The table will be created when the snapshot is deployed to production",
+                            snapshot.table_name(is_deployable=is_table_deployable),
+                            snapshot.snapshot_id,
+                        )
+                        continue
+
                     evaluation_strategy.create(
                         table_name=snapshot.table_name(is_deployable=is_table_deployable),
                         model=snapshot.model,
@@ -829,15 +844,47 @@ class SnapshotEvaluator:
         if not needs_migration:
             return
 
-        tmp_table_name = snapshot.table_name(is_deployable=False)
+        evaluation_strategy = _evaluation_strategy(snapshot, adapter)
+
         target_table_name = snapshot.table_name()
-        _evaluation_strategy(snapshot, adapter).migrate(
-            target_table_name=target_table_name,
-            source_table_name=tmp_table_name,
-            snapshot=snapshot,
-            snapshots=parent_snapshots_by_name(snapshot, snapshots),
-            allow_destructive_snapshots=allow_destructive_snapshots,
-        )
+        if adapter.table_exists(target_table_name):
+            tmp_table_name = snapshot.table_name(is_deployable=False)
+            logger.info(
+                "Migrating table schema from '%s' to '%s'",
+                tmp_table_name,
+                target_table_name,
+            )
+            evaluation_strategy.migrate(
+                target_table_name=target_table_name,
+                source_table_name=tmp_table_name,
+                snapshot=snapshot,
+                snapshots=parent_snapshots_by_name(snapshot, snapshots),
+                allow_destructive_snapshots=allow_destructive_snapshots,
+            )
+        else:
+            logger.info(
+                "Creating table '%s' for the snapshot of the forward-only model %s",
+                target_table_name,
+                snapshot.snapshot_id,
+            )
+            render_kwargs: t.Dict[str, t.Any] = dict(
+                engine_adapter=adapter,
+                snapshots=parent_snapshots_by_name(snapshot, snapshots),
+                runtime_stage=RuntimeStage.CREATING,
+                deployability_index=DeployabilityIndex.all_deployable(),
+            )
+            with adapter.transaction(), adapter.session(snapshot.model.session_properties):
+                adapter.execute(snapshot.model.render_pre_statements(**render_kwargs))
+                evaluation_strategy.create(
+                    table_name=target_table_name,
+                    model=snapshot.model,
+                    is_table_deployable=True,
+                    render_kwargs=render_kwargs,
+                    is_snapshot_deployable=True,
+                    is_snapshot_representative=True,
+                    dry_run=False,
+                )
+                adapter.execute(snapshot.model.render_post_statements(**render_kwargs))
 
     def _promote_snapshot(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ from sqlmesh.core.snapshot import (
     SnapshotChangeCategory,
     SnapshotDataVersion,
     SnapshotFingerprint,
+    DeployabilityIndex,
 )
 from sqlmesh.utils import random_id
 from sqlmesh.utils.date import TimeLike, to_date
@@ -246,9 +247,12 @@ def push_plan(context: Context, plan: Plan) -> None:
         context.create_scheduler,
         context.default_catalog,
     )
-    plan_evaluator._push(plan.to_evaluatable(), plan.snapshots)
+    deployability_index = DeployabilityIndex.create(context.snapshots.values())
+    plan_evaluator._push(plan.to_evaluatable(), plan.snapshots, deployability_index)
     promotion_result = plan_evaluator._promote(plan.to_evaluatable(), plan.snapshots)
-    plan_evaluator._update_views(plan.to_evaluatable(), plan.snapshots, promotion_result)
+    plan_evaluator._update_views(
+        plan.to_evaluatable(), plan.snapshots, promotion_result, deployability_index
+    )
 
 
 @pytest.fixture()

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -1476,10 +1476,6 @@ def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
                 "table": "Sushi customer data",
                 "column": {"customer_id": "customer_id uniquely identifies customers"},
             },
-            "marketing": {
-                "table": "Sushi marketing data",
-                "column": {"customer_id": "customer_id uniquely identifies customers \\"},
-            },
             "orders": {
                 "table": "Table of sushi orders.",
             },

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -788,6 +788,24 @@ def test_forward_only_parent_created_in_dev_child_created_in_prod(
     context.apply(plan)
 
 
+@time_machine.travel("2023-01-08 00:00:00 UTC")
+def test_new_forward_only_model(init_and_plan_context: t.Callable):
+    context, _ = init_and_plan_context("examples/sushi")
+
+    context.plan("dev", skip_tests=True, no_prompts=True, auto_apply=True)
+
+    snapshot = context.get_snapshot("sushi.marketing")
+
+    # The deployable table should not exist yet
+    assert not context.engine_adapter.table_exists(snapshot.table_name())
+    assert context.engine_adapter.table_exists(snapshot.table_name(is_deployable=False))
+
+    context.plan("prod", skip_tests=True, no_prompts=True, auto_apply=True)
+
+    assert context.engine_adapter.table_exists(snapshot.table_name())
+    assert context.engine_adapter.table_exists(snapshot.table_name(is_deployable=False))
+
+
 @time_machine.travel("2023-01-08 15:00:00 UTC")
 def test_plan_set_choice_is_reflected_in_missing_intervals(init_and_plan_context: t.Callable):
     context, plan = init_and_plan_context("examples/sushi")


### PR DESCRIPTION
After adding a new forward-only model in a dev environment, the user may later iterate on it by adding or removing columns. 

If `on_destructive_change` is set to `fail`, the user might encounter an error when removing a previously existing column.

This behavior is generally expected and correct, assuming the model was previously deployed to prod. However, if this is a new model that only exists within the current dev environment, failing due to destructive changes is counterintuitive. Nothing will actually be destroyed as a result of the change, since no production copy exists yet.

This fix addresses the issue by deferring the creation of the deployable physical table for a new forward-only model until it is deployed to prod.