### PR TITLE
fix: run integration tests in session

### DIFF
--- a/tests/core/engine_adapter/integration/conftest.py
+++ b/tests/core/engine_adapter/integration/conftest.py
@@ -89,7 +89,8 @@ def ctx(
     ctx = TestContext(test_type, engine_adapter, mark, gateway, is_remote=is_remote)
     ctx.init()
 
-    yield ctx
+    with ctx.engine_adapter.session({}):
+        yield ctx
 
     try:
         ctx.cleanup()


### PR DESCRIPTION
This better emulates how things run in SQLMesh by having all model evaluations run with a begin session first. 