### PR TITLE
Fix!: include names of decorator argument references when building python env

### DIFF
--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -132,8 +132,8 @@ class _ClassFinder(ast.NodeVisitor):
 
 
 class _DecoratorDependencyFinder(ast.NodeVisitor):
-    def __init__(self, dependencies: t.List[str]) -> None:
-        self.dependencies = dependencies
+    def __init__(self) -> None:
+        self.dependencies: t.List[str] = []
 
     def _extract_dependencies(self, node: ast.ClassDef | ast.FunctionDef) -> None:
         for decorator in node.decorator_list:
@@ -225,10 +225,10 @@ def decorator_vars(func: t.Callable, root_node: t.Optional[ast.Module] = None) -
     are referenced in their argument list. These objects may be transitive dependencies
     that we need to include in the serialized python environments.
     """
-    names: t.List[str] = []
     root_node = root_node or parse_source(func)
-    _DecoratorDependencyFinder(names).visit(root_node)
-    return unique(names)
+    finder = _DecoratorDependencyFinder()
+    finder.visit(root_node)
+    return unique(finder.dependencies)
 
 
 def normalize_source(obj: t.Any) -> str:

--- a/tests/core/engine_adapter/test_trino.py
+++ b/tests/core/engine_adapter/test_trino.py
@@ -514,7 +514,7 @@ def test_schema_location_mapping():
         catalog="catalog",
         schema_location_mapping={
             "^utils$": "s3://utils-bucket/@{schema_name}",
-            "^landing\..*$": "s3://raw-data/@{catalog_name}/@{schema_name}",
+            "^landing\\..*$": "s3://raw-data/@{catalog_name}/@{schema_name}",
             "^staging.*$": "s3://bucket/@{schema_name}_dev",
             "^sqlmesh.*$": "s3://sqlmesh-internal/dev/@{schema_name}",
         },
@@ -561,10 +561,10 @@ def test_create_schema_sets_location(make_mocked_engine_adapter: t.Callable, moc
         catalog="catalog",
         schema_location_mapping={
             "^utils$": "s3://utils-bucket/@{schema_name}",
-            "^landing\..*$": "s3://raw-data/@{catalog_name}/@{schema_name}",
+            "^landing\\..*$": "s3://raw-data/@{catalog_name}/@{schema_name}",
             "^staging.*$": "s3://bucket/@{schema_name}_dev",
             "^sqlmesh.*$": "s3://sqlmesh-internal/dev/@{schema_name}",
-            "^iceberg\.staging.*$": "s3://iceberg-catalog/foo_@{schema_name}",
+            "^iceberg\\.staging.*$": "s3://iceberg-catalog/foo_@{schema_name}",
         },
     )
 

--- a/tests/utils/test_metaprogramming.py
+++ b/tests/utils/test_metaprogramming.py
@@ -166,7 +166,9 @@ def test_func_globals() -> None:
 
         return closure
 
-    assert func_globals(closure_test()) == {
+    # We pass __file__ here because in practice `func_globals` will always be called
+    # by `build_env`, which in turn is expected to always pass to it the module's path
+    assert func_globals(closure_test(), path=Path(__file__)) == {
         "main_func": main_func,
         "y": 1,
     }
@@ -286,14 +288,6 @@ class DataClass:
         "expressions": Executable(
             kind=ExecutableKind.IMPORT, payload="import sqlglot.expressions as expressions"
         ),
-        "func": Executable(
-            payload="""@contextmanager
-def test_context_manager():
-    yield""",
-            name="test_context_manager",
-            path="test_metaprogramming.py",
-            alias="func",
-        ),
         "my_lambda": Executable(
             name="my_lambda",
             path="test_metaprogramming.py",
@@ -331,20 +325,8 @@ def test_context_manager():
         "stop_after_attempt": Executable(
             payload="from tenacity.stop import stop_after_attempt", kind=ExecutableKind.IMPORT
         ),
-        "wrapped_f": Executable(
-            payload="from tests.utils.test_metaprogramming import fetch_data",
-            kind=ExecutableKind.IMPORT,
-        ),
         "fetch_data": Executable(
             payload="from tests.utils.test_metaprogramming import fetch_data",
             kind=ExecutableKind.IMPORT,
-        ),
-        "f": Executable(
-            payload="""@retry(stop=stop_after_attempt(3))
-def fetch_data():
-    return 'test data'""",
-            name="fetch_data",
-            path="test_metaprogramming.py",
-            alias="f",
         ),
     }

--- a/tests/utils/test_metaprogramming.py
+++ b/tests/utils/test_metaprogramming.py
@@ -115,7 +115,7 @@ def test_context_manager():
 
 @retry(stop=stop_after_attempt(3))
 def fetch_data():
-    return "test data"
+    return "'test data'"
 
 
 def main_func(y: int, foo=exp.true(), *, bar=expressions.Literal.number(1) + 2) -> int:
@@ -316,8 +316,11 @@ class DataClass:
     return X + a""",
         ),
         "test_context_manager": Executable(
-            payload="from tests.utils.test_metaprogramming import test_context_manager",
-            kind=ExecutableKind.IMPORT,
+            payload="""@contextmanager
+def test_context_manager():
+    yield""",
+            name="test_context_manager",
+            path="test_metaprogramming.py",
         ),
         "wraps": Executable(payload="from functools import wraps", kind=ExecutableKind.IMPORT),
         "functools": Executable(payload="import functools", kind=ExecutableKind.IMPORT),
