### PR TITLE
Feat!: add model blueprinting

### DIFF
--- a/docs/concepts/models/python_models.md
+++ b/docs/concepts/models/python_models.md
@@ -315,6 +315,10 @@ Make sure the argument has a default value if it's possible for the variable to 
 
 Note that arguments must be specified explicitly - variables cannot be accessed using `kwargs`.
 
+## Python model blueprinting
+
+A Python model can also serve as a template for creating multiple models, or _blueprints_, by specifying a list of key-value dicts in the `blueprints` property. Please refer to the Python-based SQL model [documentation page](./sql_models.md#Python-model-blueprinting)) for more details.
+
 ## Examples
 ### Basic
 The following is an example of a Python model returning a static Pandas DataFrame.

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -548,8 +548,6 @@ def _create_parser(expression_type: t.Type[exp.Expression], table_keys: t.List[s
         from sqlmesh.core.model.kind import ModelKindName
 
         expressions: t.List[exp.Expression] = []
-        gateway: t.Optional[exp.Expression] = None
-        blueprints: t.List[exp.Expression] = []
 
         while True:
             prev_property = seq_get(expressions, -1)
@@ -613,36 +611,12 @@ def _create_parser(expression_type: t.Type[exp.Expression], table_keys: t.List[s
             else:
                 value = self._parse_bracket(self._parse_field(any_token=True))
 
-                if key == "gateway":
-                    gateway = value
-                elif key == "blueprints":
-                    if isinstance(value, exp.Paren):
-                        blueprints = [value.this]
-                    elif isinstance(value, (exp.Tuple, exp.Array)):
-                        blueprints = value.expressions
-                    else:
-                        raise ConfigError(
-                            "The 'blueprints' values need to be enclosed in "
-                            f"parentheses or brackets, got {value} instead."
-                        )
-
-                    # We don't want to include blueprints in the property list
-                    continue
-
             if isinstance(value, exp.Expression):
                 value.meta["sql"] = self._find_sql(start, self._prev)
 
             expressions.append(self.expression(exp.Property, this=key, value=value))
 
-        expression = self.expression(expression_type, expressions=expressions)
-
-        # We store these properties in the meta to provide quick access at load time
-        if blueprints:
-            expression.meta["blueprints"] = blueprints
-            if gateway:
-                expression.meta["gateway"] = gateway
-
-        return expression
+        return self.expression(expression_type, expressions=expressions)
 
     return parse
 

--- a/sqlmesh/core/model/__init__.py
+++ b/sqlmesh/core/model/__init__.py
@@ -15,6 +15,7 @@ from sqlmesh.core.model.definition import (
     create_seed_model as create_seed_model,
     create_sql_model as create_sql_model,
     load_sql_based_model as load_sql_based_model,
+    load_sql_based_models as load_sql_based_models,
 )
 from sqlmesh.core.model.kind import (
     CustomKind as CustomKind,

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -88,13 +88,19 @@ class model(registry_decorator):
     def models(
         self,
         get_variables: t.Callable[[t.Optional[str]], t.Dict[str, str]],
+        path: Path,
+        module_path: Path,
+        dialect: t.Optional[str] = None,
         **loader_kwargs: t.Any,
     ) -> t.List[Model]:
         return create_models_from_blueprints(
             gateway=self.kwargs.get("gateway"),
-            blueprints=self.kwargs.pop("blueprints", None),
+            blueprints=self.kwargs.get("blueprints"),
             get_variables=get_variables,
             loader=self.model,
+            path=path,
+            module_path=module_path,
+            dialect=dialect,
             **loader_kwargs,
         )
 

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -16,7 +16,7 @@ from sqlmesh.core.model.definition import (
     Model,
     create_python_model,
     create_sql_model,
-    create_model_blueprints,
+    create_models_from_blueprints,
     get_model_name,
     render_meta_fields,
 )
@@ -90,7 +90,7 @@ class model(registry_decorator):
         get_variables: t.Callable[[t.Optional[str]], t.Dict[str, str]],
         **loader_kwargs: t.Any,
     ) -> t.List[Model]:
-        return create_model_blueprints(
+        return create_models_from_blueprints(
             gateway=self.kwargs.get("gateway"),
             blueprints=self.kwargs.pop("blueprints", None),
             get_variables=get_variables,

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -16,6 +16,7 @@ from sqlmesh.core.model.definition import (
     Model,
     create_python_model,
     create_sql_model,
+    create_model_blueprints,
     get_model_name,
     render_meta_fields,
 )
@@ -83,6 +84,19 @@ class model(registry_decorator):
         if not self.name_provided:
             self.name = get_model_name(Path(inspect.getfile(func)))
         return super().__call__(func)
+
+    def models(
+        self,
+        get_variables: t.Callable[[t.Optional[str]], t.Dict[str, str]],
+        **loader_kwargs: t.Any,
+    ) -> t.List[Model]:
+        return create_model_blueprints(
+            gateway=self.kwargs.get("gateway"),
+            blueprints=self.kwargs.pop("blueprints", None),
+            get_variables=get_variables,
+            loader=self.model,
+            **loader_kwargs,
+        )
 
     def model(
         self,

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1785,7 +1785,7 @@ class AuditResult(PydanticModel):
     blocking: bool = True
 
 
-def create_model_blueprints(
+def create_models_from_blueprints(
     gateway: t.Optional[str | exp.Expression],
     blueprints: t.Any,
     get_variables: t.Callable[[t.Optional[str]], t.Dict[str, str]],
@@ -1854,7 +1854,7 @@ def load_sql_based_models(
             # We pop the blueprints property here because it shouldn't be part of the model
             blueprints = prop.pop().args["value"]
 
-    return create_model_blueprints(
+    return create_models_from_blueprints(
         gateway=gateway,
         blueprints=blueprints,
         get_variables=get_variables,

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -7593,13 +7593,23 @@ def test_model_blueprinting(tmp_path: Path) -> None:
         model_defaults=ModelDefaultsConfig(dialect="duckdb"),
     )
 
+    blueprint_sql = tmp_path / "macros" / "identity_macro.py"
+    blueprint_sql.parent.mkdir(parents=True, exist_ok=True)
+    blueprint_sql.write_text(
+        """from sqlmesh import macro
+
+@macro()
+def identity(evaluator, value):
+    return value
+"""
+    )
     blueprint_sql = tmp_path / "models" / "blueprint.sql"
     blueprint_sql.parent.mkdir(parents=True, exist_ok=True)
     blueprint_sql.write_text(
         """
         MODEL (
           name @{blueprint}.test_model_sql,
-          gateway @blueprint,
+          gateway @identity(@blueprint),
           blueprints ((blueprint := gw1), (blueprint := gw2)),
           kind FULL
         );

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -11,7 +11,7 @@ from pytest_mock.plugin import MockerFixture
 from sqlglot import exp, parse_one
 from sqlglot.errors import ParseError
 from sqlglot.schema import MappingSchema
-from sqlmesh.cli.example_project import init_example_project
+from sqlmesh.cli.example_project import init_example_project, ProjectTemplate
 
 from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
@@ -2437,16 +2437,16 @@ def test_model_cache(tmp_path: Path, mocker: MockerFixture):
 
     model = load_sql_based_model([e for e in expressions if e])
 
-    loader = mocker.Mock(return_value=model)
+    loader = mocker.Mock(return_value=[model])
 
-    assert cache.get_or_load("test_model", "test_entry_a", loader=loader).dict() == model.dict()
-    assert cache.get_or_load("test_model", "test_entry_a", loader=loader).dict() == model.dict()
+    assert cache.get_or_load("test_model", "test_entry_a", loader=loader)[0].dict() == model.dict()
+    assert cache.get_or_load("test_model", "test_entry_a", loader=loader)[0].dict() == model.dict()
 
-    assert cache.get_or_load("test_model", "test_entry_b", loader=loader).dict() == model.dict()
-    assert cache.get_or_load("test_model", "test_entry_b", loader=loader).dict() == model.dict()
+    assert cache.get_or_load("test_model", "test_entry_b", loader=loader)[0].dict() == model.dict()
+    assert cache.get_or_load("test_model", "test_entry_b", loader=loader)[0].dict() == model.dict()
 
-    assert cache.get_or_load("test_model", "test_entry_a", loader=loader).dict() == model.dict()
-    assert cache.get_or_load("test_model", "test_entry_a", loader=loader).dict() == model.dict()
+    assert cache.get_or_load("test_model", "test_entry_a", loader=loader)[0].dict() == model.dict()
+    assert cache.get_or_load("test_model", "test_entry_a", loader=loader)[0].dict() == model.dict()
 
     assert loader.call_count == 2
 
@@ -7576,3 +7576,131 @@ def test_partition_interval_unit():
     )
     model = load_sql_based_model(expressions)
     assert model.partition_interval_unit is None
+
+
+def test_model_blueprinting(tmp_path: Path) -> None:
+    init_example_project(tmp_path, dialect="duckdb", template=ProjectTemplate.EMPTY)
+
+    db_path = str(tmp_path / "db.db")
+    db_connection = DuckDBConnectionConfig(database=db_path)
+
+    gateways = {
+        "gw1": GatewayConfig(connection=db_connection, variables={"x": 1}),
+        "gw2": GatewayConfig(connection=db_connection, variables={"x": 2}),
+    }
+    config = Config(
+        gateways=gateways,
+        model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+    )
+
+    blueprint_sql = tmp_path / "models" / "blueprint.sql"
+    blueprint_sql.parent.mkdir(parents=True, exist_ok=True)
+    blueprint_sql.write_text(
+        """
+        MODEL (
+          name @{blueprint}.test_model_sql,
+          gateway @blueprint,
+          blueprints (gw1, gw2),
+          kind FULL
+        );
+
+        SELECT
+          @x AS x
+        """
+    )
+    blueprint_pydf = tmp_path / "models" / "blueprint_df.py"
+    blueprint_pydf.parent.mkdir(parents=True, exist_ok=True)
+    blueprint_pydf.write_text(
+        """
+import pandas as pd
+from sqlmesh import model
+
+
+@model(
+    "@{blueprint}.test_model_pydf",
+    gateway="@blueprint",
+    blueprints=["gw1", "gw2"],
+    kind="FULL",
+    columns={"x": "INT"},
+)
+def entrypoint(context, *args, **kwargs):
+    x_var = context.var("x")
+    return pd.DataFrame({"x": [x_var]})"""
+    )
+    blueprint_pysql = tmp_path / "models" / "blueprint_sql.py"
+    blueprint_pysql.parent.mkdir(parents=True, exist_ok=True)
+    blueprint_pysql.write_text(
+        """
+from sqlmesh import model
+
+
+@model(
+    "@{blueprint}.test_model_pysql",
+    gateway="@blueprint",
+    blueprints=["gw1", "gw2"],
+    kind="FULL",
+    is_sql=True,
+)
+def entrypoint(evaluator):
+    x_var = evaluator.var("x")
+    return f'SELECT {x_var} AS x'"""
+    )
+
+    context = Context(paths=tmp_path, config=config)
+    models = context.models
+
+    # Each of the three model files "expands" into two models
+    assert len(models) == 6
+
+    context.plan(no_prompts=True, auto_apply=True, no_diff=True)
+
+    for model_name in ("test_model_sql", "test_model_pydf", "test_model_pysql"):
+        for gateway_no in range(1, 3):
+            model = models.get(f'"db"."gw{gateway_no}"."{model_name}"')
+
+            assert model is not None
+            assert "blueprints" not in model.all_fields()
+            assert model.python_env.get(c.SQLMESH_VARS) == Executable.value({"x": gateway_no})
+            assert context.fetchdf(f"from {model.fqn}").to_dict() == {"x": {0: gateway_no}}
+
+    multi_variable_blueprint_example = tmp_path / "models" / "multi_variable_blueprint_example.sql"
+    multi_variable_blueprint_example.parent.mkdir(parents=True, exist_ok=True)
+    multi_variable_blueprint_example.write_text(
+        """
+        MODEL (
+          name @{customer}.my_table,
+          blueprints [(customer=customer1, foo='bar'), (customer=customer2, foo=qux)],
+          kind FULL
+        );
+
+        SELECT
+          @VAR('foo') AS foo,
+        FROM @VAR('customer').my_source
+        """
+    )
+
+    context = Context(paths=tmp_path, config=config)
+    models = context.models
+
+    # The new model expands into another 2 new models
+    assert len(models) == 8
+
+    customer1_model = models.get('"db"."customer1"."my_table"')
+
+    assert customer1_model is not None
+    assert customer1_model.python_env.get(c.SQLMESH_VARS) == Executable.value(
+        {"customer": "customer1", "foo": "'bar'"}
+    )
+    assert t.cast(exp.Expression, customer1_model.render_query()).sql() == (
+        """SELECT '''bar''' AS "foo" FROM "db"."customer1"."my_source" AS "my_source\""""
+    )
+
+    customer2_model = models.get('"db"."customer2"."my_table"')
+
+    assert customer2_model is not None
+    assert customer2_model.python_env.get(c.SQLMESH_VARS) == Executable.value(
+        {"customer": "customer2", "foo": "qux"}
+    )
+    assert t.cast(exp.Expression, customer2_model.render_query()).sql() == (
+        '''SELECT 'qux' AS "foo" FROM "db"."customer2"."my_source" AS "my_source"'''
+    )

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -7600,7 +7600,7 @@ def test_model_blueprinting(tmp_path: Path) -> None:
         MODEL (
           name @{blueprint}.test_model_sql,
           gateway @blueprint,
-          blueprints (gw1, gw2),
+          blueprints ((blueprint := gw1), (blueprint := gw2)),
           kind FULL
         );
 
@@ -7619,7 +7619,7 @@ from sqlmesh import model
 @model(
     "@{blueprint}.test_model_pydf",
     gateway="@blueprint",
-    blueprints=["gw1", "gw2"],
+    blueprints=[{"blueprint": "gw1"}, {"blueprint": "gw2"}],
     kind="FULL",
     columns={"x": "INT"},
 )
@@ -7637,7 +7637,7 @@ from sqlmesh import model
 @model(
     "@{blueprint}.test_model_pysql",
     gateway="@blueprint",
-    blueprints=["gw1", "gw2"],
+    blueprints=[{"blueprint": "gw1"}, {"blueprint": "gw2"}],
     kind="FULL",
     is_sql=True,
 )
@@ -7669,7 +7669,10 @@ def entrypoint(evaluator):
         """
         MODEL (
           name @{customer}.my_table,
-          blueprints [(customer=customer1, foo='bar'), (customer=customer2, foo=qux)],
+          blueprints (
+            (customer := customer1, foo := 'bar'),
+            (customer := customer2, foo := qux),
+          ),
           kind FULL
         );
 


### PR DESCRIPTION
This PR adds a new feature: the ability to implement model blueprints based on a single template.

This feature is useful when multiple models need to share the same logic, but parameterized differently. Today, this is generally possible by either duplicating model definitions, thus violating the [DRY principle](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself), or creating a custom loader, which involves knowing the inner workings of the codebase.

A simple example that demonstrates the syntax to achieve model blueprinting is shown below:

```sql
MODEL (
  name @blueprint.some_table,
  blueprints (
    (blueprint := customer1),
    (blueprint := customer2),
    (blueprint := customer3),
  ),
);

SELECT
  *
FROM @blueprint.some_source
```

This definition essentially expands into three different models, each one sharing the same logic but using a different value for the `@blueprint` variable. A blueprint can be further customized by specifying additional variables:

```sql
MODEL (
  name @customer.some_table,
  blueprints (
    (customer := customer1, field_a := x, field_b := y),
    (customer := customer2, field_a := z, field_b := w),
  )
);

SELECT
  @field_a,
  @field_b
FROM @customer.some_source
```

Similarly, this will expand into two different models, where each one will contain the variables specified in the corresponding `blueprints` tuple. For example, the first model would look like:

```sql
MODEL (
  name customer1.some_table,
);

SELECT
  x,
  y
FROM customer1.some_source
```

The blueprint variable mappings can be combined with custom macros to implement even more complicated patterns, e.g., where the model logic itself changes completely depending on a variable's value.