### PR TITLE
fix: respect disable_restatement remove intervals across env

### DIFF
--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -255,6 +255,11 @@ class Plan(PydanticModel, frozen=True):
             models_to_backfill=self.models_to_backfill,
             interval_end_per_model=self.interval_end_per_model,
             execution_time=self.execution_time,
+            disabled_restatement_models={
+                s.name
+                for s in self.snapshots.values()
+                if s.is_model and s.model.disable_restatement
+            },
         )
 
     @cached_property
@@ -285,6 +290,7 @@ class EvaluatablePlan(PydanticModel):
     models_to_backfill: t.Optional[t.Set[str]] = None
     interval_end_per_model: t.Optional[t.Dict[str, int]] = None
     execution_time: t.Optional[TimeLike] = None
+    disabled_restatement_models: t.Set[str]
 
     def is_selected_for_backfill(self, model_fqn: str) -> bool:
         return self.models_to_backfill is None or model_fqn in self.models_to_backfill

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -409,7 +409,9 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         #
         # Without this rule, its possible that promoting a dev table to prod will introduce old data to prod
         snapshot_intervals_to_restate.update(
-            self._restatement_intervals_across_all_environments(plan.restatements)
+            self._restatement_intervals_across_all_environments(
+                plan.restatements, plan.disabled_restatement_models
+            )
         )
 
         self.state_sync.remove_intervals(
@@ -418,12 +420,12 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         )
 
     def _restatement_intervals_across_all_environments(
-        self, prod_restatements: t.Dict[str, Interval]
+        self, prod_restatements: t.Dict[str, Interval], disable_restatement_models: t.Set[str]
     ) -> t.Set[t.Tuple[SnapshotTableInfo, Interval]]:
         """
         Given a map of snapshot names + intervals to restate in prod:
          - Look up matching snapshots across all environments (match based on name - regardless of version)
-         - For each match, also match downstream snapshots
+         - For each match, also match downstream snapshots while filtering out models that have restatement disabled
          - Return all matches mapped to the intervals of the prod snapshot being restated
 
         The goal here is to produce a list of intervals to invalidate across all environments so that a cadence
@@ -444,7 +446,11 @@ class BuiltInPlanEvaluator(PlanEvaluator):
             for restatement, intervals in prod_restatements.items():
                 if restatement not in keyed_snapshots:
                     continue
-                affected_snapshot_names = [restatement] + env_dag.downstream(restatement)
+                affected_snapshot_names = [
+                    x
+                    for x in ([restatement] + env_dag.downstream(restatement))
+                    if x not in disable_restatement_models
+                ]
                 snapshots_to_restate.update(
                     {(keyed_snapshots[a], intervals) for a in affected_snapshot_names}
                 )

--- a/tests/schedulers/airflow/test_client.py
+++ b/tests/schedulers/airflow/test_client.py
@@ -77,6 +77,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
         removed_snapshots=[],
         requires_backfill=True,
         models_to_backfill={'"test_model"'},
+        disabled_restatement_models=set(),
     )
 
     client = AirflowClient(airflow_url=common.AIRFLOW_LOCAL_URL, session=requests.Session())
@@ -196,6 +197,7 @@ def test_apply_plan(mocker: MockerFixture, snapshot: Snapshot):
                 '"test_model"': [to_timestamp("2024-01-01"), to_timestamp("2024-01-02")]
             },
             "requires_backfill": True,
+            "disabled_restatement_models": [],
         },
         "notification_targets": [],
         "backfill_concurrent_tasks": 1,

--- a/tests/schedulers/airflow/test_integration.py
+++ b/tests/schedulers/airflow/test_integration.py
@@ -115,6 +115,7 @@ def _create_evaluatable_plan(
         indirectly_modified_snapshots={},
         removed_snapshots=[],
         requires_backfill=True,
+        disabled_restatement_models=set(),
     )
 
 

--- a/tests/schedulers/airflow/test_plan.py
+++ b/tests/schedulers/airflow/test_plan.py
@@ -125,6 +125,7 @@ def test_create_plan_dag_spec(
         interval_end_per_model=None,
         allow_destructive_models=set(),
         requires_backfill=True,
+        disabled_restatement_models=set(),
     )
 
     plan_request = common.PlanApplicationRequest(
@@ -269,6 +270,7 @@ def test_restatement(
         interval_end_per_model=None,
         allow_destructive_models=set(),
         requires_backfill=True,
+        disabled_restatement_models=set(),
     )
 
     plan_request = common.PlanApplicationRequest(
@@ -390,6 +392,7 @@ def test_select_models_for_backfill(mocker: MockerFixture, random_name, make_sna
         interval_end_per_model=None,
         allow_destructive_models=set(),
         requires_backfill=True,
+        disabled_restatement_models=set(),
     )
 
     plan_request = common.PlanApplicationRequest(
@@ -475,6 +478,7 @@ def test_create_plan_dag_spec_duplicated_snapshot(
         interval_end_per_model=None,
         allow_destructive_models=set(),
         requires_backfill=True,
+        disabled_restatement_models=set(),
     )
 
     plan_request = common.PlanApplicationRequest(
@@ -537,6 +541,7 @@ def test_create_plan_dag_spec_unbounded_end(
         interval_end_per_model=None,
         allow_destructive_models=set(),
         requires_backfill=True,
+        disabled_restatement_models=set(),
     )
 
     plan_request = common.PlanApplicationRequest(


### PR DESCRIPTION
Prior to this PR, when we removed intervals across environments, introduced in https://github.com/TobikoData/sqlmesh/pull/3511, we would also remove intervals for downstream snapshots even if they had `disable_restatement` enabled. One tricky part is that the model, in most cases, would not be backfilled in that plan and this would not be communicated in console output. A case where it would be shown is if that downstream model was also an upstream model of one of the restated models or it's downstream models. I get that was confusing - lets give this example:

A -> B -> C

If `B` had `disable_restatement`, and `A` was being restated, then `B` would both have it's intervals removed and it would be backfilled in the plan since it is upstream of `C`. But if `C` had `disable_restatement` then it would have it's intervals removed but would not be backfilled in the plan since it was not upstream of anything else. 

Going through the effort of explaining this in case someone needs to try to reproduce this in the future because I kept trying patterns where just `C` was disabled and couldn't repro.

This PR fixes the issue by doing the following:
* EvaluatablePlan now includes `disabled_restatement_models`
   * This is needed since `EvaluatablePlan` doesn't include any Snapshots, just `SnapshotTableInfo`, and `SnapshotTableInfo` just includes the model kind type but not addition info for the given kind. 
* When finding downstream snapshots across environments, we now filter out the snapshots that have `disabled_restatement_models`

We are basing what is disabled or not on what is in prod but it seems the worst case scenario for this is that a dev snapshot could be restated when it wasn't intended but that seems fine since it is just in development. 