### PR TITLE
Feat: Allow macros in python model properties

### DIFF
--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -97,7 +97,5 @@ RUNTIME_RENDERED_MODEL_FIELDS = {
     "description",
     "cron",
     "physical_properties",
-    "virtual_properties",
-    "session_properties",
     "merge_filter",
 }

--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -90,12 +90,3 @@ NATIVE = "native"
 HYBRID = "hybrid"
 
 DISABLE_SQLMESH_STATE_MIGRATION = "SQLMESH__AIRFLOW__DISABLE_STATE_MIGRATION"
-
-RUNTIME_RENDERED_MODEL_FIELDS = {
-    "audits",
-    "signals",
-    "description",
-    "cron",
-    "physical_properties",
-    "merge_filter",
-}

--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -90,3 +90,13 @@ NATIVE = "native"
 HYBRID = "hybrid"
 
 DISABLE_SQLMESH_STATE_MIGRATION = "SQLMESH__AIRFLOW__DISABLE_STATE_MIGRATION"
+
+RUNTIME_RENDERED_MODEL_FIELDS = {
+    "audits",
+    "signals",
+    "cron",
+    "physical_properties",
+    "virtual_properties",
+    "session_properties",
+    "merge_filter",
+}

--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -94,6 +94,7 @@ DISABLE_SQLMESH_STATE_MIGRATION = "SQLMESH__AIRFLOW__DISABLE_STATE_MIGRATION"
 RUNTIME_RENDERED_MODEL_FIELDS = {
     "audits",
     "signals",
+    "description",
     "cron",
     "physical_properties",
     "virtual_properties",

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -129,6 +129,8 @@ class model(registry_decorator):
             dialect=dialect,
             default_catalog=default_catalog,
         )
+        if not isinstance(rendered_fields["name"], str):
+            rendered_fields["name"] = rendered_fields["name"].sql(dialect=dialect)
         common_kwargs = {
             "defaults": defaults,
             "path": path,

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -129,8 +129,11 @@ class model(registry_decorator):
             dialect=dialect,
             default_catalog=default_catalog,
         )
