### PR TITLE
Chore: Improve the missing dates output by wrapping them into square brackets

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -889,7 +889,7 @@ class TerminalConsole(Console):
         missing_intervals = plan.missing_intervals
         if not missing_intervals:
             return
-        backfill = Tree("[bold]Models needing backfill (missing dates):")
+        backfill = Tree("[bold]Models needing backfill \[missing dates]:")
         for missing in missing_intervals:
             snapshot = plan.context_diff.snapshots[missing.snapshot_id]
             if not snapshot.is_model:
@@ -903,7 +903,7 @@ class TerminalConsole(Console):
                 plan.environment_naming_info, default_catalog, dialect=self.dialect
             )
             backfill.add(
-                f"{display_name}: {_format_missing_intervals(snapshot, missing)}{preview_modifier}"
+                f"{display_name}: \[{_format_missing_intervals(snapshot, missing)}]{preview_modifier}"
             )
 
         if backfill:
@@ -1723,7 +1723,7 @@ class MarkdownConsole(CaptureTerminalConsole):
         missing_intervals = plan.missing_intervals
         if not missing_intervals:
             return
-        self._print("\n**Models needing backfill (missing dates):**")
+        self._print("\n**Models needing backfill \[missing dates]:**")
         snapshots = []
         for missing in missing_intervals:
             snapshot = plan.context_diff.snapshots[missing.snapshot_id]
@@ -1738,7 +1738,7 @@ class MarkdownConsole(CaptureTerminalConsole):
                 plan.environment_naming_info, default_catalog, dialect=self.dialect
             )
             snapshots.append(
-                f"* `{display_name}`: {_format_missing_intervals(snapshot, missing)}{preview_modifier}"
+                f"* `{display_name}`: [{_format_missing_intervals(snapshot, missing)}]{preview_modifier}"
             )
 
         length = len(snapshots)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -294,8 +294,8 @@ def test_plan_dev_start_date(runner, tmp_path):
         input="\ny\n",
     )
     assert_plan_success(result, "dev")
-    assert "sqlmesh_example__dev.full_model: full refresh" in result.output
-    assert "sqlmesh_example__dev.incremental_model: 2023-01-01" in result.output
+    assert "sqlmesh_example__dev.full_model: [full refresh]" in result.output
+    assert "sqlmesh_example__dev.incremental_model: [2023-01-01" in result.output
 
 
 def test_plan_dev_end_date(runner, tmp_path):
@@ -308,8 +308,8 @@ def test_plan_dev_end_date(runner, tmp_path):
         input="\ny\n",
     )
     assert_plan_success(result, "dev")
-    assert "sqlmesh_example__dev.full_model: full refresh" in result.output
-    assert "sqlmesh_example__dev.incremental_model: 2020-01-01 - 2023-01-01" in result.output
+    assert "sqlmesh_example__dev.full_model: [full refresh]" in result.output
+    assert "sqlmesh_example__dev.incremental_model: [2020-01-01 - 2023-01-01]" in result.output
 
 
 def test_plan_dev_create_from_virtual(runner, tmp_path):

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -379,8 +379,8 @@ def test_merge_pr_has_non_breaking_change_diff_start(
 - `sushi.top_waiters`
 
 
-**Models needing backfill (missing dates):**
-* `sushi.waiter_revenue_by_day`: 2022-12-25 - 2022-12-28
+**Models needing backfill [missing dates]:**
+* `sushi.waiter_revenue_by_day`: [2022-12-25 - 2022-12-28]
 """
     assert prod_plan_preview_checks_runs[2]["output"]["summary"] == expected_prod_plan
 
@@ -1066,8 +1066,8 @@ def test_no_merge_since_no_deploy_signal_no_approvers_defined(
 - `sushi.top_waiters`
 
 
-**Models needing backfill (missing dates):**
-* `sushi.waiter_revenue_by_day`: 2022-12-25 - 2022-12-29
+**Models needing backfill [missing dates]:**
+* `sushi.waiter_revenue_by_day`: [2022-12-25 - 2022-12-29]
 """
     assert prod_plan_preview_checks_runs[2]["output"]["title"] == "Prod Plan Preview"
     assert prod_plan_preview_checks_runs[2]["output"]["summary"] == expected_prod_plan


### PR DESCRIPTION
New output:
```
Models needing backfill [missing dates]:
├── raw__dev.demographics: [full refresh]
├── sushi__dev.active_customers: [full refresh] (preview)
├── sushi__dev.customer_revenue_by_day: [2025-01-20 - 2025-01-20]
├── sushi__dev.customer_revenue_lifetime: [2025-01-20 - 2025-01-20] (preview)
├── sushi__dev.customers: [full refresh] (preview)
├── sushi__dev.items: [2025-01-20 - 2025-01-20]
├── sushi__dev.marketing: [2025-01-20 - 2025-01-20] (preview)
├── sushi__dev.order_items: [2025-01-20 - 2025-01-20]
├── sushi__dev.orders: [2025-01-20 - 2025-01-20]
├── sushi__dev.raw_marketing: [full refresh] (preview)
├── sushi__dev.top_waiters: [recreate view] (preview)
├── sushi__dev.waiter_as_customer_by_day: [2025-01-20 - 2025-01-20] (preview)
├── sushi__dev.waiter_names: [full refresh]
└── sushi__dev.waiter_revenue_by_day: [2025-01-20 - 2025-01-20]
```