### PR TITLE
fix: only expand restatement range if incremental

### DIFF
--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -351,7 +351,7 @@ class PlanBuilder:
                 if is_restateable_snapshot(self._context_diff.snapshots[downstream_s_id]):
                     restatements[downstream_s_id] = dummy_interval
 
-        # Get restatement intervals for all restated snapshots and make sure that if a snapshot expands it's
+        # Get restatement intervals for all restated snapshots and make sure that if an incremental snapshot expands it's
         # restatement range that it's downstream dependencies all expand their restatement ranges as well.
         for s_id in dag:
             if s_id not in restatements:
@@ -368,7 +368,9 @@ class PlanBuilder:
             # the graph we just have to check our immediate parents in the graph and not the whole upstream graph.
             snapshot_dependencies = snapshot.parents
             possible_intervals = [
-                restatements.get(s, dummy_interval) for s in snapshot_dependencies
+                restatements.get(s, dummy_interval)
+                for s in snapshot_dependencies
+                if self._context_diff.snapshots[s].is_incremental
             ] + [interval]
             snapshot_start = min(i[0] for i in possible_intervals)
             snapshot_end = max(i[1] for i in possible_intervals)


### PR DESCRIPTION
Resolves Repro here: https://github.com/TobikoData/sqlmesh/pull/3845
Slack context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1739560750218099

Prior to this PR we would expand the range of a restatement if a model involved in the restatement expanded the range due to it's model properties. For example a full can't restate a subset so it expands the provided start to match it's model start. The problem was that this expansion is needed to maintain correctness of that model but downstream models can respect the provided start as a limit. 

The thinking is that we really only want to expand the restatement range for downstream if an upstream *incremental* model expanded the range. This would make the restatement consistent across incremental while ignoring the models that aren't incremental that will expand it due to how they are defined. 