### PR TITLE
Fix: Make sure that full / view models only backfilled once

### DIFF
--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -136,6 +136,8 @@ class ModelKindMixin:
             ModelKindName.INCREMENTAL_BY_PARTITION,
             ModelKindName.SCD_TYPE_2,
             ModelKindName.MANAGED,
+            ModelKindName.FULL,
+            ModelKindName.VIEW,
         )
 
     @property

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -601,7 +601,7 @@ class PlanBuilder:
             if (
                 snapshot.evaluatable
                 and not snapshot.disable_restatement
-                and not snapshot.full_history_restatement_only
+                and (not snapshot.full_history_restatement_only or not snapshot.is_incremental)
             ):
                 snapshot.effective_from = self._effective_from
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -294,7 +294,7 @@ def test_plan_dev_start_date(runner, tmp_path):
         input="\ny\n",
     )
     assert_plan_success(result, "dev")
-    assert "sqlmesh_example__dev.full_model: 2023-01-01" in result.output
+    assert "sqlmesh_example__dev.full_model: full refresh" in result.output
     assert "sqlmesh_example__dev.incremental_model: 2023-01-01" in result.output
 
 
@@ -308,7 +308,7 @@ def test_plan_dev_end_date(runner, tmp_path):
         input="\ny\n",
     )
     assert_plan_success(result, "dev")
-    assert "sqlmesh_example__dev.full_model: 2020-01-01 - 2023-01-01" in result.output
+    assert "sqlmesh_example__dev.full_model: full refresh" in result.output
     assert "sqlmesh_example__dev.incremental_model: 2020-01-01 - 2023-01-01" in result.output
 
 

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -259,6 +259,11 @@ def test_forward_only_model_regular_plan(init_and_plan_context: t.Callable):
         SnapshotIntervals(
             snapshot_id=top_waiters_snapshot.snapshot_id,
             intervals=[
+                (to_timestamp("2023-01-01"), to_timestamp("2023-01-02")),
+                (to_timestamp("2023-01-02"), to_timestamp("2023-01-03")),
+                (to_timestamp("2023-01-03"), to_timestamp("2023-01-04")),
+                (to_timestamp("2023-01-04"), to_timestamp("2023-01-05")),
+                (to_timestamp("2023-01-05"), to_timestamp("2023-01-06")),
                 (to_timestamp("2023-01-06"), to_timestamp("2023-01-07")),
                 (to_timestamp("2023-01-07"), to_timestamp("2023-01-08")),
             ],
@@ -278,6 +283,12 @@ def test_forward_only_model_regular_plan(init_and_plan_context: t.Callable):
         SnapshotIntervals(
             snapshot_id=top_waiters_snapshot.snapshot_id,
             intervals=[
+                (to_timestamp("2023-01-01"), to_timestamp("2023-01-02")),
+                (to_timestamp("2023-01-02"), to_timestamp("2023-01-03")),
+                (to_timestamp("2023-01-03"), to_timestamp("2023-01-04")),
+                (to_timestamp("2023-01-04"), to_timestamp("2023-01-05")),
+                (to_timestamp("2023-01-05"), to_timestamp("2023-01-06")),
+                (to_timestamp("2023-01-06"), to_timestamp("2023-01-07")),
                 (to_timestamp("2023-01-07"), to_timestamp("2023-01-08")),
             ],
         ),
@@ -1923,7 +1934,7 @@ def test_restatement_plan_ignores_changes(init_and_plan_context: t.Callable):
     model = context.get_model("sushi.waiter_revenue_by_day")
     context.upsert_model(add_projection_to_model(t.cast(SqlModel, model)))
 
-    plan = context.plan_builder(restate_models=["sushi.top_waiters"], start="2023-01-07").build()
+    plan = context.plan_builder(restate_models=["sushi.top_waiters"]).build()
     assert plan.snapshots != context.snapshots
 
     assert not plan.directly_modified
@@ -1931,12 +1942,20 @@ def test_restatement_plan_ignores_changes(init_and_plan_context: t.Callable):
     assert not plan.new_snapshots
     assert plan.requires_backfill
     assert plan.restatements == {
-        restated_snapshot.snapshot_id: (to_timestamp("2023-01-07"), to_timestamp("2023-01-08"))
+        restated_snapshot.snapshot_id: (to_timestamp("2023-01-01"), to_timestamp("2023-01-08"))
     }
     assert plan.missing_intervals == [
         SnapshotIntervals(
             snapshot_id=restated_snapshot.snapshot_id,
-            intervals=[(to_timestamp("2023-01-07"), to_timestamp("2023-01-08"))],
+            intervals=[
+                (to_timestamp("2023-01-01"), to_timestamp("2023-01-02")),
+                (to_timestamp("2023-01-02"), to_timestamp("2023-01-03")),
+                (to_timestamp("2023-01-03"), to_timestamp("2023-01-04")),
+                (to_timestamp("2023-01-04"), to_timestamp("2023-01-05")),
+                (to_timestamp("2023-01-05"), to_timestamp("2023-01-06")),
+                (to_timestamp("2023-01-06"), to_timestamp("2023-01-07")),
+                (to_timestamp("2023-01-07"), to_timestamp("2023-01-08")),
+            ],
         )
     ]
 

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -696,6 +696,7 @@ def test_signal_intervals(mocker: MockerFixture, make_snapshot, get_batched_miss
     assert batches == {
         a: [(to_timestamp("2023-01-01"), to_timestamp("2023-01-03"))],
         b: [(to_timestamp("2023-01-01 23:00:00"), to_timestamp("2023-01-04"))],
-        c: [(to_timestamp("2023-01-02"), to_timestamp("2023-01-03"))],
+        # Full models and models that depend on past can't run for a discontinuous range
+        c: [],
         d: [],
     }


### PR DESCRIPTION
When there are gaps in missing intervals like in the following example:
```
[1, 2) [3, 4)
```
SQLMesh ends up backfilling both `[1, 2)` and `[3, 4)` intervals even for non-incremental model kinds like `FULL` and `VIEW`. This behavior is correct for incremental models but doesn't make much sense for non-incremental ones.