### PR TITLE
Chore: silence a few warnings related to string escaping

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -889,7 +889,7 @@ class TerminalConsole(Console):
         missing_intervals = plan.missing_intervals
         if not missing_intervals:
             return
-        backfill = Tree("[bold]Models needing backfill \[missing dates]:")
+        backfill = Tree("[bold]Models needing backfill \\[missing dates]:")
         for missing in missing_intervals:
             snapshot = plan.context_diff.snapshots[missing.snapshot_id]
             if not snapshot.is_model:
@@ -903,7 +903,7 @@ class TerminalConsole(Console):
                 plan.environment_naming_info, default_catalog, dialect=self.dialect
             )
             backfill.add(
-                f"{display_name}: \[{_format_missing_intervals(snapshot, missing)}]{preview_modifier}"
+                f"{display_name}: \\[{_format_missing_intervals(snapshot, missing)}]{preview_modifier}"
             )
 
         if backfill:
@@ -1723,7 +1723,7 @@ class MarkdownConsole(CaptureTerminalConsole):
         missing_intervals = plan.missing_intervals
         if not missing_intervals:
             return
-        self._print("\n**Models needing backfill \[missing dates]:**")
+        self._print("\n**Models needing backfill \\[missing dates]:**")
         snapshots = []
         for missing in missing_intervals:
             snapshot = plan.context_diff.snapshots[missing.snapshot_id]


### PR DESCRIPTION
Small lift to get rid of these warnings:

```
(.venv) ➜  playground sqlmesh init duckdb
/<path>/sqlmesh/core/console.py:892: SyntaxWarning: invalid escape sequence '\['
  backfill = Tree("[bold]Models needing backfill \[missing dates]:")
/<path>/sqlmesh/core/console.py:906: SyntaxWarning: invalid escape sequence '\['
  f"{display_name}: \[{_format_missing_intervals(snapshot, missing)}]{preview_modifier}"
/<path>/sqlmesh/core/console.py:1726: SyntaxWarning: invalid escape sequence '\['
  self._print("\n**Models needing backfill \[missing dates]:**")
```