### PR TITLE
Fix: Unexpected backfill of a parent of a changed forward-only child when the child runs before the parent

### DIFF
--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -2289,11 +2289,10 @@ def test_missing_intervals_interval_end_per_model(make_snapshot):
             snapshot_a.name: to_timestamp("2023-01-09"),
             snapshot_b.name: to_timestamp(
                 "2023-01-06"
-            ),  # The interval end is before the start. This should be ignored.
+            ),  # The interval end is before the start. The snapshot will be skipped
         },
     ) == {
         snapshot_a: [(to_timestamp("2023-01-08"), to_timestamp("2023-01-09"))],
-        snapshot_b: [(to_timestamp("2023-01-08"), to_timestamp("2023-01-09"))],
     }
 
 


### PR DESCRIPTION
In this case, the plan start is set to a value that is greater than the parent's max interval end, which leads to SQLMesh picking up missing intervals for the unchanged parent if the time for the parent to run has already arrived but it hasn't run yet.