### PR TITLE
Feat: traverse python objects in post-order to support custom decorators

### DIFF
--- a/tests/utils/test_metaprogramming.py
+++ b/tests/utils/test_metaprogramming.py
@@ -115,6 +115,18 @@ def fetch_data():
     return "'test data'"
 
 
+def custom_decorator(_func):
+    def wrapper(*args, **kwargs):
+        return _func(*args, **kwargs)
+
+    return wrapper
+
+
+@custom_decorator
+def function_with_custom_decorator():
+    return
+
+
 def main_func(y: int, foo=exp.true(), *, bar=expressions.Literal.number(1) + 2) -> int:
     """DOC STRING"""
     sqlglot.parse_one("1")
@@ -123,6 +135,7 @@ def main_func(y: int, foo=exp.true(), *, bar=expressions.Literal.number(1) + 2) 
     noop_metadata()
     normalize_model_name("test")
     fetch_data()
+    function_with_custom_decorator()
 
     def closure(z: int) -> int:
         return z + Z
@@ -147,6 +160,7 @@ def test_func_globals() -> None:
         "expressions": exp,
         "fetch_data": fetch_data,
         "test_context_manager": test_context_manager,
+        "function_with_custom_decorator": function_with_custom_decorator,
     }
     assert func_globals(other_func) == {
         "X": 1,
@@ -180,6 +194,7 @@ def test_normalize_source() -> None:
     noop_metadata()
     normalize_model_name('test')
     fetch_data()
+    function_with_custom_decorator()
 
     def closure(z: int):
         return z + Z
@@ -226,6 +241,7 @@ def test_serialize_env() -> None:
     noop_metadata()
     normalize_model_name('test')
     fetch_data()
+    function_with_custom_decorator()
 
     def closure(z: int):
         return z + Z
@@ -353,5 +369,29 @@ def fetch_data():
             name="fetch_data",
             path="test_metaprogramming.py",
             alias="f",
+        ),
+        "function_with_custom_decorator": Executable(
+            name="wrapper",
+            path="test_metaprogramming.py",
+            payload="""def wrapper(*args, **kwargs):
+    return _func(*args, **kwargs)""",
+            alias="function_with_custom_decorator",
+        ),
+        "custom_decorator": Executable(
+            name="custom_decorator",
+            path="test_metaprogramming.py",
+            payload="""def custom_decorator(_func):
+
+    def wrapper(*args, **kwargs):
+        return _func(*args, **kwargs)
+    return wrapper""",
+        ),
+        "_func": Executable(
+            name="function_with_custom_decorator",
+            path="test_metaprogramming.py",
+            payload="""@custom_decorator
+def function_with_custom_decorator():
+    return""",
+            alias="_func",
         ),
     }


### PR DESCRIPTION
This should take care of the issue mentioned [here](https://github.com/TobikoData/sqlmesh/pull/3742) and also add support for custom decorators, e.g. this now works (fails to load in current main branch):

```python
# models/test_model.py
import pandas as pd
from sqlmesh import model

def custom_decorator(_func):
    def wrapper(*args, **kwargs):
        return _func(*args, **kwargs)

    return wrapper

@custom_decorator
def function_with_custom_decorator():
    return

@model(
    "test_model",
    kind="FULL",
    columns={"id": "INT"},
)
def execute(*args, **kwargs):
    function_with_custom_decorator()
    return pd.DataFrame({"id": [1, 2, 3]})
```