### PR TITLE
fix: signals that return an empty list are considered ready

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -2083,7 +2083,7 @@ def _check_ready_intervals(
             for i in ready_intervals:
                 if i not in batch:
                     raise SQLMeshError(f"Unknown interval {i} for signal")
-                batch = ready_intervals
+            batch = ready_intervals
         else:
             raise SQLMeshError(f"Expected bool | list, got {type(ready_intervals)} for signal")
 

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -2326,7 +2326,7 @@ def test_contiguous_intervals():
 
 def test_check_ready_intervals(mocker: MockerFixture):
     def assert_always_signal(intervals):
-        _check_ready_intervals(lambda _: True, intervals) == intervals
+        assert _check_ready_intervals(lambda _: True, intervals) == intervals
 
     assert_always_signal([])
     assert_always_signal([(0, 1)])
@@ -2334,12 +2334,20 @@ def test_check_ready_intervals(mocker: MockerFixture):
     assert_always_signal([(0, 1), (2, 3)])
 
     def assert_never_signal(intervals):
-        _check_ready_intervals(lambda _: False, intervals) == []
+        assert _check_ready_intervals(lambda _: False, intervals) == []
 
     assert_never_signal([])
     assert_never_signal([(0, 1)])
     assert_never_signal([(0, 1), (1, 2)])
     assert_never_signal([(0, 1), (2, 3)])
+
+    def assert_empty_signal(intervals):
+        assert _check_ready_intervals(lambda _: [], intervals) == []
+
+    assert_empty_signal([])
+    assert_empty_signal([(0, 1)])
+    assert_empty_signal([(0, 1), (1, 2)])
+    assert_empty_signal([(0, 1), (2, 3)])
 
     def to_intervals(values: t.List[t.Tuple[int, int]]) -> DatetimeRanges:
         return [(to_datetime(s), to_datetime(e)) for s, e in values]


### PR DESCRIPTION
This fixes the test which was not asserting, adds a test to cover this case (which fails) and fixes the actual problem by de-denting a line (the line is skipped when the returned list is empty because it skips the iteration).