@@ -326,7 +329,10 @@ class DataClass:
             payload="from tenacity.stop import stop_after_attempt", kind=ExecutableKind.IMPORT
         ),
         "fetch_data": Executable(
-            payload="from tests.utils.test_metaprogramming import fetch_data",
-            kind=ExecutableKind.IMPORT,
+            payload='''@retry(stop=stop_after_attempt(3))
+def fetch_data():
+    return "'test data'"''',
+            name="fetch_data",
+            path="test_metaprogramming.py",
         ),
     }

--- a/tests/utils/test_metaprogramming.py
+++ b/tests/utils/test_metaprogramming.py
@@ -286,11 +286,6 @@ class DataClass:
         "expressions": Executable(
             kind=ExecutableKind.IMPORT, payload="import sqlglot.expressions as expressions"
         ),
-        "my_lambda": Executable(
-            name="my_lambda",
-            path="test_metaprogramming.py",
-            payload="my_lambda = lambda : print('z')",
-        ),
         "func": Executable(
             payload="""@contextmanager
 def test_context_manager():
@@ -298,6 +293,11 @@ def test_context_manager():
             name="test_context_manager",
             path="test_metaprogramming.py",
             alias="func",
+        ),
+        "my_lambda": Executable(
+            name="my_lambda",
+            path="test_metaprogramming.py",
+            payload="my_lambda = lambda : print('z')",
         ),
         "noop_metadata": Executable(
             name="noop_metadata",

--- a/tests/utils/test_metaprogramming.py
+++ b/tests/utils/test_metaprogramming.py
@@ -166,9 +166,7 @@ def test_func_globals() -> None:
 
         return closure
 
-    # We pass __file__ here because in practice `func_globals` will always be called
-    # by `build_env`, which in turn is expected to always pass to it the module's path
-    assert func_globals(closure_test(), path=Path(__file__)) == {
+    assert func_globals(closure_test()) == {
         "main_func": main_func,
         "y": 1,
     }
@@ -293,6 +291,14 @@ class DataClass:
             path="test_metaprogramming.py",
             payload="my_lambda = lambda : print('z')",
         ),
+        "func": Executable(
+            payload="""@contextmanager
+def test_context_manager():
+    yield""",
+            name="test_context_manager",
+            path="test_metaprogramming.py",
+            alias="func",
+        ),
         "noop_metadata": Executable(
             name="noop_metadata",
             path="test_metaprogramming.py",
@@ -328,11 +334,27 @@ def test_context_manager():
         "stop_after_attempt": Executable(
             payload="from tenacity.stop import stop_after_attempt", kind=ExecutableKind.IMPORT
         ),
+        "wrapped_f": Executable(
+            payload='''@retry(stop=stop_after_attempt(3))
+def fetch_data():
+    return "'test data'"''',
+            name="fetch_data",
+            path="test_metaprogramming.py",
+            alias="wrapped_f",
+        ),
         "fetch_data": Executable(
             payload='''@retry(stop=stop_after_attempt(3))
 def fetch_data():
     return "'test data'"''',
             name="fetch_data",
             path="test_metaprogramming.py",
+        ),
+        "f": Executable(
+            payload='''@retry(stop=stop_after_attempt(3))
+def fetch_data():
+    return "'test data'"''',
+            name="fetch_data",
+            path="test_metaprogramming.py",
+            alias="f",
         ),
     }

--- a/tests/utils/test_metaprogramming.py
+++ b/tests/utils/test_metaprogramming.py
@@ -2,6 +2,7 @@ import typing as t
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from tenacity import retry, stop_after_attempt
 
 import pandas as pd
 import pytest
@@ -46,7 +47,7 @@ def test_print_exception(mocker: MockerFixture):
 
     expected_message = f"""Traceback (most recent call last):
 
-  File "{__file__}", line 43, in test_print_exception
+  File "{__file__}", line 44, in test_print_exception
     eval("test_fun()", env)
 
   File "<string>", line 1, in <module>
@@ -112,6 +113,11 @@ def test_context_manager():
     yield
 
 
+@retry(stop=stop_after_attempt(3))
+def fetch_data():
+    return "test data"
+
+
 def main_func(y: int, foo=exp.true(), *, bar=expressions.Literal.number(1) + 2) -> int:
     """DOC STRING"""
     sqlglot.parse_one("1")
@@ -119,6 +125,7 @@ def main_func(y: int, foo=exp.true(), *, bar=expressions.Literal.number(1) + 2) 
     DataClass(x=y)
     noop_metadata()
     normalize_model_name("test")
+    fetch_data()
 
     def closure(z: int) -> int:
         return z + Z
@@ -141,6 +148,7 @@ def test_func_globals() -> None:
         "sqlglot": sqlglot,
         "exp": exp,
         "expressions": exp,
+        "fetch_data": fetch_data,
         "test_context_manager": test_context_manager,
     }
     assert func_globals(other_func) == {
@@ -174,6 +182,7 @@ def test_normalize_source() -> None:
     DataClass(x=y)
     noop_metadata()
     normalize_model_name('test')
+    fetch_data()
 
     def closure(z: int):
         return z + Z
@@ -219,6 +228,7 @@ def test_serialize_env() -> None:
     DataClass(x=y)
     noop_metadata()
     normalize_model_name('test')
+    fetch_data()
 
     def closure(z: int):
         return z + Z
@@ -316,4 +326,25 @@ def test_context_manager():
             kind=ExecutableKind.IMPORT,
         ),
         "wraps": Executable(payload="from functools import wraps", kind=ExecutableKind.IMPORT),
