### PR TITLE
Feat: Extend support of project wide model properties

### DIFF
--- a/docs/reference/model_configuration.md
+++ b/docs/reference/model_configuration.md
@@ -127,7 +127,6 @@ The SQLMesh project-level `model_defaults` key supports the following options, d
 - allow_partials
 - enabled
 - interval_unit
-- description
 
 
 ### Model Naming

--- a/docs/reference/model_configuration.md
+++ b/docs/reference/model_configuration.md
@@ -45,7 +45,7 @@ Configuration options for SQLMesh model properties. Supported by all model kinds
 
 The SQLMesh project-level configuration must contain the `model_defaults` key and must specify a value for its `dialect` key. Other values are set automatically unless explicitly overridden in the model definition. Learn more about project-level configuration in the [configuration guide](../guides/configuration.md).
 
-In `column_descriptions`, `physical_properties`, `virtual_properties`, and `session_properties`, when both project-level and model-specific properties are defined, they are merged, with model-level properties taking precedence. To unset a project-wide property for a specific model, set it to `None` in the `MODEL`'s DDL properties or within the `@model` decorator for Python models.
+In `physical_properties`, `virtual_properties`, and `session_properties`, when both project-level and model-specific properties are defined, they are merged, with model-level properties taking precedence. To unset a project-wide property for a specific model, set it to `None` in the `MODEL`'s DDL properties or within the `@model` decorator for Python models.
 
 For example, with the following `model_defaults` configuration:
 
@@ -127,13 +127,7 @@ The SQLMesh project-level `model_defaults` key supports the following options, d
 - allow_partials
 - enabled
 - interval_unit
-- column_descriptions
 - description
-- grains
-- references
-- clustered_by
-- partitioned_by
-- tags
 
 
 ### Model Naming

--- a/docs/reference/model_configuration.md
+++ b/docs/reference/model_configuration.md
@@ -45,7 +45,7 @@ Configuration options for SQLMesh model properties. Supported by all model kinds
 
 The SQLMesh project-level configuration must contain the `model_defaults` key and must specify a value for its `dialect` key. Other values are set automatically unless explicitly overridden in the model definition. Learn more about project-level configuration in the [configuration guide](../guides/configuration.md).
 
-In `physical_properties`, `virtual_properties`, and `session_properties`, when both project-level and model-specific properties are defined, they are merged, with model-level properties taking precedence. To unset a project-wide property for a specific model, set it to `None` in the `MODEL`'s DDL properties or within the `@model` decorator for Python models.
+In `column_descriptions`, `physical_properties`, `virtual_properties`, and `session_properties`, when both project-level and model-specific properties are defined, they are merged, with model-level properties taking precedence. To unset a project-wide property for a specific model, set it to `None` in the `MODEL`'s DDL properties or within the `@model` decorator for Python models.
 
 For example, with the following `model_defaults` configuration:
 
