### PR TITLE
Fix decouple logging from console

### DIFF
--- a/sqlmesh/__init__.py
+++ b/sqlmesh/__init__.py
@@ -136,7 +136,6 @@ class CustomFormatter(logging.Formatter):
 
 def configure_logging(
     force_debug: bool = False,
-    ignore_warnings: bool = False,
     write_to_stdout: bool = False,
     write_to_file: bool = True,
     log_limit: int = c.DEFAULT_LOG_LIMIT,
@@ -149,12 +148,11 @@ def configure_logging(
     level = logging.DEBUG if debug else logging.INFO
     logger.setLevel(level)
 
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setFormatter(CustomFormatter())
-    stdout_handler.setLevel(
-        level if write_to_stdout else (logging.ERROR if ignore_warnings else logging.WARNING)
-    )
-    logger.addHandler(stdout_handler)
+    if write_to_stdout:
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stdout_handler.setFormatter(CustomFormatter())
+        stdout_handler.setLevel(level)
+        logger.addHandler(stdout_handler)
 
     log_file_dir = log_file_dir or c.DEFAULT_LOG_FILE_DIR
     log_path_prefix = Path(log_file_dir) / LOG_FILENAME_PREFIX

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -12,6 +12,7 @@ from sqlmesh.cli import error_handler
 from sqlmesh.cli import options as opt
 from sqlmesh.cli.example_project import ProjectTemplate, init_example_project
 from sqlmesh.core.analytics import cli_analytics
+from sqlmesh.core.console import configure_console, get_console
 from sqlmesh.core.config import load_configs
 from sqlmesh.core.context import Context
 from sqlmesh.utils.date import TimeLike
@@ -91,9 +92,8 @@ def cli(
 
     configs = load_configs(config, Context.CONFIG_TYPE, paths)
     log_limit = list(configs.values())[0].log_limit
-    configure_logging(
-        debug, ignore_warnings, log_to_stdout, log_limit=log_limit, log_file_dir=log_file_dir
-    )
+    configure_logging(debug, log_to_stdout, log_limit=log_limit, log_file_dir=log_file_dir)
+    configure_console(ignore_warnings=ignore_warnings)
 
     try:
         context = Context(
@@ -433,7 +433,7 @@ def plan(
     select_models = kwargs.pop("select_model") or None
     allow_destructive_models = kwargs.pop("allow_destructive_model") or None
     backfill_models = kwargs.pop("backfill_model") or None
-    context.console.verbose = verbose
+    setattr(get_console(), "verbose", verbose)
     context.plan(
         environment,
         restate_models=restate_models,

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -1776,7 +1776,7 @@ def _connection_config_validator(
     return parse_connection_config(v)
 
 
-connection_config_validator = field_validator(
+connection_config_validator: t.Callable = field_validator(
     "connection",
     "state_connection",
     "test_connection",

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -4,7 +4,6 @@ import pickle
 import re
 import typing as t
 import zlib
-import logging
 
 from pydantic import Field
 from sqlglot import exp
@@ -13,6 +12,7 @@ from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
 from sqlmesh.cicd.config import CICDBotConfig
 from sqlmesh.core import constants as c
+from sqlmesh.core.console import get_console
 from sqlmesh.core.config import EnvironmentSuffixTarget
 from sqlmesh.core.config.base import BaseConfig, UpdateStrategy
 from sqlmesh.core.config.common import variables_validator, compile_regex_mapping
@@ -44,8 +44,6 @@ from sqlmesh.utils.pydantic import field_validator, model_validator
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import Self
-
-logger = logging.getLogger(__name__)
 
 
 class Config(BaseConfig):
@@ -175,7 +173,7 @@ class Config(BaseConfig):
                 )
 
         if "physical_schema_override" in data:
-            logger.warning(
+            get_console().log_warning(
                 "`physical_schema_override` is deprecated. Please use `physical_schema_mapping` instead"
             )
 

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -174,12 +174,12 @@ class Config(BaseConfig):
 
         if "physical_schema_override" in data:
             get_console().log_warning(
-                "`physical_schema_override` is deprecated. Please use `physical_schema_mapping` instead"
+                "`physical_schema_override` is deprecated. Please use `physical_schema_mapping` instead."
             )
 
             if "physical_schema_mapping" in data:
                 raise ConfigError(
-                    "Only one of `physical_schema_override` and `physical_schema_mapping` can be specified"
+                    "Only one of `physical_schema_override` and `physical_schema_mapping` can be specified."
                 )
 
             physical_schema_override: t.Dict[str, str] = data.pop("physical_schema_override")

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-import logging
 import typing as t
 
 from pydantic import Field
@@ -10,7 +9,7 @@ from requests import Session
 from sqlglot.helper import subclasses
 from sqlmesh.core.config.base import BaseConfig
 from sqlmesh.core.config.common import concurrent_tasks_validator
-from sqlmesh.core.console import Console
+from sqlmesh.core.console import Console, get_console
 from sqlmesh.core.plan import (
     AirflowPlanEvaluator,
     BuiltInPlanEvaluator,
@@ -31,8 +30,6 @@ if t.TYPE_CHECKING:
     from sqlmesh.core.context import GenericContext
 
 from sqlmesh.utils.config import sensitive_fields, excluded_fields
-
-logger = logging.getLogger(__name__)
 
 
 class SchedulerConfig(abc.ABC):
@@ -88,7 +85,7 @@ class _EngineAdapterStateSyncSchedulerConfig(SchedulerConfig):
         ):
             # If we are using DuckDB, ensure that multithreaded mode gets enabled if necessary
             if warehouse_connection.concurrent_tasks > 1:
-                logger.warning(
+                get_console().log_warning(
                     "The duckdb state connection is configured for single threaded mode but the warehouse connection is configured for "
                     + f"multi threaded mode with {warehouse_connection.concurrent_tasks} concurrent tasks."
                     + " This can cause SQLMesh to hang. Overriding the duckdb state connection config to use multi threaded mode"
@@ -109,7 +106,7 @@ class _EngineAdapterStateSyncSchedulerConfig(SchedulerConfig):
             warehouse_connection, DuckDBConnectionConfig
         ):
             if not state_connection.is_recommended_for_state_sync:
-                logger.warning(
+                get_console().log_warning(
                     f"The {state_connection.type_} engine is not recommended for storing SQLMesh state in production deployments. Please see"
                     + " https://sqlmesh.readthedocs.io/en/stable/guides/configuration/#state-connection for a list of recommended engines and more information."
                 )
@@ -205,7 +202,7 @@ class _BaseAirflowSchedulerConfig(_EngineAdapterStateSyncSchedulerConfig):
 
 
 def _max_snapshot_ids_per_request_validator(v: t.Any) -> t.Optional[int]:
-    logger.warning(
+    get_console().log_warning(
         "The `max_snapshot_ids_per_request` field is deprecated and will be removed in a future release."
     )
     return None

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -88,7 +88,7 @@ class _EngineAdapterStateSyncSchedulerConfig(SchedulerConfig):
                 get_console().log_warning(
                     "The duckdb state connection is configured for single threaded mode but the warehouse connection is configured for "
                     + f"multi threaded mode with {warehouse_connection.concurrent_tasks} concurrent tasks."
-                    + " This can cause SQLMesh to hang. Overriding the duckdb state connection config to use multi threaded mode"
+                    + " This can cause SQLMesh to hang. Overriding the duckdb state connection config to use multi threaded mode."
                 )
                 # this triggers multithreaded mode and has to happen before the engine adapter is created below
                 state_connection.concurrent_tasks = warehouse_connection.concurrent_tasks

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -283,6 +283,152 @@ class Console(abc.ABC):
         return tree
 
 
+class NoopConsole(Console):
+    def start_plan_evaluation(self, plan: EvaluatablePlan) -> None:
+        pass
+
+    def stop_plan_evaluation(self) -> None:
+        pass
+
+    def start_evaluation_progress(
+        self,
+        batches: t.Dict[Snapshot, int],
+        environment_naming_info: EnvironmentNamingInfo,
+        default_catalog: t.Optional[str],
+    ) -> None:
+        pass
+
+    def start_snapshot_evaluation_progress(self, snapshot: Snapshot) -> None:
+        pass
+
+    def update_snapshot_evaluation_progress(
+        self, snapshot: Snapshot, batch_idx: int, duration_ms: t.Optional[int]
+    ) -> None:
+        pass
+
+    def stop_evaluation_progress(self, success: bool = True) -> None:
+        pass
+
+    def start_creation_progress(
+        self,
+        total_tasks: int,
+        environment_naming_info: EnvironmentNamingInfo,
+        default_catalog: t.Optional[str],
+    ) -> None:
+        pass
+
+    def update_creation_progress(self, snapshot: SnapshotInfoLike) -> None:
+        pass
+
+    def stop_creation_progress(self, success: bool = True) -> None:
+        pass
+
+    def start_cleanup(self, ignore_ttl: bool) -> bool:
+        return True
+
+    def update_cleanup_progress(self, object_name: str) -> None:
+        pass
+
+    def stop_cleanup(self, success: bool = True) -> None:
+        pass
+
+    def start_promotion_progress(
+        self,
+        total_tasks: int,
+        environment_naming_info: EnvironmentNamingInfo,
+        default_catalog: t.Optional[str],
+    ) -> None:
+        pass
+
+    def update_promotion_progress(self, snapshot: SnapshotInfoLike, promoted: bool) -> None:
+        pass
+
+    def stop_promotion_progress(self, success: bool = True) -> None:
+        pass
+
+    def start_snapshot_migration_progress(self, total_tasks: int) -> None:
+        pass
+
+    def update_snapshot_migration_progress(self, num_tasks: int) -> None:
+        pass
+
+    def log_migration_status(self, success: bool = True) -> None:
+        pass
+
+    def stop_snapshot_migration_progress(self, success: bool = True) -> None:
+        pass
+
+    def start_env_migration_progress(self, total_tasks: int) -> None:
+        pass
+
+    def update_env_migration_progress(self, num_tasks: int) -> None:
+        pass
+
+    def stop_env_migration_progress(self, success: bool = True) -> None:
+        pass
+
+    def show_model_difference_summary(
+        self,
+        context_diff: ContextDiff,
+        environment_naming_info: EnvironmentNamingInfo,
+        default_catalog: t.Optional[str],
+        no_diff: bool = True,
+        ignored_snapshot_ids: t.Optional[t.Set[SnapshotId]] = None,
+    ) -> None:
+        pass
+
+    def plan(
+        self,
+        plan_builder: PlanBuilder,
+        auto_apply: bool,
+        default_catalog: t.Optional[str],
+        no_diff: bool = False,
+        no_prompts: bool = False,
+    ) -> None:
+        if auto_apply:
+            plan_builder.apply()
+
+    def log_test_results(
+        self, result: unittest.result.TestResult, output: t.Optional[str], target_dialect: str
+    ) -> None:
+        pass
+
+    def show_sql(self, sql: str) -> None:
+        pass
+
+    def log_status_update(self, message: str) -> None:
+        pass
+
+    def log_skipped_models(self, snapshot_names: t.Set[str]) -> None:
+        pass
+
+    def log_failed_models(self, errors: t.List[NodeExecutionFailedError]) -> None:
+        pass
+
+    def log_error(self, message: str) -> None:
+        pass
+
+    def log_warning(self, message: str) -> None:
+        pass
+
+    def log_success(self, message: str) -> None:
+        pass
+
+    def loading_start(self, message: t.Optional[str] = None) -> uuid.UUID:
+        return uuid.uuid4()
+
+    def loading_stop(self, id: uuid.UUID) -> None:
+        pass
+
+    def show_schema_diff(self, schema_diff: SchemaDiff) -> None:
+        pass
+
+    def show_row_diff(
+        self, row_diff: RowDiff, show_sample: bool = True, skip_grain_check: bool = False
+    ) -> None:
+        pass
+
+
 def make_progress_bar(message: str, console: t.Optional[RichConsole] = None) -> Progress:
     return Progress(
         TextColumn(f"[bold blue]{message}", justify="right"),
@@ -2187,7 +2333,7 @@ class DebuggerTerminalConsole(TerminalConsole):
         self._write(row_diff)
 
 
-_CONSOLE: t.Optional[Console] = None
+_CONSOLE: Console = NoopConsole()
 
 
 def set_console(console: Console) -> None:
@@ -2204,9 +2350,6 @@ def configure_console(**kwargs: t.Any) -> None:
 
 def get_console() -> Console:
     """Returns the console instance or creates a new one if it hasn't been created yet."""
-    global _CONSOLE
-    if _CONSOLE is None:
-        _CONSOLE = create_console()
     return _CONSOLE
 
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -62,7 +62,7 @@ from sqlmesh.core.config import (
     load_configs,
 )
 from sqlmesh.core.config.loader import C
-from sqlmesh.core.console import Console, get_console
+from sqlmesh.core.console import get_console
 from sqlmesh.core.context_diff import ContextDiff
 from sqlmesh.core.dialect import (
     format_model_expressions,
@@ -180,7 +180,7 @@ class BaseContext(abc.ABC):
         raise NotImplementedError
 
     def table(self, model_name: str) -> str:
-        logger.warning(
+        get_console().log_warning(
             "The SQLMesh context's `table` method is deprecated and will be removed "
             "in a future release. Please use the `resolve_table` method instead."
         )
@@ -329,7 +329,6 @@ class GenericContext(BaseContext, t.Generic[C]):
         concurrent_tasks: t.Optional[int] = None,
         loader: t.Optional[t.Type[Loader]] = None,
         load: bool = True,
-        console: t.Optional[Console] = None,
         users: t.Optional[t.List[User]] = None,
     ):
         self.configs = (
@@ -384,7 +383,9 @@ class GenericContext(BaseContext, t.Generic[C]):
 
         self._snapshot_evaluator: t.Optional[SnapshotEvaluator] = None
 
-        self.console = console or get_console(dialect=self.engine_adapter.dialect)
+        self.console = get_console()
+        setattr(self.console, "dialect", self.engine_adapter.dialect)
+
         self._test_connection_config = self.config.get_test_connection(
             self.gateway, self.default_catalog, default_catalog_dialect=self.engine_adapter.DIALECT
         )
@@ -1647,7 +1648,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         suffix = file_path.suffix
         if suffix != ".html":
             if suffix:
-                logger.warning(
+                get_console().log_warning(
                     f"The extension {suffix} does not designate an html file. A file with a `.html` extension will be created instead."
                 )
             path = str(file_path.with_suffix(".html"))

--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -18,10 +18,10 @@ import typing as t
 from difflib import ndiff
 from functools import cached_property
 from sqlmesh.core import constants as c
+from sqlmesh.core.console import get_console
 from sqlmesh.core.snapshot import Snapshot, SnapshotId, SnapshotTableInfo
 from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.pydantic import PydanticModel
-
 
 if sys.version_info >= (3, 12):
     from importlib import metadata
@@ -116,7 +116,7 @@ class ContextDiff(PydanticModel):
             env = state_reader.get_environment(create_from.lower())
 
             if not env and create_from != c.PROD:
-                logger.warning(
+                get_console().log_warning(
                     f"The environment name '{create_from}' was passed to the `plan` command's `--create-from` argument, but '{create_from}' does not exist. Initializing new environment '{environment}' from scratch."
                 )
 
@@ -396,7 +396,7 @@ class ContextDiff(PydanticModel):
         try:
             return old.node.text_diff(new.node, rendered=self.diff_rendered)
         except SQLMeshError as e:
-            logger.warning("Failed to diff model '%s': %s", name, str(e))
+            get_console().log_warning(f"Failed to diff model '{name}': {str(e)}")
             return ""
 
 

--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -12,7 +12,6 @@ another remote environment and determine if nodes have been added, removed, or m
 
 from __future__ import annotations
 
-import logging
 import sys
 import typing as t
 from difflib import ndiff
@@ -33,8 +32,6 @@ if t.TYPE_CHECKING:
     from sqlmesh.core.state_sync import StateReader
 
 IGNORED_PACKAGES = {"sqlmesh", "sqlglot"}
-
-logger = logging.getLogger(__name__)
 
 
 class ContextDiff(PydanticModel):
@@ -396,7 +393,7 @@ class ContextDiff(PydanticModel):
         try:
             return old.node.text_diff(new.node, rendered=self.diff_rendered)
         except SQLMeshError as e:
-            get_console().log_warning(f"Failed to diff model '{name}': {str(e)}")
+            get_console().log_warning(f"Failed to diff model '{name}': {str(e)}.")
             return ""
 
 
@@ -426,5 +423,7 @@ def _build_requirements(
                                 ):
                                     requirements[dist] = metadata.version(dist)
                     except metadata.PackageNotFoundError:
-                        logger.warning("Failed to find package for %s", lib)
+                        from sqlmesh.core.console import get_console
+
+                        get_console().log_warning(f"Failed to find package for {lib}.")
     return requirements

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -23,7 +23,6 @@ from sqlglot.schema import MappingSchema
 from sqlglot.tokens import Token
 
 from sqlmesh.core.constants import MAX_MODEL_DEFINITION_SIZE
-from sqlmesh.core.console import get_console
 from sqlmesh.utils.errors import SQLMeshError, ConfigError
 from sqlmesh.utils.pandas import columns_to_types_from_df
 
@@ -330,6 +329,8 @@ def _parse_join(
 
 
 def _warn_unsupported(self: Parser) -> None:
+    from sqlmesh.core.console import get_console
+
     sql = self._find_sql(self._tokens[0], self._tokens[-1])[: self.error_message_context]
 
     get_console().log_warning(

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -23,6 +23,7 @@ from sqlglot.schema import MappingSchema
 from sqlglot.tokens import Token
 
 from sqlmesh.core.constants import MAX_MODEL_DEFINITION_SIZE
+from sqlmesh.core.console import get_console
 from sqlmesh.utils.errors import SQLMeshError, ConfigError
 from sqlmesh.utils.pandas import columns_to_types_from_df
 
@@ -331,7 +332,7 @@ def _parse_join(
 def _warn_unsupported(self: Parser) -> None:
     sql = self._find_sql(self._tokens[0], self._tokens[-1])[: self.error_message_context]
 
-    logger.warning(
+    get_console().log_warning(
         f"'{sql}' could not be semantically understood as it contains unsupported syntax, SQLMesh will treat the command as is. Note that any references to the model's "
         "underlying physical table can't be resolved in this case, consider using Jinja as explained here https://sqlmesh.readthedocs.io/en/stable/concepts/macros/macro_variables/#audit-only-variables"
     )

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -2362,7 +2362,7 @@ class EngineAdapter:
             self.execute(self._build_create_comment_table_exp(table, table_comment, table_kind))
         except Exception:
             logger.warning(
-                f"Table comment for '{table.alias_or_name}' not registered - this may be due to limited permissions.",
+                f"Table comment for '{table.alias_or_name}' not registered - this may be due to limited permissions",
                 exc_info=True,
             )
 
@@ -2389,7 +2389,7 @@ class EngineAdapter:
                 self.execute(self._build_create_comment_column_exp(table, col, comment, table_kind))
             except Exception:
                 logger.warning(
-                    f"Column comments for column '{col}' in table '{table.alias_or_name}' not registered - this may be due to limited permissions.",
+                    f"Column comments for column '{col}' in table '{table.alias_or_name}' not registered - this may be due to limited permissions",
                     exc_info=True,
                 )
 

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -221,8 +221,8 @@ class MSSQLEngineAdapter(
                 self._convert_df_datetime(df, columns_to_types_create)
                 self.create_table(temp_table, columns_to_types_create)
                 rows: t.List[t.Tuple[t.Any, ...]] = list(
-                    df.replace({np.nan: None}).itertuples(index=False, name=None)
-                )  # type: ignore
+                    df.replace({np.nan: None}).itertuples(index=False, name=None)  # type: ignore
+                )
                 conn = self._connection_pool.get()
                 conn.bulk_copy(temp_table.sql(dialect=self.dialect), rows)
             return exp.select(*self._casted_columns(columns_to_types)).from_(temp_table)  # type: ignore

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -65,8 +65,10 @@ class Loader(abc.ABC):
         try:
             gateway = self.config.get_gateway(gateway_name)
         except ConfigError:
-            logger.warning(
-                "Gateway '%s' not found in project '%s'", gateway_name, self.config.project
+            from sqlmesh.core.console import get_console
+
+            get_console().log_warning(
+                f"Gateway '{gateway_name}' not found in project '{self.config.project}'."
             )
             gateway = None
         self._variables = {

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -21,7 +21,6 @@ from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 from sqlglot.schema import MappingSchema
 
 from sqlmesh.core import constants as c
-from sqlmesh.core.console import get_console
 from sqlmesh.core.dialect import (
     SQLMESH_MACRO_PREFIX,
     Dialect,
@@ -770,6 +769,8 @@ def star(
     if exclude and not isinstance(exclude, (exp.Array, exp.Tuple)):
         raise SQLMeshError(f"Invalid exclude '{exclude}'. Expected an array.")
     if except_ != exp.tuple_():
+        from sqlmesh.core.console import get_console
+
         get_console().log_warning(
             "The 'except_' argument in @STAR will soon be deprecated. Use 'exclude' instead."
         )
@@ -1300,6 +1301,9 @@ def _coerce(
     except Exception:
         if strict:
             raise
+
+        from sqlmesh.core.console import get_console
+
         get_console().log_error(
             f"Coercion of expression '{expr}' to type '{typ}' failed. Using non coerced expression at '{path}'",
         )

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-import logging
 import sys
 import types
 import typing as t
@@ -22,6 +21,7 @@ from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 from sqlglot.schema import MappingSchema
 
 from sqlmesh.core import constants as c
+from sqlmesh.core.console import get_console
 from sqlmesh.core.dialect import (
     SQLMESH_MACRO_PREFIX,
     Dialect,
@@ -55,9 +55,6 @@ if sys.version_info >= (3, 10):
     UNION_TYPES = (t.Union, types.UnionType)
 else:
     UNION_TYPES = (t.Union,)
-
-
-logger = logging.getLogger(__name__)
 
 
 class RuntimeStage(Enum):
@@ -773,7 +770,7 @@ def star(
     if exclude and not isinstance(exclude, (exp.Array, exp.Tuple)):
         raise SQLMeshError(f"Invalid exclude '{exclude}'. Expected an array.")
     if except_ != exp.tuple_():
-        logger.warning(
+        get_console().log_warning(
             "The 'except_' argument in @STAR will soon be deprecated. Use 'exclude' instead."
         )
         if not isinstance(exclude, (exp.Array, exp.Tuple)):
@@ -1303,10 +1300,7 @@ def _coerce(
     except Exception:
         if strict:
             raise
-        logger.error(
-            "Coercion of expression '%s' to type '%s' failed. Using non coerced expression at '%s'",
-            expr,
-            typ,
-            path,
+        get_console().log_error(
+            f"Coercion of expression '{expr}' to type '{typ}' failed. Using non coerced expression at '{path}'",
         )
         return expr

--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -300,7 +300,7 @@ def depends_on(cls: t.Type, v: t.Any, info: ValidationInfo) -> t.Optional[t.Set[
     return v
 
 
-expression_validator = field_validator(
+expression_validator: t.Callable = field_validator(
     "query",
     "expressions_",
     "pre_statements_",
@@ -312,7 +312,7 @@ expression_validator = field_validator(
 )(parse_expression)
 
 
-bool_validator = field_validator(
+bool_validator: t.Callable = field_validator(
     "skip",
     "blocking",
     "forward_only",
@@ -327,7 +327,7 @@ bool_validator = field_validator(
 )(parse_bool)
 
 
-properties_validator = field_validator(
+properties_validator: t.Callable = field_validator(
     "physical_properties_",
     "virtual_properties_",
     "session_properties_",
@@ -337,14 +337,14 @@ properties_validator = field_validator(
 )(parse_properties)
 
 
-default_catalog_validator = field_validator(
+default_catalog_validator: t.Callable = field_validator(
     "default_catalog",
     mode="before",
     check_fields=False,
 )(default_catalog)
 
 
-depends_on_validator = field_validator(
+depends_on_validator: t.Callable = field_validator(
     "depends_on_",
     mode="before",
     check_fields=False,

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -12,7 +12,6 @@ from sqlmesh.core.macros import MacroRegistry
 from sqlmesh.utils.jinja import JinjaMacroRegistry
 from sqlmesh.core import constants as c
 from sqlmesh.core.dialect import MacroFunc, parse_one
-from sqlmesh.core.console import get_console
 from sqlmesh.core.model.definition import (
     Model,
     create_python_model,
@@ -106,6 +105,8 @@ class model(registry_decorator):
         kind = self.kwargs.get("kind", None)
         if kind is not None:
             if isinstance(kind, _ModelKind):
+                from sqlmesh.core.console import get_console
+
                 get_console().log_warning(
                     f"""Python model "{self.name}"'s `kind` argument was passed a SQLMesh `{type(kind).__name__}` object. This may result in unexpected behavior - provide a dictionary instead."""
                 )

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import typing as t
 from pathlib import Path
 import inspect
@@ -13,6 +12,7 @@ from sqlmesh.core.macros import MacroRegistry
 from sqlmesh.utils.jinja import JinjaMacroRegistry
 from sqlmesh.core import constants as c
 from sqlmesh.core.dialect import MacroFunc, parse_one
+from sqlmesh.core.console import get_console
 from sqlmesh.core.model.definition import (
     Model,
     create_python_model,
@@ -24,8 +24,6 @@ from sqlmesh.utils import registry_decorator
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.metaprogramming import build_env, serialize_env
 
-
-logger = logging.getLogger(__name__)
 
 if t.TYPE_CHECKING:
     from sqlmesh.core.audit import ModelAudit
@@ -108,7 +106,7 @@ class model(registry_decorator):
         kind = self.kwargs.get("kind", None)
         if kind is not None:
             if isinstance(kind, _ModelKind):
-                logger.warning(
+                get_console().log_warning(
                     f"""Python model "{self.name}"'s `kind` argument was passed a SQLMesh `{type(kind).__name__}` object. This may result in unexpected behavior - provide a dictionary instead."""
                 )
             elif isinstance(kind, dict):

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -986,7 +986,7 @@ def _model_kind_validator(cls: t.Type, v: t.Any, info: t.Optional[ValidationInfo
     return create_model_kind(v, dialect, {})
 
 
-model_kind_validator = field_validator("kind", mode="before")(_model_kind_validator)
+model_kind_validator: t.Callable = field_validator("kind", mode="before")(_model_kind_validator)
 
 
 def _property(name: str, value: t.Any) -> exp.Property:

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -10,7 +10,6 @@ from sqlglot.helper import ensure_collection, ensure_list
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
 from sqlmesh.core import dialect as d
-from sqlmesh.core.console import get_console
 from sqlmesh.core.dialect import normalize_model_name, extract_func_call
 from sqlmesh.core.model.common import (
     bool_validator,
@@ -300,6 +299,8 @@ class ModelMeta(_Node):
             if not isinstance(table_properties, str):
                 # Do not warn when deserializing from the state.
                 model_name = data["name"]
+                from sqlmesh.core.console import get_console
+
                 get_console().log_warning(
                     f"Model '{model_name}' is using the `table_properties` attribute which is deprecated. Please use `physical_properties` instead."
                 )
@@ -335,8 +336,10 @@ class ModelMeta(_Node):
             "hudi",
             "delta",
         }:
+            from sqlmesh.core.console import get_console
+
             get_console().log_warning(
-                f"Model {self.name} has `storage_format` set to a table format '{storage_format}' which is deprecated. Please use the `table_format` property instead"
+                f"Model {self.name} has `storage_format` set to a table format '{storage_format}' which is deprecated. Please use the `table_format` property instead."
             )
 
         return self

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import typing as t
 from functools import cached_property
 from typing_extensions import Self
@@ -11,6 +10,7 @@ from sqlglot.helper import ensure_collection, ensure_list
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
 from sqlmesh.core import dialect as d
+from sqlmesh.core.console import get_console
 from sqlmesh.core.dialect import normalize_model_name, extract_func_call
 from sqlmesh.core.model.common import (
     bool_validator,
@@ -45,8 +45,6 @@ if t.TYPE_CHECKING:
     from sqlmesh.core._typing import CustomMaterializationProperties, SessionProperties
 
 FunctionCall = t.Tuple[str, t.Dict[str, exp.Expression]]
-
-logger = logging.getLogger(__name__)
 
 
 class ModelMeta(_Node):
@@ -302,7 +300,7 @@ class ModelMeta(_Node):
             if not isinstance(table_properties, str):
                 # Do not warn when deserializing from the state.
                 model_name = data["name"]
-                logger.warning(
+                get_console().log_warning(
                     f"Model '{model_name}' is using the `table_properties` attribute which is deprecated. Please use `physical_properties` instead."
                 )
             physical_properties = data.get("physical_properties")
@@ -337,7 +335,7 @@ class ModelMeta(_Node):
             "hudi",
             "delta",
         }:
-            logger.warning(
+            get_console().log_warning(
                 f"Model {self.name} has `storage_format` set to a table format '{storage_format}' which is deprecated. Please use the `table_format` property instead"
             )
 

--- a/sqlmesh/core/model/schema.py
+++ b/sqlmesh/core/model/schema.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import typing as t
 from concurrent.futures import as_completed
 from pathlib import Path
@@ -19,9 +18,6 @@ if t.TYPE_CHECKING:
     from sqlmesh.core.model.definition import Model
     from sqlmesh.utils import UniqueKeyDict
     from sqlmesh.utils.dag import DAG
-
-
-logger = logging.getLogger(__name__)
 
 
 def update_model_schemas(
@@ -45,7 +41,9 @@ def _update_schema_with_model(schema: MappingSchema, model: Model) -> None:
             schema.add_table(model.fqn, columns_to_types, dialect=model.dialect)
         except SchemaError as e:
             if "nesting level:" in str(e):
-                logger.error(
+                from sqlmesh.core.console import get_console
+
+                get_console().log_error(
                     "SQLMesh requires all model names and references to have the same level of nesting."
                 )
             raise

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -493,7 +493,7 @@ class PlanBuilder:
                     )
                     warning_msg = f"Plan results in a destructive change to forward-only model '{snapshot.name}'s schema{dropped_column_msg}."
                     if snapshot.model.on_destructive_change.is_warn:
-                        logger.warning(warning_msg)
+                        get_console().log_warning(warning_msg)
                     else:
                         raise PlanError(
                             f"{warning_msg} To allow this, change the model's `on_destructive_change` setting to `warn` or `allow` or include it in the plan's `--allow-destructive-model` option."

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -14,7 +14,6 @@ from sqlglot.optimizer.simplify import simplify
 
 from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
-from sqlmesh.core.console import get_console
 from sqlmesh.core.macros import MacroEvaluator, RuntimeStage
 from sqlmesh.utils.date import TimeLike, date_dict, make_inclusive, to_datetime
 from sqlmesh.utils.errors import (
@@ -535,6 +534,8 @@ class QueryRenderer(BaseExpressionRenderer):
                 missing_deps.add(dep)
 
         if self._model_fqn and not should_optimize and any(s.is_star for s in query.selects):
+            from sqlmesh.core.console import get_console
+
             deps = ", ".join(f"'{dep}'" for dep in sorted(missing_deps))
 
             warning = (
@@ -566,6 +567,8 @@ class QueryRenderer(BaseExpressionRenderer):
                     )
                 )
         except SqlglotError as ex:
+            from sqlmesh.core.console import get_console
+
             warning = (
                 f"{ex} for model '{self._model_fqn}', the column may not exist or is ambiguous"
             )

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -14,6 +14,7 @@ from sqlglot.optimizer.simplify import simplify
 
 from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
+from sqlmesh.core.console import get_console
 from sqlmesh.core.macros import MacroEvaluator, RuntimeStage
 from sqlmesh.utils.date import TimeLike, date_dict, make_inclusive, to_datetime
 from sqlmesh.utils.errors import (
@@ -546,6 +547,7 @@ class QueryRenderer(BaseExpressionRenderer):
                 raise_config_error(warning, self._path)
 
             logger.warning(warning)
+            get_console().log_warning(warning)
 
         try:
             if should_optimize:
@@ -574,6 +576,7 @@ class QueryRenderer(BaseExpressionRenderer):
             query = original
 
             logger.warning(warning)
+            get_console().log_warning(warning)
         except Exception as ex:
             raise_config_error(
                 f"Failed to optimize query, please file an issue at https://github.com/TobikoData/sqlmesh/issues/new. {ex}",

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -570,7 +570,7 @@ class QueryRenderer(BaseExpressionRenderer):
             from sqlmesh.core.console import get_console
 
             warning = (
-                f"{ex} for model '{self._model_fqn}', the column may not exist or is ambiguous"
+                f"{ex} for model '{self._model_fqn}', the column may not exist or is ambiguous."
             )
 
             if self._validate_query:

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -222,7 +222,9 @@ class Scheduler:
             if audit_result.blocking:
                 audit_error_to_raise = error
             else:
-                logger.warning(f"{error}\nAudit is non-blocking so proceeding with execution.")
+                get_console().log_warning(
+                    f"{error}\nAudit is non-blocking so proceeding with execution."
+                )
 
         if audit_error_to_raise:
             raise audit_error_to_raise

--- a/sqlmesh/core/schema_diff.py
+++ b/sqlmesh/core/schema_diff.py
@@ -10,7 +10,6 @@ from sqlglot.helper import ensure_list, seq_get
 
 from sqlmesh.utils import columns_to_types_to_struct
 from sqlmesh.utils.pydantic import PydanticModel
-from sqlmesh.core.console import get_console
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import TableName
@@ -382,6 +381,8 @@ class SchemaDiffer(PydanticModel):
         if current_type in self.coerceable_types:
             is_coerceable = new_type in self.coerceable_types[current_type]
             if is_coerceable:
+                from sqlmesh.core.console import get_console
+
                 warning = f"Coercing type {current_type} to {new_type} which means an alter will not be performed and therefore the resulting table structure will not match what is in the query.\nUpdate your model to cast the value to {current_type} type in order to remove this warning."
                 logger.warning(warning)
                 get_console().log_warning(warning)

--- a/sqlmesh/core/schema_diff.py
+++ b/sqlmesh/core/schema_diff.py
@@ -10,6 +10,7 @@ from sqlglot.helper import ensure_list, seq_get
 
 from sqlmesh.utils import columns_to_types_to_struct
 from sqlmesh.utils.pydantic import PydanticModel
+from sqlmesh.core.console import get_console
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import TableName
@@ -381,9 +382,9 @@ class SchemaDiffer(PydanticModel):
         if current_type in self.coerceable_types:
             is_coerceable = new_type in self.coerceable_types[current_type]
             if is_coerceable:
-                logger.warning(
-                    f"Coercing type {current_type} to {new_type} which means an alter will not be performed and therefore the resulting table structure will not match what is in the query.\nUpdate your model to cast the value to {current_type} type in order to remove this warning.",
-                )
+                warning = f"Coercing type {current_type} to {new_type} which means an alter will not be performed and therefore the resulting table structure will not match what is in the query.\nUpdate your model to cast the value to {current_type} type in order to remove this warning."
+                logger.warning(warning)
+                get_console().log_warning(warning)
             return is_coerceable
         return False
 

--- a/sqlmesh/core/schema_loader.py
+++ b/sqlmesh/core/schema_loader.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import typing as t
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -8,13 +7,12 @@ from pathlib import Path
 from sqlglot import exp
 from sqlglot.dialects.dialect import DialectType
 
+from sqlmesh.core.console import get_console
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.model.definition import Model
 from sqlmesh.core.state_sync import StateReader
 from sqlmesh.utils import UniqueKeyDict, yaml
 from sqlmesh.utils.errors import SQLMeshError
-
-logger = logging.getLogger(__name__)
 
 
 def create_external_models_file(
@@ -51,10 +49,10 @@ def create_external_models_file(
     # Make sure we don't convert internal models into external ones.
     existing_model_fqns = state_reader.nodes_exist(external_model_fqns, exclude_external=True)
     if existing_model_fqns:
-        logger.warning(
-            "The following models already exist and can't be converted to external: %s."
-            "Perhaps these models have been removed, while downstream models that reference them weren't updated accordingly",
-            ", ".join(existing_model_fqns),
+        existing_model_fqns_str = ", ".join(existing_model_fqns)
+        get_console().log_warning(
+            f"The following models already exist and can't be converted to external: {existing_model_fqns_str}. "
+            "Perhaps these models have been removed, while downstream models that reference them weren't updated accordingly"
         )
         external_model_fqns -= existing_model_fqns
 
@@ -67,7 +65,7 @@ def create_external_models_file(
                 msg = f"Unable to get schema for '{table}': '{e}'."
                 if strict:
                     raise SQLMeshError(msg) from e
-                logger.warning(msg)
+                get_console().log_warning(msg)
                 return None
 
         gateway_part = {"gateway": gateway} if gateway else {}

--- a/sqlmesh/core/schema_loader.py
+++ b/sqlmesh/core/schema_loader.py
@@ -52,7 +52,7 @@ def create_external_models_file(
         existing_model_fqns_str = ", ".join(existing_model_fqns)
         get_console().log_warning(
             f"The following models already exist and can't be converted to external: {existing_model_fqns_str}. "
-            "Perhaps these models have been removed, while downstream models that reference them weren't updated accordingly"
+            "Perhaps these models have been removed, while downstream models that reference them weren't updated accordingly."
         )
         external_model_fqns -= existing_model_fqns
 

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -18,7 +18,6 @@ from sqlglot.optimizer.annotate_types import annotate_types
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
 from sqlmesh.core import constants as c
-from sqlmesh.core.console import get_console
 from sqlmesh.core.dialect import normalize_model_name, schema_
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.macros import RuntimeStage
@@ -241,9 +240,11 @@ class ModelTest(unittest.TestCase):
                 elif type(value) is datetime.datetime:
                     expected[col] = pd.to_datetime(expected[col]).dt.to_pydatetime()
             except Exception as e:
+                from sqlmesh.core.console import get_console
+
                 get_console().log_warning(
                     f"Failed to convert expected value for {col} into `datetime` "
-                    f"for unit test '{str(self)}'. {str(e)}"
+                    f"for unit test '{str(self)}'. {str(e)}."
                 )
 
         actual = actual.replace({np.nan: None})

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import logging
 import typing as t
 import unittest
 from collections import Counter
@@ -19,6 +18,7 @@ from sqlglot.optimizer.annotate_types import annotate_types
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
 from sqlmesh.core import constants as c
+from sqlmesh.core.console import get_console
 from sqlmesh.core.dialect import normalize_model_name, schema_
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.macros import RuntimeStage
@@ -33,7 +33,6 @@ if t.TYPE_CHECKING:
 
     Row = t.Dict[str, t.Any]
 
-logger = logging.getLogger(__name__)
 
 TIME_KWARG_KEYS = {
     "start",
@@ -242,7 +241,7 @@ class ModelTest(unittest.TestCase):
                 elif type(value) is datetime.datetime:
                     expected[col] = pd.to_datetime(expected[col]).dt.to_pydatetime()
             except Exception as e:
-                logger.warning(
+                get_console().log_warning(
                     f"Failed to convert expected value for {col} into `datetime` "
                     f"for unit test '{str(self)}'. {str(e)}"
                 )

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -219,7 +219,9 @@ class DbtLoader(Loader):
             try:
                 requirements[target_package] = metadata.version(target_package)
             except metadata.PackageNotFoundError:
-                logger.warning("dbt package %s is not installed", target_package)
+                from sqlmesh.core.console import get_console
+
+                get_console().log_warning(f"dbt package {target_package} is not installed.")
 
         return requirements, excluded_requirements
 

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -38,7 +38,7 @@ INCREMENTAL_BY_UNIQUE_KEY_STRATEGIES = set(["merge"])
 
 
 def collection_to_str(collection: t.Iterable) -> str:
-    return ", ".join(f"'{item}'" for item in collection)
+    return ", ".join(f"'{item}'" for item in sorted(collection))
 
 
 class ModelConfig(BaseModelConfig):

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import typing as t
 
 from sqlglot import exp
@@ -9,6 +8,7 @@ from sqlglot.helper import ensure_list
 
 from sqlmesh.core import dialect as d
 from sqlmesh.core.config.base import UpdateStrategy
+from sqlmesh.core.console import get_console
 from sqlmesh.core.model import (
     EmbeddedKind,
     FullKind,
@@ -32,8 +32,6 @@ if t.TYPE_CHECKING:
     from sqlmesh.core.audit.definition import ModelAudit
     from sqlmesh.dbt.context import DbtContext
 
-
-logger = logging.getLogger(__name__)
 
 INCREMENTAL_BY_TIME_STRATEGIES = set(["delete+insert", "insert_overwrite"])
 INCREMENTAL_BY_UNIQUE_KEY_STRATEGIES = set(["merge"])
@@ -190,7 +188,9 @@ class ModelConfig(BaseModelConfig):
                 # dictionary materialization
                 raise ConfigError(msg)
             else:
-                logger.warning(f"{msg} Falling back to the '{fallback[1]}' materialization.")
+                get_console().log_warning(
+                    f"{msg} Falling back to the '{fallback[1]}' materialization."
+                )
 
             return fallback[1]
         return v
@@ -259,11 +259,9 @@ class ModelConfig(BaseModelConfig):
                 )
 
                 if strategy not in INCREMENTAL_BY_TIME_STRATEGIES:
-                    logger.warning(
-                        "SQLMesh incremental by time strategy is not compatible with '%s' incremental strategy in model '%s'. Supported strategies include %s.",
-                        strategy,
-                        self.canonical_name(context),
-                        collection_to_str(INCREMENTAL_BY_TIME_STRATEGIES),
+                    get_console().log_warning(
+                        f"SQLMesh incremental by time strategy is not compatible with '{strategy}' incremental strategy in model '{self.canonical_name(context)}'. "
+                        f"Supported strategies include {collection_to_str(INCREMENTAL_BY_TIME_STRATEGIES)}."
                     )
 
                 return IncrementalByTimeRangeKind(
@@ -312,11 +310,13 @@ class ModelConfig(BaseModelConfig):
                     **incremental_by_kind_kwargs,
                 )
 
-            logger.warning(
-                "Using unmanaged incremental materialization for model '%s'. Some features might not be available. Consider adding either a time_column (%s) or a unique_key (%s) configuration to mitigate this",
-                self.canonical_name(context),
-                collection_to_str(INCREMENTAL_BY_TIME_STRATEGIES),
-                collection_to_str(INCREMENTAL_BY_UNIQUE_KEY_STRATEGIES.union(["none"])),
+            incremental_by_time_str = collection_to_str(INCREMENTAL_BY_TIME_STRATEGIES)
+            incremental_by_unique_key_str = collection_to_str(
+                INCREMENTAL_BY_UNIQUE_KEY_STRATEGIES.union(["none"])
+            )
+            get_console().log_warning(
+                f"Using unmanaged incremental materialization for model '{self.canonical_name(context)}'. "
+                f"Some features might not be available. Consider adding either a time_column ({incremental_by_time_str}) or a unique_key ({incremental_by_unique_key_str}) configuration to mitigate this",
             )
             strategy = self.incremental_strategy or target.default_incremental_strategy(
                 IncrementalUnmanagedKind
@@ -499,17 +499,17 @@ class ModelConfig(BaseModelConfig):
                     self.incremental_strategy = "append"
 
                 if self.incremental_strategy == "delete+insert":
-                    logger.warning(
+                    get_console().log_warning(
                         f"The '{self.incremental_strategy}' incremental strategy is not supported - SQLMesh will use the temp table/partition swap strategy."
                     )
 
                 if self.incremental_predicates:
-                    logger.warning(
+                    get_console().log_warning(
                         "SQLMesh does not support 'incremental_predicates' - they will not be applied."
                     )
 
             if self.query_settings:
-                logger.warning(
+                get_console().log_warning(
                     "SQLMesh does not support the 'query_settings' model configuration parameter. Specify the query settings directly in the model query."
                 )
 
@@ -539,7 +539,7 @@ class ModelConfig(BaseModelConfig):
                 physical_properties["primary_key"] = primary_key
 
             if self.sharding_key:
-                logger.warning(
+                get_console().log_warning(
                     "SQLMesh does not support the 'sharding_key' model configuration parameter or distributed materializations."
                 )
 

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -316,7 +316,7 @@ class ModelConfig(BaseModelConfig):
             )
             get_console().log_warning(
                 f"Using unmanaged incremental materialization for model '{self.canonical_name(context)}'. "
-                f"Some features might not be available. Consider adding either a time_column ({incremental_by_time_str}) or a unique_key ({incremental_by_unique_key_str}) configuration to mitigate this",
+                f"Some features might not be available. Consider adding either a time_column ({incremental_by_time_str}) or a unique_key ({incremental_by_unique_key_str}) configuration to mitigate this.",
             )
             strategy = self.incremental_strategy or target.default_incremental_strategy(
                 IncrementalUnmanagedKind

--- a/sqlmesh/dbt/project.py
+++ b/sqlmesh/dbt/project.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import logging
 import typing as t
+import logging
 from pathlib import Path
 
+from sqlmesh.core.console import get_console
 from sqlmesh.dbt.common import PROJECT_FILENAME, load_yaml
 from sqlmesh.dbt.context import DbtContext
 from sqlmesh.dbt.manifest import ManifestHelper
@@ -79,8 +80,8 @@ class Project:
         extra_fields = profile.target.extra
         if extra_fields:
             extra_str = ",".join(f"'{field}'" for field in extra_fields)
-            logger.warning(
-                "%s adapter does not currently support %s", profile.target.type, extra_str
+            get_console().log_warning(
+                f"{profile.target.type} adapter does not currently support {extra_str}"
             )
 
         packages = {}

--- a/sqlmesh/dbt/project.py
+++ b/sqlmesh/dbt/project.py
@@ -81,7 +81,7 @@ class Project:
         if extra_fields:
             extra_str = ",".join(f"'{field}'" for field in extra_fields)
             get_console().log_warning(
-                f"{profile.target.type} adapter does not currently support {extra_str}"
+                f"{profile.target.type} adapter does not currently support {extra_str}."
             )
 
         packages = {}

--- a/sqlmesh/dbt/target.py
+++ b/sqlmesh/dbt/target.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import abc
-import logging
 import typing as t
 from pathlib import Path
 
 from dbt.adapters.base import BaseRelation, Column
 from pydantic import Field
 
+from sqlmesh.core.console import get_console
 from sqlmesh.core.config.connection import (
     AthenaConnectionConfig,
     BigQueryConnectionConfig,
@@ -35,8 +35,6 @@ from sqlmesh.dbt.util import DBT_VERSION
 from sqlmesh.utils import AttributeDict, classproperty
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.pydantic import field_validator, model_validator
-
-logger = logging.getLogger(__name__)
 
 IncrementalKind = t.Union[
     t.Type[IncrementalByUniqueKeyKind],
@@ -176,7 +174,7 @@ class DuckDbConfig(TargetConfig):
             )
 
         if "threads" in data and t.cast(int, data["threads"]) > 1:
-            logger.warning("DuckDB does not support concurrency - setting threads to 1.")
+            get_console().log_warning("DuckDB does not support concurrency - setting threads to 1.")
 
         return data
 

--- a/sqlmesh/integrations/github/cicd/command.py
+++ b/sqlmesh/integrations/github/cicd/command.py
@@ -6,6 +6,7 @@ import traceback
 import click
 
 from sqlmesh.core.analytics import cli_analytics
+from sqlmesh.core.console import set_console, MarkdownConsole
 from sqlmesh.integrations.github.cicd.controller import (
     GithubCheckConclusion,
     GithubCheckStatus,
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 @click.pass_context
 def github(ctx: click.Context, token: str) -> None:
     """Github Action CI/CD Bot. See https://sqlmesh.readthedocs.io/en/stable/integrations/github/ for details"""
+    set_console(MarkdownConsole())
     ctx.obj["github"] = GithubController(
         paths=ctx.obj["paths"],
         token=token,

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -14,11 +14,10 @@ from typing import List
 
 import requests
 from hyperscript import Element, h
-from rich.console import Console
 from sqlglot.helper import seq_get
 
 from sqlmesh.core import constants as c
-from sqlmesh.core.console import SNAPSHOT_CHANGE_CATEGORY_STR, MarkdownConsole
+from sqlmesh.core.console import SNAPSHOT_CHANGE_CATEGORY_STR, get_console, MarkdownConsole
 from sqlmesh.core.context import Context
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.plan import Plan, PlanBuilder
@@ -303,7 +302,11 @@ class GithubController:
         self._prod_plan_builder: t.Optional[PlanBuilder] = None
         self._prod_plan_with_gaps_builder: t.Optional[PlanBuilder] = None
         self._check_run_mapping: t.Dict[str, CheckRun] = {}
-        self._console = MarkdownConsole(console=Console(no_color=True))
+
+        if not isinstance(get_console(), MarkdownConsole):
+            raise CICDBotError("Console must be a markdown console.")
+        self._console = t.cast(MarkdownConsole, get_console())
+
         self._client: Github = client or Github(
             base_url=os.environ["GITHUB_API_URL"],
             login_or_token=self._token,
@@ -326,7 +329,6 @@ class GithubController:
         self._context: Context = Context(
             paths=self._paths,
             config=self.config,
-            console=self._console,
         )
 
     @property

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2,7 +2,6 @@ import logging
 from contextlib import contextmanager
 from os import getcwd, path, remove
 from pathlib import Path
-from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 import time_machine
@@ -416,30 +415,28 @@ def test_plan_dev_bad_create_from(runner, tmp_path):
     update_incremental_model(tmp_path)
 
     # create dev2 environment from non-existent dev3
-    logger = logging.getLogger("sqlmesh.core.context_diff")
-    with patch.object(logger, "warning") as mock_logger:
-        result = runner.invoke(
-            cli,
-            [
-                "--log-file-dir",
-                tmp_path,
-                "--paths",
-                tmp_path,
-                "plan",
-                "dev2",
-                "--create-from",
-                "dev3",
-                "--no-prompts",
-                "--auto-apply",
-            ],
-        )
+    result = runner.invoke(
+        cli,
+        [
+            "--log-file-dir",
+            tmp_path,
+            "--paths",
+            tmp_path,
+            "plan",
+            "dev2",
+            "--create-from",
+            "dev3",
+            "--no-prompts",
+            "--auto-apply",
+        ],
+    )
 
-        assert result.exit_code == 0
-        assert_new_env(result, "dev2", "dev")
-        assert (
-            mock_logger.call_args[0][0]
-            == "The environment name 'dev3' was passed to the `plan` command's `--create-from` argument, but 'dev3' does not exist. Initializing new environment 'dev2' from scratch."
-        )
+    assert result.exit_code == 0
+    assert_new_env(result, "dev2", "dev")
+    assert (
+        "The environment name 'dev3' was passed to the `plan` command's `--create-from` argument, but 'dev3' does not exist. Initializing new environment 'dev2' from scratch."
+        in result.output.replace("\n", "")
+    )
 
 
 def test_plan_dev_no_prompts(runner, tmp_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,6 +235,13 @@ def rescope_lineage_cache(request):
     yield
 
 
+@pytest.fixture(autouse=True)
+def reset_console():
+    from sqlmesh.core.console import set_console, NoopConsole
+
+    set_console(NoopConsole())
+
+
 @pytest.fixture
 def duck_conn() -> duckdb.DuckDBPyConnection:
     return duckdb.connect()

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -459,8 +459,7 @@ def test_override_builtin_audit_blocking_mode():
         )
     )
 
-    logger = logging.getLogger("sqlmesh.core.scheduler")
-    with patch.object(logger, "warning") as mock_logger:
+    with patch.object(context.console, "log_warning") as mock_logger:
         plan = context.plan(auto_apply=True, no_prompts=True)
         new_snapshot = next(iter(plan.context_diff.new_snapshots.values()))
 
@@ -1008,8 +1007,7 @@ def test_load_external_models(copy_to_temp_path):
     assert context.resolve_table("raw.demographics") == '"memory"."raw"."demographics"'
     assert context.resolve_table("raw.model2") == '"memory"."raw"."model2"'
 
-    logger = logging.getLogger("sqlmesh.core.context")
-    with patch.object(logger, "warning") as mock_logger:
+    with patch.object(context.console, "log_warning") as mock_logger:
         context.table("raw.model1") == '"memory"."raw"."model1"'
 
         assert mock_logger.mock_calls == [

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -26,6 +26,7 @@ from sqlmesh.core.config import (
     load_configs,
 )
 from sqlmesh.core.context import Context
+from sqlmesh.core.console import create_console
 from sqlmesh.core.dialect import parse, schema_
 from sqlmesh.core.engine_adapter.duckdb import DuckDBEngineAdapter
 from sqlmesh.core.environment import Environment
@@ -505,6 +506,8 @@ def test_override_builtin_audit_blocking_mode():
 
 
 def test_python_model_empty_df_raises(sushi_context, capsys):
+    sushi_context.console = create_console()
+
     @model(
         "memory.sushi.test_model",
         columns={"col": "int"},
@@ -523,8 +526,8 @@ def test_python_model_empty_df_raises(sushi_context, capsys):
         sushi_context.plan(no_prompts=True, auto_apply=True)
 
     assert (
-        "Cannot construct source query from an empty DataFrame. This error is \ncommonly related to Python models that produce no data. For such models, \nconsider yielding from an empty generator if the resulting set is empty, i.e. \nuse"
-    ) in capsys.readouterr().out
+        "Cannot construct source query from an empty DataFrame. This error is commonly related to Python models that produce no data. For such models, consider yielding from an empty generator if the resulting set is empty, i.e. use"
+    ) in capsys.readouterr().out.replace("\n", "")
 
 
 def test_env_and_default_schema_normalization(mocker: MockerFixture):

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -293,7 +293,7 @@ def test_model_qualification():
         model.render_query(needs_optimization=True)
         assert (
             mock_logger.call_args[0][0]
-            == """Column '"a"' could not be resolved for model '"db"."table"', the column may not exist or is ambiguous"""
+            == """Column '"a"' could not be resolved for model '"db"."table"', the column may not exist or is ambiguous."""
         )
 
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -16,6 +16,7 @@ from sqlmesh.cli.example_project import init_example_project
 
 from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
+from sqlmesh.core.console import get_console
 from sqlmesh.core.audit import ModelAudit, load_audit
 from sqlmesh.core.config import (
     Config,
@@ -2082,8 +2083,6 @@ def test_python_models_returning_sql(assert_exp_eq) -> None:
 
 
 def test_python_model_decorator_kind() -> None:
-    logger = logging.getLogger("sqlmesh.core.model.decorator")
-
     # no kind specified -> default Full kind
     @model("default_kind", columns={'"COL"': "int"})
     def a_model(context):
@@ -2152,7 +2151,7 @@ def test_python_model_decorator_kind() -> None:
         pass
 
     # warning if kind is ModelKind instance
-    with patch.object(logger, "warning") as mock_logger:
+    with patch.object(get_console(), "log_warning") as mock_logger:
         python_model = model.get_registry()["kind_instance"].model(
             module_path=Path("."),
             path=Path("."),
@@ -2164,7 +2163,7 @@ def test_python_model_decorator_kind() -> None:
         )
 
     # no warning with valid kind dict
-    with patch.object(logger, "warning") as mock_logger:
+    with patch.object(get_console(), "log_warning") as mock_logger:
 
         @model("kind_valid_dict", kind=dict(name=ModelKindName.FULL), columns={'"COL"': "int"})
         def my_model(context):

--- a/tests/core/test_schema_loader.py
+++ b/tests/core/test_schema_loader.py
@@ -1,5 +1,4 @@
 import pytest
-import logging
 import typing as t
 from pathlib import Path
 from unittest.mock import patch
@@ -349,8 +348,7 @@ def test_missing_table(tmp_path: Path):
     model = SqlModel(name="a", query=parse_one("select * FROM tbl_source"))
 
     filename = tmp_path / c.EXTERNAL_MODELS_YAML
-    logger = logging.getLogger("sqlmesh.core.schema_loader")
-    with patch.object(logger, "warning") as mock_logger:
+    with patch.object(context.console, "log_warning") as mock_logger:
         create_external_models_file(
             filename,
             {"a": model},  # type: ignore

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -1260,8 +1260,7 @@ def test_clickhouse_properties(mocker: MockerFixture):
         sql="""SELECT 1 AS one, ds FROM foo""",
     )
 
-    logger = logging.getLogger("sqlmesh.dbt.model")
-    with patch.object(logger, "warning") as mock_logger:
+    with patch.object(get_console(), "log_warning") as mock_logger:
         model_to_sqlmesh = model_config.to_sqlmesh(context)
 
     assert [call[0][0] for call in mock_logger.call_args_list] == [
@@ -1269,7 +1268,7 @@ def test_clickhouse_properties(mocker: MockerFixture):
         "SQLMesh does not support 'incremental_predicates' - they will not be applied.",
         "SQLMesh does not support the 'query_settings' model configuration parameter. Specify the query settings directly in the model query.",
         "SQLMesh does not support the 'sharding_key' model configuration parameter or distributed materializations.",
-        "Using unmanaged incremental materialization for model '%s'. Some features might not be available. Consider adding either a time_column (%s) or a unique_key (%s) configuration to mitigate this",
+        "Using unmanaged incremental materialization for model '`test`.`model`'. Some features might not be available. Consider adding either a time_column ('delete+insert', 'insert_overwrite') or a unique_key ('merge', 'none') configuration to mitigate this.",
     ]
 
     assert [e.sql("clickhouse") for e in model_to_sqlmesh.partitioned_by] == [

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -15,6 +15,7 @@ from sqlglot import exp, parse_one
 from sqlmesh.core import dialect as d
 from sqlmesh.core.audit import StandaloneAudit
 from sqlmesh.core.context import Context
+from sqlmesh.core.console import get_console
 from sqlmesh.core.model import (
     EmbeddedKind,
     FullKind,
@@ -73,8 +74,7 @@ def test_materialization():
     context.project_name = "Test"
     context.target = DuckDbConfig(name="target", schema="foo")
 
-    logger = logging.getLogger("sqlmesh.dbt.model")
-    with patch.object(logger, "warning") as mock_logger:
+    with patch.object(get_console(), "log_warning") as mock_logger:
         model_config = ModelConfig(
             name="model", alias="model", schema="schema", materialized="materialized_view"
         )

--- a/tests/integrations/github/cicd/fixtures.py
+++ b/tests/integrations/github/cicd/fixtures.py
@@ -3,6 +3,7 @@ import typing as t
 import pytest
 from pytest_mock.plugin import MockerFixture
 
+from sqlmesh.core.console import set_console, MarkdownConsole
 from sqlmesh.integrations.github.cicd.config import GithubCICDBotConfig
 from sqlmesh.integrations.github.cicd.controller import (
     GithubController,
@@ -80,6 +81,7 @@ def make_controller(mocker: MockerFixture) -> t.Callable:
                 "sqlmesh.integrations.github.cicd.controller.GithubController.bot_config",
                 bot_config,
             )
+        set_console(MarkdownConsole())
         return GithubController(
             paths=["examples/sushi"],
             token="abc",

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -615,7 +615,7 @@ def test_create_external_models(notebook, loaded_sushi_context, convert_all_html
     assert not output.stdout
     assert not output.stderr
     assert len(output.outputs) == 2
-    converted = convert_all_html_output_to_text(output)
+    converted = sorted(convert_all_html_output_to_text(output))
     assert 'Unable to get schema for \'"memory"."raw"."model1"\'' in converted[0]
     assert 'Unable to get schema for \'"memory"."raw"."model2"\'' in converted[1]
 

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -604,7 +604,7 @@ def test_migrate(
 
 
 @pytest.mark.slow
-def test_create_external_models(notebook, loaded_sushi_context):
+def test_create_external_models(notebook, loaded_sushi_context, convert_all_html_output_to_text):
     external_model_file = loaded_sushi_context.path / "external_models.yaml"
     external_model_file.unlink()
     assert not external_model_file.exists()
@@ -614,7 +614,11 @@ def test_create_external_models(notebook, loaded_sushi_context):
 
     assert not output.stdout
     assert not output.stderr
-    assert not output.outputs
+    assert len(output.outputs) == 2
+    converted = convert_all_html_output_to_text(output)
+    assert 'Unable to get schema for \'"memory"."raw"."model1"\'' in converted[0]
+    assert 'Unable to get schema for \'"memory"."raw"."model2"\'' in converted[1]
+
     assert external_model_file.exists()
     assert (
         external_model_file.read_text()

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -4,6 +4,8 @@ import pytest
 from fastapi import FastAPI
 
 from sqlmesh.core.context import Context
+from sqlmesh.core.console import set_console
+
 from web.server.console import api_console
 from web.server.settings import Settings, get_loaded_context, get_settings
 
@@ -34,7 +36,8 @@ config = Config(model_defaults=ModelDefaultsConfig(dialect=''))
 
 @pytest.fixture
 def project_context(web_app: FastAPI, project_tmp_path: Path):
-    context = Context(paths=project_tmp_path, console=api_console)
+    set_console(api_console)
+    context = Context(paths=project_tmp_path)
 
     def get_loaded_context_override() -> Context:
         return context

--- a/web/server/settings.py
+++ b/web/server/settings.py
@@ -63,9 +63,11 @@ def get_settings() -> Settings:
 
 @lru_cache()
 def _get_context(path: str | Path, config: str, gateway: str) -> Context:
+    from sqlmesh.core.console import set_console
     from web.server.main import api_console
 
-    return Context(paths=str(path), config=config, console=api_console, gateway=gateway, load=False)
+    set_console(api_console)
+    return Context(paths=str(path), config=config, gateway=gateway, load=False)
 
 
 @lru_cache()


### PR DESCRIPTION
This PR decouples information that we present to the user in the console from the logging specifically for warnings and errors.