### PR TITLE
Feat!: Adjust physical_properties evaluation and add macro to resolve physical table names

### DIFF
--- a/docs/concepts/macros/sqlmesh_macros.md
+++ b/docs/concepts/macros/sqlmesh_macros.md
@@ -1000,6 +1000,46 @@ Note: This is DuckDB SQL and other dialects will be transpiled accordingly.
 - Recursive CTEs (common table expressions) will be used for `Redshift / MySQL / MSSQL`.
 - For `MSSQL` in particular, there's a recursion limit of approximately 100. If this becomes a problem, you can add an `OPTION (MAXRECURSION 0)` clause after the date spine macro logic to remove the limit. This applies for long date ranges.
 
+### @PHYSICAL_LOCATION
+
+`@PHYSICAL_LOCATION` is a helper macro intended to be used in situations where you need to gain access to the *components* of the physical table name. It's intended for use in the following situations:
+
+- Providing explicit control over table locations on a per-model basis for engines that decouple storage and compute (such as Athena, Trino, Spark etc)
+- Generating references to engine-specific metadata tables that are derived from the physical table name, such as the [`<table>$properties`](https://trino.io/docs/current/connector/iceberg.html#metadata-tables) metadata table in Trino.
+
+Under the hood, it uses the `@this_model` variable so it can only be used during the `creating` and `evaluation` [runtime stages](./macro_variables.md#runtime-variables).
+
+The `@PHYSICAL_LOCATION` supports the following arguments:
+
+ - `template` - The string template to render into
+ - `mode` - What to return after rendering the template. Valid values are `literal` or `table`. Defaults to `literal`.
+
+The `template` can contain the following placeholders that will be substituted:
+
+  - `@{catalog_name}` - The name of the catalog, eg `datalake`
+  - `@{schema_name}` - The name of the physical schema that SQLMesh is using for the model version table, eg `sqlmesh__landing`
+  - `@{table_name}` - The name of the physical table that SQLMesh is using for the model version, eg `landing__customers__2517971505`
+
+It can be used in a `MODEL` block:
+
+```sql linenums="1" hl_lines="5"
+MODEL (
+  name datalake.landing.customers,
+  ...
+  physical_properties (
+    location = @physical_location('s3://warehouse-data/@{catalog_name}/prod/@{schema_name}/@{table_name}')
+  )
+);
+-- CREATE TABLE "datalake"."sqlmesh__landing"."landing__customers__2517971505" ...
+-- WITH (location = 's3://warehouse-data/datalake/prod/sqlmesh__landing/landing__customers__2517971505')
+```
+
+And also within a query, using `mode := 'table'`:
+
+```sql linenums="1"
+SELECT * FROM @physical_location('@{catalog_name}.@{schema_name}.@{table_name}$properties', mode := 'table')
+-- SELECT * FROM "datalake"."sqlmesh__landing"."landing__customers__2517971505$properties"
+```
 
 ### @AND
 

--- a/docs/concepts/macros/sqlmesh_macros.md
+++ b/docs/concepts/macros/sqlmesh_macros.md
@@ -1000,19 +1000,19 @@ Note: This is DuckDB SQL and other dialects will be transpiled accordingly.
 - Recursive CTEs (common table expressions) will be used for `Redshift / MySQL / MSSQL`.
 - For `MSSQL` in particular, there's a recursion limit of approximately 100. If this becomes a problem, you can add an `OPTION (MAXRECURSION 0)` clause after the date spine macro logic to remove the limit. This applies for long date ranges.
 
-### @PHYSICAL_LOCATION
+### @RESOLVE_TEMPLATE
 
-`@PHYSICAL_LOCATION` is a helper macro intended to be used in situations where you need to gain access to the *components* of the physical table name. It's intended for use in the following situations:
+`@resolve_template` is a helper macro intended to be used in situations where you need to gain access to the *components* of the physical object name. It's intended for use in the following situations:
 
 - Providing explicit control over table locations on a per-model basis for engines that decouple storage and compute (such as Athena, Trino, Spark etc)
 - Generating references to engine-specific metadata tables that are derived from the physical table name, such as the [`<table>$properties`](https://trino.io/docs/current/connector/iceberg.html#metadata-tables) metadata table in Trino.
 
-Under the hood, it uses the `@this_model` variable so it can only be used during the `creating` and `evaluation` [runtime stages](./macro_variables.md#runtime-variables).
+Under the hood, it uses the `@this_model` variable so it can only be used during the `creating` and `evaluation` [runtime stages](./macro_variables.md#runtime-variables). Attempting to use it at the `loading` runtime stage will result in a no-op.
 
-The `@PHYSICAL_LOCATION` supports the following arguments:
+The `@resolve_template` macro supports the following arguments:
 
- - `template` - The string template to render into
- - `mode` - What to return after rendering the template. Valid values are `literal` or `table`. Defaults to `literal`.
+ - `template` - The string template to render into an AST node
+ - `mode` - What type of SQLGlot AST node to return after rendering the template. Valid values are `literal` or `table`. Defaults to `literal`.
 
 The `template` can contain the following placeholders that will be substituted:
 
@@ -1027,7 +1027,7 @@ MODEL (
   name datalake.landing.customers,
   ...
   physical_properties (
-    location = @physical_location('s3://warehouse-data/@{catalog_name}/prod/@{schema_name}/@{table_name}')
+    location = @resolve_template('s3://warehouse-data/@{catalog_name}/prod/@{schema_name}/@{table_name}')
   )
 );
 -- CREATE TABLE "datalake"."sqlmesh__landing"."landing__customers__2517971505" ...
@@ -1037,7 +1037,7 @@ MODEL (
 And also within a query, using `mode := 'table'`:
 
 ```sql linenums="1"
-SELECT * FROM @physical_location('@{catalog_name}.@{schema_name}.@{table_name}$properties', mode := 'table')
+SELECT * FROM @resolve_template('@{catalog_name}.@{schema_name}.@{table_name}$properties', mode := 'table')
 -- SELECT * FROM "datalake"."sqlmesh__landing"."landing__customers__2517971505$properties"
 ```
 

--- a/docs/integrations/engines/trino.md
+++ b/docs/integrations/engines/trino.md
@@ -185,14 +185,16 @@ This would perform the following mappings:
 
 Often, you dont need to configure an explicit table location because if you have configured explicit schema locations, table locations are automatically inferred by Trino to be a subdirectory under the schema location.
 
-However, if you need to, you can configure an explicit table location by adding a `location` property to the model `physical_properties`:
+However, if you need to, you can configure an explicit table location by adding a `location` property to the model `physical_properties`.
 
-```
+Note that you need to use the [@physical_location](../../concepts/macros/sqlmesh_macros.md#physical_location) macro to generate a unique table location for each model version. Otherwise, all model versions will be written to the same location and clobber each other.
+
+```sql hl_lines="5"
 MODEL (
   name staging.customers,
   kind FULL,
   physical_properties (
-    location = 's3://warehouse/staging/customers'
+    location = @physical_location('s3://warehouse/@{catalog_name}/@{schema_name}/@{table_name}')
   )
 );
 

--- a/docs/integrations/engines/trino.md
+++ b/docs/integrations/engines/trino.md
@@ -187,14 +187,14 @@ Often, you dont need to configure an explicit table location because if you have
 
 However, if you need to, you can configure an explicit table location by adding a `location` property to the model `physical_properties`.
 
-Note that you need to use the [@physical_location](../../concepts/macros/sqlmesh_macros.md#physical_location) macro to generate a unique table location for each model version. Otherwise, all model versions will be written to the same location and clobber each other.
+Note that you need to use the [@resolve_template](../../concepts/macros/sqlmesh_macros.md#resolve_template) macro to generate a unique table location for each model version. Otherwise, all model versions will be written to the same location and clobber each other.
 
 ```sql hl_lines="5"
 MODEL (
   name staging.customers,
   kind FULL,
   physical_properties (
-    location = @physical_location('s3://warehouse/@{catalog_name}/@{schema_name}/@{table_name}')
+    location = @resolve_template('s3://warehouse/@{catalog_name}/@{schema_name}/@{table_name}')
   )
 );
 

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -1184,7 +1184,7 @@ def date_spine(
 
 
 @macro()
-def physical_location(
+def resolve_template(
     evaluator: MacroEvaluator,
     template: exp.Literal,
     mode: exp.Literal = exp.Literal.string("literal"),
@@ -1194,7 +1194,7 @@ def physical_location(
 
     Note: It relies on the @this_model variable being available in the evaluation context (@this_model resolves to an exp.Table object
     representing the current physical table).
-    Therefore, the @physical_location macro must be used at creation or evaluation time and not at load time.
+    Therefore, the @resolve_template macro must be used at creation or evaluation time and not at load time.
 
     Args:
         template: Template string literal. Can contain the following placeholders:
@@ -1208,7 +1208,7 @@ def physical_location(
     Example:
         >>> from sqlglot import parse_one, exp
         >>> from sqlmesh.core.macros import MacroEvaluator, RuntimeStage
-        >>> sql = "@physical_location('s3://data-bucket/prod/@{catalog_name}/@{schema_name}/@{table_name}')"
+        >>> sql = "@resolve_template('s3://data-bucket/prod/@{catalog_name}/@{schema_name}/@{table_name}')"
         >>> evaluator = MacroEvaluator(runtime_stage=RuntimeStage.CREATING)
         >>> evaluator.locals.update({"this_model": exp.to_table("test_catalog.sqlmesh__test.test__test_model__2517971505")})
         >>> evaluator.transform(parse_one(sql)).sql()
@@ -1217,7 +1217,7 @@ def physical_location(
     if evaluator.runtime_stage != "loading":
         if "this_model" not in evaluator.locals:
             raise SQLMeshError(
-                "@this_model must be present in the macro evaluation context in order to use @physical_location"
+                "@this_model must be present in the macro evaluation context in order to use @resolve_template"
             )
 
         this_model = exp.to_table(evaluator.locals["this_model"])

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -1190,7 +1190,7 @@ def physical_location(
     mode: exp.Literal = exp.Literal.string("literal"),
 ) -> t.Union[exp.Literal, exp.Table]:
     """
-    Generates a either a String literal or an exp.Table representing a physical table location, based on rendering the provided template String literal.
+    Generates either a String literal or an exp.Table representing a physical table location, based on rendering the provided template String literal.
 
     Note: It relies on the @this_model variable being available in the evaluation context (@this_model resolves to an exp.Table object
     representing the current physical table).

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -630,6 +630,26 @@ class _Model(ModelMeta, frozen=True):
             raise SQLMeshError(f"Expected one expression but got {len(rendered_exprs)}")
         return rendered_exprs[0].transform(d.replace_merge_table_aliases)
 
+    def render_physical_properties(self, **render_kwargs: t.Any) -> t.Dict[str, exp.Expression]:
+        def _render(expression: exp.Expression) -> exp.Expression:
+            # note: we use the _statement_renderer instead of _create_renderer because it sets model_fqn which
+            # in turn makes @this_model available in the evaluation context
+            rendered_exprs = self._statement_renderer(expression).render(**render_kwargs)
+
+            if not rendered_exprs:
+                raise SQLMeshError(
+                    f"Expected rendering '{expression.sql(dialect=self.dialect)}' to return an expression"
+                )
+
+            if len(rendered_exprs) != 1:
+                raise SQLMeshError(
+                    f"Expected one result when rendering '{expression.sql(dialect=self.dialect)}' but got {len(rendered_exprs)}"
+                )
+
+            return rendered_exprs[0]
+
+        return {k: _render(v) for k, v in self.physical_properties.items()}
+
     def _create_renderer(self, expression: exp.Expression) -> ExpressionRenderer:
         return ExpressionRenderer(
             expression,
@@ -1784,16 +1804,16 @@ def load_sql_based_model(
         meta = d.Model(expressions=[])  # Dummy meta node
         expressions.insert(0, meta)
 
+    # We deliberately hold off rendering some properties at load time because there is not enough information available
+    # at load time to render them. They will get rendered later at evaluation time
+    unrendered_properties = {}
     unrendered_merge_filter = None
-    unrendered_signals = None
-    unrendered_audits = None
 
     for prop in meta.expressions:
-        if prop.name.lower() == "signals":
-            unrendered_signals = prop.args.get("value")
-        if prop.name.lower() == "audits":
-            unrendered_audits = prop.args.get("value")
-        if (
+        prop_name = prop.name.lower()
+        if prop_name in ("signals", "audits", "physical_properties"):
+            unrendered_properties[prop_name] = prop.args.get("value")
+        elif (
             prop.name.lower() == "kind"
             and (value := prop.args.get("value"))
             and value.name.lower() == "incremental_by_unique_key"
@@ -1839,12 +1859,9 @@ def load_sql_based_model(
         **kwargs,
     }
 
-    # signals, audits and merge_filter must remain unrendered, so that they can be rendered later at evaluation runtime
-    if unrendered_signals:
-        meta_fields["signals"] = unrendered_signals
-
-    if unrendered_audits:
-        meta_fields["audits"] = unrendered_audits
+    # Discard the potentially half-rendered versions of these properties and replace them with the
+    # original unrendered versions. They will get rendered properly at evaluation time
+    meta_fields.update(unrendered_properties)
 
     if unrendered_merge_filter:
         for idx, kind_prop in enumerate(meta_fields["kind"].expressions):
@@ -2146,6 +2163,10 @@ def _create_model(
         statements.extend(kwargs["post_statements"])
     if "on_virtual_update" in kwargs:
         statements.extend(kwargs["on_virtual_update"])
+    if physical_properties := kwargs.get("physical_properties"):
+        # to allow variables like @gateway to be used in physical_properties
+        # since rendering shifted from load time to run time
+        statements.extend(physical_properties)
 
     jinja_macro_references, used_variables = extract_macro_references_and_variables(
         *(gen(e) for e in statements)

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -590,6 +590,28 @@ class SnapshotEvaluator:
         # If there are no existing intervals yet; only consider this a first insert for the first snapshot in the batch
         is_first_insert = not _intervals(snapshot, deployability_index) and batch_index == 0
 
+        from sqlmesh.core.context import ExecutionContext
+
+        common_render_kwargs = dict(
+            start=start,
+            end=end,
+            execution_time=execution_time,
+            snapshot=snapshot,
+            runtime_stage=RuntimeStage.EVALUATING,
+            **kwargs,
+        )
+
+        render_statements_kwargs = dict(
+            engine_adapter=adapter,
+            snapshots=snapshots,
+            deployability_index=deployability_index,
+            **common_render_kwargs,
+        )
+
+        rendered_physical_properties = snapshot.model.render_physical_properties(
+            **render_statements_kwargs
+        )
+
         def apply(query_or_df: QueryOrDF, index: int = 0) -> None:
             if index > 0:
                 evaluation_strategy.append(
@@ -603,6 +625,7 @@ class SnapshotEvaluator:
                     start=start,
                     end=end,
                     execution_time=execution_time,
+                    physical_properties=rendered_physical_properties,
                 )
             else:
                 logger.info(
@@ -623,25 +646,8 @@ class SnapshotEvaluator:
                     start=start,
                     end=end,
                     execution_time=execution_time,
+                    physical_properties=rendered_physical_properties,
                 )
-
-        from sqlmesh.core.context import ExecutionContext
-
-        common_render_kwargs = dict(
-            start=start,
-            end=end,
-            execution_time=execution_time,
-            snapshot=snapshot,
-            runtime_stage=RuntimeStage.EVALUATING,
-            **kwargs,
-        )
-
-        render_statements_kwargs = dict(
-            engine_adapter=adapter,
-            snapshots=snapshots,
-            deployability_index=deployability_index,
-            **common_render_kwargs,
-        )
 
         with adapter.transaction(), adapter.session(snapshot.model.session_properties):
             wap_id: t.Optional[str] = None
@@ -754,6 +760,9 @@ class SnapshotEvaluator:
 
         with adapter.transaction(), adapter.session(snapshot.model.session_properties):
             adapter.execute(snapshot.model.render_pre_statements(**pre_post_render_kwargs))
+            rendered_physical_properties = snapshot.model.render_physical_properties(
+                **create_render_kwargs
+            )
 
             if (
                 snapshot.is_forward_only
@@ -781,6 +790,7 @@ class SnapshotEvaluator:
                     ),
                     is_snapshot_deployable=is_snapshot_deployable,
                     is_snapshot_representative=is_snapshot_representative,
+                    physical_properties=rendered_physical_properties,
                 )
                 try:
                     adapter.clone_table(target_table_name, snapshot.table_name(), replace=True)
@@ -820,6 +830,7 @@ class SnapshotEvaluator:
                         is_snapshot_deployable=is_snapshot_deployable,
                         is_snapshot_representative=is_snapshot_representative,
                         dry_run=dry_run,
+                        physical_properties=rendered_physical_properties,
                     )
 
             adapter.execute(snapshot.model.render_post_statements(**pre_post_render_kwargs))
@@ -883,6 +894,7 @@ class SnapshotEvaluator:
                     is_snapshot_deployable=True,
                     is_snapshot_representative=True,
                     dry_run=False,
+                    physical_properties=snapshot.model.render_physical_properties(**render_kwargs),
                 )
                 adapter.execute(snapshot.model.render_post_statements(**render_kwargs))
 
@@ -1204,7 +1216,9 @@ class EvaluationStrategy(abc.ABC):
             view_name: The name of the target view in the virtual layer.
         """
 
-    def _replace_query_for_model(self, model: Model, name: str, query_or_df: QueryOrDF) -> None:
+    def _replace_query_for_model(
+        self, model: Model, name: str, query_or_df: QueryOrDF, **kwargs: t.Any
+    ) -> None:
         """Replaces the table for the given model.
 
         Args:
@@ -1226,7 +1240,7 @@ class EvaluationStrategy(abc.ABC):
             partitioned_by=model.partitioned_by,
             partition_interval_unit=model.partition_interval_unit,
             clustered_by=model.clustered_by,
-            table_properties=model.physical_properties,
+            table_properties=kwargs.get("physical_properties", model.physical_properties),
             table_description=model.description,
             column_descriptions=model.column_descriptions,
             columns_to_types=columns_to_types,
@@ -1345,6 +1359,7 @@ class MaterializableStrategy(PromotableStrategy):
         **kwargs: t.Any,
     ) -> None:
         ctas_query = model.ctas_query(**render_kwargs)
+        physical_properties = kwargs.get("physical_properties", model.physical_properties)
 
         logger.info("Creating table '%s'", table_name)
         if model.annotated:
@@ -1356,7 +1371,7 @@ class MaterializableStrategy(PromotableStrategy):
                 partitioned_by=model.partitioned_by,
                 partition_interval_unit=model.partition_interval_unit,
                 clustered_by=model.clustered_by,
-                table_properties=model.physical_properties,
+                table_properties=physical_properties,
                 table_description=model.description if is_table_deployable else None,
                 column_descriptions=model.column_descriptions if is_table_deployable else None,
             )
@@ -1380,7 +1395,7 @@ class MaterializableStrategy(PromotableStrategy):
                 partitioned_by=model.partitioned_by,
                 partition_interval_unit=model.partition_interval_unit,
                 clustered_by=model.clustered_by,
-                table_properties=model.physical_properties,
+                table_properties=physical_properties,
                 table_description=model.description if is_table_deployable else None,
                 column_descriptions=model.column_descriptions if is_table_deployable else None,
             )
@@ -1415,7 +1430,7 @@ class IncrementalByPartitionStrategy(MaterializableStrategy):
         **kwargs: t.Any,
     ) -> None:
         if is_first_insert:
-            self._replace_query_for_model(model, table_name, query_or_df)
+            self._replace_query_for_model(model, table_name, query_or_df, **kwargs)
         else:
             self.adapter.insert_overwrite_by_partition(
                 table_name,
@@ -1455,7 +1470,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
         **kwargs: t.Any,
     ) -> None:
         if is_first_insert:
-            self._replace_query_for_model(model, table_name, query_or_df)
+            self._replace_query_for_model(model, table_name, query_or_df, **kwargs)
         else:
             self.adapter.merge(
                 table_name,
@@ -1501,7 +1516,7 @@ class IncrementalUnmanagedStrategy(MaterializableStrategy):
         **kwargs: t.Any,
     ) -> None:
         if is_first_insert:
-            self._replace_query_for_model(model, table_name, query_or_df)
+            self._replace_query_for_model(model, table_name, query_or_df, **kwargs)
         elif isinstance(model.kind, IncrementalUnmanagedKind) and model.kind.insert_overwrite:
             self.adapter.insert_overwrite_by_partition(
                 table_name,
@@ -1527,7 +1542,7 @@ class FullRefreshStrategy(MaterializableStrategy):
         is_first_insert: bool,
         **kwargs: t.Any,
     ) -> None:
-        self._replace_query_for_model(model, table_name, query_or_df)
+        self._replace_query_for_model(model, table_name, query_or_df, **kwargs)
 
 
 class SeedStrategy(MaterializableStrategy):
@@ -1556,7 +1571,7 @@ class SeedStrategy(MaterializableStrategy):
             try:
                 for index, df in enumerate(model.render_seed()):
                     if index == 0:
-                        self._replace_query_for_model(model, table_name, df)
+                        self._replace_query_for_model(model, table_name, df, **kwargs)
                     else:
                         self.adapter.insert_append(
                             table_name, df, columns_to_types=model.columns_to_types
@@ -1600,7 +1615,7 @@ class SCDType2Strategy(MaterializableStrategy):
                 partitioned_by=model.partitioned_by,
                 partition_interval_unit=model.partition_interval_unit,
                 clustered_by=model.clustered_by,
-                table_properties=model.physical_properties,
+                table_properties=kwargs.get("physical_properties", model.physical_properties),
                 table_description=model.description if is_table_deployable else None,
                 column_descriptions=model.column_descriptions if is_table_deployable else None,
             )
@@ -1746,7 +1761,7 @@ class ViewStrategy(PromotableStrategy):
             model.columns_to_types,
             replace=not self.adapter.HAS_VIEW_BINDING,
             materialized=self._is_materialized_view(model),
-            view_properties=model.physical_properties,
+            view_properties=kwargs.get("physical_properties", model.physical_properties),
             table_description=model.description,
             column_descriptions=model.column_descriptions,
         )
@@ -1801,7 +1816,7 @@ class ViewStrategy(PromotableStrategy):
             replace=False,
             materialized=self._is_materialized_view(model),
             materialized_properties=materialized_properties,
-            view_properties=model.physical_properties,
+            view_properties=kwargs.get("physical_properties", model.physical_properties),
             table_description=model.description if is_table_deployable else None,
             column_descriptions=model.column_descriptions if is_table_deployable else None,
         )
@@ -1815,16 +1830,16 @@ class ViewStrategy(PromotableStrategy):
     ) -> None:
         logger.info("Migrating view '%s'", target_table_name)
         model = snapshot.model
+        render_kwargs = dict(
+            execution_time=now(), snapshots=kwargs["snapshots"], engine_adapter=self.adapter
+        )
+
         self.adapter.create_view(
             target_table_name,
-            model.render_query_or_raise(
-                execution_time=now(),
-                snapshots=kwargs["snapshots"],
-                engine_adapter=self.adapter,
-            ),
+            model.render_query_or_raise(**render_kwargs),
             model.columns_to_types,
             materialized=self._is_materialized_view(model),
-            view_properties=model.physical_properties,
+            view_properties=model.render_physical_properties(**render_kwargs),
             table_description=model.description,
             column_descriptions=model.column_descriptions,
         )
@@ -1928,7 +1943,7 @@ class EngineManagedStrategy(MaterializableStrategy):
                 columns_to_types=model.columns_to_types,
                 partitioned_by=model.partitioned_by,
                 clustered_by=model.clustered_by,
-                table_properties=model.physical_properties,
+                table_properties=kwargs.get("physical_properties", model.physical_properties),
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
             )
@@ -1964,7 +1979,7 @@ class EngineManagedStrategy(MaterializableStrategy):
                 columns_to_types=model.columns_to_types,
                 partitioned_by=model.partitioned_by,
                 clustered_by=model.clustered_by,
-                table_properties=model.physical_properties,
+                table_properties=kwargs.get("physical_properties", model.physical_properties),
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
             )
@@ -1976,7 +1991,9 @@ class EngineManagedStrategy(MaterializableStrategy):
                 table_name,
                 model.name,
             )
-            self._replace_query_for_model(model=model, name=table_name, query_or_df=query_or_df)
+            self._replace_query_for_model(
+                model=model, name=table_name, query_or_df=query_or_df, **kwargs
+            )
 
     def append(
         self,

--- a/tests/core/engine_adapter/integration/test_integration_trino.py
+++ b/tests/core/engine_adapter/integration/test_integration_trino.py
@@ -1,0 +1,110 @@
+import typing as t
+import pytest
+from pathlib import Path
+from sqlmesh.core.engine_adapter import TrinoEngineAdapter
+from tests.core.engine_adapter.integration import TestContext
+from sqlglot import parse_one, exp
+
+pytestmark = [pytest.mark.docker, pytest.mark.engine, pytest.mark.trino]
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            "trino",
+            marks=[
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.trino,
+            ],
+        ),
+        pytest.param(
+            "trino_iceberg",
+            marks=[
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.trino_iceberg,
+            ],
+        ),
+        pytest.param(
+            "trino_delta",
+            marks=[
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.trino_delta,
+            ],
+        ),
+        pytest.param(
+            "trino_nessie",
+            marks=[
+                pytest.mark.docker,
+                pytest.mark.engine,
+                pytest.mark.trino_nessie,
+            ],
+        ),
+    ]
+)
+def mark_gateway(request) -> t.Tuple[str, str]:
+    return request.param, f"inttest_{request.param}"
+
+
+@pytest.fixture
+def test_type() -> str:
+    return "query"
+
+
+def test_macros_in_physical_properties(
+    tmp_path: Path, ctx: TestContext, engine_adapter: TrinoEngineAdapter
+):
+    if "iceberg" not in ctx.gateway:
+        pytest.skip("This test only needs to be run once")
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir(parents=True)
+
+    schema = ctx.schema()
+
+    with open(models_dir / "test_model.sql", "w") as f:
+        f.write(
+            """
+        MODEL (
+            name SCHEMA.test,
+            kind FULL,
+            physical_properties (
+                location = @physical_location('s3://trino/@{catalog_name}/@{schema_name}/@{table_name}'),
+                sorted_by = @if(@gateway = 'inttest_trino_iceberg', ARRAY['col_a'], ARRAY['col_b'])
+            )
+        );
+
+        select 1 as col_a, 2 as col_b;
+        """.replace("SCHEMA", schema)
+        )
+
+    context = ctx.create_context(path=tmp_path)
+    assert len(context.models) == 1
+
+    plan_result = context.plan(auto_apply=True, no_prompts=True)
+
+    assert len(plan_result.new_snapshots) == 1
+
+    snapshot = plan_result.new_snapshots[0]
+
+    physical_table_str = snapshot.table_name()
+    physical_table = exp.to_table(physical_table_str)
+    create_sql = list(engine_adapter.fetchone(f"show create table {physical_table}") or [])[0]
+
+    parsed_create_sql = parse_one(create_sql, dialect="trino")
+
+    location_property = parsed_create_sql.find(exp.LocationProperty)
+    assert location_property
+
+    assert "@{table_name}" not in location_property.sql(dialect="trino")
+    assert (
+        location_property.text("this")
+        == f"s3://trino/{physical_table.catalog}/{physical_table.db}/{physical_table.name}"
+    )
+
+    sorted_by_property = next(
+        p for p in parsed_create_sql.find_all(exp.Property) if "sorted_by" in p.sql(dialect="trino")
+    )
+    assert sorted_by_property.sql(dialect="trino") == "sorted_by=ARRAY['col_a ASC NULLS FIRST']"

--- a/tests/core/engine_adapter/integration/test_integration_trino.py
+++ b/tests/core/engine_adapter/integration/test_integration_trino.py
@@ -71,7 +71,7 @@ def test_macros_in_physical_properties(
             name SCHEMA.test,
             kind FULL,
             physical_properties (
-                location = @physical_location('s3://trino/@{catalog_name}/@{schema_name}/@{table_name}'),
+                location = @resolve_template('s3://trino/@{catalog_name}/@{schema_name}/@{table_name}'),
                 sorted_by = @if(@gateway = 'inttest_trino_iceberg', ARRAY['col_a'], ARRAY['col_b'])
             )
         );

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -1023,9 +1023,9 @@ def test_macro_union(assert_exp_eq, macro_evaluator: MacroEvaluator):
     assert_exp_eq(macro_evaluator.transform(parse_one(sql)), expected_sql)
 
 
-def test_physical_location_literal():
+def test_resolve_template_literal():
     parsed_sql = parse_one(
-        "@physical_location('s3://data-bucket/prod/@{catalog_name}/@{schema_name}/@{table_name}')"
+        "@resolve_template('s3://data-bucket/prod/@{catalog_name}/@{schema_name}/@{table_name}')"
     )
 
     # Loading
@@ -1064,9 +1064,9 @@ def test_physical_location_literal():
     )
 
 
-def test_physical_location_table():
+def test_resolve_template_table():
     parsed_sql = parse_one(
-        "SELECT * FROM @physical_location('@{catalog_name}.@{schema_name}.@{table_name}$partitions', mode := 'table')"
+        "SELECT * FROM @resolve_template('@{catalog_name}.@{schema_name}.@{table_name}$partitions', mode := 'table')"
     )
 
     evaluator = MacroEvaluator(runtime_stage=RuntimeStage.CREATING)

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -5256,11 +5256,11 @@ def test_macros_in_physical_properties(make_snapshot):
             name test.test_model,
             kind FULL,
             physical_properties (
-                location1 = @physical_location('s3://bucket/prefix/@{schema_name}/@{table_name}'),
+                location1 = @resolve_template('s3://bucket/prefix/@{schema_name}/@{table_name}'),
                 location2 = @IF(
                     @gateway = 'dev',
-                    @physical_location('hdfs://@{catalog_name}/@{schema_name}/dev/@{table_name}'),
-                    @physical_location('s3://prod/@{table_name}')
+                    @resolve_template('hdfs://@{catalog_name}/@{schema_name}/dev/@{table_name}'),
+                    @resolve_template('s3://prod/@{table_name}')
                 ),
                 sort_order = @IF(@gateway = 'prod', 'desc', 'asc')
             )


### PR DESCRIPTION
This PR:
 - Moves evaluation of `physical_properties` to run time instead of load time
   - This enables the usage of things that only exist at run time, such as `@this_model`
 - Adds a macro called `@physical_location` that allows a user to create arbitrary `exp.Literal` or `exp.Table` objects in the AST based on the *parts* of the physical table name

The motivation is twofold:
 - Right now, there is no way to set custom locations for tables on engines that separate storage and compute (Athena, Trino, Spark etc). This is true even if you write a custom macro and reference it from `physical_properties`, because `physical_properties` is currently rendered at load time which means no snapshot info is available
- Right now, `@this_model` [returns a fully rendered FQN string](https://github.com/TobikoData/sqlmesh/blob/a85a8b25be6c943a75ad282fbe84efa6ff9a0ae2/sqlmesh/core/macros.py#L452) which makes it difficult to work with. We can't change this without breaking backwards compatibility, but we can introduce something else that allows users to build new strings based on the *components* of the FQN, rather than the FQN itself

