### PR TITLE
Fix: prevent AttributeError when a DBT project is run with dbt-core >= 1.9.0

### DIFF
--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -289,6 +289,7 @@ class ManifestHelper:
         args: Namespace = Namespace(
             vars=variables,
             profile=self.profile_name,
+            project_dir=str(self.project_path),
             profiles_dir=str(self.profiles_path),
             target=self.target.name,
             macro_debugging=False,


### PR DESCRIPTION
Prior to this change, if SQLMesh tries to load a DBT project and `dbt-core==1.9.0` or newer is in use, the following error occurs:

```
AttributeError: 'Flags' object has no attribute 'state_modified_compare_more_unrendered_values'
```

The `Flags` being referred to are the `project_flags` which we currently [hardcode to None](https://github.com/TobikoData/sqlmesh/blob/7519f431af3369a2cdf8d6cf56129a0471804e7b/sqlmesh/dbt/manifest.py#L297).

This wasn't a problem until DBT 1.9.0 added a bunch of [unguarded checks](https://github.com/dbt-labs/dbt-core/blob/1dcdcd2f52f885bbb10dd14771b7c2dc6173bb63/core/dbt/parser/base.py#L385) for `get_flags().state_modified_compare_more_unrendered_values`.

I checked where this was meant to be set in DBT and it turns out that `flags.set_from_args()` will automatically include these default flags **if** both `project_dir` and `profiles_dir` [are specified](https://github.com/dbt-labs/dbt-core/blob/1dcdcd2f52f885bbb10dd14771b7c2dc6173bb63/core/dbt/flags.py#L30).

Today, we only specify `profiles_dir`. It looks like `project_dir` is expected to be the directory containing `dbt_project.yml` and it will merge values from the `flags` member of that config file with the hardcoded defaults.

So this PR sets `project_dir` to be passed to `flags.set_from_args()` which triggers the default ProjectFlags logic and SQLMesh runs successfully.

**Note**: The reason that our CI hasnt picked this up already is because pip resolves `dbt-core` to version `1.8.8`  when `make install-cicd-test` is run. This is due to conflicts in transitive dependencies. As such, im not entirely sure how to write an automated test for this without adding a bunch of complexity / test harnesses for multiple DBT versions

