### PR TITLE
Revert "Fix(postgres): Quote role names if required when running SET ROLE on cursor init"

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -1197,10 +1197,8 @@ class PostgresConnectionConfig(ConnectionConfig):
         if not self.role:
             return None
 
-        role_identifier = exp.to_identifier(self.role).sql(dialect="postgres")
-
         def init(cursor: t.Any) -> None:
-            cursor.execute(f"SET ROLE {role_identifier}")
+            cursor.execute(f"SET ROLE {self.role}")
 
         return init
 

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -4,7 +4,6 @@ import typing as t
 
 import pytest
 from _pytest.fixtures import FixtureRequest
-from pytest_mock import MockerFixture
 
 from sqlmesh.core.config.connection import (
     BigQueryConnectionConfig,
@@ -680,27 +679,6 @@ def test_postgres(make_config):
     )
     assert isinstance(config, PostgresConnectionConfig)
     assert config.is_recommended_for_state_sync is True
-
-
-def test_postgres_cursor_init(make_config, mocker: MockerFixture):
-    config = make_config(
-        type="postgres",
-        host="host",
-        user="user",
-        password="password",
-        port=5432,
-        database="database",
-        role="foo-bar",
-    )
-
-    assert isinstance(config, PostgresConnectionConfig)
-    cursor_init = config._cursor_init
-    assert cursor_init
-
-    cursor_mock = mocker.MagicMock()
-    cursor_init(cursor_mock)
-
-    cursor_mock.execute.assert_called_with('SET ROLE "foo-bar"')
 
 
 def test_gcp_postgres(make_config):


### PR DESCRIPTION
Reverts TobikoData/sqlmesh#3825

Preemptively calling `to_identifier` in the `role` field can result in incorrectly wrapping case-sensitive roles like `"myRole"` with additional quotes: `"""myRole"""` . If any user has the former in their config, that can break them.

User-facing configs / inputs should instead make sure their “unsafe” identifiers are quoted.