### PR TITLE
Feat(trino): Add the ability to control schema locations

### DIFF
--- a/docs/integrations/engines/trino.md
+++ b/docs/integrations/engines/trino.md
@@ -95,6 +95,112 @@ hive.metastore.glue.default-warehouse-dir=s3://my-bucket/
 | `retries`            | Number of retries to attempt when a request fails. Default: `3`                                                                                                           |  int   |    N     |
 | `timezone`           | Timezone to use for the connection. Default: client-side local timezone                                                                                                   | string |    N     |
 
+## Table and Schema locations
+
+When using connectors that are decoupled from their storage (such as the Iceberg, Hive or Delta connectors), when creating new tables Trino needs to know the location in the physical storage it should write the table data to.
+
+This location gets stored against the table in the metastore so that any engine trying to read the data knows where to look.
+
+### Default behaviour
+
+Trino allows you to optionally configure a `default-warehouse-dir` property at the [Metastore](https://trino.io/docs/current/object-storage/metastores.html) level. When creating objects, Trino will infer schema locations to be `<default warehouse dir>/<schema name>` and table locations to be `<default warehouse dir>/<schema name>/<table name>`.
+
+However, if you dont set this property, Trino can still infer table locations if a *schema* location is explicitly set.
+
+For example, if you specify the `LOCATION` property when creating a schema like so:
+
+```sql
+CREATE SCHEMA staging_data
+WITH (LOCATION = 's3://warehouse/production/staging_data')
+```
+
+Then any tables created under that schema will have their location inferred as `<schema location>/<table name>`.
+
+If you specify neither a `default-warehouse-dir` in the metastore config nor a schema location when creating the schema, you must specify an explicit table location when creating the table or Trino will produce an error.
+
+Creating a table in a specific location is very similar to creating a schema in a specific location:
+
+```sql
+CREATE TABLE staging_data.customers (customer_id INT)
+WITH (LOCATION = 's3://warehouse/production/staging_data/customers')
+```
+
+### Configuring in SQLMesh
+
+Within SQLMesh, you can configure the value to use for the `LOCATION` property when SQLMesh creates tables and schemas. This overrides what Trino would have inferred based on the cluster configuration.
+
+#### Schemas
+
+To configure the `LOCATION` property that SQLMesh will specify when issuing `CREATE SCHEMA` statements, you can use the `schema_location_mapping` connection property. This applies to all schemas that SQLMesh creates, including its internal ones.
+
+The simplest example is to emulate a `default-warehouse-dir`:
+
+```yaml title="config.yaml"
+gateways:
+  trino:
+    connection:
+      type: trino
+      ...
+      schema_location_mapping:
+        '.*': 's3://warehouse/production/@{schema_name}'
+```
+
+This will cause all schemas to get created with their location set to `s3://warehouse/production/<schema name>`. The table locations will be inferred by Trino as `s3://warehouse/production/<schema name>/<table name>` so all objects will effectively be created under `s3://warehouse/production/`.
+
+It's worth mentioning that if your models are using fully qualified three part names, eg `<catalog>.<schema>.<name>` then string being matched against the `schema_location_mapping` regex will be `<catalog>.<schema>` and not just the `<schema>` itself. This allows you to set different locations for the same schema name if that schema name is used across multiple catalogs.
+
+If your models are using two part names, eg `<schema>.<table>` then only the `<schema>` part will be matched against the regex.
+
+Here's an example:
+
+```yaml title="config.yaml"
+gateways:
+  trino:
+    connection:
+      type: trino
+      ...
+      schema_location_mapping:
+        '^utils$': 's3://utils-bucket/@{schema_name}'
+        '^landing\..*$': 's3://raw-data/@{catalog_name}/@{schema_name}'
+        '^staging.*$': 's3://bucket/@{schema_name}_dev'
+        '^sqlmesh.*$': 's3://sqlmesh-internal/dev/@{schema_name}'
+```
+
+This would perform the following mappings:
+
+- a schema called `sales` would not be mapped to a location at all because it doesnt match any of the patterns. It would be created without a `LOCATION` property
+- a schema called `utils` would be mapped to the location `s3://utils-bucket/utils` because it directly matches the `^utils$` pattern
+- a schema called `transactions` in a catalog called `landing` would be mapped to the location `s3://raw-data/landing/transactions` because the string `landing.transactions` matches the `^landing\..*$` pattern
+- schemas called `staging_customers` and `staging_accounts` would be mapped to the locations `s3://bucket/staging_customers_dev` and `s3://bucket/staging_accounts_dev` respectively because they match the `^staging.*$` pattern
+- a schema called `accounts` in a catalog called `staging` would be mapped to the location `s3://bucket/accounts_dev` because the string `staging.accounts` matches the `^staging.*$` pattern
+- schemas called `sqlmesh__staging_customers` and `sqlmesh__staging_utils` would be mapped to the locations `s3://sqlmesh-internal/dev/sqlmesh__staging_customers` and `s3://sqlmesh-internal/dev/sqlmesh__staging_utils` respectively because they match the `^sqlmesh.*$` pattern
+
+!!! info "Placeholders"
+    You may use the `@{catalog_name}` and `@{schema_name}` placeholders in the mapping value.
+
+    If there is a match on one of the patterns then the catalog / schema that SQLMesh is about to use in the `CREATE SCHEMA` statement will be subsitituted into these placeholders.
+
+
+#### Tables
+
+Often, you dont need to configure an explicit table location because if you have configured explicit schema locations, table locations are automatically inferred by Trino to be a subdirectory under the schema location.
+
+However, if you need to, you can configure an explicit table location by adding a `location` property to the model `physical_properties`:
+
+```
+MODEL (
+  name staging.customers,
+  kind FULL,
+  physical_properties (
+    location = 's3://warehouse/staging/customers'
+  )
+);
+
+SELECT ...
+```
+
+This will cause SQLMesh to set the specified `LOCATION` when issuing a `CREATE TABLE` statement.
+
 ## Airflow Scheduler
 **Engine Name:** `trino`
 

--- a/sqlmesh/core/config/common.py
+++ b/sqlmesh/core/config/common.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing as t
 from enum import Enum
+import re
 
 from sqlmesh.utils import classproperty
 from sqlmesh.utils.errors import ConfigError
@@ -86,3 +87,16 @@ variables_validator = field_validator(
     mode="before",
     check_fields=False,
 )(_variables_validator)
+
+
+def compile_regex_mapping(value: t.Dict[str | re.Pattern, t.Any]) -> t.Dict[re.Pattern, t.Any]:
+    """
+    Utility function to compile a dict of { "string regex pattern" : "string value" } into { "<re.Pattern>": "string value" }
+    """
+    compiled_regexes = {}
+    for k, v in value.items():
+        try:
+            compiled_regexes[re.compile(k)] = v
+        except re.error:
+            raise ConfigError(f"`{k}` is not a valid regular expression.")
+    return compiled_regexes

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -5,6 +5,7 @@ import base64
 import logging
 import os
 import pathlib
+import re
 import typing as t
 from enum import Enum
 from functools import partial, lru_cache
@@ -19,6 +20,7 @@ from sqlmesh.core.config.base import BaseConfig
 from sqlmesh.core.config.common import (
     concurrent_tasks_validator,
     http_headers_validator,
+    compile_regex_mapping,
 )
 from sqlmesh.core.engine_adapter.shared import CatalogSupport
 from sqlmesh.core.engine_adapter import EngineAdapter
@@ -1431,11 +1433,26 @@ class TrinoConnectionConfig(ConnectionConfig):
     client_private_key: t.Optional[str] = None
     cert: t.Optional[str] = None
 
+    # SQLMesh options
+    schema_location_mapping: t.Optional[dict[re.Pattern, str]] = None
     concurrent_tasks: int = 4
     register_comments: bool = True
     pre_ping: t.Literal[False] = False
 
     type_: t.Literal["trino"] = Field(alias="type", default="trino")
+
+    @field_validator("schema_location_mapping", mode="before")
+    @classmethod
+    def _validate_regex_keys(
+        cls, value: t.Dict[str | re.Pattern, str]
+    ) -> t.Dict[re.Pattern, t.Any]:
+        compiled = compile_regex_mapping(value)
+        for replacement in compiled.values():
+            if "@{schema_name}" not in replacement:
+                raise ConfigError(
+                    "schema_location_mapping needs to include the '@{schema_name}' placeholder in the value so SQLMesh knows where to substitute the schema name"
+                )
+        return compiled
 
     @model_validator(mode="after")
     def _root_validator(self) -> Self:
@@ -1536,6 +1553,10 @@ class TrinoConnectionConfig(ConnectionConfig):
             "verify": self.cert if self.cert is not None else self.verify,
             "source": "sqlmesh",
         }
