### PR TITLE
Fix: Streamline execution of pre- / post- statements when creating a physical table

### DIFF
--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -114,6 +114,7 @@ class BaseExpressionRenderer:
                 self._model_fqn,
                 snapshots={self._model_fqn: this_snapshot} if this_snapshot else None,
                 deployability_index=deployability_index,
+                table_mapping=table_mapping,
             )
 
         expressions = [self._expression]


### PR DESCRIPTION
Previously we'd only run pre- / post- statements for the non-dev tables, completely ignoring the dev tables. This update makes it so that pre- and post- statements run consistently for **every** table SQLMesh creates.