### PR TITLE
fix: stop from get loaded context in async

### DIFF
--- a/web/server/api/endpoints/directories.py
+++ b/web/server/api/endpoints/directories.py
@@ -21,7 +21,7 @@ async def write_directory(
 ) -> models.Directory:
     """Create or rename a directory."""
     if new_path:
-        new_path = await validate_path(new_path, settings)
+        new_path = validate_path(new_path, settings)
         replace_file(settings.project_path / path, settings.project_path / new_path)
         return models.Directory(name=os.path.basename(new_path), path=new_path)
 

--- a/web/server/api/endpoints/files.py
+++ b/web/server/api/endpoints/files.py
@@ -25,9 +25,9 @@ router = APIRouter()
 
 
 @router.get("", response_model=models.Directory)
-async def get_files(settings: Settings = Depends(get_settings)) -> models.Directory:
+def get_files(settings: Settings = Depends(get_settings)) -> models.Directory:
     """Get all project files."""
-    return await _get_directory(settings.project_path, settings)
+    return _get_directory(settings.project_path, settings)
 
 
 @router.get("/{path:path}", response_model=models.File)
@@ -56,7 +56,7 @@ async def write_file(
     """Create, update, or rename a file."""
     path_or_new_path = path
     if new_path:
-        path_or_new_path = await validate_path(new_path, settings)
+        path_or_new_path = validate_path(new_path, settings)
         replace_file(settings.project_path / path, settings.project_path / path_or_new_path)
     else:
         full_path = settings.project_path / path
@@ -70,7 +70,7 @@ async def write_file(
             format_file_status = models.FormatFileStatus(
                 status=models.Status.INIT, path=path_or_new_path
             )
-            path_to_model_mapping = await get_path_to_model_mapping(settings=settings)
+            path_to_model_mapping = get_path_to_model_mapping(settings=settings)
             model = path_to_model_mapping.get(Path(full_path))
             default_dialect = config.dialect
             dialect = model.dialect if model and model.is_sql else default_dialect
@@ -118,8 +118,8 @@ async def delete_file(
         )
 
 
-async def _get_directory(path: str | Path, settings: Settings) -> models.Directory:
-    context = await get_context(settings)
+def _get_directory(path: str | Path, settings: Settings) -> models.Directory:
+    context = get_context(settings)
     ignore_patterns = context.config.ignore_patterns if context else c.IGNORE_PATTERNS
 
     def walk_path(

--- a/web/server/main.py
+++ b/web/server/main.py
@@ -35,7 +35,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator:
 
     app.state.dispatch_task.cancel()
     app.state.watch_task.cancel()
-    context = await get_context_or_raise(settings=get_settings())
+    context = get_context_or_raise(settings=get_settings())
     context.close()
 
 

--- a/web/server/utils.py
+++ b/web/server/utils.py
@@ -51,8 +51,8 @@ async def run_in_executor(func: t.Callable[..., R], *args: t.Any) -> R:
     return await loop.run_in_executor(None, func_wrapper)
 
 
-async def validate_path(path: str, settings: Settings = Depends(get_settings)) -> str:
-    context = await get_context(settings)
+def validate_path(path: str, settings: Settings = Depends(get_settings)) -> str:
+    context = get_context(settings)
     resolved_path = settings.project_path.resolve()
     full_path = (resolved_path / path).resolve()
     try:

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -21,7 +21,7 @@ from sqlglot.helper import ensure_list
 
 async def watch_project() -> None:
     settings = get_settings()
-    context = await get_context(settings)
+    context = get_context(settings)
     paths = [
         (settings.project_path / c.AUDITS).resolve(),
         (settings.project_path / c.MACROS).resolve(),
@@ -57,10 +57,10 @@ async def watch_project() -> None:
                         )
                     )
                 elif change == Change.added:
-                    directory = await _get_directory(path.parent, settings)
+                    directory = _get_directory(path.parent, settings)
                     directories[directory.path] = directory
                 elif path.is_dir() and change == Change.modified:
-                    directory = await _get_directory(path, settings)
+                    directory = _get_directory(path, settings)
                     directories[directory.path] = directory
                 elif path.is_file() and change == Change.modified:
                     changes.append(


### PR DESCRIPTION
**Problem**

In enterprise, we are seeing the above error with tasks. 

![image](https://github.com/user-attachments/assets/b45e8ac5-93ac-49e0-8f00-10ad9dbfe37a)

**Solution**

Move the work out of the separate executor which solves the above conflict. 

The problem with that change alone is that it make the call slower because in async await context it's now blocking. To avoid that I've made the dependency injection sync which means FastAPI runs it in itsthreadpool, which means it doesn't slow other calls down. Once thing that needed to be done is to then move the lock protecting the work into a thread.

