### PR TITLE
Feat: Add plan option to show rendered model diff

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -335,6 +335,7 @@ Options:
                                   application (prod environment only).
   --enable-preview                Enable preview for forward-only models when
                                   targeting a development environment.
+  --rendered-model-diff           Output text differences for the rendered versions of models
   -v, --verbose                   Verbose output.
   --help                          Show this message and exit.
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -335,7 +335,7 @@ Options:
                                   application (prod environment only).
   --enable-preview                Enable preview for forward-only models when
                                   targeting a development environment.
-  --rendered-model-diff           Output text differences for the rendered versions of models
+  --diff-rendered                 Output text differences for the rendered versions of models and standalone audits
   -v, --verbose                   Verbose output.
   --help                          Show this message and exit.
 ```

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -103,7 +103,7 @@ options:
             [--no-auto-categorization] [--include-unmodified]
             [--select-model [SELECT_MODEL ...]]
             [--backfill-model [BACKFILL_MODEL ...]] [--no-diff] [--run]
-            [environment]
+            [environment] [--rendered-model-diff]
 
 Goes through a set of prompts to both establish a plan and apply it
 
@@ -153,6 +153,8 @@ options:
   --no-diff             Hide text differences for changed models.
   --run                 Run latest intervals as part of the plan application
                         (prod environment only).
+  --rendered-model-diff Output text differences for the rendered versions of models
+
 ```
 
 #### run_dag

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -103,7 +103,7 @@ options:
             [--no-auto-categorization] [--include-unmodified]
             [--select-model [SELECT_MODEL ...]]
             [--backfill-model [BACKFILL_MODEL ...]] [--no-diff] [--run]
-            [environment] [--rendered-model-diff]
+            [environment] [--diff-rendered]
 
 Goes through a set of prompts to both establish a plan and apply it
 
@@ -153,7 +153,7 @@ options:
   --no-diff             Hide text differences for changed models.
   --run                 Run latest intervals as part of the plan application
                         (prod environment only).
