### PR TITLE
Fix: Ensure diff sample displays when table names have been uppercased

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1297,12 +1297,12 @@ class TerminalConsole(Console):
                 columns: dict[str, list[str]] = {}
                 source_prefix, source_name = (
                     (f"{source_name}__", source_name)
-                    if source_name != row_diff.source
+                    if source_name.lower() != row_diff.source.lower()
                     else ("s__", "SOURCE")
                 )
                 target_prefix, target_name = (
                     (f"{target_name}__", target_name)
-                    if target_name != row_diff.target
+                    if target_name.lower() != row_diff.target.lower()
                     else ("t__", "TARGET")
                 )
 


### PR DESCRIPTION
This fix ensures the sample of table_diff command displays, by comparing the lowercase table names, because the source and target names might have been uppercased before based on the aliases:
https://github.com/TobikoData/sqlmesh/blob/e6dff9b7e0042fb5c567e8d46233f2bc1765fbe3/sqlmesh/core/console.py#L1208-L1213