-        if not isinstance(rendered_fields["name"], str):
-            rendered_fields["name"] = rendered_fields["name"].sql(dialect=dialect)
+
+        rendered_name = rendered_fields["name"]
+        if isinstance(rendered_name, exp.Expression):
+            rendered_fields["name"] = rendered_name.sql(dialect=dialect)
+
         common_kwargs = {
             "defaults": defaults,
             "path": path,

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2386,41 +2386,34 @@ def render_meta_fields(
         if isinstance(value, exp.Expression) or (
             isinstance(value, str) and d.SQLMESH_MACRO_PREFIX in value
         ):
-            try:
-                rendered_expr = render_expression(
-                    expression=exp.maybe_parse(value, dialect=dialect),
-                    module_path=module_path,
-                    macros=macros,
-                    jinja_macros=jinja_macros,
-                    variables=variables,
-                    path=path,
-                    dialect=dialect,
-                    default_catalog=default_catalog,
-                )
-                assert rendered_expr and len(rendered_expr) == 1
-                return rendered_expr[0].sql(dialect=dialect)
-            except Exception:
-                pass
+            rendered_expr = render_expression(
+                expression=exp.maybe_parse(value, dialect=dialect),
+                module_path=module_path,
+                macros=macros,
+                jinja_macros=jinja_macros,
+                variables=variables,
+                path=path,
+                dialect=dialect,
+                default_catalog=default_catalog,
+            )
+            if rendered_expr is None or len(rendered_expr) != 1:
+                raise SQLMeshError("Expected one expression.")
+            return rendered_expr[0]
 
         return value
 
-    for field_name, _ in ModelMeta.all_field_infos().items():
-        field_name = field_name[:-1] if field_name.endswith("_") else field_name
-        if (field_value := fields.get(field_name)) and field_name not in {
-            "audits",
-            "signals",
-            "physical_properties",
-            "virtual_properties",
-            "session_properties",
-        }:
-            if isinstance(field_value, t.Dict):
+    for field_name, field_info in ModelMeta.all_field_infos().items():
+        field = field_info.alias or field_name
+        if (field_value := fields.get(field)) and field not in c.RUNTIME_RENDERED_MODEL_FIELDS:
+            if isinstance(field_value, dict):
                 for key, value in field_value.items():
-                    if key != "merge_filter":
-                        fields[field_name][key] = render_field_value(value)
-            elif isinstance(field_value, t.List):
-                fields[field_name] = [render_field_value(value) for value in field_value]
+                    if key not in c.RUNTIME_RENDERED_MODEL_FIELDS:
+                        fields[field][key] = render_field_value(value)
+            elif isinstance(field_value, list):
+                fields[field] = [render_field_value(value) for value in field_value]
             else:
-                fields[field_name] = render_field_value(field_value)
+                fields[field] = render_field_value(field_value)
+
     return fields
 
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2385,11 +2385,11 @@ def render_meta_fields(
     fields: t.Dict[str, t.Any],
     module_path: Path,
     path: Path,
-    jinja_macros: t.Optional[JinjaMacroRegistry] = None,
-    macros: t.Optional[MacroRegistry] = None,
-    dialect: DialectType = None,
-    variables: t.Optional[t.Dict[str, t.Any]] = None,
-    default_catalog: t.Optional[str] = None,
+    jinja_macros: t.Optional[JinjaMacroRegistry],
+    macros: t.Optional[MacroRegistry],
+    dialect: DialectType,
+    variables: t.Optional[t.Dict[str, t.Any]],
+    default_catalog: t.Optional[str],
 ) -> t.Dict[str, t.Any]:
     def render_field_value(value: t.Any) -> t.Any:
         if isinstance(value, exp.Expression) or (
@@ -2408,13 +2408,13 @@ def render_meta_fields(
             )
             if rendered_expr is None:
                 raise SQLMeshError(
-                    f"Failed to render model: `{fields['name']}` at `{path}`\n"
-                    f"Expected rendering `{expression.sql(dialect=dialect)}` to return an expression"
+                    f"Failed to render model attribute `{fields['name']}` at `{path}`\n"
+                    f"'{expression.sql(dialect=dialect)}' must return an expression"
                 )
             if len(rendered_expr) != 1:
                 raise SQLMeshError(
-                    f"Failed to render model: `{fields['name']}` at `{path}`.\n"
-                    f"Expected rendering `{expression.sql(dialect=dialect)}` to return one result, but got {len(rendered_expr)}"
+                    f"Failed to render model attribute `{fields['name']}` at `{path}`.\n"
+                    f"`{expression.sql(dialect=dialect)}` must return one result, but got {len(rendered_expr)}"
                 )
             return rendered_expr[0]
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2409,7 +2409,7 @@ def render_meta_fields(
             if rendered_expr is None:
                 raise SQLMeshError(
                     f"Failed to render model: `{fields['name']}` at `{path}`\n"
-                    f"\tExpected rendering `{expression.sql(dialect=dialect)}` to return an expression"
+                    f"Expected rendering `{expression.sql(dialect=dialect)}` to return an expression"
                 )
             if len(rendered_expr) != 1:
                 raise SQLMeshError(
@@ -2424,8 +2424,7 @@ def render_meta_fields(
         field = field_info.alias or field_name
         if field not in RUNTIME_RENDERED_MODEL_FIELDS and (field_value := fields.get(field)):
             if isinstance(field_value, dict):
-                dict_keys = list(field_value.keys())
-                for key in dict_keys:
+                for key in list(field_value.keys()):
                     if key not in RUNTIME_RENDERED_MODEL_FIELDS:
                         fields[field][key] = render_field_value(field_value[key])
             elif isinstance(field_value, list):

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -4972,7 +4972,7 @@ def test_macros_python_model(mocker: MockerFixture) -> None:
     assert python_model.name == "foo_macro_model_suffix"
     assert python_model.python_env[c.SQLMESH_VARS] == Executable.value({"test_var_a": "test_value"})
     assert not python_model.enabled
-    assert python_model.start == "'2024-01-01'"
+    assert python_model.start == "2024-01-01"
     assert python_model.owner == "pr_1"
     assert python_model.stamp == "bump"
     assert python_model.time_column.column == exp.column("a", quoted=True)
@@ -4986,7 +4986,7 @@ def test_macros_python_model(mocker: MockerFixture) -> None:
 def test_macros_python_sql_model(mocker: MockerFixture) -> None:
     @macro()
     def end_date_macro(evaluator: MacroEvaluator, var: bool):
-        return f"@IF({var} = True, '1 day ago', '2025-01-01 12:00:00')"
+        return f"@IF({var} = False, '1 day ago', '2025-01-01 12:00:00')"
 
     @model(
         "test_macros_python_model_@{bar}",
@@ -5020,9 +5020,10 @@ def test_macros_python_sql_model(mocker: MockerFixture) -> None:
     assert python_sql_model.python_env[c.SQLMESH_VARS] == Executable.value(
         {"test_var_a": "test_value"}
     )
+
     assert python_sql_model.enabled
-    assert python_sql_model.start == "'1 month ago'"
-    assert python_sql_model.end == "'2025-01-01 12:00:00'"
+    assert python_sql_model.start == "1 month ago"
+    assert python_sql_model.end == "1 day ago"
 
     context = ExecutionContext(mocker.Mock(), {}, None, None)
     query = list(python_sql_model.render(context=context))[0]


### PR DESCRIPTION
This update enables macros to be passed in the properties for Python models, aside from `audits`, `signals`, `merge filter` and `physical_properties` which are rendered at evaluation time (the latter will be addressed on a subsequent pr). This allows to dynamically control for example the `enabled` flag based on the gateway:

```python
@model(
  ...,
  enabled="@IF(@gateway = 'local', True, False)",
)
```