-  --rendered-model-diff Output text differences for the rendered versions of models
+  --diff-rendered       Output text differences for the rendered versions of models and standalone audits
 
 ```
 

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -418,7 +418,7 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
 @click.option(
     "--diff-rendered",
     is_flag=True,
-    help="Output text differences for the rendered versions of the models",
+    help="Output text differences for the rendered versions of the models and standalone audits",
 )
 @opt.verbose
 @click.pass_context

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -415,6 +415,12 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
     help="Enable preview for forward-only models when targeting a development environment.",
     default=None,
 )
+@click.option(
+    "--rendered-model-diff",
+    is_flag=True,
+    help="Output text differences for the rendered versions of the models",
+    default=None,
+)
 @opt.verbose
 @click.pass_context
 @error_handler

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -416,10 +416,9 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
     default=None,
 )
 @click.option(
-    "--rendered-model-diff",
+    "--diff-rendered",
     is_flag=True,
     help="Output text differences for the rendered versions of the models",
-    default=None,
 )
 @opt.verbose
 @click.pass_context

--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -283,7 +283,7 @@ class StandaloneAudit(_Node, AuditMixin):
             self._metadata_hash = hash_data(data)
         return self._metadata_hash
 
-    def text_diff(self, other: Node) -> str:
+    def text_diff(self, other: Node, rendered_model_diff: bool = False) -> str:
         """Produce a text diff against another node.
 
         Args:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1068,7 +1068,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         enable_preview: t.Optional[bool] = None,
         no_diff: t.Optional[bool] = None,
         run: bool = False,
-        rendered_model_diff: t.Optional[bool] = None,
+        diff_rendered: bool = False,
     ) -> Plan:
         """Interactively creates a plan.
 
@@ -1112,7 +1112,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             enable_preview: Indicates whether to enable preview for forward-only models in development environments.
             no_diff: Hide text differences for changed models.
             run: Whether to run latest intervals as part of the plan application.
-            rendered_model_diff: Whether the diff should compare raw vs rendered models
+            diff_rendered: Whether the diff should compare raw vs rendered models
 
         Returns:
             The populated Plan object.
@@ -1138,7 +1138,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             categorizer_config=categorizer_config,
             enable_preview=enable_preview,
             run=run,
-            rendered_model_diff=rendered_model_diff,
+            diff_rendered=diff_rendered,
         )
 
         self.console.plan(
@@ -1175,7 +1175,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         categorizer_config: t.Optional[CategorizerConfig] = None,
         enable_preview: t.Optional[bool] = None,
         run: bool = False,
-        rendered_model_diff: t.Optional[bool] = None,
+        diff_rendered: bool = False,
     ) -> PlanBuilder:
         """Creates a plan builder.
 
@@ -1211,7 +1211,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             backfill_models: A list of model selection strings to filter the models for which the data should be backfilled.
             enable_preview: Indicates whether to enable preview for forward-only models in development environments.
             run: Whether to run latest intervals as part of the plan application.
-            rendered_model_diff: Whether the diff should compare raw vs rendered models
+            diff_rendered: Whether the diff should compare raw vs rendered models
 
         Returns:
             The plan builder.
@@ -1275,7 +1275,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             force_no_diff=restate_models is not None
             or (backfill_models is not None and not backfill_models),
             ensure_finalized_snapshots=self.config.plan.use_finalized_state,
-            rendered_model_diff=rendered_model_diff,
+            diff_rendered=diff_rendered,
         )
         modified_model_names = {
             *context_diff.modified_snapshots,
@@ -2148,7 +2148,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         create_from: t.Optional[str] = None,
         force_no_diff: bool = False,
         ensure_finalized_snapshots: bool = False,
-        rendered_model_diff: t.Optional[bool] = None,
+        diff_rendered: bool = False,
     ) -> ContextDiff:
         environment = Environment.sanitize_name(environment)
         if force_no_diff:
@@ -2162,7 +2162,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             provided_requirements=self._requirements,
             excluded_requirements=self._excluded_requirements,
             ensure_finalized_snapshots=ensure_finalized_snapshots,
-            rendered_model_diff=rendered_model_diff,
+            diff_rendered=diff_rendered,
         )
 
     def _run_janitor(self, ignore_ttl: bool = False) -> None:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1068,6 +1068,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         enable_preview: t.Optional[bool] = None,
         no_diff: t.Optional[bool] = None,
         run: bool = False,
+        rendered_model_diff: t.Optional[bool] = None,
     ) -> Plan:
         """Interactively creates a plan.
 
@@ -1111,6 +1112,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             enable_preview: Indicates whether to enable preview for forward-only models in development environments.
             no_diff: Hide text differences for changed models.
             run: Whether to run latest intervals as part of the plan application.
+            rendered_model_diff: Whether the diff should compare raw vs rendered models
 
         Returns:
             The populated Plan object.
@@ -1136,6 +1138,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             categorizer_config=categorizer_config,
             enable_preview=enable_preview,
             run=run,
+            rendered_model_diff=rendered_model_diff,
         )
 
         self.console.plan(
@@ -1172,6 +1175,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         categorizer_config: t.Optional[CategorizerConfig] = None,
         enable_preview: t.Optional[bool] = None,
         run: bool = False,
+        rendered_model_diff: t.Optional[bool] = None,
     ) -> PlanBuilder:
         """Creates a plan builder.
 
@@ -1207,6 +1211,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             backfill_models: A list of model selection strings to filter the models for which the data should be backfilled.
             enable_preview: Indicates whether to enable preview for forward-only models in development environments.
             run: Whether to run latest intervals as part of the plan application.
+            rendered_model_diff: Whether the diff should compare raw vs rendered models
 
         Returns:
             The plan builder.
@@ -1270,6 +1275,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             force_no_diff=restate_models is not None
             or (backfill_models is not None and not backfill_models),
             ensure_finalized_snapshots=self.config.plan.use_finalized_state,
+            rendered_model_diff=rendered_model_diff,
         )
         modified_model_names = {
             *context_diff.modified_snapshots,
@@ -2142,6 +2148,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         create_from: t.Optional[str] = None,
         force_no_diff: bool = False,
         ensure_finalized_snapshots: bool = False,
+        rendered_model_diff: t.Optional[bool] = None,
     ) -> ContextDiff:
         environment = Environment.sanitize_name(environment)
         if force_no_diff:
@@ -2155,6 +2162,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             provided_requirements=self._requirements,
             excluded_requirements=self._excluded_requirements,
             ensure_finalized_snapshots=ensure_finalized_snapshots,
+            rendered_model_diff=rendered_model_diff,
         )
 
     def _run_janitor(self, ignore_ttl: bool = False) -> None:

--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -76,6 +76,8 @@ class ContextDiff(PydanticModel):
     """Previous requirements."""
     requirements: t.Dict[str, str] = {}
     """Python dependencies."""
+    rendered_model_diff: t.Optional[bool] = None
+    """Whether the diff should compare raw vs rendered models"""
 
     @classmethod
     def create(
@@ -87,6 +89,7 @@ class ContextDiff(PydanticModel):
         ensure_finalized_snapshots: bool = False,
         provided_requirements: t.Optional[t.Dict[str, str]] = None,
         excluded_requirements: t.Optional[t.Set[str]] = None,
+        rendered_model_diff: t.Optional[bool] = None,
     ) -> ContextDiff:
         """Create a ContextDiff object.
 
@@ -212,6 +215,7 @@ class ContextDiff(PydanticModel):
             previous_finalized_snapshots=env.previous_finalized_snapshots if env else None,
             previous_requirements=env.requirements if env else {},
             requirements=requirements,
+            rendered_model_diff=rendered_model_diff,
         )
 
     @classmethod
@@ -390,7 +394,9 @@ class ContextDiff(PydanticModel):
 
         new, old = self.modified_snapshots[name]
         try:
-            return old.node.text_diff(new.node)
+            return old.node.text_diff(
+                new.node, rendered_model_diff=self.rendered_model_diff or False
+            )
         except SQLMeshError as e:
             logger.warning("Failed to diff model '%s': %s", name, str(e))
             return ""

--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -76,7 +76,7 @@ class ContextDiff(PydanticModel):
     """Previous requirements."""
     requirements: t.Dict[str, str] = {}
     """Python dependencies."""
-    rendered_model_diff: t.Optional[bool] = None
+    diff_rendered: bool = False
     """Whether the diff should compare raw vs rendered models"""
 
     @classmethod
@@ -89,7 +89,7 @@ class ContextDiff(PydanticModel):
         ensure_finalized_snapshots: bool = False,
         provided_requirements: t.Optional[t.Dict[str, str]] = None,
         excluded_requirements: t.Optional[t.Set[str]] = None,
-        rendered_model_diff: t.Optional[bool] = None,
+        diff_rendered: bool = False,
     ) -> ContextDiff:
         """Create a ContextDiff object.
 
@@ -215,7 +215,7 @@ class ContextDiff(PydanticModel):
             previous_finalized_snapshots=env.previous_finalized_snapshots if env else None,
             previous_requirements=env.requirements if env else {},
             requirements=requirements,
-            rendered_model_diff=rendered_model_diff,
+            diff_rendered=diff_rendered,
         )
 
     @classmethod
@@ -394,9 +394,7 @@ class ContextDiff(PydanticModel):
 
         new, old = self.modified_snapshots[name]
         try:
-            return old.node.text_diff(
-                new.node, rendered_model_diff=self.rendered_model_diff or False
-            )
+            return old.node.text_diff(new.node, rendered=self.diff_rendered)
         except SQLMeshError as e:
             logger.warning("Failed to diff model '%s': %s", name, str(e))
             return ""

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -190,7 +190,7 @@ class _Model(ModelMeta, frozen=True):
         self,
         include_python: bool = True,
         include_defaults: bool = False,
-        render_model: bool = False,
+        render_query: bool = False,
     ) -> t.List[exp.Expression]:
         """Returns the original list of sql expressions comprising the model definition.
 
@@ -677,12 +677,12 @@ class _Model(ModelMeta, frozen=True):
             )
         return query
 
-    def text_diff(self, other: Node, rendered_model_diff: bool = False) -> str:
+    def text_diff(self, other: Node, rendered: bool = False) -> str:
         """Produce a text diff against another node.
 
         Args:
             other: The node to diff against.
-            rendered_model_diff: Whether the diff should compare raw vs rendered models
+            diff_rendered: Whether the diff should compare raw vs rendered models
 
         Returns:
             A unified text diff showing additions and deletions.
@@ -693,8 +693,8 @@ class _Model(ModelMeta, frozen=True):
             )
 
         return d.text_diff(
-            self.render_definition(render_model=rendered_model_diff),
-            other.render_definition(render_model=rendered_model_diff),
+            self.render_definition(render_query=rendered),
+            other.render_definition(render_query=rendered),
             self.dialect,
             other.dialect,
         ).strip()
@@ -1227,13 +1227,13 @@ class SqlModel(_Model):
         self,
         include_python: bool = True,
         include_defaults: bool = False,
-        render_model: bool = False,
+        render_query: bool = False,
     ) -> t.List[exp.Expression]:
         result = super().render_definition(
             include_python=include_python, include_defaults=include_defaults
         )
 
-        if render_model:
+        if render_query:
             result.extend(self.render_pre_statements())
             result.append(self.render_query() or self.query)
             result.extend(self.render_post_statements())
@@ -1673,12 +1673,12 @@ class PythonModel(_Model):
         self,
         include_python: bool = True,
         include_defaults: bool = False,
-        render_model: bool = False,
+        render_query: bool = False,
     ) -> t.List[exp.Expression]:
         # Ignore the provided value for the include_python flag, since the Pyhon model's
         # definition without Python code is meaningless.
         return super().render_definition(
-            include_python=True, include_defaults=include_defaults, render_model=render_model
+            include_python=True, include_defaults=include_defaults, render_query=render_query
         )
 
     @property

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -682,7 +682,7 @@ class _Model(ModelMeta, frozen=True):
 
         Args:
             other: The node to diff against.
-            diff_rendered: Whether the diff should compare raw vs rendered models
+            rendered: Whether the diff should compare raw vs rendered models
 
         Returns:
             A unified text diff showing additions and deletions.

--- a/sqlmesh/core/node.py
+++ b/sqlmesh/core/node.py
@@ -365,7 +365,7 @@ class _Node(PydanticModel):
         """
         return self.croniter(self.cron_next(value, estimate=estimate)).get_prev(estimate=True)
 
-    def text_diff(self, other: Node) -> str:
+    def text_diff(self, other: Node, rendered: bool = False) -> str:
         """Produce a text diff against another node.
 
         Args:

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -421,7 +421,7 @@ class SQLMeshMagics(Magics):
     @argument(
         "--diff-rendered",
         action="store_true",
-        help="Output text differences for the rendered versions of the models",
+        help="Output text differences for the rendered versions of the models and standalone audits",
     )
     @line_magic
     @pass_sqlmesh_context

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -418,6 +418,12 @@ class SQLMeshMagics(Magics):
         help="Enable preview for forward-only models when targeting a development environment.",
         default=None,
     )
+    @argument(
+        "--rendered-model-diff",
+        action="store_true",
+        help="Output text differences for the rendered versions of the models",
+        default=None,
+    )
     @line_magic
     @pass_sqlmesh_context
     def plan(self, context: Context, line: str) -> None:
@@ -446,6 +452,7 @@ class SQLMeshMagics(Magics):
             no_diff=args.no_diff,
             run=args.run,
             enable_preview=args.enable_preview,
+            rendered_model_diff=args.rendered_model_diff,
         )
 
     @magic_arguments()

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -419,10 +419,9 @@ class SQLMeshMagics(Magics):
         default=None,
     )
     @argument(
-        "--rendered-model-diff",
+        "--diff-rendered",
         action="store_true",
         help="Output text differences for the rendered versions of the models",
-        default=None,
     )
     @line_magic
     @pass_sqlmesh_context
@@ -452,7 +451,7 @@ class SQLMeshMagics(Magics):
             no_diff=args.no_diff,
             run=args.run,
             enable_preview=args.enable_preview,
-            rendered_model_diff=args.rendered_model_diff,
+            diff_rendered=args.diff_rendered,
         )
 
     @magic_arguments()

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -898,3 +898,21 @@ def test_audit_query_normalization():
         rendered_audit_query.sql("snowflake")
         == """SELECT * FROM (SELECT * FROM "DB"."TEST_MODEL" AS "TEST_MODEL") AS "_Q_0" WHERE "A" IS NULL AND TRUE"""
     )
+
+
+def test_rendered_diff():
+    audit1 = StandaloneAudit(
+        name="test_audit", query=parse_one("SELECT * FROM 'test' WHERE @AND(TRUE, NULL) > 2")
+    )
+
+    audit2 = StandaloneAudit(
+        name="test_audit", query=parse_one("SELECT * FROM 'test' WHERE @OR(FALSE, NULL) > 2")
+    )
+
+    assert """@@ -6,4 +6,4 @@
+
+   *
+ FROM "test" AS "test"
+ WHERE
+-  TRUE > 2
++  FALSE > 2""" in audit1.text_diff(audit2, rendered=True)

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1193,3 +1193,78 @@ def test_requirements(copy_to_temp_path: t.Callable):
     diff = context.plan_builder("dev", skip_tests=True, skip_backfill=True).build().context_diff
     assert set(diff.previous_requirements) == requirements
     assert set(diff.requirements) == {"numpy", "pandas"}
+
+
+@pytest.mark.slow
+def test_rendered_model_diff():
+    ctx = Context(config=Config())
+
+    ctx.upsert_model(
+        load_sql_based_model(
+            parse(
+                """
+                MODEL (
+                    name test,
+                );
+
+                CREATE TABLE IF NOT EXISTS foo AS (SELECT @OR(FALSE, TRUE));
+
+                SELECT 4 + 2;
+
+                CREATE TABLE IF NOT EXISTS foo2 AS (SELECT @AND(TRUE, FALSE));
+
+                ON_VIRTUAL_UPDATE_BEGIN;
+                DROP VIEW @this_model
+                ON_VIRTUAL_UPDATE_END;
+
+                """
+            )
+        )
+    )
+
+    ctx.plan("dev", auto_apply=True, no_prompts=True)
+
+    # Alter the model's query and pre/post/virtual statements to cause the diff
+    ctx.upsert_model(
+        load_sql_based_model(
+            parse(
+                """
+                MODEL (
+                    name test,
+                );
+
+                CREATE TABLE IF NOT EXISTS foo AS (SELECT @AND(TRUE, NULL));
+
+                SELECT 5 + 2;
+
+                CREATE TABLE IF NOT EXISTS foo2 AS (SELECT @OR(TRUE, NULL));
+
+                ON_VIRTUAL_UPDATE_BEGIN;
+                DROP VIEW IF EXISTS @this_model
+                ON_VIRTUAL_UPDATE_END;
+                """
+            )
+        )
+    )
+
+    plan = ctx.plan("dev", auto_apply=True, no_prompts=True, rendered_model_diff=True)
+
+    assert '''@@ -4,13 +4,13 @@
+
+ CREATE TABLE IF NOT EXISTS "foo" AS
+ (
+   SELECT
+-    FALSE OR TRUE
++    TRUE
+ )
+ SELECT
+-  6 AS "_col_0"
++  7 AS "_col_0"
+ CREATE TABLE IF NOT EXISTS "foo2" AS
+ (
+   SELECT
+-    TRUE AND FALSE
++    TRUE
+ )
+-DROP VIEW "test"
++DROP VIEW IF EXISTS "test"''' in plan.context_diff.text_diff('"test"')

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1196,7 +1196,7 @@ def test_requirements(copy_to_temp_path: t.Callable):
 
 
 @pytest.mark.slow
-def test_rendered_model_diff():
+def test_rendered_diff():
     ctx = Context(config=Config())
 
     ctx.upsert_model(
@@ -1247,7 +1247,7 @@ def test_rendered_model_diff():
         )
     )
 
-    plan = ctx.plan("dev", auto_apply=True, no_prompts=True, rendered_model_diff=True)
+    plan = ctx.plan("dev", auto_apply=True, no_prompts=True, diff_rendered=True)
 
     assert '''@@ -4,13 +4,13 @@
 


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/1254

The default behavior of plan diff is to compare raw models i.e the original queries & statements:

```SQL
Differences from the `dev` environment:

Models:
└── Directly Modified:
    └── default__dev.test

--- 

+++ 

@@ -4,13 +4,13 @@

 CREATE TABLE IF NOT EXISTS foo AS
 (
   SELECT
-    @OR(FALSE, TRUE)
+    @AND(TRUE, NULL)
 )
 SELECT
-  4 + 2
+  5 + 2
 CREATE TABLE IF NOT EXISTS foo2 AS
 (
   SELECT
-    @AND(TRUE, FALSE)
+    @OR(TRUE, NULL)
 )
-DROP VIEW @this_model
+DROP VIEW IF EXISTS @this_model

```


This PR introduces the `sqlmesh plan --rendered-model-diff` which instead compares rendered queries/statements:


```SQL
@@ -4,13 +4,13 @@

 CREATE TABLE IF NOT EXISTS "foo" AS
 (
   SELECT
-    FALSE OR TRUE
+    TRUE
 )
 SELECT
-  6 AS "_col_0"
+  7 AS "_col_0"
 CREATE TABLE IF NOT EXISTS "foo2" AS
 (
   SELECT
-    TRUE AND FALSE
+    TRUE
 )
-DROP VIEW "test"
+DROP VIEW IF EXISTS "test"
```