### PR TITLE
Chore: remove [missing dates] from CLI model backfills title

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1055,7 +1055,7 @@ class TerminalConsole(Console):
         missing_intervals = plan.missing_intervals
         if not missing_intervals:
             return
-        backfill = Tree("[bold]Models needing backfill \\[missing dates]:")
+        backfill = Tree("[bold]Models needing backfill:[/bold]")
         for missing in missing_intervals:
             snapshot = plan.context_diff.snapshots[missing.snapshot_id]
             if not snapshot.is_model:
@@ -1923,7 +1923,7 @@ class MarkdownConsole(CaptureTerminalConsole):
         missing_intervals = plan.missing_intervals
         if not missing_intervals:
             return
-        self._print("\n**Models needing backfill \\[missing dates]:**")
+        self._print("\n**Models needing backfill:**")
         snapshots = []
         for missing in missing_intervals:
             snapshot = plan.context_diff.snapshots[missing.snapshot_id]

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -379,7 +379,7 @@ def test_merge_pr_has_non_breaking_change_diff_start(
 - `sushi.top_waiters`
 
 
-**Models needing backfill [missing dates]:**
+**Models needing backfill:**
 * `sushi.waiter_revenue_by_day`: [2022-12-25 - 2022-12-28]
 """
     assert prod_plan_preview_checks_runs[2]["output"]["summary"] == expected_prod_plan
@@ -1066,7 +1066,7 @@ def test_no_merge_since_no_deploy_signal_no_approvers_defined(
 - `sushi.top_waiters`
 
 
-**Models needing backfill [missing dates]:**
+**Models needing backfill:**
 * `sushi.waiter_revenue_by_day`: [2022-12-25 - 2022-12-29]
 """
     assert prod_plan_preview_checks_runs[2]["output"]["title"] == "Prod Plan Preview"


### PR DESCRIPTION
No longer accurate because we now display other information for non-incremental models