### PR TITLE
Fix: pass model dialect to sqlglot.diff to avoid possible generation issues

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1405,6 +1405,7 @@ class SqlModel(_Model):
                 matchings=[(previous_query, this_query)],
                 delta_only=True,
                 copy=False,
+                dialect=self.dialect if self.dialect == previous.dialect else None,
             )
         inserted_expressions = {e.expression for e in edits if isinstance(e, Insert)}
 


### PR DESCRIPTION
Fixes #3876

The cause of the issue here is that we parse these parameterized aggregate functions in ClickHouse into an AST that contains a `"parts"` node, whose value can't be generated by the base class because it's a tuple (see [here](https://github.com/tobymao/sqlglot/blob/ec4e97c31c16a1c8b5eb1acfba0ef77f064505b4/sqlglot/dialects/clickhouse.py#L732-L735)). It works when using the ClickHouse generator, because it skips it in the `func` call (see [here](https://github.com/tobymao/sqlglot/blob/ec4e97c31c16a1c8b5eb1acfba0ef77f064505b4/sqlglot/dialects/clickhouse.py#L1216-L1217)).

I will fix this upstream by moving the generation logic in the base class, but I think the change in this PR is useful regardless. Passing the dialect to the differ means we'll actually use the SQL generated for the target dialect when computing the bigram histograms for the change distiller.