### PR TITLE
WIP: Runtime values in model physical_properties

### DIFF
--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -154,6 +154,20 @@ class BaseExpressionRenderer:
                 dialect=self._dialect, identify=True, comments=False
             )
 
+            if isinstance(this_model, exp.Table):
+                # sometimes you want to render the parts rather than just a fqn string
+                # but the macro syntax doesnt support eg @{this_table.db}, so we break them out
+                # into their own variables here
+                #
+                # note that they are deliberately unquoted to so they can be used in filesystem paths
+                physical_table_parts = {
+                    "catalog_name": this_model.catalog,
+                    "schema_name": this_model.db,
+                    "table_name": this_model.name,
+                }
+                render_kwargs.update(physical_table_parts)
+                jinja_env_kwargs.update(physical_table_parts)
+
         jinja_env = self._jinja_macro_registry.build_environment(**jinja_env_kwargs)
 
         if isinstance(self._expression, d.Jinja):

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -1345,6 +1345,7 @@ class MaterializableStrategy(PromotableStrategy):
         **kwargs: t.Any,
     ) -> None:
         ctas_query = model.ctas_query(**render_kwargs)
+        rendered_physical_properties = model.render_physical_properties(**render_kwargs)
 
         logger.info("Creating table '%s'", table_name)
         if model.annotated:
@@ -1356,7 +1357,7 @@ class MaterializableStrategy(PromotableStrategy):
                 partitioned_by=model.partitioned_by,
                 partition_interval_unit=model.partition_interval_unit,
                 clustered_by=model.clustered_by,
-                table_properties=model.physical_properties,
+                table_properties=rendered_physical_properties,
                 table_description=model.description if is_table_deployable else None,
                 column_descriptions=model.column_descriptions if is_table_deployable else None,
             )
@@ -1380,7 +1381,7 @@ class MaterializableStrategy(PromotableStrategy):
                 partitioned_by=model.partitioned_by,
                 partition_interval_unit=model.partition_interval_unit,
                 clustered_by=model.clustered_by,
-                table_properties=model.physical_properties,
+                table_properties=rendered_physical_properties,
                 table_description=model.description if is_table_deployable else None,
                 column_descriptions=model.column_descriptions if is_table_deployable else None,
             )
@@ -1600,7 +1601,7 @@ class SCDType2Strategy(MaterializableStrategy):
                 partitioned_by=model.partitioned_by,
                 partition_interval_unit=model.partition_interval_unit,
                 clustered_by=model.clustered_by,
-                table_properties=model.physical_properties,
+                table_properties=model.render_physical_properties(**render_kwargs),
                 table_description=model.description if is_table_deployable else None,
                 column_descriptions=model.column_descriptions if is_table_deployable else None,
             )
@@ -1801,7 +1802,7 @@ class ViewStrategy(PromotableStrategy):
             replace=False,
             materialized=self._is_materialized_view(model),
             materialized_properties=materialized_properties,
-            view_properties=model.physical_properties,
+            view_properties=model.render_physical_properties(**render_kwargs),
             table_description=model.description if is_table_deployable else None,
             column_descriptions=model.column_descriptions if is_table_deployable else None,
         )
@@ -1928,7 +1929,7 @@ class EngineManagedStrategy(MaterializableStrategy):
                 columns_to_types=model.columns_to_types,
                 partitioned_by=model.partitioned_by,
                 clustered_by=model.clustered_by,
-                table_properties=model.physical_properties,
+                table_properties=model.render_physical_properties(**render_kwargs),
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
             )

