### PR TITLE
Chore: Update docs to specify that postgres catalog should use the actual name

### DIFF
--- a/docs/integrations/engines/duckdb.md
+++ b/docs/integrations/engines/duckdb.md
@@ -122,6 +122,10 @@ The SQLite database is read-write, while the PostgreSQL database is read-only.
     )
     ```
 
+##### Catalogs for PostgreSQL
+
+In PostgreSQL, the catalog name must match the actual catalog name it is associated with, as shown in the example above, where the database name (`dbname` in the path) is the same as the catalog name.
+
 ##### Connectors without schemas
 
 Some connections, like SQLite, do not support schema names and therefore objects will be attached under the default schema name of `main`.


### PR DESCRIPTION
Update docs to clarify that PostgreSQL catalog must use the actual catalog name, since the view layer relies on the actual catalog, using an alias for the catalog would not be feasible for most sqlmesh queries, closes #3663 