### PR TITLE
Feat: include alter statements in destructive change error message

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1220,10 +1220,7 @@ class TerminalConsole(Console):
                 )
             )
         else:
-            self._print(
-                f"[yellow]WARNING: Plan requires a destructive change to forward-only model '{snapshot_name}'s schema[/yellow]"
-            )
-            logger.warning(
+            self.log_warning(
                 format_destructive_change_msg(
                     snapshot_name, dropped_column_names, alter_expressions, dialect, error
                 )

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -486,18 +486,14 @@ class PlanBuilder:
                     dropped_column_names = get_dropped_column_names(schema_diff)
                     model_dialect = snapshot.model.dialect
 
-                    if snapshot.model.on_destructive_change.is_warn:
-                        get_console().log_destructive_change(
-                            snapshot_name,
-                            dropped_column_names,
-                            schema_diff,
-                            model_dialect,
-                            error=False,
-                        )
-                    else:
-                        get_console().log_destructive_change(
-                            snapshot_name, dropped_column_names, schema_diff, model_dialect
-                        )
+                    get_console().log_destructive_change(
+                        snapshot_name,
+                        dropped_column_names,
+                        schema_diff,
+                        model_dialect,
+                        error=not snapshot.model.on_destructive_change.is_warn,
+                    )
+                    if snapshot.model.on_destructive_change.is_error:
                         raise PlanError(
                             "Plan requires a destructive change to a forward-only model."
                         )

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -294,8 +294,8 @@ class BuiltInPlanEvaluator(PlanEvaluator):
                     snapshots,
                     plan.allow_destructive_models,
                 )
-            except Exception as ex:
-                raise PlanError(str(ex.__cause__))
+            except NodeExecutionFailedError as ex:
+                raise PlanError(str(ex.__cause__) if ex.__cause__ else str(ex))
 
             if not plan.ensure_finalized_snapshots:
                 # Only unpause at this point if we don't have to use the finalized snapshots

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -294,11 +294,8 @@ class BuiltInPlanEvaluator(PlanEvaluator):
                     snapshots,
                     plan.allow_destructive_models,
                 )
-            except NodeExecutionFailedError as ex:
-                logger.info(str(ex), exc_info=ex)
-                self.console.log_failed_models([ex])
-
-                raise PlanError("Plan application failed.")
+            except Exception as ex:
+                raise PlanError(str(ex.__cause__))
 
             if not plan.ensure_finalized_snapshots:
                 # Only unpause at this point if we don't have to use the finalized snapshots

--- a/sqlmesh/utils/errors.py
+++ b/sqlmesh/utils/errors.py
@@ -193,7 +193,7 @@ def format_destructive_change_msg(
     dialect: str,
     error: bool = True,
 ) -> str:
-    dropped_column_str = "', '".join(dropped_column_names) if dropped_column_names else None
+    dropped_column_str = "', '".join(dropped_column_names)
     dropped_column_msg = (
         f" that drops column{'s' if dropped_column_names and len(dropped_column_names) > 1 else ''} '{dropped_column_str}'"
         if dropped_column_str

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -364,7 +364,9 @@ def test_forward_only_plan_allow_destructive_models(
         previous_finalized_snapshots=None,
     )
 
-    with pytest.raises(PlanError, match="Plan results in a destructive change to forward-only"):
+    with pytest.raises(
+        PlanError, match="Plan requires a destructive change to a forward-only model"
+    ):
         PlanBuilder(context_diff_a, schema_differ, forward_only=False).build()
 
     logger = logging.getLogger("sqlmesh.core.plan.builder")
@@ -438,13 +440,13 @@ def test_forward_only_plan_allow_destructive_models(
 
     with pytest.raises(
         PlanError,
-        match="""Plan results in a destructive change to forward-only model '"b"'s schema.""",
+        match="""Plan requires a destructive change to a forward-only model.""",
     ):
         PlanBuilder(context_diff_b, schema_differ, forward_only=True).build()
 
     with pytest.raises(
         PlanError,
-        match="""Plan results in a destructive change to forward-only model '"c"'s schema.""",
+        match="""Plan requires a destructive change to a forward-only model.""",
     ):
         PlanBuilder(
             context_diff_b, schema_differ, forward_only=True, allow_destructive_models=['"b"']
@@ -494,7 +496,7 @@ def test_forward_only_model_on_destructive_change(
 
     with pytest.raises(
         PlanError,
-        match="""Plan results in a destructive change to forward-only model '"a"'s schema that drops columns 'one', 'two'.""",
+        match="""Plan requires a destructive change to a forward-only model.""",
     ):
         PlanBuilder(context_diff_1, schema_differ).build()
 


### PR DESCRIPTION
When someone gets the destructive change error message, they want to understand more about the problem than just the name of the affected column(s).

SQLMesh has not actually run any ALTER statements when this error occurs, so the statements are not printed to the log. That makes it difficult to figure out what SQLMesh "wanted to do" that it decided it shouldn't.

This PR adds those ALTER statements to the destructive error/warning message.