### PR TITLE
Feat: Generate per-dialect options on init project

### DIFF
--- a/sqlmesh/cli/example_project.py
+++ b/sqlmesh/cli/example_project.py
@@ -29,11 +29,16 @@ def _gen_config(
         connection_settings = """      type: duckdb
       database: db.db"""
 
-        if dialect in CONNECTION_CONFIG_TO_TYPE:
+        doc_link = "# Visit https://sqlmesh.readthedocs.io/en/stable/integrations/engines{dialect_link} for more information on configuring the connection to your execution engine."
+
+        dialect_alias = "mssql" if dialect == "tsql" else dialect
+
+        dialect_link = ""
+        if dialect_alias in CONNECTION_CONFIG_TO_TYPE:
             required_fields = []
             non_required_fields = []
 
-            for name, field in CONNECTION_CONFIG_TO_TYPE[dialect].model_fields.items():
+            for name, field in CONNECTION_CONFIG_TO_TYPE[dialect_alias].model_fields.items():
                 field_name = field.alias or name
                 default_value = field.get_default()
 
@@ -54,6 +59,11 @@ def _gen_config(
 
             connection_settings = "".join(required_fields + non_required_fields)
 
+            dialect_link = f"/{dialect_alias}/#connection-options"
+
+        connection_settings = (
+            f"      {doc_link.format(dialect_link=dialect_link)}\n{connection_settings}"
+        )
     else:
         connection_settings = settings
 

--- a/sqlmesh/cli/example_project.py
+++ b/sqlmesh/cli/example_project.py
@@ -9,33 +9,7 @@ from sqlglot import Dialect
 from sqlmesh.integrations.dlt import generate_dlt_models_and_settings
 from sqlmesh.utils.date import yesterday_ds
 
-from sqlmesh.core.config.connection import (
-    AthenaConnectionConfig,
-    BigQueryConnectionConfig,
-    ClickhouseConnectionConfig,
-    ConnectionConfig,
-    DatabricksConnectionConfig,
-    DuckDBConnectionConfig,
-    MSSQLConnectionConfig,
-    PostgresConnectionConfig,
-    RedshiftConnectionConfig,
-    SnowflakeConnectionConfig,
-    TrinoConnectionConfig,
-)
-
-DIALECT_TO_CONFIG_CLASS: t.Dict[str, t.Type[ConnectionConfig]] = {
-    "databricks": DatabricksConnectionConfig,
-    "duckdb": DuckDBConnectionConfig,
-    "postgres": PostgresConnectionConfig,
-    "redshift": RedshiftConnectionConfig,
-    "snowflake": SnowflakeConnectionConfig,
-    "bigquery": BigQueryConnectionConfig,
-    "sqlserver": MSSQLConnectionConfig,
-    "tsql": MSSQLConnectionConfig,
-    "trino": TrinoConnectionConfig,
-    "athena": AthenaConnectionConfig,
-    "clickhouse": ClickhouseConnectionConfig,
-}
+from sqlmesh.core.config.connection import CONNECTION_CONFIG_TO_TYPE
 
 
 class ProjectTemplate(Enum):
@@ -53,11 +27,11 @@ def _gen_config(
     template: ProjectTemplate,
 ) -> str:
     if not settings:
-        if dialect in DIALECT_TO_CONFIG_CLASS:
+        if dialect in CONNECTION_CONFIG_TO_TYPE:
             required_fields = []
             non_required_fields = []
 
-            for name, field in DIALECT_TO_CONFIG_CLASS[dialect].model_fields.items():
+            for name, field in CONNECTION_CONFIG_TO_TYPE[dialect].model_fields.items():
                 field_name = field.alias or name
                 default_value = field.get_default()
 

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -1755,6 +1755,8 @@ CONNECTION_CONFIG_TO_TYPE = {
         exclude=(ConnectionConfig, BaseDuckDBConnectionConfig),
     )
 }
+CONNECTION_CONFIG_TO_TYPE["tsql"] = CONNECTION_CONFIG_TO_TYPE["mssql"]
+CONNECTION_CONFIG_TO_TYPE["sqlserver"] = CONNECTION_CONFIG_TO_TYPE["mssql"]
 
 
 def parse_connection_config(v: t.Dict[str, t.Any]) -> ConnectionConfig:

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -1755,8 +1755,6 @@ CONNECTION_CONFIG_TO_TYPE = {
         exclude=(ConnectionConfig, BaseDuckDBConnectionConfig),
     )
 }
