### PR TITLE
feat: improve gcp postgres connection config options

### DIFF
--- a/docs/integrations/engines/gcp-postgres.md
+++ b/docs/integrations/engines/gcp-postgres.md
@@ -10,13 +10,17 @@ pip install "sqlmesh[gcppostgres]"
 
 ### Connection options
 
-| Option                       | Description                                                                         |  Type   | Required |
-| ---------------------------- | ----------------------------------------------------------------------------------- | :-----: | :------: |
-| `type`                       | Engine type name - must be `gcp_postgres`                                           | string  |    Y     |
-| `instance_connection_string` | Connection name for the postgres instance                                           | string  |    Y     |
-| `user`                       | The username (postgres or IAM) to use for authentication                            | string  |    Y     |
-| `password`                   | The password to use for authentication. Required when connecting as a Postgres user | string  |    N     |
-| `enable_iam_auth`            | Enables IAM authentication. Required when connecting as an IAM user                 | boolean |    N     |
-| `keyfile`                    | Path to the keyfile to be used with enable_iam_auth instead of ADC                  | string  |    N     |
-| `keyfile_json`               | Keyfile information provided inline (not recommended)                               |  dict   |    N     |
-| `db`                         | The name of the database instance to connect to                                     | string  |    Y     |
+| Option                       | Description                                                                                            |    Type    | Required |
+|------------------------------|--------------------------------------------------------------------------------------------------------|:----------:|:--------:|
+| `type`                       | Engine type name - must be `gcp_postgres`                                                              |   string   |    Y     |
+| `instance_connection_string` | Connection name for the postgres instance                                                              |   string   |    Y     |
+| `user`                       | The username (postgres or IAM) to use for authentication                                               |   string   |    Y     |
+| `password`                   | The password to use for authentication. Required when connecting as a Postgres user                    |   string   |    N     |
+| `enable_iam_auth`            | Enables IAM authentication. Required when connecting as an IAM user                                    |  boolean   |    N     |
+| `keyfile`                    | Path to the keyfile to be used with enable_iam_auth instead of ADC                                     |   string   |    N     |
+| `keyfile_json`               | Keyfile information provided inline (not recommended)                                                  |    dict    |    N     |
+| `db`                         | The name of the database instance to connect to                                                        |   string   |    Y     |
+| `ip_type`                    | The IP type to use for the connection. Must be one of `public`, `private`, or `psc`. Default: `public` |   string   |    N     |
+| `timeout`                    | The connection timeout in seconds. Default: `30`                                                       |  integer   |    N     |
+| `scopes`                     | The scopes to use for the connection. Default: `(https://www.googleapis.com/auth/sqlservice.admin,)`   | tuple[str] |    N     |
+| `driver`                     | The driver to use for the connection. Default: `pg8000`. Note: only `pg8000` is tested                 |   string   |    N     |

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -987,6 +987,7 @@ class GCPPostgresConnectionConfig(ConnectionConfig):
     password: t.Optional[str] = None
     enable_iam_auth: t.Optional[bool] = None
     db: str
+    ip_type: t.Union[t.Literal["public"], t.Literal["private"], t.Literal["psc"]] = "public"
     # Keyfile Auth
     keyfile: t.Optional[str] = None
     keyfile_json: t.Optional[t.Dict[str, t.Any]] = None
@@ -1052,7 +1053,15 @@ class GCPPostgresConnectionConfig(ConnectionConfig):
                 self.keyfile_json, scopes=self.scopes
             )
 
-        return Connector(credentials=creds).connect
+        kwargs = {
+            "credentials": creds,
+            "ip_type": self.ip_type,
+        }
+
+        if self.timeout:
+            kwargs["timeout"] = self.timeout
+
+        return Connector(**kwargs).connect  # type: ignore
 
 
 class RedshiftConnectionConfig(ConnectionConfig):

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -691,6 +691,16 @@ def test_gcp_postgres(make_config):
     )
     assert isinstance(config, GCPPostgresConnectionConfig)
     assert config.is_recommended_for_state_sync is True
+    assert config.ip_type == "public"
+    config = make_config(
+        type="gcp_postgres",
+        instance_connection_string="something",
+        user="user",
+        password="password",
+        db="database",
+        ip_type="private",
+    )
+    assert config.ip_type == "private"
 
 
 def test_mysql(make_config):


### PR DESCRIPTION
Prior to this PR, it was assumed that customers would be connecting to GCP Postgres using the public IP. This is most likely the case but they could also connect using private if on a VPN. 

Also noticed that `timeout` was an argument that could be passed into the GCP Postgres connector class but we didn't include it and just passed into the resulting connection class. Also noticed some config options weren't documented or tested which was also fixed. 