### PR TITLE
Feat: Allow CustomKind subclasses for custom materializations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install-dev:
 	pip3 install -e ".[dev,web,slack,dlt]"
 
 install-cicd-test:
-	pip3 install -e ".[dev,web,slack,cicdtest,dlt]"
+	pip3 install -e ".[dev,web,slack,cicdtest,dlt]" ./examples/custom_materializations
 
 install-doc:
 	pip3 install -r ./docs/requirements.txt
@@ -153,7 +153,7 @@ guard-%:
 	fi
 
 engine-%-install:
-	pip3 install -e ".[dev,web,slack,${*}]"
+	pip3 install -e ".[dev,web,slack,${*}]" ./examples/custom_materializations
 
 engine-docker-%-up:
 	docker compose -f ./tests/core/engine_adapter/integration/docker/compose.${*}.yaml up -d

--- a/docs/guides/custom_materializations.md
+++ b/docs/guides/custom_materializations.md
@@ -243,7 +243,7 @@ In this example, this means that:
 
 ### Data vs Metadata changes
 
-Subclasses of `CustomKind` that add extra properties can also decide if they are data properties (changes trigger the recreation of the underlying tables) or metadata properties (changes just update metadata about the model).
+Subclasses of `CustomKind` that add extra properties can also decide if they are data properties (changes may trigger the creation of new snapshots) or metadata properties (changes just update metadata about the model).
 
 They can also decide if they are relevant for text diffing when SQLMesh detects changes to a model.
 

--- a/examples/custom_materializations/custom_materializations/custom_kind.py
+++ b/examples/custom_materializations/custom_materializations/custom_kind.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import typing as t
+
+from sqlmesh import CustomMaterialization, CustomKind, Model
+from sqlmesh.utils.pydantic import validate_string
+from pydantic import field_validator
+
+if t.TYPE_CHECKING:
+    from sqlmesh import QueryOrDF
+
+
+class CustomCustomKind(CustomKind):
+    custom_property: t.Optional[str] = None
+
+    @field_validator("custom_property", mode="before")
+    @classmethod
+    def _validate_custom_property(cls, v: t.Any) -> str:
+        return validate_string(v)
+
+
+class CustomFullWithCustomKindMaterialization(CustomMaterialization[CustomCustomKind]):
+    NAME = "custom_full_with_custom_kind"
+
+    def insert(
+        self,
+        table_name: str,
+        query_or_df: QueryOrDF,
+        model: Model,
+        is_first_insert: bool,
+        **kwargs: t.Any,
+    ) -> None:
+        assert type(model.kind).__name__ == "CustomCustomKind"
+
+        self._replace_query_for_model(model, table_name, query_or_df)

--- a/examples/custom_materializations/custom_materializations/custom_kind.py
+++ b/examples/custom_materializations/custom_materializations/custom_kind.py
@@ -10,7 +10,7 @@ if t.TYPE_CHECKING:
     from sqlmesh import QueryOrDF
 
 
-class CustomCustomKind(CustomKind):
+class ExtendedCustomKind(CustomKind):
     custom_property: t.Optional[str] = None
 
     @field_validator("custom_property", mode="before")
@@ -19,7 +19,7 @@ class CustomCustomKind(CustomKind):
         return validate_string(v)
 
 
