### PR TITLE
Chore: Address Clickhouse Cloud test flakiness

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -308,15 +308,15 @@ workflows:
             parameters:
               engine:
                 - snowflake
-                - databricks
-                - redshift
-                - bigquery
+                #- databricks
+                #- redshift
+                #- bigquery
                 - clickhouse-cloud
-                - athena
-          filters:
-           branches:
-             only:
-               - main
+                #- athena
+          #filters:
+          # branches:
+          #   only:
+          #     - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -308,15 +308,15 @@ workflows:
             parameters:
               engine:
                 - snowflake
-                #- databricks
-                #- redshift
-                #- bigquery
+                - databricks
+                - redshift
+                - bigquery
                 - clickhouse-cloud
-                #- athena
-          #filters:
-          # branches:
-          #   only:
-          #     - main
+                - athena
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/.circleci/manage-test-db.sh
+++ b/.circleci/manage-test-db.sh
@@ -97,12 +97,16 @@ bigquery_init() {
     echo "$BIGQUERY_KEYFILE_CONTENTS" > $BIGQUERY_KEYFILE
 }
 
-bigquery_up() {
-    echo "BigQuery doesnt support creating databases"
-}
 
-bigquery_down() {
-    echo "BigQuery doesnt support dropping databases"
+# Clickhouse cloud
+clickhouse-cloud_init() {
+    # note: the ping endpoint doesnt seem to need any API keys
+    until curl https://$CLICKHOUSE_CLOUD_HOST:8443/ping
+    do
+        echo "Pinging Clickhouse Cloud service to ensure it's not in idle mode..."
+        sleep 5
+    done
+    echo "Clickhouse Cloud instance $CLICKHOUSE_CLOUD_HOST is up and running"
 }
 
 INIT_FUNC="${ENGINE}_init"
@@ -118,10 +122,10 @@ fi
 echo "Initializing $ENGINE"
 $INIT_FUNC
 
-if [ "$DIRECTION" == "up" ]; then
+if [ "$DIRECTION" == "up" ] && function_exists $UP_FUNC; then
     echo "Creating database $DB_NAME"
     $UP_FUNC $DB_NAME
-elif [ "$DIRECTION" == "down" ]; then
+elif [ "$DIRECTION" == "down" ] && function_exists $DOWN_FUNC; then
     echo "Dropping database $DB_NAME"
     $DOWN_FUNC $DB_NAME
 fi

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ redshift-test: guard-REDSHIFT_HOST guard-REDSHIFT_USER guard-REDSHIFT_PASSWORD g
 	pytest -n auto -x -m "redshift" --retries 3 --junitxml=test-results/junit-redshift.xml
 
 clickhouse-cloud-test: guard-CLICKHOUSE_CLOUD_HOST guard-CLICKHOUSE_CLOUD_USERNAME guard-CLICKHOUSE_CLOUD_PASSWORD engine-clickhouse-install
-	pytest -n auto -x -m "clickhouse_cloud" --retries 3 --junitxml=test-results/junit-clickhouse-cloud.xml
+	pytest -n 1 -m "clickhouse_cloud" --retries 3 --junitxml=test-results/junit-clickhouse-cloud.xml
 
 athena-test: guard-AWS_ACCESS_KEY_ID guard-AWS_SECRET_ACCESS_KEY guard-ATHENA_S3_WAREHOUSE_LOCATION engine-athena-install
 	pytest -n auto -x -m "athena" --retries 3 --retry-delay 10 --junitxml=test-results/junit-athena.xml

--- a/tests/core/engine_adapter/integration/config.yaml
+++ b/tests/core/engine_adapter/integration/config.yaml
@@ -150,6 +150,8 @@ gateways:
       username: {{ env_var("CLICKHOUSE_CLOUD_USERNAME") }}
       password: {{ env_var("CLICKHOUSE_CLOUD_PASSWORD") }}
       connect_timeout: 30
+      connection_pool_options:
+        retries: 5
     state_connection:
       type: duckdb
 

--- a/tests/core/engine_adapter/integration/config.yaml
+++ b/tests/core/engine_adapter/integration/config.yaml
@@ -149,6 +149,7 @@ gateways:
       port: 8443
       username: {{ env_var("CLICKHOUSE_CLOUD_USERNAME") }}
       password: {{ env_var("CLICKHOUSE_CLOUD_PASSWORD") }}
+      connect_timeout: 30
     state_connection:
       type: duckdb
 


### PR DESCRIPTION
This PR attempts to debug the following issue noticed in the failing clickhouse cloud tests on main:
```
 http.client.RemoteDisconnected: Remote end closed connection without response
```

It looks like Clickhouse Cloud can now go into an `idle` state. I added a pre-ping to ensure the cicd instance is running before triggering the tests.

However, the issue still occurred. So I set:
```
connect_timeout: 30
```
on the connection config (previously it was using the default value of 10).

This actually did fix the connection issue but it raised another issue:

```
DB::Exception: Too many databases. The limit (server configuration parameter `max_database_num_to_throw`) is set to 100, the current number of databases is 272.
```

So it looks like Clickhouse Cloud is now limiting the number of "databases" (schemas) that you can have on a single instance. I cleared out a bunch of test schemas left over from failed runs and now the tests can run successfully again.

After this, I still experienced some flakiness. I reduced the pytest concurrency to 1 and increased the number of HTTP retries on the Clickhouse connection pool. I also removed the `-x` option because I notice it conflicts with `pytest-retry` and results in `pytest-retry` not retrying tests (this is a problem for the other engine adapter integration tests too, however that can be addressed in a different PR)