### PR TITLE
fix: respect disable restate dev unpaused snapshots

### DIFF
--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -329,7 +329,7 @@ class PlanBuilder:
             if not snapshot:
                 raise PlanError(f"Cannot restate model '{model_fqn}'. Model does not exist.")
             if not forward_only_preview_needed:
-                if not self._is_dev and snapshot.disable_restatement:
+                if (not self._is_dev or not snapshot.is_paused) and snapshot.disable_restatement:
                     # This is a warning but we print this as error since the Console is lacking API for warnings.
                     self._console.log_error(
                         f"Cannot restate model '{model_fqn}'. "

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -1853,6 +1853,12 @@ def test_disable_restatement(make_snapshot, mocker: MockerFixture):
         snapshot.snapshot_id: (to_timestamp(plan.start), to_timestamp(to_date("today")))
     }
 
+    # We don't want to restate a disable_restatement model if it is unpaused since that would be mean we are violating
+    # the model kind property
+    snapshot.unpaused_ts = 9999999999
+    plan = PlanBuilder(context_diff, schema_differ, is_dev=True, restate_models=['"a"']).build()
+    assert plan.restatements == {}
+
 
 def test_revert_to_previous_value(make_snapshot, mocker: MockerFixture):
     """


### PR DESCRIPTION
Prior to this PR, the assumption was made that if a model was being restated in dev that it must either be restating a table that has the dev suffix or it is a new snapshot that isn't used in prod. This isn't always the case and a simple example is creating a dev environment with `--include-unmodified`. If you did that then issued a restatement to your dev environment against a model that had `disable_restatement` then it would restate prod. 

This PR addresses that immediate use case by checking if the snapshot is paused along with if it is in dev in order to determine if `disable_restatement` should be respected. 