### PR TITLE
Fix!: ensure unsafe catalog identifiers are quoted before parsed

### DIFF
--- a/sqlmesh/core/engine_adapter/shared.py
+++ b/sqlmesh/core/engine_adapter/shared.py
@@ -317,6 +317,7 @@ def set_catalog(override_mapping: t.Optional[t.Dict[str, CatalogSupport]] = None
             catalog_name = expression.catalog
             if not catalog_name:
                 return func(*list_args, **kwargs)
+
             # If we have a catalog and this engine doesn't support catalogs then we need to error
             if catalog_support.is_unsupported:
                 raise UnsupportedCatalogOperationError(

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1478,7 +1478,7 @@ def table_name(
     table.set("this", exp.to_identifier(f"{name}__{version}{temp_suffix}"))
     table.set("db", exp.to_identifier(physical_schema))
     if not table.catalog and catalog:
-        table.set("catalog", exp.parse_identifier(catalog))
+        table.set("catalog", exp.to_identifier(catalog))
     return exp.table_name(table)
 
 


### PR DESCRIPTION
Fixes #3783