-class CustomFullWithCustomKindMaterialization(CustomMaterialization[CustomCustomKind]):
+class CustomFullWithCustomKindMaterialization(CustomMaterialization[ExtendedCustomKind]):
     NAME = "custom_full_with_custom_kind"
 
     def insert(
@@ -30,6 +30,6 @@ class CustomFullWithCustomKindMaterialization(CustomMaterialization[CustomCustom
         is_first_insert: bool,
         **kwargs: t.Any,
     ) -> None:
-        assert type(model.kind).__name__ == "CustomCustomKind"
+        assert type(model.kind).__name__ == "ExtendedCustomKind"
 
         self._replace_query_for_model(model, table_name, query_or_df)

--- a/examples/custom_materializations/setup.py
+++ b/examples/custom_materializations/setup.py
@@ -6,6 +6,7 @@ setup(
     entry_points={
         "sqlmesh.materializations": [
             "custom_full_materialization = custom_materializations.full:CustomFullMaterialization",
+            "custom_full_with_custom_kind = custom_materializations.custom_kind:CustomFullWithCustomKindMaterialization",
         ],
     },
     install_requires=[

--- a/examples/sushi/models/latest_order.sql
+++ b/examples/sushi/models/latest_order.sql
@@ -1,0 +1,13 @@
+MODEL (
+  name sushi.latest_order,
+  kind CUSTOM (
+    materialization 'custom_full_with_custom_kind',
+    custom_property 'sushi!!!'
+  ),
+  cron '@daily'
+);
+
+SELECT id, customer_id, start_ts, end_ts, event_date
+FROM sushi.orders
+ORDER BY event_date DESC LIMIT 1
+

--- a/sqlmesh/__init__.py
+++ b/sqlmesh/__init__.py
@@ -29,6 +29,7 @@ from sqlmesh.core.snapshot import Snapshot as Snapshot
 from sqlmesh.core.snapshot.evaluator import (
     CustomMaterialization as CustomMaterialization,
 )
+from sqlmesh.core.model.kind import CustomKind as CustomKind
 from sqlmesh.utils import (
     debug_mode_enabled as debug_mode_enabled,
     enable_debug_mode as enable_debug_mode,

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -979,6 +979,11 @@ def create_model_kind(v: t.Any, dialect: str, defaults: t.Dict[str, t.Any]) -> M
             # load the custom materialization class and check if it uses a custom kind type
             from sqlmesh.core.snapshot.evaluator import get_custom_materialization_type
 
+            if "materialization" not in props:
+                raise ConfigError(
+                    "The 'materialization' property is required for models of the CUSTOM kind"
+                )
+
             actual_kind_type, _ = get_custom_materialization_type(
                 validate_string(props.get("materialization"))
             )

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -975,6 +975,16 @@ def create_model_kind(v: t.Any, dialect: str, defaults: t.Dict[str, t.Any]) -> M
         ):
             props["on_destructive_change"] = defaults.get("on_destructive_change")
 
+        if kind_type == CustomKind:
+            # load the custom materialization class and check if it uses a custom kind type
+            from sqlmesh.core.snapshot.evaluator import get_custom_materialization_type
+
+            actual_kind_type, _ = get_custom_materialization_type(
+                validate_string(props.get("materialization"))
+            )
+
+            return actual_kind_type(**props)
+
         return kind_type(**props)
 
     name = (v.name if isinstance(v, exp.Expression) else str(v)).upper()

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -1944,7 +1944,7 @@ def get_custom_materialization_kind_type(st: t.Type[CustomMaterialization]) -> t
                 for generic_arg in t.get_args(base):
                     if not issubclass(generic_arg, CustomKind):
                         raise SQLMeshError(
-                            "Custom materialization kind '{generic_arg.__name__}' must be a subclass of CustomKind"
+                            f"Custom materialization kind '{generic_arg.__name__}' must be a subclass of CustomKind"
                         )
 
                     return generic_arg

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -49,6 +49,7 @@ from sqlmesh.core.model import (
     SCDType2ByColumnKind,
     SCDType2ByTimeKind,
     ViewKind,
+    CustomKind,
 )
 from sqlmesh.core.schema_diff import has_drop_alteration, get_dropped_column_names
 from sqlmesh.core.snapshot import (
@@ -1130,7 +1131,7 @@ def _evaluation_strategy(snapshot: SnapshotInfoLike, adapter: EngineAdapter) -> 
             raise SQLMeshError(
                 f"Missing the name of a custom evaluation strategy in model '{snapshot.name}'."
             )
-        klass = get_custom_materialization_type(snapshot.custom_materialization)
+        _, klass = get_custom_materialization_type(snapshot.custom_materialization)
         return klass(adapter)
     elif snapshot.is_managed:
         klass = EngineManagedStrategy
@@ -1897,7 +1898,10 @@ class ViewStrategy(PromotableStrategy):
         return isinstance(model.kind, ViewKind) and model.kind.materialized
 
 
-class CustomMaterialization(MaterializableStrategy):
+C = t.TypeVar("C", bound=CustomKind)
+
+
+class CustomMaterialization(MaterializableStrategy, t.Generic[C]):
     """Base class for custom materializations."""
 
     def insert(
@@ -1924,14 +1928,36 @@ class CustomMaterialization(MaterializableStrategy):
         )
 
 
-_custom_materialization_type_cache: t.Optional[t.Dict[str, t.Type[CustomMaterialization]]] = None
+_custom_materialization_type_cache: t.Optional[
+    t.Dict[str, t.Tuple[t.Type[CustomKind], t.Type[CustomMaterialization]]]
+] = None
 
 
-def get_custom_materialization_type(name: str) -> t.Type[CustomMaterialization]:
+def get_custom_materialization_kind_type(st: t.Type[CustomMaterialization]) -> t.Type[CustomKind]:
+    # try to read if there is a custom 'kind' type in use by inspecting the type signature
+    # eg try to read 'MyCustomKind' from:
+    # >>>> class MyCustomMaterialization(CustomMaterialization[MyCustomKind])
+    # and fall back to base CustomKind if there is no generic type declared
+    if hasattr(st, "__orig_bases__"):
+        for base in st.__orig_bases__:
+            if hasattr(base, "__origin__") and base.__origin__ == CustomMaterialization:
+                for generic_arg in t.get_args(base):
+                    if not issubclass(generic_arg, CustomKind):
+                        raise SQLMeshError(
+                            "Custom materialization kind '{generic_arg.__name__}' must be a subclass of CustomKind"
+                        )
+
+                    return generic_arg
+
+    return CustomKind
+
+
+def get_custom_materialization_type(
+    name: str,
+) -> t.Tuple[t.Type[CustomKind], t.Type[CustomMaterialization]]:
     global _custom_materialization_type_cache
 
     strategy_key = name.lower()
-
     if (
         _custom_materialization_type_cache is None
         or strategy_key not in _custom_materialization_type_cache
@@ -1948,16 +1974,22 @@ def get_custom_materialization_type(name: str) -> t.Type[CustomMaterialization]:
             strategy_types.append(strategy_type)
 
         _custom_materialization_type_cache = {
-            getattr(strategy_type, "NAME", strategy_type.__name__).lower(): strategy_type
+            getattr(strategy_type, "NAME", strategy_type.__name__).lower(): (
+                get_custom_materialization_kind_type(strategy_type),
+                strategy_type,
+            )
             for strategy_type in strategy_types
         }
 
     if strategy_key not in _custom_materialization_type_cache:
         raise ConfigError(f"Materialization strategy with name '{name}' was not found.")
 
-    strategy_type = _custom_materialization_type_cache[strategy_key]
-    logger.debug("Resolved custom materialization '%s' to '%s'", name, strategy_type)
-    return strategy_type
+    strategy_kind_type, strategy_type = _custom_materialization_type_cache[strategy_key]
+    logger.debug(
+        "Resolved custom materialization '%s' to '%s' (%s)", name, strategy_type, strategy_kind_type
+    )
+
+    return strategy_kind_type, strategy_type
 
 
 class EngineManagedStrategy(MaterializableStrategy):

--- a/tests/core/analytics/test_collector.py
+++ b/tests/core/analytics/test_collector.py
@@ -183,7 +183,7 @@ def test_on_plan_apply(
                 {
                     "seq_num": 0,
                     "event_type": "PLAN_APPLY_START",
-                    "event": f'{{"plan_id": "{plan_id}", "engine_type": "bigquery", "state_sync_type": "mysql", "scheduler_type": "builtin", "is_dev": false, "skip_backfill": false, "no_gaps": false, "forward_only": false, "ensure_finalized_snapshots": false, "has_restatements": false, "directly_modified_count": 18, "indirectly_modified_count": 0, "environment_name_hash": "d6e4a9b6646c62fc48baa6dd6150d1f7"}}',
+                    "event": f'{{"plan_id": "{plan_id}", "engine_type": "bigquery", "state_sync_type": "mysql", "scheduler_type": "builtin", "is_dev": false, "skip_backfill": false, "no_gaps": false, "forward_only": false, "ensure_finalized_snapshots": false, "has_restatements": false, "directly_modified_count": 19, "indirectly_modified_count": 0, "environment_name_hash": "d6e4a9b6646c62fc48baa6dd6150d1f7"}}',
                     **common_fields,
                 }
             ),

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -813,7 +813,7 @@ def test_janitor(sushi_context, mocker: MockerFixture) -> None:
     )
     # Assert that the views are dropped for each snapshot just once and make sure that the name used is the
     # view name with the environment as a suffix
-    assert adapter_mock.drop_view.call_count == 13
+    assert adapter_mock.drop_view.call_count == 14
     adapter_mock.drop_view.assert_has_calls(
         [
             call(

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -3185,7 +3185,7 @@ def test_custom_materialization_strategy_with_custom_properties(adapter_mock, ma
             return list_of_fields_validator(value, info.data)
 
     class TestCustomMaterializationStrategy(CustomMaterialization[TestCustomKind]):
-        NAME = "custom_materialization_test"
+        NAME = "custom_materialization_test_1"
 
         def insert(
             self,
@@ -3211,7 +3211,7 @@ def test_custom_materialization_strategy_with_custom_properties(adapter_mock, ma
                 MODEL (
                     name test_schema.test_model,
                     kind CUSTOM (
-                        materialization 'custom_materialization_test',
+                        materialization 'custom_materialization_test_1',
                     )
                 );
 
@@ -3226,7 +3226,7 @@ def test_custom_materialization_strategy_with_custom_properties(adapter_mock, ma
             MODEL (
                 name test_schema.test_model,
                 kind CUSTOM (
-                    materialization 'custom_materialization_test',
+                    materialization 'custom_materialization_test_1',
                     primary_key id
                 )
             );

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -3250,6 +3250,33 @@ def test_custom_materialization_strategy_with_custom_properties(adapter_mock, ma
     assert custom_insert_called
 
 
+def test_custom_materialization_strategy_with_custom_kind_must_be_correct_type():
+    # note: deliberately doesnt extend CustomKind
+    class TestCustomKind:
+        pass
+
+    class TestCustomMaterializationStrategy(CustomMaterialization[TestCustomKind]):  # type: ignore
+        NAME = "custom_materialization_test_2"
+
+    with pytest.raises(
+        SQLMeshError, match=r"kind 'TestCustomKind' must be a subclass of CustomKind"
+    ):
+        load_sql_based_model(
+            parse(  # type: ignore
+                """
+                MODEL (
+                    name test_schema.test_model,
+                    kind CUSTOM (
+                        materialization 'custom_materialization_test_2',
+                    )
+                );
+
+                SELECT * FROM tbl;
+                """
+            )
+        )
+
+
 def test_create_managed(adapter_mock, make_snapshot, mocker: MockerFixture):
     evaluator = SnapshotEvaluator(adapter_mock)
 

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -300,7 +300,7 @@ def test_plan(
 
     # TODO: Should this be going to stdout? This is printing the status updates for when each batch finishes for
     # the models and how long it took
-    assert len(output.stdout.strip().split("\n")) == 23
+    assert len(output.stdout.strip().split("\n")) == 24
     assert not output.stderr
     assert len(output.outputs) == 4
     text_output = convert_all_html_output_to_text(output)
@@ -558,7 +558,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
     assert not output.stderr
     assert len(output.outputs) == 6
     assert convert_all_html_output_to_text(output) == [
-        "Models: 17",
+        "Models: 18",
         "Macros: 7",
         "",
         "Connection:\n  type: duckdb\n  concurrent_tasks: 1\n  register_comments: true\n  pre_ping: false\n  pretty_sql: false\n  extensions: []\n  connector_config: {}",
@@ -566,7 +566,7 @@ def test_info(notebook, sushi_context, convert_all_html_output_to_text, get_all_
         "Data warehouse connection succeeded",
     ]
     assert get_all_html_output(output) == [
-        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Models: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">17</span></pre>",
+        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Models: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">18</span></pre>",
         "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Macros: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7</span></pre>",
         "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>",
         '<pre style="white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,\'DejaVu Sans Mono\',consolas,\'Courier New\',monospace">Connection:  type: duckdb  concurrent_tasks: <span style="color: #008080; text-decoration-color: #008080; font-weight: bold">1</span>  register_comments: true  pre_ping: false  pretty_sql: false  extensions: <span style="font-weight: bold">[]</span>  connector_config: <span style="font-weight: bold">{}</span></pre>',


### PR DESCRIPTION
The motivation behind this pull request is to allow custom materializations to fill a role of "behaves similar to an existing materialization - except with some requirements relaxed or changed".

Right now this is either difficult / requires copy+pasting a bunch of code or is just not possible (eg if your custom materialization needs to leverage the project level `time_column_format` config property).

The current custom materializations also dont play nicely with the builtin audits because there is no way of exposing `model.kind.time_column` (which this PR addresses)

