### PR TITLE
Fix: nothing to run message should not appear during plan

### DIFF
--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -26,7 +26,6 @@ from sqlmesh.core.snapshot import (
 from sqlmesh.core.snapshot.definition import (
     Interval,
     expand_range,
-    get_next_model_interval_start,
     parent_snapshots_by_name,
 )
 from sqlmesh.core.state_sync import StateSync
@@ -35,7 +34,6 @@ from sqlmesh.utils.concurrency import concurrent_apply_to_dag, NodeExecutionFail
 from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.date import (
     TimeLike,
-    format_tz_datetime,
     now_timestamp,
     to_timestamp,
     validate_date_range,
@@ -313,18 +311,6 @@ class Scheduler:
         )
 
         if not merged_intervals:
-            next_run_ready_msg = ""
-
-            next_ready_interval_start = get_next_model_interval_start(self.snapshots.values())
-            if next_ready_interval_start:
-                utc_time = format_tz_datetime(next_ready_interval_start)
-                local_time = format_tz_datetime(next_ready_interval_start, use_local_timezone=True)
-                time_msg = local_time if local_time == utc_time else f"{local_time} ({utc_time})"
-                next_run_ready_msg = f"\n\nNext run will be ready at {time_msg}."
-
-            self.console.log_status_update(
-                f"No models are ready to run. Please wait until a model `cron` interval has elapsed.{next_run_ready_msg}"
-            )
             return CompletionStatus.NOTHING_TO_DO
 
         errors, skipped_intervals = self.run_merged_intervals(


### PR DESCRIPTION
Moves the nothing to run message out of scheduler (which is called during `plan`) and into the context run call.