### PR TITLE
Fix: Pin PyGithub to 2.5.0 so tests can run

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
             "psycopg2-binary",
             "pydantic",
             "PyAthena[Pandas]",
-            "PyGithub",
+            "PyGithub~=2.5.0",
             "pyspark~=3.5.0",
             "pytest",
             "pytest-asyncio",
@@ -123,7 +123,7 @@ setup(
             "cloud-sql-python-connector[pg8000]",
         ],
         "github": [
-            "PyGithub",
+            "PyGithub~=2.5.0",
         ],
         "llm": [
             "langchain",


### PR DESCRIPTION
PyGithub 2.6.0 just got released, which caused our cicd bot tests to start failing.

It looks like theyve changed a bunch of stuff. I spent some time trying to make the tests compatible but was ultimately unsuccessful because I dont have enough context of how its meant to work.

I've pinned the older version 2.5.0 so at least the build can continue working in the short term