--- a/tests/core/engine_adapter/integration/test_integration_trino.py
+++ b/tests/core/engine_adapter/integration/test_integration_trino.py
@@ -1,0 +1,104 @@
+import typing as t
+import pytest
+from pathlib import Path
+from sqlmesh.core.engine_adapter import TrinoEngineAdapter
+from tests.core.engine_adapter.integration import TestContext
+from sqlglot import parse_one, exp
+
+pytestmark = [pytest.mark.docker, pytest.mark.engine, pytest.mark.trino]
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            "trino",
+            marks=[
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.trino,
+            ],
+        ),
+        pytest.param(
+            "trino_iceberg",
+            marks=[
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.trino_iceberg,
+            ],
+        ),
+        pytest.param(
+            "trino_delta",
+            marks=[
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.trino_delta,
+            ],
+        ),
+        pytest.param(
+            "trino_nessie",
+            marks=[
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.trino_nessie,
+            ],
+        ),
+    ]
+)
+def mark_gateway(request) -> t.Tuple[str, str]:
+    return request.param, f"inttest_{request.param}"
+
+
+@pytest.fixture
+def test_type() -> str:
+    return "query"
+
+
+def test_macro_variables_in_location(
+    tmp_path: Path, ctx: TestContext, engine_adapter: TrinoEngineAdapter
+):
+    if "iceberg" not in ctx.gateway:
+        pytest.skip("This test only needs to be run once")
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir(parents=True)
+
+    schema = ctx.schema()
+
+    with open(models_dir / "test_model.sql", "w") as f:
+        f.write(
+            """
+        MODEL (
+            name SCHEMA.test,
+            kind FULL,
+            physical_properties (
+                location = @'s3://trino/@{catalog_name}/@{schema_name}/@{table_name}'
+            )
+        );
+
+        select 1 as col_a;
+        """.replace("SCHEMA", schema)
+        )
+
+    context = ctx.create_context(path=tmp_path)
+    assert len(context.models) == 1
+
+    plan_result = context.plan(auto_apply=True, no_prompts=True)
+
+    assert len(plan_result.new_snapshots) == 1
+
+    snapshot = plan_result.new_snapshots[0]
+
+    physical_table_str = snapshot.table_name()
+    physical_table = exp.to_table(physical_table_str)
+    create_sql = list(engine_adapter.fetchone(f"show create table {physical_table}") or [])[0]
+
+    parsed_create_sql = parse_one(create_sql, dialect="trino")
+
+    location_property = parsed_create_sql.find(exp.LocationProperty)
+    assert location_property
+
+    assert "@{table_name}" not in location_property.sql(dialect="trino")
+    assert (
+        location_property.text("this")
+        == f"s3://trino/{physical_table.catalog}/{physical_table.db}/{physical_table.name}"
+    )


### PR DESCRIPTION
The goal here is to gain access to the **physical** table parts (catalog, schema and table name) within the `physical_properties` of a Model.

The use-case is being able to specify custom table locations in object storage for engines that support it (trino, athena, spark etc) and have it actually work. Right now, SQLMesh relies on these engines having default table locations set up. If you try to hardcode the location to something like `s3://bucket/prefix/model_name`, then all snapshots will be written to the same physical location and will clobber each other. We need to be able to substitute in the actual physical table name.

The key thing I tried to gain access to was the `@this_model` macro, attempting to use it like so:
```
MODEL (
  name test.test_model,
  kind FULL,
  physical_properties (
    location = @'s3://bucket/prefix/@{this_model}',  
  )
);
```

However, it gets expanded to a quoted fqn string like `"catalog"."sqlmesh__test"."test__test_model__12345"` which isnt very useful when you want to turn it into a path. I was unable to access members of the SQLGlot `exp.Table` AST node like `@this_model.db` to get the schema, not sure if this syntax is supported.

So I experimented with breaking it up into parts and making each part available as its own variable:
```
  physical_properties (
    location = @'s3://bucket/prefix/@{catalog_name}/@{schema_name}/@{table_name}',  
  )
```

This works but expansion requires both `_model_fqn` to be set on the ExpressionRenderer as well as a list of snapshots made available as a render argument `@this_table` can be resolved. `physical_properties` gets accessed in a bunch of places where these fields are not always available / populated.

Raising this draft PR to get feedback on the approach, is this a road I should continue down or is there a better way?