### PR TITLE
fix: databricks set default catalog for both connections

### DIFF
--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -51,6 +51,8 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
         self._set_spark_engine_adapter_if_needed()
+        # Set the default catalog for both connections to make sure they are aligned
+        self.set_current_catalog(self.default_catalog)  # type: ignore
 
     @classmethod
     def can_access_spark_session(cls, disable_spark_session: bool) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -440,6 +440,7 @@ def make_mocked_engine_adapter(mocker: MockerFixture) -> t.Callable:
         klass: t.Type[T],
         dialect: t.Optional[str] = None,
         register_comments: bool = True,
+        default_catalog: t.Optional[str] = None,
         **kwargs: t.Any,
     ) -> T:
         connection_mock = mocker.NonCallableMock()
@@ -450,6 +451,7 @@ def make_mocked_engine_adapter(mocker: MockerFixture) -> t.Callable:
             lambda: connection_mock,
             dialect=dialect or klass.DIALECT,
             register_comments=register_comments,
+            default_catalog=default_catalog,
             **kwargs,
         )
         if isinstance(adapter, SparkEngineAdapter):


### PR DESCRIPTION
Follow up to: https://github.com/TobikoData/sqlmesh/pull/3786

In our tests we had some code which references to schemas/tables without a catalog and therefore relies on the connection default catalog to resolve to the correct schema/table. This doesn't match SQLMesh code since we always fully qualify references. Therefore some tests would fail if the default catalog was set incorrectly. This could happen if the SQL connector default catalog and databricks-connect default catalog were different and produce unexpected behavior. This change forces the two to be aligned to the default catalog the user provided or the default catalog returned by the connection (with databricks-connect preferred if configured). 

If a user reports an issue with this line, then it likely means they did not have a default catalog defined in their connection and the one returned by either databricks-connect or the sql connector was an unexpected value. The fix would be to have the user define a catalog in their connection. 