### PR TITLE
Chore: Use 'dev' suffix instead of 'temp' for non-deployable physical tables

### DIFF
--- a/docs/examples/incremental_time_full_walkthrough.md
+++ b/docs/examples/incremental_time_full_walkthrough.md
@@ -748,10 +748,10 @@ The target environment has been updated successfully
 
 ```
 
-??? "Create another empty table with the proper schema that’s also versioned (ex: `__2896326998__temp__schema_migration_source`)."
+??? "Create another empty table with the proper schema that’s also versioned (ex: `__2896326998__dev__schema_migration_source`)."
 
     ```sql
-    CREATE TABLE IF NOT EXISTS `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__temp__schema_migration_source` (
+    CREATE TABLE IF NOT EXISTS `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__dev__schema_migration_source` (
       `transaction_id` STRING, `product_id` STRING, `customer_id` STRING, `transaction_amount` NUMERIC, `transaction_date` DATE,
       `transaction_timestamp_pst` DATETIME, `payment_method` STRING, `currency` STRING, `last_usage_date` TIMESTAMP, `usage_count` INT64,
       `feature_utilization_score` FLOAT64, `user_segment` STRING, `user_type` STRING, `days_since_last_usage` INT64
@@ -825,7 +825,7 @@ The target environment has been updated successfully
     This will NOT be reused when deployed to prod.
 
     ```sql
-    CREATE OR REPLACE TABLE `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__temp`
+    CREATE OR REPLACE TABLE `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__dev`
     CLONE `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__843752089`
     ```
 
@@ -862,7 +862,7 @@ The target environment has been updated successfully
       `ci`.`clustering_key` AS `clustering_key`
     FROM `sqlmesh-public-demo`.`sqlmesh__demo`.`INFORMATION_SCHEMA`.`TABLES`
     LEFT JOIN `clustering_info` AS `ci` USING (`table_catalog`, `table_schema`, `table_name`)
-    WHERE `table_name` IN ('demo__incrementals_demo__2896326998__temp')
+    WHERE `table_name` IN ('demo__incrementals_demo__2896326998__dev')
     ```
 
 ??? "Inspect metadata to track journey for the migration source schema"
@@ -895,19 +895,19 @@ The target environment has been updated successfully
       `ci`.`clustering_key` AS `clustering_key`
     FROM `sqlmesh-public-demo`.`sqlmesh__demo`.`INFORMATION_SCHEMA`.`TABLES`
     LEFT JOIN `clustering_info` AS `ci` USING (`table_catalog`, `table_schema`, `table_name`)
-    WHERE `table_name` IN ('demo__incrementals_demo__2896326998__temp__schema_migration_source')
+    WHERE `table_name` IN ('demo__incrementals_demo__2896326998__dev__schema_migration_source')
     ```
 
 ??? "Drop the migration source table because we have the metadata we need now for proper state tracking"
 
     ```sql
-    DROP TABLE IF EXISTS `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__temp__schema_migration_source`
+    DROP TABLE IF EXISTS `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__dev__schema_migration_source`
     ```
 
 ??? "Merge data into empty table for only the intervals I care about: 2024-10-27 to 'up until now'"
 
     ```sql
-    MERGE INTO `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__temp` AS `__MERGE_TARGET__` USING (
+    MERGE INTO `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__dev` AS `__MERGE_TARGET__` USING (
       WITH `sales_data` AS (
         SELECT
           `sales`.`transaction_id` AS `transaction_id`,
@@ -1007,7 +1007,7 @@ The target environment has been updated successfully
           ) AS `rank_`
         FROM (
           SELECT *
-          FROM `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__temp` AS `demo__incrementals_demo__2896326998__temp`
+          FROM `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__dev` AS `demo__incrementals_demo__2896326998__dev`
           WHERE `transaction_date` BETWEEN CAST('2024-10-27' AS DATE) AND CAST('2024-11-08' AS DATE)
         ) AS `_q_0`
       WHERE TRUE
@@ -1024,7 +1024,7 @@ The target environment has been updated successfully
         SELECT *
         FROM (
           SELECT *
-          FROM `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__temp` AS `demo__incrementals_demo__2896326998__temp`
+          FROM `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__dev` AS `demo__incrementals_demo__2896326998__dev`
         WHERE `transaction_date` BETWEEN CAST('2024-10-27' AS DATE) AND CAST('2024-11-08' AS DATE)
       ) AS `_q_0`
     WHERE
@@ -1043,7 +1043,7 @@ The target environment has been updated successfully
 
     ```sql
     CREATE OR REPLACE VIEW `sqlmesh-public-demo`.`demo__dev`.`incrementals_demo` AS
-    SELECT * FROM `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__temp`
+    SELECT * FROM `sqlmesh-public-demo`.`sqlmesh__demo`.`demo__incrementals_demo__2896326998__dev`
     ```
 
 Now I’m getting exactly what I expect when I preview the data.

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -582,10 +582,10 @@ class EngineAdapterStateSync(StateSync):
             snapshots = self._get_snapshots_with_same_version(versions_batch)
 
             snapshots_by_version = defaultdict(set)
-            snapshots_by_temp_version = defaultdict(set)
+            snapshots_by_dev_version = defaultdict(set)
             for s in snapshots:
                 snapshots_by_version[(s.name, s.version)].add(s.snapshot_id)
-                snapshots_by_temp_version[(s.name, s.temp_version)].add(s.snapshot_id)
+                snapshots_by_dev_version[(s.name, s.dev_version)].add(s.snapshot_id)
 
             expired_snapshots = [s for s in snapshots if not _is_snapshot_used(s)]
 
@@ -596,12 +596,12 @@ class EngineAdapterStateSync(StateSync):
                 shared_version_snapshots = snapshots_by_version[(snapshot.name, snapshot.version)]
                 shared_version_snapshots.discard(snapshot.snapshot_id)
 
-                shared_temp_version_snapshots = snapshots_by_temp_version[
-                    (snapshot.name, snapshot.temp_version)
+                shared_dev_version_snapshots = snapshots_by_dev_version[
+                    (snapshot.name, snapshot.dev_version)
                 ]
-                shared_temp_version_snapshots.discard(snapshot.snapshot_id)
+                shared_dev_version_snapshots.discard(snapshot.snapshot_id)
 
-                if not shared_temp_version_snapshots:
+                if not shared_dev_version_snapshots:
                     cleanup_targets.append(
                         SnapshotTableCleanupTask(
                             snapshot=snapshot.full_snapshot.table_info,
@@ -1615,8 +1615,8 @@ class EngineAdapterStateSync(StateSync):
             new_snapshot.effective_from = None
             new_snapshot.previous_versions = snapshot.all_versions
             new_snapshot.migrated = True
-            if not new_snapshot.temp_version:
-                new_snapshot.temp_version = snapshot.fingerprint.to_version()
+            if not new_snapshot.dev_version:
+                new_snapshot.dev_version = snapshot.fingerprint.to_version()
 
             self.console.update_snapshot_migration_progress(1)
 
@@ -1992,7 +1992,7 @@ class SharedVersionSnapshot(PydanticModel):
 
     name: str
     version: str
-    temp_version_: t.Optional[str] = Field(alias="temp_version")
+    dev_version_: t.Optional[str] = Field(alias="dev_version")
     identifier: str
     fingerprint: SnapshotFingerprint
     interval_unit: IntervalUnit
@@ -2021,8 +2021,8 @@ class SharedVersionSnapshot(PydanticModel):
         )
 
     @property
-    def temp_version(self) -> str:
-        return self.temp_version_ or self.fingerprint.to_version()
+    def dev_version(self) -> str:
+        return self.dev_version_ or self.fingerprint.to_version()
 
     @property
     def full_snapshot(self) -> Snapshot:
@@ -2062,7 +2062,7 @@ class SharedVersionSnapshot(PydanticModel):
         return SharedVersionSnapshot(
             name=name,
             version=version,
-            temp_version=raw_snapshot.get("temp_version"),
+            dev_version=raw_snapshot.get("dev_version"),
             identifier=identifier,
             fingerprint=raw_snapshot["fingerprint"],
             interval_unit=raw_node.get("interval_unit", IntervalUnit.from_cron(raw_node["cron"])),

--- a/sqlmesh/migrations/v0069_update_dev_table_suffix.py
+++ b/sqlmesh/migrations/v0069_update_dev_table_suffix.py
@@ -1,0 +1,165 @@
+"""Update the dev table suffix to be 'dev'. Rename temp_version to dev_version."""
+
+import json
+
+import pandas as pd
+from sqlglot import exp
+
+from sqlmesh.utils.migration import index_text_type, blob_text_type
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    environments_table = "_environments"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+        environments_table = f"{schema}.{environments_table}"
+
+    index_type = index_text_type(engine_adapter.dialect)
+    blob_type = blob_text_type(engine_adapter.dialect)
+    snapshots_columns_to_types = {
+        "name": exp.DataType.build(index_type),
+        "identifier": exp.DataType.build(index_type),
+        "version": exp.DataType.build(index_type),
+        "snapshot": exp.DataType.build(blob_type),
+        "kind_name": exp.DataType.build(index_type),
+        "updated_ts": exp.DataType.build("bigint"),
+        "unpaused_ts": exp.DataType.build("bigint"),
+        "ttl_ms": exp.DataType.build("bigint"),
+        "unrestorable": exp.DataType.build("boolean"),
+    }
+    environments_columns_to_types = {
+        "name": exp.DataType.build(index_type),
+        "snapshots": exp.DataType.build(blob_type),
+        "start_at": exp.DataType.build("text"),
+        "end_at": exp.DataType.build("text"),
+        "plan_id": exp.DataType.build("text"),
+        "previous_plan_id": exp.DataType.build("text"),
+        "expiration_ts": exp.DataType.build("bigint"),
+        "finalized_ts": exp.DataType.build("bigint"),
+        "promoted_snapshot_ids": exp.DataType.build(blob_type),
+        "suffix_target": exp.DataType.build("text"),
+        "catalog_name_override": exp.DataType.build("text"),
+        "previous_finalized_snapshots": exp.DataType.build(blob_type),
+        "normalize_name": exp.DataType.build("boolean"),
+        "requirements": exp.DataType.build(blob_type),
+    }
+
+    new_snapshots = []
+    for (
+        name,
+        identifier,
+        version,
+        snapshot,
+        kind_name,
+        updated_ts,
+        unpaused_ts,
+        ttl_ms,
+        unrestorable,
+    ) in engine_adapter.fetchall(
+        exp.select(*snapshots_columns_to_types).from_(snapshots_table),
+        quote_identifiers=True,
+    ):
+        parsed_snapshot = json.loads(snapshot)
+        parsed_snapshot = _update_snapshot(parsed_snapshot)
+
+        new_snapshots.append(
+            {
+                "name": name,
+                "identifier": identifier,
+                "version": version,
+                "snapshot": json.dumps(parsed_snapshot),
+                "kind_name": kind_name,
+                "updated_ts": updated_ts,
+                "unpaused_ts": unpaused_ts,
+                "ttl_ms": ttl_ms,
+                "unrestorable": unrestorable,
+            }
+        )
+
+    if new_snapshots:
+        engine_adapter.delete_from(snapshots_table, "TRUE")
+        engine_adapter.insert_append(
+            snapshots_table,
+            pd.DataFrame(new_snapshots),
+            columns_to_types=snapshots_columns_to_types,
+        )
+
+    new_environments = []
+    for (
+        name,
+        snapshots,
+        start_at,
+        end_at,
+        plan_id,
+        previous_plan_id,
+        expiration_ts,
+        finalized_ts,
+        promoted_snapshot_ids,
+        suffix_target,
+        catalog_name_override,
+        previous_finalized_snapshots,
+        normalize_name,
+        requirements,
+    ) in engine_adapter.fetchall(
+        exp.select(*environments_columns_to_types).from_(environments_table),
+        quote_identifiers=True,
+    ):
+        if snapshots:
+            parsed_snapshots = json.loads(snapshots)
+            for s in parsed_snapshots:
+                _update_snapshot(s)
+
+        if previous_finalized_snapshots:
+            parsed_previous_finalized_snapshots = json.loads(previous_finalized_snapshots)
+            for s in parsed_previous_finalized_snapshots:
+                _update_snapshot(s)
+
+        new_environments.append(
+            {
+                "name": name,
+                "snapshots": json.dumps(parsed_snapshots) if snapshots else None,
+                "start_at": start_at,
+                "end_at": end_at,
+                "plan_id": plan_id,
+                "previous_plan_id": previous_plan_id,
+                "expiration_ts": expiration_ts,
+                "finalized_ts": finalized_ts,
+                "promoted_snapshot_ids": promoted_snapshot_ids,
+                "suffix_target": suffix_target,
+                "catalog_name_override": catalog_name_override,
+                "previous_finalized_snapshots": json.dumps(parsed_previous_finalized_snapshots)
+                if previous_finalized_snapshots
+                else None,
+                "normalize_name": normalize_name,
+                "requirements": requirements,
+            }
+        )
+
+    if new_environments:
+        engine_adapter.delete_from(environments_table, "TRUE")
+        engine_adapter.insert_append(
+            environments_table,
+            pd.DataFrame(new_environments),
+            columns_to_types=environments_columns_to_types,
+        )
+
+
+def _update_snapshot(snapshot: dict) -> dict:
+    snapshot = _update_fields(snapshot)
+
+    if "previous_versions" in snapshot:
+        for previous_version in snapshot["previous_versions"]:
+            _update_fields(previous_version)
+
+    return snapshot
+
+
+def _update_fields(target: dict) -> dict:
+    # Setting the old suffix to match the names of existing tables.
+    target["dev_table_suffix"] = "temp"
+    if "temp_version" in target:
+        target["dev_version"] = target.pop("temp_version")
+    return target

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -411,6 +411,7 @@ def make_snapshot_on_destructive_change(make_snapshot: t.Callable) -> t.Callable
                 ),
                 version="test_version",
                 change_category=SnapshotChangeCategory.FORWARD_ONLY,
+                dev_table_suffix="dev",
             ),
         )
 

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -1520,7 +1520,7 @@ def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
                     "is_view": x.type == DataObjectType.VIEW,
                 }
                 for x in layer_objects
-                if not x.name.endswith("__temp")
+                if not x.name.endswith("__dev")
             }
 
             for model_name, comment in comments.items():
@@ -1602,7 +1602,7 @@ def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
                 if x.name.endswith(table_name_suffix)
             }
             if not check_temp_tables:
-                layer_models = {k: v for k, v in layer_models.items() if not k.endswith("__temp")}
+                layer_models = {k: v for k, v in layer_models.items() if not k.endswith("__dev")}
 
             for model_name, comment in comments.items():
                 layer_table_name = layer_models[model_name]["table_name"]

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -60,6 +60,7 @@ def test_forward_only_plan_sets_version(make_snapshot, mocker: MockerFixture):
             ),
             version="test_version",
             change_category=SnapshotChangeCategory.FORWARD_ONLY,
+            dev_table_suffix="dev",
         ),
     )
     assert not snapshot_b.version
@@ -303,6 +304,7 @@ def test_paused_forward_only_parent(make_snapshot, mocker: MockerFixture):
             ),
             version="test_version",
             change_category=SnapshotChangeCategory.BREAKING,
+            dev_table_suffix="dev",
         ),
     )
     snapshot_a.categorize_as(SnapshotChangeCategory.FORWARD_ONLY)
@@ -518,6 +520,7 @@ def test_forward_only_model_on_destructive_change(
                 metadata_hash="test_metadata_hash",
             ),
             version="test_version",
+            dev_table_suffix="dev",
         ),
     )
 
@@ -575,6 +578,7 @@ def test_forward_only_model_on_destructive_change(
                 metadata_hash="test_metadata_hash",
             ),
             version="test_version",
+            dev_table_suffix="dev",
         ),
     )
 
@@ -597,6 +601,7 @@ def test_forward_only_model_on_destructive_change(
                 metadata_hash="test_metadata_hash",
             ),
             version="test_version",
+            dev_table_suffix="dev",
         ),
     )
 

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -954,7 +954,7 @@ def test_table_name(snapshot: Snapshot, make_snapshot: t.Callable):
     assert snapshot.table_name(is_deployable=True) == "sqlmesh__default.name__3078928823"
     assert snapshot.table_name(is_deployable=False) == "sqlmesh__default.name__3078928823__temp"
 
-    assert not snapshot.temp_version
+    assert not snapshot.dev_version
 
     # Mimic an indirect non-breaking change.
     previous_data_version = snapshot.data_version
@@ -967,7 +967,7 @@ def test_table_name(snapshot: Snapshot, make_snapshot: t.Callable):
     assert snapshot.table_name(is_deployable=True) == "sqlmesh__default.name__3078928823"
     # Indirect non-breaking snapshots reuse the dev table as well.
     assert snapshot.table_name(is_deployable=False) == "sqlmesh__default.name__3078928823__temp"
-    assert snapshot.temp_version
+    assert snapshot.dev_version
 
     # Mimic a direct forward-only change.
     snapshot.fingerprint = SnapshotFingerprint(
@@ -1006,10 +1006,10 @@ def test_table_name_view(make_snapshot: t.Callable):
     assert snapshot.table_name(is_deployable=True) == f"sqlmesh__default.name__{snapshot.version}"
     assert (
         snapshot.table_name(is_deployable=False)
-        == f"sqlmesh__default.name__{snapshot.temp_version_get_or_generate()}__temp"
+        == f"sqlmesh__default.name__{snapshot.dev_version_get_or_generate()}__temp"
     )
 
-    assert not snapshot.temp_version
+    assert not snapshot.dev_version
 
     # Mimic an indirect non-breaking change.
     new_snapshot = make_snapshot(SqlModel(name="name", query=parse_one("select 2"), kind="VIEW"))
@@ -1022,11 +1022,11 @@ def test_table_name_view(make_snapshot: t.Callable):
     # Indirect non-breaking view snapshots should not reuse the dev table.
     assert (
         new_snapshot.table_name(is_deployable=False)
-        == f"sqlmesh__default.name__{new_snapshot.temp_version_get_or_generate()}__temp"
+        == f"sqlmesh__default.name__{new_snapshot.dev_version_get_or_generate()}__temp"
     )
-    assert not new_snapshot.temp_version
+    assert not new_snapshot.dev_version
     assert new_snapshot.version == snapshot.version
-    assert new_snapshot.temp_version_get_or_generate() != snapshot.temp_version_get_or_generate()
+    assert new_snapshot.dev_version_get_or_generate() != snapshot.dev_version_get_or_generate()
 
 
 def test_categorize_change_sql(make_snapshot):

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -112,6 +112,7 @@ def test_json(snapshot: Snapshot):
         "fingerprint": snapshot.fingerprint.dict(),
         "intervals": [],
         "dev_intervals": [],
+        "dev_table_suffix": "dev",
         "pending_restatement_intervals": [],
         "node": {
             "audits": [],
@@ -952,7 +953,7 @@ def test_table_name(snapshot: Snapshot, make_snapshot: t.Callable):
     snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
     snapshot.previous_versions = ()
     assert snapshot.table_name(is_deployable=True) == "sqlmesh__default.name__3078928823"
-    assert snapshot.table_name(is_deployable=False) == "sqlmesh__default.name__3078928823__temp"
+    assert snapshot.table_name(is_deployable=False) == "sqlmesh__default.name__3078928823__dev"
 
     assert not snapshot.dev_version
 
@@ -966,7 +967,7 @@ def test_table_name(snapshot: Snapshot, make_snapshot: t.Callable):
     snapshot.categorize_as(SnapshotChangeCategory.INDIRECT_NON_BREAKING)
     assert snapshot.table_name(is_deployable=True) == "sqlmesh__default.name__3078928823"
     # Indirect non-breaking snapshots reuse the dev table as well.
-    assert snapshot.table_name(is_deployable=False) == "sqlmesh__default.name__3078928823__temp"
+    assert snapshot.table_name(is_deployable=False) == "sqlmesh__default.name__3078928823__dev"
     assert snapshot.dev_version
 
     # Mimic a direct forward-only change.
@@ -976,7 +977,7 @@ def test_table_name(snapshot: Snapshot, make_snapshot: t.Callable):
     snapshot.previous_versions = (previous_data_version,)
     snapshot.categorize_as(SnapshotChangeCategory.FORWARD_ONLY)
     assert snapshot.table_name(is_deployable=True) == "sqlmesh__default.name__3078928823"
-    assert snapshot.table_name(is_deployable=False) == "sqlmesh__default.name__3049392110__temp"
+    assert snapshot.table_name(is_deployable=False) == "sqlmesh__default.name__3049392110__dev"
 
     fully_qualified_snapshot = make_snapshot(
         SqlModel(name='"my-catalog".db.table', query=parse_one("select 1, ds"))
@@ -1006,7 +1007,7 @@ def test_table_name_view(make_snapshot: t.Callable):
     assert snapshot.table_name(is_deployable=True) == f"sqlmesh__default.name__{snapshot.version}"
     assert (
         snapshot.table_name(is_deployable=False)
-        == f"sqlmesh__default.name__{snapshot.dev_version_get_or_generate()}__temp"
+        == f"sqlmesh__default.name__{snapshot.dev_version_get_or_generate()}__dev"
     )
 
     assert not snapshot.dev_version
@@ -1022,7 +1023,7 @@ def test_table_name_view(make_snapshot: t.Callable):
     # Indirect non-breaking view snapshots should not reuse the dev table.
     assert (
         new_snapshot.table_name(is_deployable=False)
-        == f"sqlmesh__default.name__{new_snapshot.dev_version_get_or_generate()}__temp"
+        == f"sqlmesh__default.name__{new_snapshot.dev_version_get_or_generate()}__dev"
     )
     assert not new_snapshot.dev_version
     assert new_snapshot.version == snapshot.version

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -385,7 +385,7 @@ def test_promote_forward_only(mocker: MockerFixture, adapter_mock, make_snapshot
             call(
                 "test_schema__test_env.test_model",
                 parse_one(
-                    f"SELECT * FROM sqlmesh__test_schema.test_schema__test_model__{snapshot.fingerprint.to_version()}__temp"
+                    f"SELECT * FROM sqlmesh__test_schema.test_schema__test_model__{snapshot.fingerprint.to_version()}__dev"
                 ),
                 table_description=None,
                 column_descriptions=None,
@@ -427,7 +427,7 @@ def test_cleanup(mocker: MockerFixture, adapter_mock, make_snapshot):
 
     snapshot = create_and_cleanup("catalog.test_schema.test_model", True)
     adapter_mock.drop_table.assert_called_once_with(
-        f"catalog.sqlmesh__test_schema.test_schema__test_model__{snapshot.fingerprint.to_version()}__temp"
+        f"catalog.sqlmesh__test_schema.test_schema__test_model__{snapshot.fingerprint.to_version()}__dev"
     )
     adapter_mock.reset_mock()
 
@@ -435,7 +435,7 @@ def test_cleanup(mocker: MockerFixture, adapter_mock, make_snapshot):
     adapter_mock.drop_table.assert_has_calls(
         [
             call(
-                f"sqlmesh__test_schema.test_schema__test_model__{snapshot.fingerprint.to_version()}__temp"
+                f"sqlmesh__test_schema.test_schema__test_model__{snapshot.fingerprint.to_version()}__dev"
             ),
             call(f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}"),
         ]
@@ -445,7 +445,7 @@ def test_cleanup(mocker: MockerFixture, adapter_mock, make_snapshot):
     snapshot = create_and_cleanup("test_model", False)
     adapter_mock.drop_table.assert_has_calls(
         [
-            call(f"sqlmesh__default.test_model__{snapshot.fingerprint.to_version()}__temp"),
+            call(f"sqlmesh__default.test_model__{snapshot.fingerprint.to_version()}__dev"),
             call(f"sqlmesh__default.test_model__{snapshot.version}"),
         ]
     )
@@ -747,7 +747,7 @@ def test_create_only_dev_table_exists(mocker: MockerFixture, adapter_mock, make_
 
     adapter_mock.get_data_objects.return_value = [
         DataObject(
-            name=f"test_schema__test_model__{snapshot.version}__temp",
+            name=f"test_schema__test_model__{snapshot.version}__dev",
             schema="sqlmesh__test_schema",
             type=DataObjectType.VIEW,
         ),
@@ -794,7 +794,7 @@ def test_create_new_forward_only_model(mocker: MockerFixture, adapter_mock, make
     adapter_mock.create_schema.assert_called_once_with(to_schema("sqlmesh__test_schema"))
     # Only non-deployable table should be created
     adapter_mock.create_table.assert_called_once_with(
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.dev_version_get_or_generate()}__temp",
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.dev_version_get_or_generate()}__dev",
         columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("varchar")},
         table_format=None,
         storage_format=None,
@@ -809,7 +809,7 @@ def test_create_new_forward_only_model(mocker: MockerFixture, adapter_mock, make
         schema_("sqlmesh__test_schema"),
         {
             f"test_schema__test_model__{snapshot.version}",
-            f"test_schema__test_model__{snapshot.dev_version_get_or_generate()}__temp",
+            f"test_schema__test_model__{snapshot.dev_version_get_or_generate()}__dev",
         },
     )
 
@@ -871,7 +871,7 @@ def test_create_tables_exist(
 
     adapter_mock.get_data_objects.return_value = [
         DataObject(
-            name=f"db__model__{snapshot.version}__temp",
+            name=f"db__model__{snapshot.version}__dev",
             schema="sqlmesh__db",
             type=DataObjectType.TABLE,
         ),
@@ -891,7 +891,7 @@ def test_create_tables_exist(
     adapter_mock.get_data_objects.assert_called_once_with(
         schema_("sqlmesh__db"),
         {
-            f"db__model__{snapshot.version}" if not flag else f"db__model__{snapshot.version}__temp"
+            f"db__model__{snapshot.version}" if not flag else f"db__model__{snapshot.version}__dev"
             for flag in set(deployability_flags + [False])
         },
     )
@@ -929,14 +929,14 @@ def test_create_prod_table_exists_forward_only(mocker: MockerFixture, adapter_mo
     adapter_mock.get_data_objects.assert_called_once_with(
         schema_("sqlmesh__test_schema"),
         {
-            f"test_schema__test_model__{snapshot.version}__temp",
+            f"test_schema__test_model__{snapshot.version}__dev",
             f"test_schema__test_model__{snapshot.version}",
         },
     )
 
     adapter_mock.create_schema.assert_called_once_with(to_schema("sqlmesh__test_schema"))
     adapter_mock.create_table.assert_called_once_with(
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp",
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev",
         columns_to_types={"a": exp.DataType.build("int")},
         table_format=None,
         storage_format=None,
@@ -1483,7 +1483,7 @@ def test_create_clone_in_dev(mocker: MockerFixture, adapter_mock, make_snapshot)
     evaluator.create([snapshot], {})
 
     adapter_mock.create_table.assert_called_once_with(
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp__schema_migration_source",
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev__schema_migration_source",
         columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("date")},
         table_format=None,
         storage_format=None,
@@ -1496,20 +1496,20 @@ def test_create_clone_in_dev(mocker: MockerFixture, adapter_mock, make_snapshot)
     )
 
     adapter_mock.clone_table.assert_called_once_with(
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp",
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev",
         f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}",
         replace=True,
     )
 
     adapter_mock.get_alter_expressions.assert_called_once_with(
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp",
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp__schema_migration_source",
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev",
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev__schema_migration_source",
     )
 
     adapter_mock.alter_table.assert_called_once_with([])
 
     adapter_mock.drop_table.assert_called_once_with(
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp__schema_migration_source"
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev__schema_migration_source"
     )
 
 
@@ -1541,7 +1541,7 @@ def test_create_clone_in_dev_missing_table(mocker: MockerFixture, adapter_mock, 
     evaluator.create([snapshot], {}, deployability_index=DeployabilityIndex.none_deployable())
 
     adapter_mock.create_table.assert_called_once_with(
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.dev_version_get_or_generate()}__temp",
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.dev_version_get_or_generate()}__dev",
         columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("date")},
         table_format=None,
         storage_format=None,
@@ -1594,23 +1594,23 @@ def test_drop_clone_in_dev_when_migration_fails(mocker: MockerFixture, adapter_m
     evaluator.create([snapshot], {})
 
     adapter_mock.clone_table.assert_called_once_with(
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp",
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev",
         f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}",
         replace=True,
     )
 
     adapter_mock.get_alter_expressions.assert_called_once_with(
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp",
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp__schema_migration_source",
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev",
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev__schema_migration_source",
     )
 
     adapter_mock.alter_table.assert_called_once_with([])
 
     adapter_mock.drop_table.assert_has_calls(
         [
-            call(f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp"),
+            call(f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev"),
             call(
-                f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp__schema_migration_source"
+                f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev__schema_migration_source"
             ),
         ]
     )
@@ -1651,7 +1651,7 @@ def test_create_clone_in_dev_self_referencing(mocker: MockerFixture, adapter_moc
     evaluator.create([snapshot], {})
 
     adapter_mock.create_table.assert_called_once_with(
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp__schema_migration_source",
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev__schema_migration_source",
         columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("date")},
         table_format=None,
         storage_format=None,
@@ -1667,7 +1667,7 @@ def test_create_clone_in_dev_self_referencing(mocker: MockerFixture, adapter_moc
     dry_run_query = adapter_mock.fetchall.call_args[0][0].sql()
     assert (
         dry_run_query
-        == f'SELECT CAST(1 AS INT) AS "a", CAST("ds" AS DATE) AS "ds" FROM "sqlmesh__test_schema"."test_schema__test_model__{snapshot.version}__temp__schema_migration_source" AS "test_model" /* test_schema.test_model */ WHERE FALSE LIMIT 0'
+        == f'SELECT CAST(1 AS INT) AS "a", CAST("ds" AS DATE) AS "ds" FROM "sqlmesh__test_schema"."test_schema__test_model__{snapshot.version}__dev__schema_migration_source" AS "test_model" /* test_schema.test_model */ WHERE FALSE LIMIT 0'
     )
 
 
@@ -1779,7 +1779,7 @@ def test_forward_only_snapshot_for_added_model(mocker: MockerFixture, adapter_mo
     adapter_mock.create_table.assert_has_calls(
         [
             call(
-                f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__temp",
+                f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev",
                 column_descriptions=None,
                 **common_create_args,
             ),
@@ -2561,7 +2561,7 @@ def test_create_seed_no_intervals(mocker: MockerFixture, adapter_mock, make_snap
             type=DataObjectType.TABLE,
         ),
         DataObject(
-            name=f"db__seed__{snapshot.version}__temp",
+            name=f"db__seed__{snapshot.version}__dev",
             schema="sqlmesh__db",
             type=DataObjectType.TABLE,
         ),
@@ -3181,7 +3181,7 @@ def test_create_managed(adapter_mock, make_snapshot, mocker: MockerFixture):
 
     # first call to evaluation_strategy.create(), is_table_deployable=False triggers a normal table
     adapter_mock.ctas.assert_called_once_with(
-        f"{snapshot.table_name()}__temp",
+        f"{snapshot.table_name()}__dev",
         mocker.ANY,
         model.columns_to_types,
         table_format=model.table_format,
@@ -3313,7 +3313,7 @@ def test_cleanup_managed(adapter_mock, make_snapshot, mocker: MockerFixture):
     evaluator.cleanup(target_snapshots=[cleanup_task])
 
     physical_name = f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}"
-    adapter_mock.drop_table.assert_called_once_with(f"{physical_name}__temp")
+    adapter_mock.drop_table.assert_called_once_with(f"{physical_name}__dev")
     adapter_mock.drop_managed_table.assert_called_once_with(f"{physical_name}")
 
 
@@ -3345,6 +3345,7 @@ def test_create_managed_forward_only_with_previous_version_doesnt_clone_for_dev_
             ),
             version="test_version",
             change_category=SnapshotChangeCategory.FORWARD_ONLY,
+            dev_table_suffix="dev",
         ),
     )
 
@@ -3807,10 +3808,10 @@ def test_multiple_engine_cleanup(snapshot: Snapshot, adapters, make_snapshot):
 
     # The clean up will happen using the specific gateway the model was created with
     engine_adapters["default"].drop_table.assert_called_once_with(
-        f"sqlmesh__db.db__model__{snapshot.version}__temp"
+        f"sqlmesh__db.db__model__{snapshot.version}__dev"
     )
     engine_adapters["secondary"].drop_table.assert_called_once_with(
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot_2.version}__temp"
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot_2.version}__dev"
     )
 
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -794,7 +794,7 @@ def test_create_new_forward_only_model(mocker: MockerFixture, adapter_mock, make
     adapter_mock.create_schema.assert_called_once_with(to_schema("sqlmesh__test_schema"))
     # Only non-deployable table should be created
     adapter_mock.create_table.assert_called_once_with(
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.temp_version_get_or_generate()}__temp",
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.dev_version_get_or_generate()}__temp",
         columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("varchar")},
         table_format=None,
         storage_format=None,
@@ -809,7 +809,7 @@ def test_create_new_forward_only_model(mocker: MockerFixture, adapter_mock, make
         schema_("sqlmesh__test_schema"),
         {
             f"test_schema__test_model__{snapshot.version}",
-            f"test_schema__test_model__{snapshot.temp_version_get_or_generate()}__temp",
+            f"test_schema__test_model__{snapshot.dev_version_get_or_generate()}__temp",
         },
     )
 
@@ -1541,7 +1541,7 @@ def test_create_clone_in_dev_missing_table(mocker: MockerFixture, adapter_mock, 
     evaluator.create([snapshot], {}, deployability_index=DeployabilityIndex.none_deployable())
 
     adapter_mock.create_table.assert_called_once_with(
-        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.temp_version_get_or_generate()}__temp",
+        f"sqlmesh__test_schema.test_schema__test_model__{snapshot.dev_version_get_or_generate()}__temp",
         columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("date")},
         table_format=None,
         storage_format=None,

--- a/tests/core/test_state_sync.py
+++ b/tests/core/test_state_sync.py
@@ -1307,7 +1307,7 @@ def test_delete_expired_snapshots_shared_dev_table(
     new_snapshot.ttl = "in 10 seconds"
     new_snapshot.categorize_as(SnapshotChangeCategory.FORWARD_ONLY)
     new_snapshot.version = snapshot.version
-    new_snapshot.temp_version = snapshot.temp_version_get_or_generate()
+    new_snapshot.dev_version = snapshot.dev_version_get_or_generate()
     new_snapshot.updated_ts = now_ts - 5000
 
     all_snapshots = [snapshot, new_snapshot]

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -98,6 +98,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
                     "fingerprint": snapshot.fingerprint.dict(),
                     "intervals": [],
                     "dev_intervals": [],
+                    "dev_table_suffix": "dev",
                     "pending_restatement_intervals": [],
                     "node": {
                         "audits": [],
@@ -160,6 +161,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
                         "change_category": snapshot.change_category,
                         "parents": [],
                         "kind_name": "INCREMENTAL_BY_TIME_RANGE",
+                        "dev_table_suffix": "dev",
                     }
                 ],
                 "start_at": "2022-01-01",

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -144,6 +144,7 @@ def test_create_plan_dag_spec(
         change_category=SnapshotChangeCategory.BREAKING,
         kind_name=ModelKindName.FULL,
         node_type=NodeType.MODEL,
+        dev_table_suffix="dev",
     )
     old_environment = Environment(
         name=environment_name,


### PR DESCRIPTION
This PR ensures consistent terminology in the codebase for referring to non-deployable physical tables. The non-deployable physical tables are going to be called as "dev" tables going forward.

Additionally, this updates changes the suffix for non-deployable table names from `__temp` to `__dev` for the following reasons:
* These tables are not truly temporary; their lifespan matches that of the snapshots they are associated with. As long as a snapshot exists, its corresponding dev table persists
* The existing suffix confuses users who don't like seeing something that looks like a temporary table in their warehouse
* `__temp` is used elsewhere in the codebase to denote actual temporary tables, whose lifespan does not extend beyond the duration of the user session

At the same time, this update ensures that existing dev tables with the old suffix are not lost or orphaned. Existing snapshots will continue to follow the old naming pattern. All new snapshots will follow the new naming pattern.