### PR TITLE
Feat: Support top level properties in model_defaults

### DIFF
--- a/docs/reference/model_configuration.md
+++ b/docs/reference/model_configuration.md
@@ -52,10 +52,15 @@ The SQLMesh project-level `model_defaults` key supports the following options, d
 - cron
 - owner
 - start
+- table_format
 - storage_format
+- physical_properties
+- virtual_properties
 - session_properties (on per key basis)
 - on_destructive_change (described [below](#incremental-models))
 - audits (described [here](../concepts/audits.md#generic-audits))
+- optimize_query
+- validate_query
 
 
 ### Model Naming

--- a/docs/reference/model_configuration.md
+++ b/docs/reference/model_configuration.md
@@ -45,6 +45,69 @@ Configuration options for SQLMesh model properties. Supported by all model kinds
 
 The SQLMesh project-level configuration must contain the `model_defaults` key and must specify a value for its `dialect` key. Other values are set automatically unless explicitly overridden in the model definition. Learn more about project-level configuration in the [configuration guide](../guides/configuration.md).
 
+In `physical_properties`, `virtual_properties`, and `session_properties`, when both project-level and model-specific properties are defined, they are merged, with model-level properties taking precedence. To unset a project-wide property for a specific model, set it to `None` in the `MODEL`'s DDL properties or within the `@model` decorator for Python models.
+
+For example, with the following `model_defaults` configuration:
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    model_defaults:
+      dialect: snowflake
+      start: 2022-01-01
+      physical_properties:
+        partition_expiration_days: 7
+        require_partition_filter: True
+        project_level_property: "value"
+    ```
+
+=== "Python"
+
+    ```python linenums="1"
+    from sqlmesh.core.config import Config, ModelDefaultsConfig
+
+    config = Config(
+      model_defaults=ModelDefaultsConfig(
+        dialect="snowflake",
+        start="2022-01-01",
+        physical_properties={
+          "partition_expiration_days": 7,
+          "require_partition_filter": True,
+          "project_level_property": "value"
+        },
+      ),
+    )
+    ```
+
+To override `partition_expiration_days`, add a new `creatable_type` property and unset `project_level_property`, you can define the model as follows:
+
+=== "SQL"
+
+    ```sql linenums="1"
+    MODEL (
+      ...,
+      physical_properties (
+        partition_expiration_days = 14,
+        creatable_type = TRANSIENT,
+        project_level_property = None,
+      )
+    );
+    ```
+
+=== "Python"
+
+    ```python linenums="1"
+    @model(
+      ...,
+      physical_properties={
+        "partition_expiration_days": 14,
+        "creatable_type": "TRANSIENT",
+        "project_level_property": None
+      },
+    )
+    ```
+
+
 The SQLMesh project-level `model_defaults` key supports the following options, described in the [general model properties](#general-model-properties) table above:
 
 - kind

--- a/sqlmesh/core/config/model.py
+++ b/sqlmesh/core/config/model.py
@@ -32,6 +32,9 @@ class ModelDefaultsConfig(BaseConfig):
         storage_format: The storage format used to store the physical table, only applicable in certain engines.
             (eg. 'parquet', 'orc')
         on_destructive_change: What should happen when a forward-only model requires a destructive schema change.
+        physical_properties: A key-value mapping of arbitrary properties that are applied to the model table / view in the physical layer.
+        virtual_properties: A key-value mapping of arbitrary properties that are applied to the model view in the virtual layer.
+        session_properties: A key-value mapping of properties specific to the target engine that are applied to the engine session.
         audits: The audits to be applied globally to all models in the project.
         optimize_query: Whether the SQL models should be optimized
     """
@@ -44,6 +47,8 @@ class ModelDefaultsConfig(BaseConfig):
     table_format: t.Optional[str] = None
     storage_format: t.Optional[str] = None
     on_destructive_change: t.Optional[OnDestructiveChange] = None
+    physical_properties: t.Optional[t.Dict[str, t.Any]] = None
+    virtual_properties: t.Optional[t.Dict[str, t.Any]] = None
     session_properties: t.Optional[t.Dict[str, t.Any]] = None
     audits: t.Optional[t.List[FunctionCall]] = None
     optimize_query: t.Optional[bool] = None


### PR DESCRIPTION
This update extends the support for top-level properties to be enabled project wide, fixes: #3599 

- when both project-wide and model-specific properties are defined, they are combined. 
- if a property is set at the model level, it takes precedence over the project-wide setting. 
- if a user wants to unset a project-wide property on a specific model, they can do so by explicitly setting it to None.

Don't know if it makes sense to include more, as the others seem quite model-specific, but I’m happy to add them if anyone feels they’re necessary.