### PR TITLE
Fix: Mask MotherDuck connection token in the logs

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -41,6 +41,7 @@ FORBIDDEN_STATE_SYNC_ENGINES = {
     # Nullable types are problematic
     "clickhouse",
 }
+MOTHERDUCK_TOKEN_REGEX = re.compile(r"(\?motherduck_token=)(\S*)")
 
 
 class ConnectionConfig(abc.ABC, BaseConfig):
@@ -330,7 +331,6 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
         return None
 
     def _mask_motherduck_token(self, path: str) -> str:
-        MOTHERDUCK_TOKEN_REGEX = re.compile(r"(\?motherduck_token=)(\S*)")
         if token_match := MOTHERDUCK_TOKEN_REGEX.search(path):
             path = re.sub(
                 MOTHERDUCK_TOKEN_REGEX,

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -330,14 +330,8 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
             return list(self.catalogs)[0]
         return None
 
-    def _mask_motherduck_token(self, path: str) -> str:
-        if token_match := MOTHERDUCK_TOKEN_REGEX.search(path):
-            path = re.sub(
-                MOTHERDUCK_TOKEN_REGEX,
-                r"\1" + "*" * len(token_match.group(2)),
-                path,
-            )
-        return path
+    def _mask_motherduck_token(self, string: str) -> str:
+        return MOTHERDUCK_TOKEN_REGEX.sub(lambda m: f"{m.group(1)}{'*' * len(m.group(2))}", string)
 
 
 class MotherDuckConnectionConfig(BaseDuckDBConnectionConfig):

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -330,10 +330,10 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
         return None
 
     def _mask_motherduck_token(self, path: str) -> str:
-        token_regex = r"(\?motherduck_token=)(\S*)"
-        if token_match := re.search(token_regex, path):
+        MOTHERDUCK_TOKEN_REGEX = re.compile(r"(\?motherduck_token=)(\S*)")
+        if token_match := MOTHERDUCK_TOKEN_REGEX.search(path):
             path = re.sub(
-                token_regex,
+                MOTHERDUCK_TOKEN_REGEX,
                 r"\1" + "*" * len(token_match.group(2)),
                 path,
             )

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -303,13 +303,13 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
             key = data_file if isinstance(data_file, str) else data_file.path
             if adapter := BaseDuckDBConnectionConfig._data_file_to_adapter.get(key):
                 logger.info(
-                    f"Using existing DuckDB adapter due to overlapping data file: {_mask_motherduck_token(key)}"
+                    f"Using existing DuckDB adapter due to overlapping data file: {self._mask_motherduck_token(key)}"
                 )
                 return adapter
 
         if data_files:
             masked_files = {
-                _mask_motherduck_token(file if isinstance(file, str) else str(file))
+                self._mask_motherduck_token(file if isinstance(file, str) else file.path)
                 for file in data_files
             }
             logger.info(f"Creating new DuckDB adapter for data files: {masked_files}")
@@ -329,16 +329,15 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
             return list(self.catalogs)[0]
         return None
 
-
-def _mask_motherduck_token(path: str) -> str:
-    MOTHERDUCK_TOKEN_REGEX = re.compile(r"(\?motherduck_token=)(\S*)")
-    if token_match := MOTHERDUCK_TOKEN_REGEX.search(path):
-        path = re.sub(
-            MOTHERDUCK_TOKEN_REGEX,
-            r"\1" + "*" * len(token_match.group(2)),
-            path,
-        )
-    return path
+    def _mask_motherduck_token(self, path: str) -> str:
+        MOTHERDUCK_TOKEN_REGEX = re.compile(r"(\?motherduck_token=)(\S*)")
+        if token_match := MOTHERDUCK_TOKEN_REGEX.search(path):
+            path = re.sub(
+                MOTHERDUCK_TOKEN_REGEX,
+                r"\1" + "*" * len(token_match.group(2)),
+                path,
+            )
+        return path
 
 
 class MotherDuckConnectionConfig(BaseDuckDBConnectionConfig):
@@ -369,12 +368,6 @@ class DuckDBAttachOptions(BaseConfig):
     path: str
     read_only: bool = False
     token: t.Optional[str] = None
-
-    def __str__(self) -> str:
-        return f"DuckDBAttachOptions(type={self.type}, path={_mask_motherduck_token(self.path)}, read_only={self.read_only}, token={'*' * len(self.token) if self.token else None})"
-
-    def __repr__(self) -> str:
-        return self.__str__()
 
     def to_sql(self, alias: str) -> str:
         options = []

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -649,8 +649,23 @@ def test_duckdb_multithreaded_connection_factory(make_config):
 def test_motherduck_token_mask(make_config):
     config = make_config(
         type="motherduck",
+        catalogs={
+            "test2": DuckDBAttachOptions(
+                type="motherduck",
+                path="md:whodunnit?motherduck_token=short",
+            ),
+            "test1": DuckDBAttachOptions(
+                type="motherduck", path="md:whodunnit", token="longtoken123456789"
+            ),
+        },
     )
     assert isinstance(config, MotherDuckConnectionConfig)
+
+    assert config._mask_motherduck_token(config.catalogs["test1"].path) == "md:whodunnit"
+    assert (
+        config._mask_motherduck_token(config.catalogs["test2"].path)
+        == "md:whodunnit?motherduck_token=*****"
+    )
     assert (
         config._mask_motherduck_token("?motherduck_token=secret1235")
         == "?motherduck_token=**********"

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -20,7 +20,6 @@ from sqlmesh.core.config.connection import (
     TrinoAuthenticationMethod,
     AthenaConnectionConfig,
     _connection_config_validator,
-    _mask_motherduck_token,
 )
 from sqlmesh.utils.errors import ConfigError
 
@@ -650,59 +649,25 @@ def test_duckdb_multithreaded_connection_factory(make_config):
 def test_motherduck_token_mask(make_config):
     config = make_config(
         type="motherduck",
-        catalogs={
-            "test1": DuckDBAttachOptions(
-                type="motherduck",
-                path="md:whodunnit?motherduck_token=short",
-            ),
-            "test2": DuckDBAttachOptions(type="motherduck", path="test3", token="secret123"),
-            "test3": DuckDBAttachOptions(
-                type="motherduck", path="test4", token="longtoken123456789"
-            ),
-            "test4": DuckDBAttachOptions(
-                type="motherduck",
-                path="test5",
-            ),
-        },
     )
     assert isinstance(config, MotherDuckConnectionConfig)
     assert (
-        str(config.catalogs["test1"])
-        == "DuckDBAttachOptions(type=motherduck, path=md:whodunnit?motherduck_token=*****, read_only=False, token=None)"
+        config._mask_motherduck_token("?motherduck_token=secret1235")
+        == "?motherduck_token=**********"
     )
     assert (
-        str(config.catalogs["test2"])
-        == "DuckDBAttachOptions(type=motherduck, path=test3, read_only=False, token=*********)"
-    )
-    assert (
-        str(config.catalogs["test3"])
-        == "DuckDBAttachOptions(type=motherduck, path=test4, read_only=False, token=******************)"
-    )
-    assert (
-        str(config.catalogs["test4"])
-        == "DuckDBAttachOptions(type=motherduck, path=test5, read_only=False, token=None)"
-    )
-
-    # Ensure accessing the token or path with token still return the actual value
-    assert not config.catalogs["test1"].token
-    assert config.catalogs["test1"].path == "md:whodunnit?motherduck_token=short"
-    assert config.catalogs["test2"].token == "secret123"
-    assert config.catalogs["test3"].token == "longtoken123456789"
-    assert not config.catalogs["test4"].token
-
-    assert _mask_motherduck_token("?motherduck_token=secret1235") == "?motherduck_token=**********"
-    assert (
-        _mask_motherduck_token("md:whodunnit?motherduck_token=short")
+        config._mask_motherduck_token("md:whodunnit?motherduck_token=short")
         == "md:whodunnit?motherduck_token=*****"
     )
     assert (
-        _mask_motherduck_token("md:whodunnit?motherduck_token=longtoken123456789")
+        config._mask_motherduck_token("md:whodunnit?motherduck_token=longtoken123456789")
         == "md:whodunnit?motherduck_token=******************"
     )
     assert (
-        _mask_motherduck_token("md:whodunnit?motherduck_token=") == "md:whodunnit?motherduck_token="
+        config._mask_motherduck_token("md:whodunnit?motherduck_token=")
+        == "md:whodunnit?motherduck_token="
     )
-    assert _mask_motherduck_token(":memory:") == ":memory:"
+    assert config._mask_motherduck_token(":memory:") == ":memory:"
 
 
 def test_bigquery(make_config):

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -13,6 +13,7 @@ from sqlmesh.core.config.connection import (
     DuckDBAttachOptions,
     DuckDBConnectionConfig,
     GCPPostgresConnectionConfig,
+    MotherDuckConnectionConfig,
     MySQLConnectionConfig,
     PostgresConnectionConfig,
     SnowflakeConnectionConfig,
@@ -643,6 +644,30 @@ def test_duckdb_multithreaded_connection_factory(make_config):
     assert adapter.fetchone("select 1") == (1,)
     adapter.recycle()
     assert adapter.fetchone("select 1") == (1,)
+
+
+def test_motherduck_token_mask(make_config):
+    config = make_config(
+        type="motherduck",
+    )
+    assert isinstance(config, MotherDuckConnectionConfig)
+    assert (
+        config._mask_motherduck_token("?motherduck_token=secret1235")
+        == "?motherduck_token=**********"
+    )
+    assert (
+        config._mask_motherduck_token("md:whodunnit?motherduck_token=short")
+        == "md:whodunnit?motherduck_token=*****"
+    )
+    assert (
+        config._mask_motherduck_token("md:whodunnit?motherduck_token=longtoken123456789")
+        == "md:whodunnit?motherduck_token=******************"
+    )
+    assert (
+        config._mask_motherduck_token("md:whodunnit?motherduck_token=")
+        == "md:whodunnit?motherduck_token="
+    )
+    assert config._mask_motherduck_token(":memory:") == ":memory:"
 
 
 def test_bigquery(make_config):


### PR DESCRIPTION
Mask the MotherDuck connection token in logs, displaying it as asterisks (`md:db?motherduck_token=************`) instead of revealing the actual value.