### PR TITLE
Chore: minor plan output formatting

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -614,9 +614,9 @@ class TerminalConsole(Console):
         """
         if context_diff.is_new_environment:
             msg = (
-                f"`{context_diff.environment}` environment will be initialized"
+                f"\n`{context_diff.environment}` environment will be initialized"
                 if not context_diff.create_from_env_exists
-                else f"New environment `{context_diff.environment}` will be created from `{context_diff.create_from}`"
+                else f"\nNew environment `{context_diff.environment}` will be created from `{context_diff.create_from}`"
             )
             self._print(Tree(f"[bold]{msg}\n"))
             if not context_diff.has_snapshot_changes:
@@ -628,7 +628,7 @@ class TerminalConsole(Console):
             #   the PlanBuilder.
             self._print(
                 Tree(
-                    f"[bold]No changes to plan: project files match the `{context_diff.environment}` environment\n"
+                    f"\n[bold]No changes to plan: project files match the `{context_diff.environment}` environment\n"
                 )
             )
             return

--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -300,7 +300,7 @@ class ContextDiff(PydanticModel):
         return {x.name: x for x in self.snapshots.values()}
 
     def requirements_diff(self) -> str:
-        return "\n".join(
+        return "    " + "\n    ".join(
             ndiff(
                 [
                     f"{k}=={self.previous_requirements[k]}"


### PR DESCRIPTION
**Adds a newline before the first message is printed**

Before
![Screenshot 2025-01-23 at 3 58 02 PM](https://github.com/user-attachments/assets/099047e8-ef9b-4394-b5a1-b7be8ef9d8ec)

After
![Screenshot 2025-01-23 at 4 01 14 PM](https://github.com/user-attachments/assets/63ea399d-a682-4259-bf29-7b01fa0a2bee)

**Adds left side indention to the python requirements (and first newline from previous change)**

Before
![Screenshot 2025-01-23 at 3 58 33 PM](https://github.com/user-attachments/assets/d7bbc2af-ba54-4683-b025-a6f0cb347157)

After
![Screenshot 2025-01-23 at 4 01 26 PM](https://github.com/user-attachments/assets/1a7769d1-3419-4493-b7ac-7d5d1fe39590)
