### PR TITLE
Chore: replace mysql-connector-python with pymysql

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ setup(
             "pymssql",
         ],
         "mysql": [
-            "mysql-connector-python",
+            "pymysql",
         ],
         "mwaa": [
             "boto3",

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ setup(
             "trino",
             "types-croniter",
             "types-dateparser",
+            "types-PyMySQL",
             "types-python-dateutil",
             "types-pytz",
             "types-requests==2.28.8",

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -109,7 +109,6 @@ class EngineAdapter:
         dialect: str = "",
         sql_gen_kwargs: t.Optional[t.Dict[str, Dialect | bool | str]] = None,
         multithreaded: bool = False,
-        cursor_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
         cursor_init: t.Optional[t.Callable[[t.Any], None]] = None,
         default_catalog: t.Optional[str] = None,
         execute_log_level: int = logging.DEBUG,
@@ -120,7 +119,7 @@ class EngineAdapter:
     ):
         self.dialect = dialect.lower() or self.DIALECT
         self._connection_pool = create_connection_pool(
-            connection_factory, multithreaded, cursor_kwargs=cursor_kwargs, cursor_init=cursor_init
+            connection_factory, multithreaded, cursor_init=cursor_init
         )
         self._sql_gen_kwargs = sql_gen_kwargs or {}
         self._default_catalog = default_catalog

--- a/sqlmesh/utils/connection_pool.py
+++ b/sqlmesh/utils/connection_pool.py
@@ -115,7 +115,6 @@ class ThreadLocalConnectionPool(_TransactionManagementMixin):
     def __init__(
         self,
         connection_factory: t.Callable[[], t.Any],
-        cursor_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
         cursor_init: t.Optional[t.Callable[[t.Any], None]] = None,
     ):
         self._connection_factory = connection_factory
@@ -126,14 +125,13 @@ class ThreadLocalConnectionPool(_TransactionManagementMixin):
         self._thread_connections_lock = Lock()
         self._thread_cursors_lock = Lock()
         self._thread_transactions_lock = Lock()
-        self._cursor_kwargs = cursor_kwargs or {}
         self._cursor_init = cursor_init
 
     def get_cursor(self) -> t.Any:
         thread_id = get_ident()
         with self._thread_cursors_lock:
             if thread_id not in self._thread_cursors:
-                self._thread_cursors[thread_id] = self.get().cursor(**self._cursor_kwargs)
+                self._thread_cursors[thread_id] = self.get().cursor()
                 if self._cursor_init:
                     self._cursor_init(self._thread_cursors[thread_id])
             return self._thread_cursors[thread_id]
@@ -209,20 +207,18 @@ class SingletonConnectionPool(_TransactionManagementMixin):
     def __init__(
         self,
         connection_factory: t.Callable[[], t.Any],
-        cursor_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
         cursor_init: t.Optional[t.Callable[[t.Any], None]] = None,
     ):
         self._connection_factory = connection_factory
         self._connection: t.Optional[t.Any] = None
         self._cursor: t.Optional[t.Any] = None
-        self._cursor_kwargs = cursor_kwargs or {}
         self._attributes: t.Dict[str, t.Any] = {}
         self._is_transaction_active: bool = False
         self._cursor_init = cursor_init
 
     def get_cursor(self) -> t.Any:
         if not self._cursor:
-            self._cursor = self.get().cursor(**self._cursor_kwargs)
+            self._cursor = self.get().cursor()
             if self._cursor_init:
                 self._cursor_init(self._cursor)
         return self._cursor
@@ -273,17 +269,12 @@ class SingletonConnectionPool(_TransactionManagementMixin):
 def create_connection_pool(
     connection_factory: t.Callable[[], t.Any],
     multithreaded: bool,
-    cursor_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
     cursor_init: t.Optional[t.Callable[[t.Any], None]] = None,
 ) -> ConnectionPool:
     return (
-        ThreadLocalConnectionPool(
-            connection_factory, cursor_kwargs=cursor_kwargs, cursor_init=cursor_init
-        )
+        ThreadLocalConnectionPool(connection_factory, cursor_init=cursor_init)
         if multithreaded
-        else SingletonConnectionPool(
-            connection_factory, cursor_kwargs=cursor_kwargs, cursor_init=cursor_init
-        )
+        else SingletonConnectionPool(connection_factory, cursor_init=cursor_init)
     )
 
 


### PR DESCRIPTION
Notes

1. Added connection params:
    - `database` (so users are able to connect to a specific database [MySQL schema equivalent])
    - `collation` (if you're changing the charset you will likely also want to change collation)

2. Cursor buffering
    - The current implementation uses buffered fetching by passing the `buffered=True` argument during cursor creation
    - This is not necessary with pymysql, as the [cursor is buffered by default](https://github.com/PyMySQL/PyMySQL/blob/01af30fea0880c3b72e6c7b3b05d66a8c28ced7a/pymysql/cursors.py#L83)

Implementation detail

- We no longer need to pass the `buffered` arg during cursor creation, so I removed `_cursor_kwargs()` entirely (it was only added for and used by MySQL)