### PR TITLE
Fix: Refresh snapshot intervals after determining the max interval end per model

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1334,6 +1334,9 @@ class GenericContext(BaseContext, t.Generic[C]):
                         ),
                     )
 
+        # Refresh snapshot intervals to ensure that they are up to date with values reflected in the max_interval_end_per_model.
+        self.state_sync.refresh_snapshot_intervals(context_diff.snapshots.values())
+
         return self.PLAN_BUILDER_TYPE(
             context_diff=context_diff,
             start=start,


### PR DESCRIPTION
This addresses the following scenario:
1. SQLMesh fetches snapshots and its intervals as part of the plan construction.
2. Right after this a concurrent `sqlmesh run` job backfills and records intervals for a certain model.
3. SQLMesh fetches maximum backfilled interval end for each model.

As a result, the intervals fetched in (3) are ahead of what's been fetched in (1), leading to inaccurate missing intervals.