### PR TITLE
Feat: make date_spine macro less strict to allow dynamic behavior

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -1139,30 +1139,35 @@ def date_spine(
         "SELECT date_week FROM UNNEST(GENERATE_DATE_ARRAY(CAST(\'2022-01-20\' AS DATE), CAST(\'2024-12-16\' AS DATE), INTERVAL \'1\' WEEK)) AS _exploded(date_week)"
     """
     datepart_name = datepart.name.lower()
-    start_date_name = start_date.name
-    end_date_name = end_date.name
-
     if datepart_name not in ("day", "week", "month", "quarter", "year"):
         raise SQLMeshError(
             f"Invalid datepart '{datepart_name}'. Expected: 'day', 'week', 'month', 'quarter', or 'year'"
         )
 
+    start_date_name = start_date.name
+    end_date_name = end_date.name
+
     try:
-        start_date_obj = datetime.strptime(start_date_name, "%Y-%m-%d").date()
-        end_date_obj = datetime.strptime(end_date_name, "%Y-%m-%d").date()
+        if start_date.is_string and end_date.is_string:
+            start_date_obj = datetime.strptime(start_date_name, "%Y-%m-%d").date()
+            end_date_obj = datetime.strptime(end_date_name, "%Y-%m-%d").date()
+        else:
+            start_date_obj = None
+            end_date_obj = None
     except Exception as e:
         raise SQLMeshError(
             f"Invalid date format - start_date and end_date must be in format: YYYY-MM-DD. Error: {e}"
         )
 
-    if start_date_obj > end_date_obj:
-        raise SQLMeshError(
-            f"Invalid date range - start_date '{start_date_name}' is after end_date '{end_date_name}'."
-        )
+    if start_date_obj and end_date_obj:
+        if start_date_obj > end_date_obj:
+            raise SQLMeshError(
+                f"Invalid date range - start_date '{start_date_name}' is after end_date '{end_date_name}'."
+            )
 
-    alias_name = f"date_{datepart_name}"
-    start_date_column = exp.cast(start_date, "DATE")
-    end_date_column = exp.cast(end_date, "DATE")
+        start_date = exp.cast(start_date, "DATE")
+        end_date = exp.cast(end_date, "DATE")
+
     if datepart_name == "quarter" and evaluator.dialect in (
         "spark",
         "spark2",
@@ -1175,11 +1180,12 @@ def date_spine(
 
     generate_date_array = exp.func(
         "GENERATE_DATE_ARRAY",
-        start_date_column,
-        end_date_column,
+        start_date,
+        end_date,
         date_interval,
     )
 
+    alias_name = f"date_{datepart_name}"
     exploded = exp.alias_(exp.func("unnest", generate_date_array), "_exploded", table=[alias_name])
 
     return exp.select(alias_name).from_(exploded)

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -461,7 +461,9 @@ def serialize_env(env: t.Dict[str, t.Any], path: Path) -> t.Dict[str, Executable
                 )
         else:
             raise SQLMeshError(
-                f"'{v}' cannot be serialized because it is a constant object. Import the module and call it from within the macro instead:\nimport module\n\ndef my_macro():\n    module.{v}"
+                f"Object '{v}' cannot be serialized. If it's defined in a library, import the corresponding "
+                "module and reference the object using its fully-qualified name. For example, the datetime "
+                "module's 'UTC' object should be accessed as 'datetime.UTC'."
             )
 
     return serialized

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -5,6 +5,7 @@ from datetime import date, datetime
 from pathlib import Path
 from unittest.mock import patch, PropertyMock
 
+import time_machine
 import pandas as pd
 import pytest
 from pytest_mock.plugin import MockerFixture
@@ -7719,6 +7720,7 @@ def entrypoint(evaluator):
     )
 
 
+@time_machine.travel("2020-01-01 00:00:00 UTC")
 def test_dynamic_date_spine_model(assert_exp_eq):
     @macro()
     def get_current_date(evaluator):
@@ -7746,7 +7748,7 @@ def test_dynamic_date_spine_model(assert_exp_eq):
         WITH "discount_promotion_dates" AS (
           SELECT
             "_exploded"."date_day" AS "date_day"
-          FROM UNNEST(CAST(GENERATE_SERIES(CAST('2025-02-19' AS DATE) - 90, CAST('2025-02-19' AS DATE), INTERVAL '1' DAY) AS DATE[])) AS "_exploded"("date_day")
+          FROM UNNEST(CAST(GENERATE_SERIES(CAST('2020-01-01' AS DATE) - 90, CAST('2020-01-01' AS DATE), INTERVAL '1' DAY) AS DATE[])) AS "_exploded"("date_day")
         )
         SELECT
           "discount_promotion_dates"."date_day" AS "date_day"

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -7717,3 +7717,39 @@ def entrypoint(evaluator):
     assert t.cast(exp.Expression, customer2_model.render_query()).sql() == (
         '''SELECT 'qux' AS "foo" FROM "db"."customer2"."my_source" AS "my_source"'''
     )
+
+
+def test_dynamic_date_spine_model(assert_exp_eq):
+    @macro()
+    def get_current_date(evaluator):
+        from sqlmesh.utils.date import now
+
+        return f"'{now().date()}'"
+
+    expressions = d.parse(
+        """
+        MODEL (name test_model, dialect duckdb);
+
+        @DEF(curr_date, @get_current_date());
+
+        WITH discount_promotion_dates AS (
+          @date_spine('day', @curr_date::date - 90, @curr_date::date)
+        )
+
+        SELECT * FROM discount_promotion_dates
+        """
+    )
+    model = load_sql_based_model(expressions)
+    assert_exp_eq(
+        model.render_query(),
+        """
+        WITH "discount_promotion_dates" AS (
+          SELECT
+            "_exploded"."date_day" AS "date_day"
+          FROM UNNEST(CAST(GENERATE_SERIES(CAST('2025-02-19' AS DATE) - 90, CAST('2025-02-19' AS DATE), INTERVAL '1' DAY) AS DATE[])) AS "_exploded"("date_day")
+        )
+        SELECT
+          "discount_promotion_dates"."date_day" AS "date_day"
+        FROM "discount_promotion_dates" AS "discount_promotion_dates"
+        """,
+    )


### PR DESCRIPTION
Fixes #3864

The validations we do in `date_spine` today are too strict. This PR relaxes them a bit so that users can supply arbitrary expressions as arguments, besides just string literals– take a look at the new test to see why that makes sense.