### PR TITLE
Feat: Add 'auditing' and 'promoting' runtime stages

### DIFF
--- a/docs/concepts/macros/macro_variables.md
+++ b/docs/concepts/macros/macro_variables.md
@@ -126,6 +126,8 @@ SQLMesh provides two other predefined variables used to modify model behavior ba
     * 'loading' - The project is being loaded into SQLMesh's runtime context.
     * 'creating' - The model tables are being created.
     * 'evaluating' - The model query logic is being evaluated.
+    * 'promoting' - The model is being promoted in the target environment (virtual layer update).
+    * 'auditing' - The audit is being run.
     * 'testing' - The model query logic is being evaluated in the context of a unit test.
 * @gateway - A string value containing the name of the current [gateway](../../guides/connections.md).
 * @this_model - A string value containing the name of the physical table the model view selects from. Typically used to create [generic audits](../audits.md#generic-audits). In the case of [on_virtual_update statements](../models/sql_models.md#optional-on-virtual-update-statements) it contains the qualified view name instead.

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -60,6 +60,8 @@ class RuntimeStage(Enum):
     LOADING = "loading"
     CREATING = "creating"
     EVALUATING = "evaluating"
+    PROMOTING = "promoting"
+    AUDITING = "auditing"
     TESTING = "testing"
 
 

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -918,6 +918,7 @@ class SnapshotEvaluator:
                 snapshots=snapshots,
                 deployability_index=deployability_index,
                 table_mapping=table_mapping,
+                runtime_stage=RuntimeStage.PROMOTING,
             )
             adapter.execute(snapshot.model.render_on_virtual_update(**render_kwargs))
 
@@ -1006,6 +1007,7 @@ class SnapshotEvaluator:
             "snapshots": snapshots,
             "deployability_index": deployability_index,
             "engine_adapter": adapter,
+            "runtime_stage": RuntimeStage.AUDITING,
             **audit_args,
             **kwargs,
         }


### PR DESCRIPTION
We render queries when executing audits as well as `on_virtual_update` statements, however neither has a runtime stage associated with it. This PR addresses the gap.