+
+    @property
+    def _extra_engine_config(self) -> t.Dict[str, t.Any]:
+        return {"schema_location_mapping": self.schema_location_mapping}
 
 
 class ClickhouseConnectionConfig(ConnectionConfig):

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -15,7 +15,7 @@ from sqlmesh.cicd.config import CICDBotConfig
 from sqlmesh.core import constants as c
 from sqlmesh.core.config import EnvironmentSuffixTarget
 from sqlmesh.core.config.base import BaseConfig, UpdateStrategy
-from sqlmesh.core.config.common import variables_validator
+from sqlmesh.core.config.common import variables_validator, compile_regex_mapping
 from sqlmesh.core.config.connection import (
     ConnectionConfig,
     DuckDBConnectionConfig,
@@ -158,13 +158,7 @@ class Config(BaseConfig):
     def _validate_regex_keys(
         cls, value: t.Dict[str | re.Pattern, t.Any]
     ) -> t.Dict[re.Pattern, t.Any]:
-        compiled_regexes = {}
-        for k, v in value.items():
-            try:
-                compiled_regexes[re.compile(k)] = v
-            except re.error:
-                raise ConfigError(f"`{k}` is not a valid regular expression.")
-        return compiled_regexes
+        return compile_regex_mapping(value)
 
     @model_validator(mode="before")
     def _normalize_and_validate_fields(cls, data: t.Any) -> t.Any:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -430,7 +430,10 @@ def sushi_fixed_date_data_validator(sushi_context_fixed_date: Context) -> SushiD
 @pytest.fixture
 def make_mocked_engine_adapter(mocker: MockerFixture) -> t.Callable:
     def _make_function(
-        klass: t.Type[T], dialect: t.Optional[str] = None, register_comments: bool = True
+        klass: t.Type[T],
+        dialect: t.Optional[str] = None,
+        register_comments: bool = True,
+        **kwargs: t.Any,
     ) -> T:
         connection_mock = mocker.NonCallableMock()
         cursor_mock = mocker.Mock()
@@ -440,6 +443,7 @@ def make_mocked_engine_adapter(mocker: MockerFixture) -> t.Callable:
             lambda: connection_mock,
             dialect=dialect or klass.DIALECT,
             register_comments=register_comments,
+            **kwargs,
         )
         if isinstance(adapter, SparkEngineAdapter):
             mocker.patch(

--- a/tests/core/engine_adapter/test_trino.py
+++ b/tests/core/engine_adapter/test_trino.py
@@ -6,9 +6,11 @@ from pytest_mock.plugin import MockerFixture
 from sqlglot import exp, parse_one
 
 import sqlmesh.core.dialect as d
+from sqlmesh.core.config.connection import TrinoConnectionConfig
 from sqlmesh.core.engine_adapter import TrinoEngineAdapter
 from sqlmesh.core.model import load_sql_based_model
 from sqlmesh.core.model.definition import SqlModel
+from sqlmesh.core.dialect import schema_
 from tests.core.engine_adapter import to_sql_calls
 
 pytestmark = [pytest.mark.engine, pytest.mark.trino]
@@ -452,3 +454,149 @@ def test_table_format(trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: M
         'CREATE TABLE IF NOT EXISTS "iceberg"."test_table" ("cola" TIMESTAMP, "colb" VARCHAR, "colc" VARCHAR) WITH (FORMAT=\'ORC\')',
         'CREATE TABLE IF NOT EXISTS "iceberg"."test_table" WITH (FORMAT=\'ORC\') AS SELECT CAST("cola" AS TIMESTAMP) AS "cola", CAST("colb" AS VARCHAR) AS "colb", CAST("colc" AS VARCHAR) AS "colc" FROM (SELECT CAST(1 AS TIMESTAMP) AS "cola", CAST(2 AS VARCHAR) AS "colb", \'foo\' AS "colc") AS "_subquery"',
     ]
+
+
+def test_table_location(trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: MockerFixture):
+    adapter = trino_mocked_engine_adapter
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.trino.TrinoEngineAdapter.get_current_catalog",
+        return_value="iceberg",
+    )
+
+    expressions = d.parse(
+        """
+        MODEL (
+            name iceberg.test_table,
+            kind FULL,
+            physical_properties (
+                location = 'hdfs://some/table/location'
+            )
+        );
+
+        SELECT 1::timestamp AS cola, 2::varchar as colb, 'foo' as colc;
+    """
+    )
+    model: SqlModel = t.cast(SqlModel, load_sql_based_model(expressions))
+
+    adapter.create_table(
+        table_name=model.name,
+        columns_to_types=model.columns_to_types_or_raise,
+        table_properties=model.physical_properties,
+    )
+
+    adapter.ctas(
+        table_name=model.name,
+        query_or_df=t.cast(exp.Query, model.query),
+        columns_to_types=model.columns_to_types_or_raise,
+        table_properties=model.physical_properties,
+    )
+
+    assert to_sql_calls(adapter) == [
+        'CREATE TABLE IF NOT EXISTS "iceberg"."test_table" ("cola" TIMESTAMP, "colb" VARCHAR, "colc" VARCHAR) WITH (location=\'hdfs://some/table/location\')',
+        'CREATE TABLE IF NOT EXISTS "iceberg"."test_table" WITH (location=\'hdfs://some/table/location\') AS SELECT CAST("cola" AS TIMESTAMP) AS "cola", CAST("colb" AS VARCHAR) AS "colb", CAST("colc" AS VARCHAR) AS "colc" FROM (SELECT CAST(1 AS TIMESTAMP) AS "cola", CAST(2 AS VARCHAR) AS "colb", \'foo\' AS "colc") AS "_subquery"',
+    ]
+
+
+def test_schema_location_mapping():
+    config = TrinoConnectionConfig(
+        user="user",
+        host="host",
+        catalog="catalog",
+    )
+
+    adapter: TrinoEngineAdapter = config.create_engine_adapter()
+    assert adapter.schema_location_mapping is None
+    assert adapter._schema_location("foo") is None
+
+    config = TrinoConnectionConfig(
+        user="user",
+        host="host",
+        catalog="catalog",
+        schema_location_mapping={
+            "^utils$": "s3://utils-bucket/@{schema_name}",
+            "^landing\..*$": "s3://raw-data/@{catalog_name}/@{schema_name}",
+            "^staging.*$": "s3://bucket/@{schema_name}_dev",
+            "^sqlmesh.*$": "s3://sqlmesh-internal/dev/@{schema_name}",
+        },
+    )
+    adapter: TrinoEngineAdapter = config.create_engine_adapter()
+    assert adapter.schema_location_mapping is not None
+    assert adapter._schema_location("foo") is None
+    assert adapter._schema_location("utils_dev") is None
+    assert adapter._schema_location("utils") == "s3://utils-bucket/utils"
+    assert adapter._schema_location("staging_customers") == "s3://bucket/staging_customers_dev"
+    assert adapter._schema_location("staging_accounts") == "s3://bucket/staging_accounts_dev"
+    assert (
+        adapter._schema_location("sqlmesh__staging_customers")
+        == "s3://sqlmesh-internal/dev/sqlmesh__staging_customers"
+    )
+    assert (
+        adapter._schema_location("sqlmesh__staging_utils")
+        == "s3://sqlmesh-internal/dev/sqlmesh__staging_utils"
+    )
+    assert adapter._schema_location("landing.transactions") == "s3://raw-data/landing/transactions"
+    assert (
+        adapter._schema_location(schema_("transactions", "landing"))
+        == "s3://raw-data/landing/transactions"
+    )
+    assert (
+        adapter._schema_location('"landing"."transactions"') == "s3://raw-data/landing/transactions"
+    )
+
+
+def test_create_schema_sets_location(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.trino.TrinoEngineAdapter.get_catalog_type",
+        return_value="iceberg",
+    )
+
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.trino.TrinoEngineAdapter._block_until_table_exists",
+        return_value=True,
+    )
+
+    config = TrinoConnectionConfig(
+        user="user",
+        host="host",
+        catalog="catalog",
+        schema_location_mapping={
+            "^utils$": "s3://utils-bucket/@{schema_name}",
+            "^landing\..*$": "s3://raw-data/@{catalog_name}/@{schema_name}",
+            "^staging.*$": "s3://bucket/@{schema_name}_dev",
+            "^sqlmesh.*$": "s3://sqlmesh-internal/dev/@{schema_name}",
+            "^iceberg\.staging.*$": "s3://iceberg-catalog/foo_@{schema_name}",
+        },
+    )
+
+    adapter: TrinoEngineAdapter = make_mocked_engine_adapter(
+        TrinoEngineAdapter, schema_location_mapping=config.schema_location_mapping
+    )
+
+    adapter.create_schema("foo")
+    adapter.create_schema(schema_("utils_dev", "db"))
+    adapter.create_schema(schema_("utils", "db"))
+    adapter.create_schema(schema_("utils"))
+    adapter.create_schema(schema_("sqlmesh"))
+    adapter.create_schema("sqlmesh__staging")
+    adapter.create_schema(schema_("snapshots", "sqlmesh"))
+    adapter.create_schema(schema_("staging_foo"))
+    adapter.create_schema(schema_("staging_bar", "iceberg"))
+    adapter.create_schema('"catalog"."staging_customers"')
+    adapter.create_schema(schema_("transactions", "landing"))
+
+    assert (
+        to_sql_calls(adapter)
+        == [
+            'CREATE SCHEMA IF NOT EXISTS "foo"',  # no match
+            'CREATE SCHEMA IF NOT EXISTS "db"."utils_dev"',  # no match
+            'CREATE SCHEMA IF NOT EXISTS "db"."utils"',  # no match on '^utils$' because of catalog
+            "CREATE SCHEMA IF NOT EXISTS \"utils\" WITH (LOCATION='s3://utils-bucket/utils')",  # match '^utils$'
+            "CREATE SCHEMA IF NOT EXISTS \"sqlmesh\" WITH (LOCATION='s3://sqlmesh-internal/dev/sqlmesh')",  # match '^sqlmesh.*$'
+            "CREATE SCHEMA IF NOT EXISTS \"sqlmesh__staging\" WITH (LOCATION='s3://sqlmesh-internal/dev/sqlmesh__staging')",  # match '^sqlmesh.*$'
+            'CREATE SCHEMA IF NOT EXISTS "sqlmesh"."snapshots" WITH (LOCATION=\'s3://sqlmesh-internal/dev/snapshots\')',  # match '^sqlmesh.*$' on the catalog
+            "CREATE SCHEMA IF NOT EXISTS \"staging_foo\" WITH (LOCATION='s3://bucket/staging_foo_dev')",  # match '^staging.*$'
+            'CREATE SCHEMA IF NOT EXISTS "iceberg"."staging_bar" WITH (LOCATION=\'s3://iceberg-catalog/foo_staging_bar\')',  # match '^iceberg\.staging.*$'
+            'CREATE SCHEMA IF NOT EXISTS "catalog"."staging_customers"',  # no match
+            'CREATE SCHEMA IF NOT EXISTS "landing"."transactions" WITH (LOCATION=\'s3://raw-data/landing/transactions\')',  # match '^landing\..*$'
+        ]
+    )


### PR DESCRIPTION
Currently, there is no way to instruct SQLMesh to create schemas with a specific `LOCATION` property set for Trino.

This PR introduces a **connection** property called `schema_location_mapping` that allows a user to use regular expressions to map schemas to their corresponding physical locations.

- It's a connection property because it's specific to the Trino adapter
- It follows the convention of our other mapping properties (`physical_schema_mapping` and `environment_catalog_mapping`)
- It takes catalog into account if one exists, because a schema is really a `catalog.schema` combination most of the time