### PR TITLE
Fix(postgres): Quote role names if required when running SET ROLE on cursor init

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -1194,8 +1194,10 @@ class PostgresConnectionConfig(ConnectionConfig):
         if not self.role:
             return None
 
+        role_identifier = exp.to_identifier(self.role).sql(dialect="postgres")
+
         def init(cursor: t.Any) -> None:
-            cursor.execute(f"SET ROLE {self.role}")
+            cursor.execute(f"SET ROLE {role_identifier}")
 
         return init
 

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -4,6 +4,7 @@ import typing as t
 
 import pytest
 from _pytest.fixtures import FixtureRequest
+from pytest_mock import MockerFixture
 
 from sqlmesh.core.config.connection import (
     BigQueryConnectionConfig,
@@ -679,6 +680,27 @@ def test_postgres(make_config):
     )
     assert isinstance(config, PostgresConnectionConfig)
     assert config.is_recommended_for_state_sync is True
+
+
+def test_postgres_cursor_init(make_config, mocker: MockerFixture):
+    config = make_config(
+        type="postgres",
+        host="host",
+        user="user",
+        password="password",
+        port=5432,
+        database="database",
+        role="foo-bar",
+    )
+
+    assert isinstance(config, PostgresConnectionConfig)
+    cursor_init = config._cursor_init
+    assert cursor_init
+
+    cursor_mock = mocker.MagicMock()
+    cursor_init(cursor_mock)
+
+    cursor_mock.execute.assert_called_with('SET ROLE "foo-bar"')
 
 
 def test_gcp_postgres(make_config):


### PR DESCRIPTION
Addresses #3814 