### PR TITLE
Feat: allow different warning messages for logger and console

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -270,12 +270,12 @@ class Console(abc.ABC):
         """Display error info to the user."""
 
     @abc.abstractmethod
-    def log_warning(self, message: str, logger_message: t.Optional[str] = None) -> None:
+    def log_warning(self, short_message: str, long_message: t.Optional[str] = None) -> None:
         """Display warning info to the user.
 
         Args:
-            message: The warning message to print to console.
-            logger_message: The warning message to log to file. If not provided, `message` is used.
+            short_message: The warning message to print to console.
+            long_message: The warning message to log to file. If not provided, `short_message` is used.
         """
 
     @abc.abstractmethod
@@ -447,8 +447,8 @@ class NoopConsole(Console):
     def log_error(self, message: str) -> None:
         pass
 
-    def log_warning(self, message: str, logger_message: t.Optional[str] = None) -> None:
-        logger.warning(message)
+    def log_warning(self, short_message: str, long_message: t.Optional[str] = None) -> None:
+        logger.warning(long_message or short_message)
 
     def log_success(self, message: str) -> None:
         pass
@@ -1246,18 +1246,18 @@ class TerminalConsole(Console):
     def log_error(self, message: str) -> None:
         self._print(f"[red]{message}[/red]")
 
-    def log_warning(self, message: str, logger_message: t.Optional[str] = None) -> None:
-        logger.warning(logger_message or message)
+    def log_warning(self, short_message: str, long_message: t.Optional[str] = None) -> None:
+        logger.warning(long_message or short_message)
         if not self.ignore_warnings:
-            if logger_message:
+            if long_message:
                 for handler in logger.root.handlers:
                     if isinstance(handler, logging.FileHandler):
                         file_path = handler.baseFilename
                         break
                 file_path_msg = f" Learn more in logs: {file_path}\n" if file_path else ""
-                message = f"{message}{file_path_msg}"
-            message_lstrip = message.lstrip()
-            leading_ws = message[: -len(message_lstrip)]
+                short_message = f"{short_message}{file_path_msg}"
+            message_lstrip = short_message.lstrip()
+            leading_ws = short_message[: -len(message_lstrip)]
             message_formatted = f"{leading_ws}[yellow]\\[WARNING] {message_lstrip}[/yellow]"
             self._print(message_formatted)
 
@@ -2090,9 +2090,9 @@ class MarkdownConsole(CaptureTerminalConsole):
     def log_error(self, message: str) -> None:
         super().log_error(f"```\n\\[ERROR] {message}```\n\n")
 
-    def log_warning(self, message: str, logger_message: t.Optional[str] = None) -> None:
-        logger.warning(logger_message or message)
-        self._print(f"```\n\\[WARNING] {message}```\n\n")
+    def log_warning(self, short_message: str, long_message: t.Optional[str] = None) -> None:
+        logger.warning(long_message or short_message)
+        self._print(f"```\n\\[WARNING] {short_message}```\n\n")
 
 
 class DatabricksMagicConsole(CaptureTerminalConsole):
@@ -2386,10 +2386,10 @@ class DebuggerTerminalConsole(TerminalConsole):
     def log_error(self, message: str) -> None:
         self._write(message, style="bold red")
 
-    def log_warning(self, message: str, logger_message: t.Optional[str] = None) -> None:
-        logger.warning(logger_message or message)
+    def log_warning(self, short_message: str, long_message: t.Optional[str] = None) -> None:
+        logger.warning(long_message or short_message)
         if not self.ignore_warnings:
-            self._write(message, style="bold yellow")
+            self._write(short_message, style="bold yellow")
 
     def log_success(self, message: str) -> None:
         self._write(message, style="bold green")

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -271,7 +271,12 @@ class Console(abc.ABC):
 
     @abc.abstractmethod
     def log_warning(self, message: str, logger_message: t.Optional[str] = None) -> None:
-        """Display warning info to the user."""
+        """Display warning info to the user.
+
+        Args:
+            message: The warning message to print to console.
+            logger_message: The warning message to log to file. If not provided, `message` is used.
+        """
 
     @abc.abstractmethod
     def log_success(self, message: str) -> None:
@@ -2382,7 +2387,7 @@ class DebuggerTerminalConsole(TerminalConsole):
         self._write(message, style="bold red")
 
     def log_warning(self, message: str, logger_message: t.Optional[str] = None) -> None:
-        logger.warning(message)
+        logger.warning(logger_message or message)
         if not self.ignore_warnings:
             self._write(message, style="bold yellow")
 

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -224,7 +224,7 @@ class Scheduler:
             else:
                 get_console().log_warning(
                     f"\n{error}.",
-                    logger_message=f"{error}. Audit query:\n{error.query.sql(error.adapter_dialect)}",
+                    long_message=f"{error}. Audit query:\n{error.query.sql(error.adapter_dialect)}",
                 )
 
         if audit_errors_to_raise:

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -223,7 +223,8 @@ class Scheduler:
                 audit_errors_to_raise.append(error)
             else:
                 get_console().log_warning(
-                    f"\n{error}. Audit is non-blocking so proceeding with execution. Audit query:\n{error.query.sql(error.adapter_dialect)}\n"
+                    f"\n{error}.",
+                    logger_message=f"{error}. Audit query:\n{error.query.sql(error.adapter_dialect)}",
                 )
 
         if audit_errors_to_raise:

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -464,11 +464,7 @@ def test_override_builtin_audit_blocking_mode():
         plan = context.plan(auto_apply=True, no_prompts=True)
         new_snapshot = next(iter(plan.context_diff.new_snapshots.values()))
 
-        version = new_snapshot.fingerprint.to_version()
-        assert (
-            mock_logger.call_args_list[0][0][0]
-            == f'\n\'not_null\' audit error: 1 row failed. Audit is non-blocking so proceeding with execution. Audit query:\nSELECT * FROM (SELECT * FROM "sqlmesh__db"."db__x__{version}" AS "db__x__{version}") AS "_q_0" WHERE "c" IS NULL AND TRUE\n'
-        )
+        assert mock_logger.call_args_list[0][0][0] == "\n'not_null' audit error: 1 row failed."
 
     # Even though there are two builtin audits referenced in the above definition, we only
     # store the one that overrides `blocking` in the snapshot; the other one isn't needed
@@ -1369,5 +1365,5 @@ def test_plan_runs_audits_on_dev_previews(sushi_context: Context, capsys, caplog
     stdout = capsys.readouterr().out
     log = caplog.text
     assert "'not_null' audit error:" in log
-    assert "Audit is non-blocking so proceeding with execution" in log
+    assert "'at_least_one_non_blocking' audit error:" in log
     assert "Target environment updated successfully" in stdout


### PR DESCRIPTION
Currently, the same warning message is print both to file and console. However, we sometimes have more information for the user than is sensible to print to the console. 

This PR adds the ability to print separate messages to file and console. If separate messages are passed, the console message will automatically include a link to the log file.