### PR TITLE
Fix: Warn when SQLMesh automatically adjusts a restatement range to cover the whole model

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -722,11 +722,9 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
             requested_start, requested_end = removal_interval
             expanded_start, expanded_end = expanded_removal_interval
 
-            is_subset = requested_start > expanded_start or requested_end < expanded_end
-
             # only warn if the requested removal interval was a subset of the actual model intervals and was automatically expanded
             # if the requested interval was the same or wider than the actual model intervals, no need to warn
-            if removal_interval != expanded_removal_interval and is_subset:
+            if requested_start > expanded_start or requested_end < expanded_end:
                 from sqlmesh.core.console import get_console
 
                 get_console().log_warning(


### PR DESCRIPTION
Prior to this change, if you tried to restate eg 1 day of a model that is [full_history_restatement_only](https://github.com/TobikoData/sqlmesh/blob/ab6b2502549d12d2a23d4af2d976c180ca6ef1f7/sqlmesh/core/model/kind.py#L131), for example an `INCREMENTAL_BY_UNIQUE_KEY` model:

```
$ sqlmesh plan --restate-model sqlmesh_example.unique_key_model --start 2020-01-01 --end 2020-01-02

No changes to plan: project files match the `prod` environment

Models needing backfill:
└── sqlmesh_example.unique_key_model: [2020-01-01 - 2020-01-10]
```

SQLMesh would automatically adjust the backfill intervals to cover the entire model without making it obvious to the user.

Even if the user notices that the end date in this example was changed to `2020-01-10` they may be confused as to _why_ SQLMesh ignored their specified end date of `2020-01-02`.

This PR adds a warning like so:
```
$ sqlmesh plan --restate-model sqlmesh_example.unique_key_model --start 2020-01-01 --end 2020-01-02

[WARNING] Model 'sqlmesh_example.unique_key_model' is 'INCREMENTAL_BY_UNIQUE_KEY' which does not support partial restatement.
Expanding the requested restatement intervals from [2020-01-01 - 2020-01-02] to [2020-01-01 - 2020-01-10] in order to fully restate the model.

No changes to plan: project files match the `prod` environment

Models needing backfill:
└── sqlmesh_example.unique_key_model: [2020-01-01 - 2020-01-10]
```