### PR TITLE
Fix!: use inspect.getsource in favor of custom parsing, stop relying on astor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         "types": [python]
         files: *files
         require_serial: true
-        exclude: ^(tests/fixtures)
+        exclude: ^(tests/fixtures|tests/core/metaprogramming_test_helper\.py)
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "fc26039"
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,9 +18,6 @@ ignore_missing_imports = True
 [mypy-tests.*]
 disallow_untyped_defs = False
 
-[mypy-astor.*]
-ignore_missing_imports = True
-
 [mypy-IPython.*]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
     },
     setup_requires=["setuptools_scm"],
     install_requires=[
-        "astor",
         "click",
         "croniter",
         "duckdb!=0.10.3",

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -15,7 +15,6 @@ from enum import Enum
 from numbers import Number
 from pathlib import Path
 
-from astor import to_source
 
 from sqlmesh.core import constants as c
 from sqlmesh.utils import format_exception, unique
@@ -260,7 +259,7 @@ def normalize_source(obj: t.Any) -> str:
             if isinstance(node, ast.FunctionDef):
                 node.returns = None
 
-    return to_source(root_node).strip()
+    return ast.unparse(root_node).strip()
 
 
 def build_env(

--- a/tests/core/metaprogramming_test_helper.py
+++ b/tests/core/metaprogramming_test_helper.py
@@ -1,0 +1,11 @@
+# This module is conditionally imported to demonstrate that we can
+# serialize `match` statements that are available only for > v3.9.
+# If we included this code as-is in test_metaprogramming.py, the
+# test harness would crash when using Python 3.9 in CI
+
+
+def match_expression():
+    match 5:
+        case 5:
+            return 1
+    return 0

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -4576,7 +4576,7 @@ def test_default_catalog_sql(assert_exp_eq):
 
 
 def test_default_catalog_python():
-    HASH_WITH_CATALOG = "770057346"
+    HASH_WITH_CATALOG = "1357281693"
 
     @model(name="db.table", kind="full", columns={'"COL"': "int"})
     def my_model(context, **kwargs):

--- a/tests/utils/test_metaprogramming.py
+++ b/tests/utils/test_metaprogramming.py
@@ -144,6 +144,10 @@ def main_func(y: int, foo=exp.true(), *, bar=expressions.Literal.number(1) + 2) 
     with test_context_manager():
         pass
 
+    match 5:
+        case 5:
+            pass
+
     return closure(y) + other_func(Y)
 
 
@@ -187,8 +191,7 @@ def test_func_globals() -> None:
 def test_normalize_source() -> None:
     assert (
         normalize_source(main_func)
-        == """def main_func(y: int, foo=exp.true(), *, bar=expressions.Literal.number(1) + 2
-    ):
+        == """def main_func(y: int, foo=exp.true(), *, bar=expressions.Literal.number(1) + 2):
     sqlglot.parse_one('1')
     MyClass()
     DataClass(x=y)
@@ -201,6 +204,9 @@ def test_normalize_source() -> None:
         return z + Z
     with test_context_manager():
         pass
+    match 5:
+        case 5:
+            pass
     return closure(y) + other_func(Y)"""
     )
 
@@ -237,8 +243,7 @@ def test_serialize_env() -> None:
             name="main_func",
             alias="MAIN",
             path="test_metaprogramming.py",
-            payload="""def main_func(y: int, foo=exp.true(), *, bar=expressions.Literal.number(1) + 2
-    ):
+            payload="""def main_func(y: int, foo=exp.true(), *, bar=expressions.Literal.number(1) + 2):
     sqlglot.parse_one('1')
     MyClass()
     DataClass(x=y)
@@ -251,6 +256,9 @@ def test_serialize_env() -> None:
         return z + Z
     with test_context_manager():
         pass
+    match 5:
+        case 5:
+            pass
     return closure(y) + other_func(Y)""",
         ),
         "X": Executable(payload="1", kind=ExecutableKind.VALUE),
@@ -314,7 +322,7 @@ def test_context_manager():
         "my_lambda": Executable(
             name="my_lambda",
             path="test_metaprogramming.py",
-            payload="my_lambda = lambda : print('z')",
+            payload="my_lambda = lambda: print('z')",
         ),
         "noop_metadata": Executable(
             name="noop_metadata",

--- a/tests/utils/test_metaprogramming.py
+++ b/tests/utils/test_metaprogramming.py
@@ -1,3 +1,4 @@
+import sys
 import typing as t
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -143,11 +144,14 @@ def main_func(y: int, foo=exp.true(), *, bar=expressions.Literal.number(1) + 2) 
     with test_context_manager():
         pass
 
-    match 5:
-        case 5:
-            pass
+    if sys.version_info >= (3, 10):
+        from tests.core.metaprogramming_test_helper import match_expression
 
-    return closure(y) + other_func(Y)
+        match_expression_value = match_expression()
+    else:
+        match_expression_value = 0
+
+    return closure(y) + other_func(Y) + match_expression_value
 
 
 def test_func_globals() -> None:
@@ -165,6 +169,7 @@ def test_func_globals() -> None:
         "fetch_data": fetch_data,
         "test_context_manager": test_context_manager,
         "function_with_custom_decorator": function_with_custom_decorator,
+        "sys": sys,
     }
     assert func_globals(other_func) == {
         "X": 1,
@@ -225,11 +230,14 @@ def test_serialize_env() -> None:
     with test_context_manager():
         pass
 
-    match 5:
-        case 5:
-            pass
+    if sys.version_info >= (3, 10):
+        from tests.core.metaprogramming_test_helper import match_expression
 
-    return closure(y) + other_func(Y)''',
+        match_expression_value = match_expression()
+    else:
+        match_expression_value = 0
+
+    return closure(y) + other_func(Y) + match_expression_value''',
         ),
         "X": Executable(payload="1", kind=ExecutableKind.VALUE),
         "Y": Executable(payload="2", kind=ExecutableKind.VALUE),
@@ -327,6 +335,7 @@ def test_context_manager():
         "stop_after_attempt": Executable(
             payload="from tenacity.stop import stop_after_attempt", kind=ExecutableKind.IMPORT
         ),
+        "sys": Executable(payload="import sys", kind=ExecutableKind.IMPORT),
         "wrapped_f": Executable(
             payload='''@retry(stop=stop_after_attempt(3))
 def fetch_data():


### PR DESCRIPTION
The motivation behind this change is that the `astor` package has a very slow release cadence, so the latest deployed version tends to be quite behind in its Python support. An example is the `match` statement, which fails to be parsed by [astor v0.8.1](https://pypi.org/project/astor/#history), even though it _is_ supported in the main branch of the project:

```python
import pandas as pd
from sqlmesh import model

@model("test_model", columns={"id": "int"})
def entrypoint(*args, **kwargs):
    match 'foo':
        case 'foo':
            pass

    return pd.DataFrame({"id": [1, 2, 3]})
```

The above model fails to be loaded:

```
  File "sqlmesh/.venv/lib/python3.12/site-packages/astor/node_util.py", line 137, in abort_visit
    raise AttributeError(msg % node.__class__.__name__)
AttributeError: No defined handler for node of type Match
```

Since this change will likely introduce diffs due to the payload changing, we decided to include the changes from https://github.com/TobikoData/sqlmesh/pull/3677 as well.

**NOTE**: a side-effect introduced here is that whitespace, comments, docstrings and return type hints will now affect the data hash of python models and hence cause breaking changes, since we're simply checking the raw text of the python model instead of modifying the ast and unparsing it.