-CONNECTION_CONFIG_TO_TYPE["tsql"] = CONNECTION_CONFIG_TO_TYPE["mssql"]
-CONNECTION_CONFIG_TO_TYPE["sqlserver"] = CONNECTION_CONFIG_TO_TYPE["mssql"]
 
 
 def parse_connection_config(v: t.Dict[str, t.Any]) -> ConnectionConfig:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -957,7 +957,7 @@ def test_init_project_dialects(runner, tmp_path):
 
         assert (
             redshift_config
-            == "gateways:\n  local:\n    connection:\n      type: redshift\n      # concurrent_tasks: 4\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # user: \n      # password: \n      # database: \n      # host: \n      # port: \n      # source_address: \n      # unix_sock: \n      # ssl: \n      # sslmode: \n      # timeout: \n      # tcp_keepalive: \n      # application_name: \n      # preferred_role: \n      # principal_arn: \n      # credentials_provider: \n      # region: \n      # cluster_identifier: \n      # iam: \n      # is_serverless: \n      # serverless_acct_id: \n      # serverless_work_group: \n\n\ndefault_gateway: local\n\nmodel_defaults:\n  dialect: redshift\n  start: 2025-01-27\n"
+            == "gateways:\n  dev:\n    connection:\n      type: redshift\n      # concurrent_tasks: 4\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # user: \n      # password: \n      # database: \n      # host: \n      # port: \n      # source_address: \n      # unix_sock: \n      # ssl: \n      # sslmode: \n      # timeout: \n      # tcp_keepalive: \n      # application_name: \n      # preferred_role: \n      # principal_arn: \n      # credentials_provider: \n      # region: \n      # cluster_identifier: \n      # iam: \n      # is_serverless: \n      # serverless_acct_id: \n      # serverless_work_group: \n\n\ndefault_gateway: dev\n\nmodel_defaults:\n  dialect: redshift\n  start: 2025-01-28\n"
         )
         remove(tmp_path / "config.yaml")
 
@@ -967,6 +967,6 @@ def test_init_project_dialects(runner, tmp_path):
 
         assert (
             bq_config
-            == "gateways:\n  local:\n    connection:\n      type: bigquery\n      # concurrent_tasks: 1\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # method: oauth\n      # project: \n      # execution_project: \n      # quota_project: \n      # location: \n      # keyfile: \n      # keyfile_json: \n      # token: \n      # refresh_token: \n      # client_id: \n      # client_secret: \n      # token_uri: \n      # scopes: \n      # job_creation_timeout_seconds: \n      # job_execution_timeout_seconds: \n      # job_retries: 1\n      # job_retry_deadline_seconds: \n      # priority: \n      # maximum_bytes_billed: \n\n\ndefault_gateway: local\n\nmodel_defaults:\n  dialect: bigquery\n  start: 2025-01-27\n"
+            == "gateways:\n  dev:\n    connection:\n      type: bigquery\n      # concurrent_tasks: 1\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # method: oauth\n      # project: \n      # execution_project: \n      # quota_project: \n      # location: \n      # keyfile: \n      # keyfile_json: \n      # token: \n      # refresh_token: \n      # client_id: \n      # client_secret: \n      # token_uri: \n      # scopes: \n      # job_creation_timeout_seconds: \n      # job_execution_timeout_seconds: \n      # job_retries: 1\n      # job_retry_deadline_seconds: \n      # priority: \n      # maximum_bytes_billed: \n\n\ndefault_gateway: dev\n\nmodel_defaults:\n  dialect: bigquery\n  start: 2025-01-28\n"
         )
         remove(tmp_path / "config.yaml")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -951,22 +951,23 @@ WHERE
 
 
 def test_init_project_dialects(runner, tmp_path):
-    init_example_project(tmp_path, "redshift")
-    with open(tmp_path / "config.yaml") as file:
-        redshift_config = file.read()
+    dialect_to_config = {
+        "redshift": "# concurrent_tasks: 4\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # user: \n      # password: \n      # database: \n      # host: \n      # port: \n      # source_address: \n      # unix_sock: \n      # ssl: \n      # sslmode: \n      # timeout: \n      # tcp_keepalive: \n      # application_name: \n      # preferred_role: \n      # principal_arn: \n      # credentials_provider: \n      # region: \n      # cluster_identifier: \n      # iam: \n      # is_serverless: \n      # serverless_acct_id: \n      # serverless_work_group: ",
+        "bigquery": "# concurrent_tasks: 1\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # method: oauth\n      # project: \n      # execution_project: \n      # quota_project: \n      # location: \n      # keyfile: \n      # keyfile_json: \n      # token: \n      # refresh_token: \n      # client_id: \n      # client_secret: \n      # token_uri: \n      # scopes: \n      # job_creation_timeout_seconds: \n      # job_execution_timeout_seconds: \n      # job_retries: 1\n      # job_retry_deadline_seconds: \n      # priority: \n      # maximum_bytes_billed: ",
+        "snowflake": "account: \n      # concurrent_tasks: 4\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # user: \n      # password: \n      # warehouse: \n      # database: \n      # role: \n      # authenticator: \n      # token: \n      # application: Tobiko_SQLMesh\n      # private_key: \n      # private_key_path: \n      # private_key_passphrase: \n      # session_parameters: ",
+        "databricks": "# concurrent_tasks: 1\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # server_hostname: \n      # http_path: \n      # access_token: \n      # auth_type: \n      # oauth_client_id: \n      # oauth_client_secret: \n      # catalog: \n      # http_headers: \n      # session_configuration: \n      # databricks_connect_server_hostname: \n      # databricks_connect_access_token: \n      # databricks_connect_cluster_id: \n      # databricks_connect_use_serverless: \n      # force_databricks_connect: \n      # disable_databricks_connect: \n      # disable_spark_session: ",
+        "postgres": "host: \n      user: \n      password: \n      port: \n      database: \n      # concurrent_tasks: 4\n      # register_comments: True\n      # pre_ping: True\n      # pretty_sql: \n      # keepalives_idle: \n      # connect_timeout: 10\n      # role: \n      # sslmode: ",
+    }
 
