### PR TITLE
Fix: fix dependency extraction order when building python env

### DIFF
--- a/tests/utils/test_metaprogramming.py
+++ b/tests/utils/test_metaprogramming.py
@@ -112,6 +112,18 @@ def test_context_manager():
     yield
 
 
+def custom_decorator(_func):
+    def wrapper(*args, **kwargs):
+        return _func(*args, **kwargs)
+
+    return wrapper
+
+
+@custom_decorator
+def function_with_custom_decorator():
+    return
+
+
 def main_func(y: int, foo=exp.true(), *, bar=expressions.Literal.number(1) + 2) -> int:
     """DOC STRING"""
     sqlglot.parse_one("1")
@@ -119,6 +131,7 @@ def main_func(y: int, foo=exp.true(), *, bar=expressions.Literal.number(1) + 2) 
     DataClass(x=y)
     noop_metadata()
     normalize_model_name("test")
+    function_with_custom_decorator()
 
     def closure(z: int) -> int:
         return z + Z
@@ -142,6 +155,7 @@ def test_func_globals() -> None:
         "exp": exp,
         "expressions": exp,
         "test_context_manager": test_context_manager,
+        "function_with_custom_decorator": function_with_custom_decorator,
     }
     assert func_globals(other_func) == {
         "X": 1,
@@ -174,6 +188,7 @@ def test_normalize_source() -> None:
     DataClass(x=y)
     noop_metadata()
     normalize_model_name('test')
+    function_with_custom_decorator()
 
     def closure(z: int):
         return z + Z
@@ -219,6 +234,7 @@ def test_serialize_env() -> None:
     DataClass(x=y)
     noop_metadata()
     normalize_model_name('test')
+    function_with_custom_decorator()
 
     def closure(z: int):
         return z + Z
@@ -316,4 +332,28 @@ def test_context_manager():
             kind=ExecutableKind.IMPORT,
         ),
         "wraps": Executable(payload="from functools import wraps", kind=ExecutableKind.IMPORT),
+        "function_with_custom_decorator": Executable(
+            name="wrapper",
+            path="test_metaprogramming.py",
+            payload="""def wrapper(*args, **kwargs):
+    return _func(*args, **kwargs)""",
+            alias="function_with_custom_decorator",
+        ),
+        "custom_decorator": Executable(
+            name="custom_decorator",
+            path="test_metaprogramming.py",
+            payload="""def custom_decorator(_func):
+
+    def wrapper(*args, **kwargs):
+        return _func(*args, **kwargs)
+    return wrapper""",
+        ),
+        "_func": Executable(
+            name="function_with_custom_decorator",
+            path="test_metaprogramming.py",
+            payload="""@custom_decorator
+def function_with_custom_decorator():
+    return""",
+            alias="_func",
+        ),
     }


### PR DESCRIPTION
This model can't be loaded today because of the serialization order:

```python
# models/python_model.py
import pandas as pd
from sqlmesh import model

def decorator(func):
    def wrapper(*args, **kwargs):
        return func(*args, **kwargs)

    return wrapper

@decorator
def decorated_func():
    return

@model("test_model", kind="FULL", columns={"id": "INT"})
def execute(context, *args, **kwargs):
    decorated_func()
    return pd.DataFrame({"id": [1, 2, 3]})
```

The corresponding python environment is:

```python
> /<path>/sqlmesh/utils/metaprogramming.py(419)prepare_env()
-> for name, executable in sorted(
(Pdb) python_env
{'execute': Executable<payload: def execute(context, *args, **kwargs):
    decorated_func()
    return pd.DataFrame({'id': [1, 2, 3]}), name: execute, path: models/python_model.py>, 'decorated_func': Executable<payload: def wrapper(*args, **kwargs):
    return func(*args, **kwargs), name: wrapper, path: models/python_model.py, alias: decorated_func>, 'func': Executable<payload: @decorator
def decorated_func():
    return, name: decorated_func, path: models/python_model.py, alias: func>, 'decorator': Executable<payload: def decorator(func):

    def wrapper(*args, **kwargs):
        return func(*args, **kwargs)
    return wrapper, name: decorator, path: models/python_model.py>, 'pd': Executable<payload: import pandas as pd, kind: import>}
```

Notice that the `'decorator'` key comes after `'func'` which references it. Since the latter is hydrated first, the decorator reference will not be found and sqlmesh will crash:

```
    exec(executable.payload, env)
  File "<string>", line 1, in <module>
NameError: name 'decorator' is not defined
```

This PR addresses the above issue by updating the environment dict with the dependencies of the visited python object first. One can run a plan-apply flow successfully for the above model given this change. The resulting python env. looks like:

```
"python_env": {"decorator":{"payload":"def decorator(func):\\n\\n    def wrapper(*args, **kwargs):\\n        return func(*args, **kwargs)\\n    return wrapper","kind":"definition","name":"decorator","path":"models/python_model.py"},"func":{"payload":"@decorator\\ndef decorated_func():\\n    return","kind":"definition","name":"decorated_func","path":"models/python_model.py","alias":"func"},"decorated_func":{"payload":"def wrapper(*args, **kwargs):\\n    return func(*args, **kwargs)","kind":"definition","name":"wrapper","path":"models/python_model.py","alias":"decorated_func"},"pd":{"payload":"import pandas as pd","kind":"import"},"execute":{"payload":"def execute(context, *args, **kwargs):\\n    decorated_func()\\n    return pd.DataFrame({\'id\': [1, 2, 3]})","kind":"definition","name":"execute","path":"models/python_model.py"}}
```

Unless I missed something, this should be backwards-compatible (i.e. no diffs), because (1) the same objects are going to be included in the serialized environment and (2) serialization order doesn't matter, since de-serialization results in a python dict with the same (key, value) pairs as before this change, and [that dict is what's included in the data hash](https://github.com/TobikoData/sqlmesh/blob/37fcce5f4728adda5dcad1159580a15586b73aab/sqlmesh/core/model/definition.py#L960-L962).