### PR TITLE
Fix!: render audits at runtime

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1765,11 +1765,13 @@ def load_sql_based_model(
 
     unrendered_merge_filter = None
     unrendered_signals = None
+    unrendered_audits = None
 
     for prop in meta.expressions:
         if prop.name.lower() == "signals":
             unrendered_signals = prop.args.get("value")
-
+        if prop.name.lower() == "audits":
+            unrendered_audits = prop.args.get("value")
         if (
             prop.name.lower() == "kind"
             and (value := prop.args.get("value"))
@@ -1816,9 +1818,12 @@ def load_sql_based_model(
         **kwargs,
     }
 
-    # Signals and merge_filter must remain unrendered, so that they can be rendered later at evaluation runtime.
+    # signals, audits and merge_filter must remain unrendered, so that they can be rendered later at evaluation runtime
     if unrendered_signals:
         meta_fields["signals"] = unrendered_signals
+
+    if unrendered_audits:
+        meta_fields["audits"] = unrendered_audits
 
     if unrendered_merge_filter:
         for idx, kind_prop in enumerate(meta_fields["kind"].expressions):

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1172,7 +1172,8 @@ def test_audits():
             name db.seed,
             audits (
                 audit_a,
-                audit_b(key='value')
+                audit_b(key='value'),
+                audit_c(key=@start_ds)
             ),
             tags (foo)
         );
@@ -1184,6 +1185,7 @@ def test_audits():
     assert model.audits == [
         ("audit_a", {}),
         ("audit_b", {"key": exp.Literal.string("value")}),
+        ("audit_c", {"key": d.MacroVar(this="start_ds")}),
     ]
     assert model.tags == ["foo"]
 


### PR DESCRIPTION
The motivation behind this PR is that, given this model:

```sql
MODEL (
  name test_model,
  kind INCREMENTAL_BY_UNIQUE_KEY (
    unique_key (a, d)
  ),
  audits (
    unique_combination_of_columns(
      columns = (a, d),
      condition = d between @start_date and @end_date
    )
  ),
);

SELECT
  1 AS a,
  CAST('2025-01-20' AS DATE) AS d
```

The audit condition renders as follows at runtime today:

```sql
"d" BETWEEN CAST('1970-01-01' AS DATE) AND CAST('1970-01-01' AS DATE)
```

The reason this happens is that the model meta is rendered at load time and we store the properties to the corresponding pydantic fields, e.g. `audits`, even though `start_date` is a variable that changes depending on the runtime stage.

Approach is similar to https://github.com/TobikoData/sqlmesh/commit/e10449184cea6369c0ac2dcd1e6b8736d2a612fb.