### PR TITLE
Fix MotherDuck token attach syntax

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -372,7 +372,7 @@ class DuckDBAttachOptions(BaseConfig):
             f" AS {alias}" if not (self.type == "motherduck" or self.path.startswith("md:")) else ""
         )
         options_sql = f" ({', '.join(options)})" if options else ""
-        token_sql = "?" + self.token if self.token else ""
+        token_sql = "?motherduck_token=" + self.token if self.token else ""
         return f"ATTACH '{self.path}{token_sql}'{alias_sql}{options_sql}"
 
 


### PR DESCRIPTION
Context: Using MotherDuck multi-catalog configs has been failing using the Tobiko Cloud environment. Not sure if this will fix things but this missing `motherduck_token=` is certainly a bug.

cc @izeigerman  