### PR TITLE
Fix: handle quoted projects properly in bigquery adapter

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -925,9 +925,12 @@ class BigQueryConnectionConfig(ConnectionConfig):
             )
         else:
             raise ConfigError("Invalid BigQuery Connection Method")
+
         options = client_options.ClientOptions(quota_project_id=self.quota_project)
+        project = self.execution_project or self.project or None
+
         client = google.cloud.bigquery.Client(
-            project=self.execution_project or self.project,
+            project=project and exp.parse_identifier(project, dialect="bigquery").name,
             credentials=creds,
             location=self.location,
             client_info=client_info.ClientInfo(user_agent="sqlmesh"),


### PR DESCRIPTION
Fixes #3783

I could get the example project to get until evaluation stage given these changes. The reason it failed was billing:

```
Skipped models

  "foo--bar"."sqlmesh_example"."full_model"

Failed models

  "foo--bar"."sqlmesh_example"."incremental_model"
```

Note that the config needs to wrap the project name with quotes:

```yaml
      project: '"foo--bar"'
```