### PR TITLE
Chore: warn instead of raising if unit test references unknown model

### DIFF
--- a/sqlmesh/core/test/__init__.py
+++ b/sqlmesh/core/test/__init__.py
@@ -57,18 +57,18 @@ def run_tests(
                 ).create_engine_adapter(register_comments_override=False)
                 testing_adapter_by_gateway[gateway] = testing_engine_adapter
 
-            tests.append(
-                ModelTest.create_test(
-                    body=body,
-                    test_name=metadata.test_name,
-                    models=models,
-                    engine_adapter=testing_engine_adapter,
-                    dialect=dialect,
-                    path=metadata.path,
-                    default_catalog=default_catalog,
-                    preserve_fixtures=preserve_fixtures,
-                )
+            test = ModelTest.create_test(
+                body=body,
+                test_name=metadata.test_name,
+                models=models,
+                engine_adapter=testing_engine_adapter,
+                dialect=dialect,
+                path=metadata.path,
+                default_catalog=default_catalog,
+                preserve_fixtures=preserve_fixtures,
             )
+            if test:
+                tests.append(test)
 
         result = t.cast(
             ModelTextTestResult,

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -310,7 +310,7 @@ class ModelTest(unittest.TestCase):
         path: Path | None,
         preserve_fixtures: bool = False,
         default_catalog: str | None = None,
-    ) -> ModelTest:
+    ) -> t.Optional[ModelTest]:
         """Create a SqlModelTest or a PythonModelTest.
 
         Args:
@@ -329,7 +329,8 @@ class ModelTest(unittest.TestCase):
         name = normalize_model_name(name, default_catalog=default_catalog, dialect=dialect)
         model = models.get(name)
         if not model:
-            _raise_error(f"Model '{name}' was not found", path)
+            logger.warning(f"Model '{name}' was not found{' at ' + str(path) if path else ''}")
+            return None
 
         if isinstance(model, SqlModel):
             test_type: t.Type[ModelTest] = SqlModelTest
@@ -759,6 +760,8 @@ def generate_test(
         path=fixture_path,
         default_catalog=model.default_catalog,
     )
+    if not test:
+        return
 
     test.setUp()
 


### PR DESCRIPTION
Motivation: when a model is disabled and there's a unit test for it, running it will result in a crash. I opted for a warning because not doing anything at all can result in masking typos in enabled models that _should_ be tested.