### PR TITLE
Fix: specify init duckdb database so quickstart works

### DIFF
--- a/sqlmesh/cli/example_project.py
+++ b/sqlmesh/cli/example_project.py
@@ -53,6 +53,11 @@ def _gen_config(
                 required = field.is_required() or field_name == "type"
                 option_str = f"      {'# ' if not required else ''}{field_name}: {default_value}\n"
 
+                # specify the DuckDB database field so quickstart runs out of the box
+                if engine == "duckdb" and field_name == "database":
+                    option_str = "      database: db.db\n"
+                    required = True
+
                 if required:
                     required_fields.append(option_str)
                 else:


### PR DESCRIPTION
#3733 made the `config.yml` file generated by `sqlmesh init [dialect]` specific to each engine. All of an engine's supported config fields are listed in the file, with the optional fields commented out.

For DuckDB, the `database` field is optional. However, the SQLMesh quickstart project cannot use an in-memory DuckDB instance and requires a value for `database`.

This PR makes `sqlmesh init duckdb` generate a config file that uses the `db.db` database.