+        "functools": Executable(payload="import functools", kind=ExecutableKind.IMPORT),
+        "retry": Executable(payload="from tenacity import retry", kind=ExecutableKind.IMPORT),
+        "stop_after_attempt": Executable(
+            payload="from tenacity.stop import stop_after_attempt", kind=ExecutableKind.IMPORT
+        ),
+        "wrapped_f": Executable(
+            payload="from tests.utils.test_metaprogramming import fetch_data",
+            kind=ExecutableKind.IMPORT,
+        ),
+        "fetch_data": Executable(
+            payload="from tests.utils.test_metaprogramming import fetch_data",
+            kind=ExecutableKind.IMPORT,
+        ),
+        "f": Executable(
+            payload="""@retry(stop=stop_after_attempt(3))
+def fetch_data():
+    return 'test data'""",
+            name="fetch_data",
+            path="test_metaprogramming.py",
+            alias="f",
+        ),
     }


### PR DESCRIPTION
Fixes #3640

The main difficulty in solving the linked issue was making SQLMesh detect the `stop_after_attempt` reference, in order to extract and inject it into the python environment so it can be (de)serialized:

```python
@retry(stop=stop_after_attempt(3))
def fetch_data():
    return "test data"
```

The decorator names themselves were already being picked up in the previous `decorators` helper. In this PR I expand that functionality by also searching for the decorator call arguments' references.

I implemented a new visitor class in order to limit the search to only the decorator sub-trees, instead of traversing the whole function tree. Without this, we'd have to do a nested `walk` within the root node traversal loop, leading to unnecessarily revisiting nodes under the decorator sub-trees.

Other than that, I also made sure to exclude callable instances of classes, because they can't be serialized. One such example is the `tenacity.Retrying` class ([source](https://github.com/jd/tenacity/blob/0d40e76f7d06d631fb127e1ec58c8bd776e70d49/tenacity/__init__.py#L652-L654)). Letting these **instances** into the python environment doesn't "just work" unfortunately, because an error is raised once we reach this [section](https://github.com/TobikoData/sqlmesh/blob/75468112ca4796adada3b6d47ea737d926e2c29d/sqlmesh/utils/metaprogramming.py#L357-L359), since there's no `__name__` attribute in them.

I verified that this fix works for a project with the model of interest, as well as the example project we have under `test_metaprogramming.py`.