-        assert (
-            redshift_config
-            == f"gateways:\n  dev:\n    connection:\n      type: redshift\n      # concurrent_tasks: 4\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # user: \n      # password: \n      # database: \n      # host: \n      # port: \n      # source_address: \n      # unix_sock: \n      # ssl: \n      # sslmode: \n      # timeout: \n      # tcp_keepalive: \n      # application_name: \n      # preferred_role: \n      # principal_arn: \n      # credentials_provider: \n      # region: \n      # cluster_identifier: \n      # iam: \n      # is_serverless: \n      # serverless_acct_id: \n      # serverless_work_group: \n\n\ndefault_gateway: dev\n\nmodel_defaults:\n  dialect: redshift\n  start: {yesterday_ds()}\n"
-        )
-        remove(tmp_path / "config.yaml")
+    for dialect, expected_config in dialect_to_config.items():
+        init_example_project(tmp_path, dialect=dialect)
 
-    init_example_project(tmp_path, "bigquery")
-    with open(tmp_path / "config.yaml") as file:
-        bq_config = file.read()
+        config_start = f"gateways:\n  dev:\n    connection:\n      # Visit https://sqlmesh.readthedocs.io/en/stable/integrations/engines/{dialect}/#connection-options for more information on configuring the connection to your execution engine.\n      type: {dialect}\n      "
+        config_end = f"\n\n\ndefault_gateway: dev\n\nmodel_defaults:\n  dialect: {dialect}\n  start: 2025-01-29\n"
 
-        assert (
-            bq_config
-            == f"gateways:\n  dev:\n    connection:\n      type: bigquery\n      # concurrent_tasks: 1\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # method: oauth\n      # project: \n      # execution_project: \n      # quota_project: \n      # location: \n      # keyfile: \n      # keyfile_json: \n      # token: \n      # refresh_token: \n      # client_id: \n      # client_secret: \n      # token_uri: \n      # scopes: \n      # job_creation_timeout_seconds: \n      # job_execution_timeout_seconds: \n      # job_retries: 1\n      # job_retry_deadline_seconds: \n      # priority: \n      # maximum_bytes_billed: \n\n\ndefault_gateway: dev\n\nmodel_defaults:\n  dialect: bigquery\n  start: {yesterday_ds()}\n"
-        )
-        remove(tmp_path / "config.yaml")
+        with open(tmp_path / "config.yaml") as file:
+            config = file.read()
+
+            assert config == f"{config_start}{expected_config}{config_end}"
+
+            remove(tmp_path / "config.yaml")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -948,3 +948,25 @@ WHERE
         assert dlt_sushi_twice_nested_model_path.exists()
     finally:
         remove(dataset_path)
