### PR TITLE
Chore: Fix flaky test

### DIFF
--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1368,8 +1368,6 @@ def test_plan_runs_audits_on_dev_previews(sushi_context: Context, capsys, caplog
     # we only see audit results if they fail
     stdout = capsys.readouterr().out
     log = caplog.text
-    assert (
-        "\n'not_null' audit error: 22 rows failed. Audit is non-blocking so proceeding with execution. Audit query:\nSELECT"
-        in log
-    )
+    assert "'not_null' audit error:" in log
+    assert "Audit is non-blocking so proceeding with execution" in log
     assert "Target environment updated successfully" in stdout


### PR DESCRIPTION
After #3818 was merged there appears to be a timing issue in `test_context::test_plan_runs_audits_on_dev_previews`.

In particular, the error switches between `22` and `10` rows. The actual number of rows doesn't matter to this test, it just checks that the usually blocking audit ran at all and was automatically switched to non-blocking.

This PR relaxes the string matching on the output