@@ -124,6 +124,16 @@ The SQLMesh project-level `model_defaults` key supports the following options, d
 - audits (described [here](../concepts/audits.md#generic-audits))
 - optimize_query
 - validate_query
+- allow_partials
+- enabled
+- interval_unit
+- column_descriptions
+- description
+- grains
+- references
+- clustered_by
+- partitioned_by
+- tags
 
 
 ### Model Naming

--- a/sqlmesh/core/config/model.py
+++ b/sqlmesh/core/config/model.py
@@ -42,13 +42,6 @@ class ModelDefaultsConfig(BaseConfig):
         allow_partials: Whether the models can process partial (incomplete) data intervals.
         enabled: Whether the models are enabled.
         interval_unit: The temporal granularity of the models data intervals. By default computed from cron.
-        column_descriptions: A key-value mapping of column names to their descriptions.
-        description: Description of the models. Automatically registered in the SQL engine's table COMMENT field or equivalent.
-        grains: The column(s) whose combination uniquely identifies each row in the models.
-        references: The model column(s) used to join to models' grains.
-        clustered_by: The column(s) used to cluster the models' physical table.
-        partitioned_by: The column(s) used to define the models' partitioning key.
-        tags: Arbitrary strings used to organize or classify the models.
 
     """
 
@@ -69,13 +62,6 @@ class ModelDefaultsConfig(BaseConfig):
     allow_partials: t.Optional[bool] = None
     interval_unit: t.Optional[IntervalUnit] = None
     enabled: t.Optional[bool] = None
-    description: t.Optional[str] = None
-    column_descriptions: t.Optional[t.Dict[str, str]] = None
-    grains: t.Optional[t.List[str]] = None
-    references: t.Optional[t.List[str]] = None
-    clustered_by: t.Optional[t.Any] = None
-    partitioned_by: t.Optional[t.Any] = None
-    tags: t.Optional[t.List[str]] = None
 
     _model_kind_validator = model_kind_validator
     _on_destructive_change_validator = on_destructive_change_validator

--- a/sqlmesh/core/config/model.py
+++ b/sqlmesh/core/config/model.py
@@ -10,6 +10,7 @@ from sqlmesh.core.model.kind import (
     model_kind_validator,
     on_destructive_change_validator,
 )
+from sqlmesh.core.node import IntervalUnit
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.core.model.meta import FunctionCall
 from sqlmesh.utils.pydantic import field_validator
@@ -36,7 +37,19 @@ class ModelDefaultsConfig(BaseConfig):
         virtual_properties: A key-value mapping of arbitrary properties that are applied to the model view in the virtual layer.
         session_properties: A key-value mapping of properties specific to the target engine that are applied to the engine session.
         audits: The audits to be applied globally to all models in the project.
-        optimize_query: Whether the SQL models should be optimized
+        optimize_query: Whether the SQL models should be optimized.
+        validate_query: Whether the SQL models should be validated at compile time.
+        allow_partials: Whether the models can process partial (incomplete) data intervals.
+        enabled: Whether the models are enabled.
+        interval_unit: The temporal granularity of the models data intervals. By default computed from cron.
+        column_descriptions: A key-value mapping of column names to their descriptions.
+        description: Description of the models. Automatically registered in the SQL engine's table COMMENT field or equivalent.
+        grains: The column(s) whose combination uniquely identifies each row in the models.
+        references: The model column(s) used to join to models' grains.
+        clustered_by: The column(s) used to cluster the models' physical table.
+        partitioned_by: The column(s) used to define the models' partitioning key.
+        tags: Arbitrary strings used to organize or classify the models.
+
     """
 
     kind: t.Optional[ModelKind] = None
@@ -53,6 +66,16 @@ class ModelDefaultsConfig(BaseConfig):
     audits: t.Optional[t.List[FunctionCall]] = None
     optimize_query: t.Optional[bool] = None
     validate_query: t.Optional[bool] = None
+    allow_partials: t.Optional[bool] = None
+    interval_unit: t.Optional[IntervalUnit] = None
+    enabled: t.Optional[bool] = None
+    description: t.Optional[str] = None
+    column_descriptions: t.Optional[t.Dict[str, str]] = None
+    grains: t.Optional[t.List[str]] = None
+    references: t.Optional[t.List[str]] = None
+    clustered_by: t.Optional[t.Any] = None
+    partitioned_by: t.Optional[t.Any] = None
+    tags: t.Optional[t.List[str]] = None
 
     _model_kind_validator = model_kind_validator
     _on_destructive_change_validator = on_destructive_change_validator

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1885,6 +1885,8 @@ def load_sql_based_model(
         "description": (
             "\n".join(comment.strip() for comment in rendered_meta.comments)
             if rendered_meta.comments
+            else description
+            if defaults and (description := defaults.get("description"))
             else None
         ),
         **{prop.name.lower(): prop.args.get("value") for prop in rendered_meta.expressions},
@@ -2153,7 +2155,12 @@ def _create_model(
 ) -> Model:
     _validate_model_fields(klass, {"name", *kwargs} - {"grain", "table_properties"}, path)
 
-    for prop in ["session_properties", "physical_properties", "virtual_properties"]:
+    for prop in [
+        "session_properties",
+        "physical_properties",
+        "virtual_properties",
+        "column_descriptions",
+    ]:
         kwargs[prop] = _resolve_properties((defaults or {}).get(prop), kwargs.get(prop))
 
     dialect = dialect or ""

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1885,8 +1885,6 @@ def load_sql_based_model(
         "description": (
             "\n".join(comment.strip() for comment in rendered_meta.comments)
             if rendered_meta.comments
-            else defaults.get("description")
-            if defaults
             else None
         ),
         **{prop.name.lower(): prop.args.get("value") for prop in rendered_meta.expressions},
@@ -2159,7 +2157,6 @@ def _create_model(
         "session_properties",
         "physical_properties",
         "virtual_properties",
-        "column_descriptions",
     ]:
         kwargs[prop] = _resolve_properties((defaults or {}).get(prop), kwargs.get(prop))
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1885,8 +1885,8 @@ def load_sql_based_model(
         "description": (
             "\n".join(comment.strip() for comment in rendered_meta.comments)
             if rendered_meta.comments
-            else description
-            if defaults and (description := defaults.get("description"))
+            else defaults.get("description")
+            if defaults
             else None
         ),
         **{prop.name.lower(): prop.args.get("value") for prop in rendered_meta.expressions},

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -3402,13 +3402,6 @@ def test_project_level_properties(sushi_context):
         interval_unit="quarter_hour",
         validate_query=True,
         optimize_query=True,
-        description="Project wide description",
-        column_descriptions={"a": "Project description"},
-        grains=["a"],
-        references=["b"],
-        tags=["pii", "fact"],
-        clustered_by=["a"],
-        partitioned_by=["a"],
         cron="@hourly",
     )
 
@@ -3435,13 +3428,6 @@ def test_project_level_properties(sushi_context):
     assert model.interval_unit == IntervalUnit.QUARTER_HOUR
     assert model.optimize_query
     assert model.validate_query
-    assert model.grains == [exp.column("a", quoted=False)]
-    assert model.references == [exp.column("b", quoted=False)]
-    assert model.clustered_by == [exp.column("a", quoted=True)]
-    assert model.partitioned_by == [exp.column("a", quoted=True)]
-    assert model.tags == ["pii", "fact"]
-    assert model.description == "Project wide description"
-    assert model.column_descriptions == {"a": "Project description"}
     assert model.cron == "@hourly"
 
     assert model.session_properties == {
@@ -3464,14 +3450,7 @@ def test_project_level_properties(sushi_context):
         MODEL (
             name test_schema.test_model_2,
             kind FULL,
-            column_descriptions (
-                a = 'model description'
-            ),
             allow_partials False,
-            description 'custom model description',
-            tags ["some"],
-            partitioned_by b,
-            clustered_by b,
             interval_unit hour,
             cron '@daily'
 
@@ -3486,12 +3465,6 @@ def test_project_level_properties(sushi_context):
     # Validate overriding of project wide defaults
     assert not model_2.allow_partials
     assert model_2.interval_unit == IntervalUnit.HOUR
-    assert model_2.grains == [exp.column("a", quoted=False)]
-    assert model_2.clustered_by == [exp.column("b", quoted=True)]
-    assert model_2.partitioned_by == [exp.column("b", quoted=True)]
-    assert model_2.tags == ["some"]
-    assert model_2.description == "custom model description"
-    assert model_2.column_descriptions == {"a": "model description"}
     assert model_2.cron == "@daily"
 
 
@@ -3507,12 +3480,6 @@ def test_project_level_properties_python_model():
         "interval_unit": "quarter_hour",
         "validate_query": True,
         "optimize_query": True,
-        "column_descriptions": {"some_col": "Project description"},
-        "grains": ["some_col"],
-        "references": ["b"],
-        "tags": ["pii", "fact"],
-        "clustered_by": ["some_col"],
-        "partitioned_by": ["some_col"],
     }
 
     @model(
@@ -3543,13 +3510,6 @@ def test_project_level_properties_python_model():
     assert not m.enabled
     assert m.allow_partials
     assert m.interval_unit == IntervalUnit.QUARTER_HOUR
-    assert m.grains == [exp.column("some_col", quoted=False)]
-    assert m.references == [exp.column("b", quoted=False)]
-    assert m.clustered_by == [exp.column("some_col", quoted=True)]
-    assert m.partitioned_by == [exp.column("some_col", quoted=True)]
-    assert m.tags == ["pii", "fact"]
-    assert m.description == "general model description"
-    assert m.column_descriptions == {"some_col": "Project description"}
 
 
 def test_model_session_properties(sushi_context):


### PR DESCRIPTION
This update extends the model properties that are supported to be enabled across the entire project through the configuration to also include:  `allow_partials`, `enabled`, `interval_unit`.
