### PR TITLE
fix!: normalize catalog override name

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -222,13 +222,20 @@ class QualifiedViewName(PydanticModel, frozen=True):
         return exp.table_(
             self.table_name_for_environment(environment_naming_info, dialect=dialect),
             db=self.schema_for_environment(environment_naming_info, dialect=dialect),
-            catalog=self.catalog_for_environment(environment_naming_info),
+            catalog=self.catalog_for_environment(environment_naming_info, dialect=dialect),
         )
 
     def catalog_for_environment(
-        self, environment_naming_info: EnvironmentNamingInfo
+        self, environment_naming_info: EnvironmentNamingInfo, dialect: DialectType = None
     ) -> t.Optional[str]:
-        return environment_naming_info.catalog_name_override or self.catalog
+        if environment_naming_info.catalog_name_override:
+            catalog_name = environment_naming_info.catalog_name_override
+            return (
+                normalize_identifiers(catalog_name, dialect=dialect).name
+                if environment_naming_info.normalize_name
+                else catalog_name
+            )
+        return self.catalog
 
     def schema_for_environment(
         self, environment_naming_info: EnvironmentNamingInfo, dialect: DialectType = None

--- a/sqlmesh/core/state_sync/common.py
+++ b/sqlmesh/core/state_sync/common.py
@@ -25,7 +25,9 @@ def cleanup_expired_views(
     ]
     for expired_catalog, expired_schema in {
         (
-            snapshot.qualified_view_name.catalog_for_environment(environment.naming_info),
+            snapshot.qualified_view_name.catalog_for_environment(
+                environment.naming_info, dialect=adapter.dialect
+            ),
             snapshot.qualified_view_name.schema_for_environment(
                 environment.naming_info, dialect=adapter.dialect
             ),


### PR DESCRIPTION
Prior to this PR, if you were using Snowflake and the `environment_catalog_mapping` config it would result in lowercase catalog names. 

This PR updates the config to normalize according to the dialect. Tested against Snowflake and confirmed to be working as expected. 

Note: The PR doesn't attempt to address a potential issue if someone wanted to quote their catalog name. I think we are missing a `to_identifier` or `parse_identifier` somewhere but it is not the problem I fixing here. 