+
+
+def test_init_project_dialects(runner, tmp_path):
+    init_example_project(tmp_path, "redshift")
+    with open(tmp_path / "config.yaml") as file:
+        redshift_config = file.read()
+
+        assert (
+            redshift_config
+            == "gateways:\n  local:\n    connection:\n      type: redshift\n      # concurrent_tasks: 4\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # user: \n      # password: \n      # database: \n      # host: \n      # port: \n      # source_address: \n      # unix_sock: \n      # ssl: \n      # sslmode: \n      # timeout: \n      # tcp_keepalive: \n      # application_name: \n      # preferred_role: \n      # principal_arn: \n      # credentials_provider: \n      # region: \n      # cluster_identifier: \n      # iam: \n      # is_serverless: \n      # serverless_acct_id: \n      # serverless_work_group: \n\n\ndefault_gateway: local\n\nmodel_defaults:\n  dialect: redshift\n  start: 2025-01-27\n"
+        )
+        remove(tmp_path / "config.yaml")
+
+    init_example_project(tmp_path, "bigquery")
+    with open(tmp_path / "config.yaml") as file:
+        bq_config = file.read()
+
+        assert (
+            bq_config
+            == "gateways:\n  local:\n    connection:\n      type: bigquery\n      # concurrent_tasks: 1\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # method: oauth\n      # project: \n      # execution_project: \n      # quota_project: \n      # location: \n      # keyfile: \n      # keyfile_json: \n      # token: \n      # refresh_token: \n      # client_id: \n      # client_secret: \n      # token_uri: \n      # scopes: \n      # job_creation_timeout_seconds: \n      # job_execution_timeout_seconds: \n      # job_retries: 1\n      # job_retry_deadline_seconds: \n      # priority: \n      # maximum_bytes_billed: \n\n\ndefault_gateway: local\n\nmodel_defaults:\n  dialect: bigquery\n  start: 2025-01-27\n"
+        )
+        remove(tmp_path / "config.yaml")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -793,12 +793,12 @@ def test_plan_dlt(runner, tmp_path):
     init_example_project(tmp_path, "duckdb", ProjectTemplate.DLT, "sushi")
 
     expected_config = f"""gateways:
-  local:
+  dev:
     connection:
       type: duckdb
       database: {dataset_path}
 
-default_gateway: local
+default_gateway: dev
 
 model_defaults:
   dialect: duckdb
@@ -957,7 +957,7 @@ def test_init_project_dialects(runner, tmp_path):
 
         assert (
             redshift_config
-            == "gateways:\n  dev:\n    connection:\n      type: redshift\n      # concurrent_tasks: 4\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # user: \n      # password: \n      # database: \n      # host: \n      # port: \n      # source_address: \n      # unix_sock: \n      # ssl: \n      # sslmode: \n      # timeout: \n      # tcp_keepalive: \n      # application_name: \n      # preferred_role: \n      # principal_arn: \n      # credentials_provider: \n      # region: \n      # cluster_identifier: \n      # iam: \n      # is_serverless: \n      # serverless_acct_id: \n      # serverless_work_group: \n\n\ndefault_gateway: dev\n\nmodel_defaults:\n  dialect: redshift\n  start: 2025-01-28\n"
+            == f"gateways:\n  dev:\n    connection:\n      type: redshift\n      # concurrent_tasks: 4\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # user: \n      # password: \n      # database: \n      # host: \n      # port: \n      # source_address: \n      # unix_sock: \n      # ssl: \n      # sslmode: \n      # timeout: \n      # tcp_keepalive: \n      # application_name: \n      # preferred_role: \n      # principal_arn: \n      # credentials_provider: \n      # region: \n      # cluster_identifier: \n      # iam: \n      # is_serverless: \n      # serverless_acct_id: \n      # serverless_work_group: \n\n\ndefault_gateway: dev\n\nmodel_defaults:\n  dialect: redshift\n  start: {yesterday_ds()}\n"
         )
         remove(tmp_path / "config.yaml")
 
@@ -967,6 +967,6 @@ def test_init_project_dialects(runner, tmp_path):
 
         assert (
             bq_config
-            == "gateways:\n  dev:\n    connection:\n      type: bigquery\n      # concurrent_tasks: 1\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # method: oauth\n      # project: \n      # execution_project: \n      # quota_project: \n      # location: \n      # keyfile: \n      # keyfile_json: \n      # token: \n      # refresh_token: \n      # client_id: \n      # client_secret: \n      # token_uri: \n      # scopes: \n      # job_creation_timeout_seconds: \n      # job_execution_timeout_seconds: \n      # job_retries: 1\n      # job_retry_deadline_seconds: \n      # priority: \n      # maximum_bytes_billed: \n\n\ndefault_gateway: dev\n\nmodel_defaults:\n  dialect: bigquery\n  start: 2025-01-28\n"
+            == f"gateways:\n  dev:\n    connection:\n      type: bigquery\n      # concurrent_tasks: 1\n      # register_comments: True\n      # pre_ping: \n      # pretty_sql: \n      # method: oauth\n      # project: \n      # execution_project: \n      # quota_project: \n      # location: \n      # keyfile: \n      # keyfile_json: \n      # token: \n      # refresh_token: \n      # client_id: \n      # client_secret: \n      # token_uri: \n      # scopes: \n      # job_creation_timeout_seconds: \n      # job_execution_timeout_seconds: \n      # job_retries: 1\n      # job_retry_deadline_seconds: \n      # priority: \n      # maximum_bytes_billed: \n\n\ndefault_gateway: dev\n\nmodel_defaults:\n  dialect: bigquery\n  start: {yesterday_ds()}\n"
         )
         remove(tmp_path / "config.yaml")


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/3459

Dynamically generate the engine-appropriate connection options through Pydantic's `model_fields`. The following conventions are applied:
- If the `Field` is not required, it's commented out 
- If the `Field` has a (literal) default value it's appended to the RHS