### PR TITLE
Chore: Fix CI from failing linting checks

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -329,7 +329,11 @@ class ModelTest(unittest.TestCase):
         name = normalize_model_name(name, default_catalog=default_catalog, dialect=dialect)
         model = models.get(name)
         if not model:
-            logger.warning(f"Model '{name}' was not found{' at ' + str(path) if path else ''}")
+            from sqlmesh.core.console import get_console
+
+            get_console().log_warning(
+                f"Model '{name}' was not found{' at ' + str(path) if path else ''}"
+            )
             return None
 
         if isinstance(model, SqlModel):

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -72,6 +72,7 @@ def convert_all_html_output_to_text():
     return _convert
 
 
+@t.no_type_check
 @pytest.fixture
 def convert_all_html_output_to_tags():
     def _convert_html_to_tags(html: str) -> t.List[str]:


### PR DESCRIPTION
Lint checks are currently causing [builds to fail](https://app.circleci.com/pipelines/github/TobikoData/sqlmesh/18076/workflows/a3143b12-4a1a-4c74-940e-c31eccd35a0a/jobs/163228)

I'm not entirely sure what's causing the failures in `test_magics` because mypy version is pinned. But this check:

```
sqlmesh/core/test/definition.py:332: error: Name "logger" is not defined 
```

Is quite legitimate, the issue got introduced in [this PR](https://github.com/TobikoData/sqlmesh/pull/3765) which wasn't aware of [another PR](https://github.com/TobikoData/sqlmesh/pull/3763) that got merged to main first