### PR TITLE
Fix: handle list case in when_matched validator

### DIFF
--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -450,11 +450,13 @@ class IncrementalByUniqueKeyKind(_IncrementalBy):
     @field_validator("when_matched", mode="before")
     def _when_matched_validator(
         cls,
-        v: t.Optional[t.Union[str, exp.Whens]],
+        v: t.Optional[t.Union[str, list, exp.Whens]],
         info: ValidationInfo,
     ) -> t.Optional[exp.Whens]:
         if v is None:
             return v
+        if isinstance(v, list):
+            v = " ".join(v)
         if isinstance(v, str):
             # Whens wrap the WHEN clauses, but the parentheses aren't parsed by sqlglot
             v = v.strip()


### PR DESCRIPTION
Fixes #3669

Ideally I'd like to work out where these lists are coming from but seeking early feedback.

The assumptions seem to be that if the Whens value comes in as a string then it's coming from somewhere like state where the placeholders have already been substituted.
If it arrives as an exp.Whens then it's coming in from the IncrementalByUniqueKeyStrategy where the placeholders are still present.

I've extended the first assumption, that if it arrives as a list then it's a list of strings with placeholders already substituted.