### PR TITLE
better onboarding instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,15 @@ Install SQLMesh through [pypi](https://pypi.org/project/sqlmesh/) by running:
 ```bash
 mkdir sqlmesh-example
 cd sqlmesh-example
-python -m venv .env
-source .env/bin/activate
+python -m venv .venv
+source .venv/bin/activate
 pip install sqlmesh
+source .venv/bin/activate # reactivate the venv to ensure you're using the right installation
 sqlmesh init duckdb # get started right away with a local duckdb instance
+sqlmesh plan # see the plan for the changes you're making
 ```
+
+> Note: You may need to run `python3` or `pip3` instead of `python` or `pip`, depending on your python installation.
 
 Follow the [quickstart guide](https://sqlmesh.readthedocs.io/en/stable/quickstart/cli/#1-create-the-sqlmesh-project) to learn how to use SQLMesh. You already have a head start!
 

--- a/docs/cloud/tcloud_getting_started.md
+++ b/docs/cloud/tcloud_getting_started.md
@@ -37,7 +37,7 @@ Technical Requirements:
 
 - Tobiko Cloud requires Python version between 3.9 and 3.12
 
-??? "Installing Python"
+!!! note
     If you don't have a supported Python version installed, you can use [uv](https://docs.astral.sh/uv/getting-started/installation/#installation-methods) to install it.
     At the time of writing, these are the suggested commands to install uv and Python:
 
@@ -104,7 +104,15 @@ First, open a terminal within your terminal/IDE (ex: VSCode). Then follow the fo
 !!! note
     You may need to run `python3` or `pip3` instead of `python` or `pip`, depending on your python installation.
 
-4. Create an alias to ensure use of `tcloud`:
+    If you do not see `tcloud` in the virtual environment path above, you may need to reactivate the venv:
+
+    ```bash
+    source .venv/bin/activate
+    which tcloud
+    # expected path: /Users/person/Desktop/git_repos/tobiko-cloud-demo/.venv/bin/tcloud
+    ```
+
+- Create an alias to ensure use of `tcloud`:
 
     We recommend using a command line alias to ensure all `sqlmesh` commands run on Tobiko Cloud.
 
@@ -214,6 +222,7 @@ Now we're ready to connect your data warehouse to Tobiko Cloud:
     cicd_bot:
       type: github
       merge_method: squash
+      skip_pr_backfill: false
       enable_deploy_command: true
       auto_categorize_changes:
       external: full
@@ -223,7 +232,7 @@ Now we're ready to connect your data warehouse to Tobiko Cloud:
 
     # preview data for forward only models
     plan:
-    enable_preview: true
+      enable_preview: true
 
     # list of users that are allowed to approve PRs for synchronized deployments
     users:

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,13 +135,15 @@ Install SQLMesh through [pypi](https://pypi.org/project/sqlmesh/) by running:
 ```bash
 mkdir sqlmesh-example
 cd sqlmesh-example
-
-python -m venv .env
-source .env/bin/activate
-
+python -m venv .venv
+source .venv/bin/activate
 pip install sqlmesh
+source .venv/bin/activate # reactivate the venv to ensure you're using the right installation
 sqlmesh init duckdb # get started right away with a local duckdb instance
+sqlmesh plan # see the plan for the changes you're making
 ```
+
+> Note: You may need to run `python3` or `pip3` instead of `python` or `pip`, depending on your python installation.
 
 Follow the [quickstart guide](https://sqlmesh.readthedocs.io/en/stable/quickstart/cli/#1-create-the-sqlmesh-project) to learn how to use SQLMesh. You already have a head start!
 


### PR DESCRIPTION
I've consistently encountered friction installing and using the right installation for `tcloud`/`sqlmesh`. This calls it out proactively in the tcloud docs and prevents that friction in the main readme. 