### PR TITLE
fix: db properly support `with_log_level`

### DIFF
--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -103,7 +103,7 @@ def test_set_current_catalog(mocker: MockFixture, make_mocked_engine_adapter: t.
     adapter = make_mocked_engine_adapter(DatabricksEngineAdapter, default_catalog="test_catalog")
     adapter.set_current_catalog("test_catalog2")
 
-    assert to_sql_calls(adapter) == ["USE CATALOG `test_catalog`", "USE CATALOG `test_catalog2`"]
+    assert to_sql_calls(adapter) == ["USE CATALOG `test_catalog2`"]
 
 
 def test_get_current_catalog(mocker: MockFixture, make_mocked_engine_adapter: t.Callable):


### PR DESCRIPTION
Follow up to: https://github.com/TobikoData/sqlmesh/pull/3793

The key thing that was missing in prior PR was properly supporting the `with_log_level` method. It creates a copy of the engine adapter but since it doesn't want to create a new connection is creates it with a placeholder connection. The issue is that databricks engine adapter tries to set the default engine adapter after creation and then when it tries to do that with the placeholder connection it gets an error.

I moved the set_current_catalog to the `_begin_session` method so although now it will run multiple times it does more lazily run it which gets around the `with_log_level` issue. 

I then ran the integration tests with hybrid, no databricks connect, and only databricks connect and fixed issues that came up. I got some errors related to converting Pandas to SQL if we don't have databricks-connect but that should be unrelated to this PR. 