### PR TITLE
fix: migration 0063 loads subset of data

### DIFF
--- a/sqlmesh/migrations/v0063_change_signals.py
+++ b/sqlmesh/migrations/v0063_change_signals.py
@@ -18,6 +18,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     new_snapshots = []
 
+    signal_change = False
     for (
         name,
         identifier,
@@ -47,6 +48,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         signals = node.get("signals")
 
         if signals:
+            signal_change = True
             node["signals"] = []
 
             for signal in signals:
@@ -60,21 +62,21 @@ def migrate(state_sync, **kwargs):  # type: ignore
                     )
                 )
 
-            new_snapshots.append(
-                {
-                    "name": name,
-                    "identifier": identifier,
-                    "version": version,
-                    "snapshot": json.dumps(parsed_snapshot),
-                    "kind_name": kind_name,
-                    "updated_ts": updated_ts,
-                    "unpaused_ts": unpaused_ts,
-                    "ttl_ms": ttl_ms,
-                    "unrestorable": unrestorable,
-                }
-            )
+        new_snapshots.append(
+            {
+                "name": name,
+                "identifier": identifier,
+                "version": version,
+                "snapshot": json.dumps(parsed_snapshot),
+                "kind_name": kind_name,
+                "updated_ts": updated_ts,
+                "unpaused_ts": unpaused_ts,
+                "ttl_ms": ttl_ms,
+                "unrestorable": unrestorable,
+            }
+        )
 
-    if new_snapshots:
+    if signal_change and new_snapshots:
         engine_adapter.delete_from(snapshots_table, "TRUE")
         blob_type = blob_text_type(engine_adapter.dialect)
 


### PR DESCRIPTION
The migration intended to only reload the snapshots if a model was changed that contained signals. This was likely done since signals was just released and we didn't want to reload the data when this would be a no-op for most. The problem is that only rows that had adjusted signals were put into `new_snapshots` and then the entire snapshot table was deleted. This would result in a snapshot table with just signal models in it instead of all the snapshots.

The change keeps the desired behavior but uses `signal_change` to track if a signal was really adjusted and if so it then reloads. `new_snapshots` now contains all the snapshots. 