### PR TITLE
Chore: put connection config link in a separate line

### DIFF
--- a/sqlmesh/cli/example_project.py
+++ b/sqlmesh/cli/example_project.py
@@ -32,7 +32,7 @@ def _gen_config(
         connection_settings = """      type: duckdb
       database: db.db"""
 
-        doc_link = "# Visit https://sqlmesh.readthedocs.io/en/stable/integrations/engines{engine_link} for more information on configuring the connection to your execution engine."
+        doc_link = "https://sqlmesh.readthedocs.io/en/stable/integrations/engines{engine_link}"
         engine_link = ""
 
         engine = "mssql" if dialect == "tsql" else dialect
@@ -65,7 +65,9 @@ def _gen_config(
             engine_link = f"/{engine}/#connection-options"
 
         connection_settings = (
-            f"      {doc_link.format(engine_link=engine_link)}\n{connection_settings}"
+            "      # For more information on configuring the connection to your execution engine, visit:\n"
+            "      # https://sqlmesh.readthedocs.io/en/stable/reference/configuration/#connections\n"
+            f"      # {doc_link.format(engine_link=engine_link)}\n{connection_settings}"
         )
     else:
         connection_settings = settings

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -962,7 +962,7 @@ def test_init_project_dialects(runner, tmp_path):
     for dialect, expected_config in dialect_to_config.items():
         init_example_project(tmp_path, dialect=dialect)
 
-        config_start = f"gateways:\n  dev:\n    connection:\n      # Visit https://sqlmesh.readthedocs.io/en/stable/integrations/engines/{dialect}/#connection-options for more information on configuring the connection to your execution engine.\n      type: {dialect}\n      "
+        config_start = f"gateways:\n  dev:\n    connection:\n      # For more information on configuring the connection to your execution engine, visit:\n      # https://sqlmesh.readthedocs.io/en/stable/reference/configuration/#connections\n      # https://sqlmesh.readthedocs.io/en/stable/integrations/engines/{dialect}/#connection-options\n      type: {dialect}\n      "
         config_end = f"\n\n\ndefault_gateway: dev\n\nmodel_defaults:\n  dialect: {dialect}\n  start: {yesterday_ds()}\n"
 
         with open(tmp_path / "config.yaml") as file:


### PR DESCRIPTION
Small change to get configs to look like this instead of having a single big comment for the config connection link. Added another link to the base connection configs because they're missing from individual connection pages.

```yaml
gateways:
  dev:
    connection:
      # For more information on configuring the connection to your execution engine, visit:
      # https://sqlmesh.readthedocs.io/en/stable/reference/configuration/#connections
      # https://sqlmesh.readthedocs.io/en/stable/integrations/engines/duckdb/#connection-options
      type: duckdb
      # concurrent_tasks: 1
      # register_comments: True
      # pre_ping: 
      # pretty_sql: 
      # database: 
      # catalogs: 
      # extensions: 
      # connector_config: 
      # token: 


default_gateway: dev

model_defaults:
  dialect: duckdb
  start: 2025-01-30

```