### PR TITLE
Fix: Only promote all snapshots if the target environment expired

### DIFF
--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -332,7 +332,7 @@ class EngineAdapterStateSync(StateSync):
         if (
             existing_environment
             and existing_environment.finalized_ts
-            and not existing_environment.expiration_ts
+            and not existing_environment.expired
         ):
             # Only promote new snapshots.
             added_table_infos -= set(existing_environment.promoted_snapshots)


### PR DESCRIPTION
There was an oversight where I checked for whether the expiration timestamp was set instead of checking whether the environment was actually expired.