### PR TITLE
Chore: fix audit doc typos

### DIFF
--- a/docs/concepts/audits.md
+++ b/docs/concepts/audits.md
@@ -378,7 +378,7 @@ MODEL (
 );
 ```
 
-#### string_length_equal_audit, string_length_equal_audit_non_blocking
+#### string_length_equal, string_length_equal_non_blocking
 Ensures that all rows of a column contain a string with the specified number of characters.
 
 This example asserts that all `zip` values are 5 characters long:
@@ -387,12 +387,12 @@ This example asserts that all `zip` values are 5 characters long:
 MODEL (
   name sushi.customers,
   audits (
-    string_length_equal_audit(column := zip, v := 5)
+    string_length_equal(column := zip, v := 5)
     )
 );
 ```
 
-#### string_length_between_audit, string_length_between_audit_non_blocking
+#### string_length_between, string_length_between_non_blocking
 Ensures that all rows of a column contain a string with number of characters in the specified range. Range is inclusive by default, such that values equal to the range boundaries will pass the audit.
 
 This example asserts that all `name` values have 5 or more and 50 or fewer characters:
@@ -401,7 +401,7 @@ This example asserts that all `name` values have 5 or more and 50 or fewer chara
 MODEL (
   name sushi.customers,
   audits (
-    string_length_between_audit(column := name, min_v := 5, max_v := 50)
+    string_length_between(column := name, min_v := 5, max_v := 50)
     )
 );
 ```
@@ -412,7 +412,7 @@ This example specifies the `inclusive := false` argument to assert that all rows
 MODEL (
   name sushi.customers,
   audits (
-    string_length_between_audit(column := zip, min_v := 4, max_v := 60, inclusive := false)
+    string_length_between(column := zip, min_v := 4, max_v := 60, inclusive := false)
     )
 );
 ```

--- a/sqlmesh/core/audit/builtin.py
+++ b/sqlmesh/core/audit/builtin.py
@@ -416,7 +416,7 @@ WHERE @AND(
     """,
 )
 
-# z_score_audit(column=column_name, threshold=3)
+# z_score(column=column_name, threshold=3)
 z_score_audit = ModelAudit(
     name="z_score",
     defaults={"condition": exp.true()},
@@ -436,7 +436,7 @@ WHERE ABS((@column - mean_@column) / NULLIF(stddev_@column, 0)) > @threshold
     """,
 )
 
-# string_length_between_audit(column=column_name, max_v=22)
+# string_length_between(column=column_name, max_v=22)
 string_length_between_audit = ModelAudit(
     name="string_length_between",
     defaults={
@@ -461,7 +461,7 @@ WHERE
     """,
 )
 
-# string_length_equal_audit(column=column_name, v=22)
+# string_length_equal(column=column_name, v=22)
 string_length_equal_audit = ModelAudit(
     name="string_length_equal",
     defaults={"condition": exp.true()},


### PR DESCRIPTION
We do `foo_audit = ModelAudit("foo", ...)` in `builtin.py`, so my guess is the variable name was copied over inadvertently.