### PR TITLE
fix: prevent get_removal_interval from returning invalid interval

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -675,7 +675,8 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
                 f"Attempted to add an Invalid interval ({start}, {end}) to snapshot {self.snapshot_id}"
             )
 
-        start_ts, end_ts = self.inclusive_exclusive(start, end, strict=False)
+        start_ts, end_ts = self.inclusive_exclusive(start, end, strict=False, expand=False)
+
         if start_ts >= end_ts:
             # Skipping partial interval.
             return
@@ -709,7 +710,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         *,
         strict: bool = True,
         is_preview: bool = False,
-    ) -> t.Optional[Interval]:
+    ) -> Interval:
         """Get the interval that should be removed from the snapshot.
 
         Args:
@@ -742,9 +743,11 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
 
             removal_interval = expanded_removal_interval
 
-        if removal_interval[0] < removal_interval[1]:
-            return removal_interval
-        return None
+        return removal_interval
+
+    @property
+    def allow_partials(self) -> bool:
+        return self.is_model and self.model.allow_partials
 
     def inclusive_exclusive(
         self,
@@ -752,6 +755,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         end: TimeLike,
         strict: bool = True,
         allow_partial: t.Optional[bool] = None,
+        expand: bool = True,
     ) -> Interval:
         """Transform the inclusive start and end into a [start, end) pair.
 
@@ -760,19 +764,18 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
             end: The end date/time of the interval (inclusive)
             strict: Whether to fail when the inclusive start is the same as the exclusive end.
             allow_partial: Whether the interval can be partial or not.
+            expand: Whether or not partial intervals are expanded outwards.
 
         Returns:
             A [start, end) pair.
         """
-        if allow_partial is None:
-            allow_partial = self.is_model and self.model.allow_partials
         return inclusive_exclusive(
             start,
             end,
             self.node.interval_unit,
-            model_allow_partials=self.is_model and self.model.allow_partials,
             strict=strict,
-            allow_partial=allow_partial,
+            allow_partial=self.allow_partials if allow_partial is None else allow_partial,
+            expand=expand,
         )
 
     def merge_intervals(self, other: t.Union[Snapshot, SnapshotIntervals]) -> None:
@@ -849,9 +852,10 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         # If the amount of time being checked is less than the size of a single interval then we
         # know that there can't being missing intervals within that range and return
         validate_date_range(start, end)
+
         if (
             not is_date(end)
-            and not (self.is_model and self.model.allow_partials)
+            and not self.allow_partials
             and to_timestamp(end) - to_timestamp(start) < self.node.interval_unit.milliseconds
         ):
             return []
@@ -864,16 +868,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         if not self.evaluatable or (self.is_seed and intervals):
             return []
 
-        allow_partials = self.is_model and self.model.allow_partials
-        start_ts, end_ts = (
-            to_timestamp(ts)
-            for ts in self.inclusive_exclusive(
-                start,
-                end,
-                strict=False,
-                allow_partial=allow_partials,
-            )
-        )
+        start_ts, end_ts = (to_timestamp(ts) for ts in self.inclusive_exclusive(start, end))
 
         interval_unit = self.node.interval_unit
         execution_time_ts = to_timestamp(execution_time) if execution_time else now_timestamp()
@@ -884,7 +879,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         )
         if end_bounded:
             upper_bound_ts = min(upper_bound_ts, end_ts)
-        if not allow_partials:
+        if not self.allow_partials:
             upper_bound_ts = to_timestamp(interval_unit.cron_floor(upper_bound_ts))
 
         end_ts = min(end_ts, upper_bound_ts)
@@ -1867,9 +1862,9 @@ def inclusive_exclusive(
     start: TimeLike,
     end: TimeLike,
     interval_unit: IntervalUnit,
-    model_allow_partials: bool,
     strict: bool = True,
     allow_partial: bool = False,
+    expand: bool = True,
 ) -> Interval:
     """Transform the inclusive start and end into a [start, end) pair.
 
@@ -1877,26 +1872,34 @@ def inclusive_exclusive(
         start: The start date/time of the interval (inclusive)
         end: The end date/time of the interval (inclusive)
         interval_unit: The interval unit.
-        model_allow_partials: Whether or not the model allows partials.
         strict: Whether to fail when the inclusive start is the same as the exclusive end.
         allow_partial: Whether the interval can be partial or not.
+        expand: Whether or not partial intervals are expanded outwards.
 
     Returns:
         A [start, end) pair.
     """
-    start_ts = to_timestamp(interval_unit.cron_floor(start))
-    if start_ts < to_timestamp(start) and not model_allow_partials:
-        start_ts = to_timestamp(interval_unit.cron_next(start_ts))
+    start_dt = interval_unit.cron_floor(start)
+
+    if not expand and not allow_partial and start_dt < to_datetime(start):
+        start_dt = interval_unit.cron_next(start_dt)
+
+    start_ts = to_timestamp(start_dt)
 
     if is_date(end):
         end = to_datetime(end) + timedelta(days=1)
-    end_ts = to_timestamp(interval_unit.cron_floor(end) if not allow_partial else end)
-    if end_ts < start_ts and to_timestamp(end) > to_timestamp(start) and not strict:
-        # This can happen when the interval unit is coarser than the size of the input interval.
-        # For example, if the interval unit is monthly, but the input interval is only 1 hour long.
-        return (start_ts, end_ts)
 
-    if (strict and start_ts >= end_ts) or (start_ts > end_ts):
+    if allow_partial:
+        end_dt = end
+    else:
+        end_dt = interval_unit.cron_floor(end)
+
+        if expand and end_dt != to_datetime(end):
+            end_dt = interval_unit.cron_next(end_dt)
+
+    end_ts = to_timestamp(end_dt)
+
+    if strict and start_ts >= end_ts:
         raise ValueError(
             f"`end` ({to_datetime(end_ts)}) must be greater than `start` ({to_datetime(start_ts)})"
         )
@@ -2041,11 +2044,10 @@ def apply_auto_restatements(
                 interval_to_remove_start, interval_to_remove_end, execution_time=execution_time
             )
 
-            if removal_interval:
-                auto_restated_intervals_per_snapshot[s_id] = removal_interval
-                snapshot.pending_restatement_intervals = merge_intervals(
-                    [*snapshot.pending_restatement_intervals, removal_interval]
-                )
+            auto_restated_intervals_per_snapshot[s_id] = removal_interval
+            snapshot.pending_restatement_intervals = merge_intervals(
+                [*snapshot.pending_restatement_intervals, removal_interval]
+            )
 
         snapshot.apply_pending_restatement_intervals()
         snapshot.update_next_auto_restatement_ts(execution_time)

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -439,7 +439,7 @@ class StateSync(StateReader, abc.ABC):
             end: The end of the interval to add.
             is_dev: Indicates whether the given interval is being added while in development mode
         """
-        start_ts, end_ts = snapshot.inclusive_exclusive(start, end, strict=False)
+        start_ts, end_ts = snapshot.inclusive_exclusive(start, end, strict=False, expand=False)
         if not snapshot.version:
             raise SQLMeshError("Snapshot version must be set to add an interval.")
         intervals = [(start_ts, end_ts)]

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -473,14 +473,13 @@ class EngineAdapterStateSync(StateSync):
                         target_snapshot.snapshot_id,
                     )
                     full_snapshot = snapshot.full_snapshot
-                    self.remove_intervals(
-                        [
-                            (
-                                full_snapshot,
-                                full_snapshot.get_removal_interval(effective_from_ts, current_ts),
-                            )
-                        ]
+
+                    removal_interval = full_snapshot.get_removal_interval(
+                        effective_from_ts, current_ts
                     )
+
+                    if removal_interval:
+                        self.remove_intervals([(full_snapshot, removal_interval)])
 
                 if snapshot.unpaused_ts:
                     logger.info("Pausing snapshot %s", snapshot.snapshot_id)

--- a/sqlmesh/core/state_sync/engine_adapter.py
+++ b/sqlmesh/core/state_sync/engine_adapter.py
@@ -473,13 +473,14 @@ class EngineAdapterStateSync(StateSync):
                         target_snapshot.snapshot_id,
                     )
                     full_snapshot = snapshot.full_snapshot
-
-                    removal_interval = full_snapshot.get_removal_interval(
-                        effective_from_ts, current_ts
+                    self.remove_intervals(
+                        [
+                            (
+                                full_snapshot,
+                                full_snapshot.get_removal_interval(effective_from_ts, current_ts),
+                            )
+                        ]
                     )
-
-                    if removal_interval:
-                        self.remove_intervals([(full_snapshot, removal_interval)])
 
                 if snapshot.unpaused_ts:
                     logger.info("Pausing snapshot %s", snapshot.snapshot_id)

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -2156,7 +2156,7 @@ def test_restatement_plan_ignores_changes(init_and_plan_context: t.Callable):
     assert not plan.new_snapshots
     assert plan.requires_backfill
     assert plan.restatements == {
-        restated_snapshot.snapshot_id: (to_timestamp("2023-01-01"), to_timestamp("2023-01-08"))
+        restated_snapshot.snapshot_id: (to_timestamp("2023-01-01"), to_timestamp("2023-01-09"))
     }
     assert plan.missing_intervals == [
         SnapshotIntervals(
@@ -4565,16 +4565,14 @@ def test_restatement_of_full_model_with_start(init_and_plan_context: t.Callable)
         no_prompts=True,
     )
 
-    restatement_end = to_timestamp("2023-01-08")
-
     sushi_customer_interval = restatement_plan.restatements[
         context.get_snapshot("sushi.customers").snapshot_id
     ]
-    assert sushi_customer_interval == (to_timestamp("2023-01-01"), restatement_end)
+    assert sushi_customer_interval == (to_timestamp("2023-01-01"), to_timestamp("2023-01-09"))
     waiter_by_day_interval = restatement_plan.restatements[
         context.get_snapshot("sushi.waiter_as_customer_by_day").snapshot_id
     ]
-    assert waiter_by_day_interval == (to_timestamp("2023-01-07"), restatement_end)
+    assert waiter_by_day_interval == (to_timestamp("2023-01-07"), to_timestamp("2023-01-08"))
 
 
 def initial_add(context: Context, environment: str):

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -738,30 +738,34 @@ def test_restate_models(sushi_context_pre_scheduling: Context):
     plan = sushi_context_pre_scheduling.plan(
         restate_models=["sushi.waiter_revenue_by_day", "tag:expensive"], no_prompts=True
     )
+
+    start = to_timestamp(plan.start)
+    tomorrow = to_timestamp(to_date("tomorrow"))
+
     assert plan.restatements == {
         sushi_context_pre_scheduling.get_snapshot(
             "sushi.waiter_revenue_by_day", raise_if_missing=True
         ).snapshot_id: (
-            to_timestamp(plan.start),
-            to_timestamp(to_date("today")),
+            start,
+            tomorrow,
         ),
         sushi_context_pre_scheduling.get_snapshot(
             "sushi.top_waiters", raise_if_missing=True
         ).snapshot_id: (
-            to_timestamp(plan.start),
-            to_timestamp(to_date("today")),
+            start,
+            tomorrow,
         ),
         sushi_context_pre_scheduling.get_snapshot(
             "sushi.customer_revenue_by_day", raise_if_missing=True
         ).snapshot_id: (
-            to_timestamp(plan.start),
-            to_timestamp(to_date("today")),
+            start,
+            tomorrow,
         ),
         sushi_context_pre_scheduling.get_snapshot(
             "sushi.customer_revenue_lifetime", raise_if_missing=True
         ).snapshot_id: (
-            to_timestamp(plan.start),
-            to_timestamp(to_date("today")),
+            start,
+            tomorrow,
         ),
     }
     assert plan.requires_backfill
@@ -828,7 +832,7 @@ def test_restate_models_with_existing_missing_intervals(init_and_plan_context: t
         ),
         top_waiters_snapshot_id: (
             plan_start_ts,
-            today_ts,
+            to_timestamp(to_date("tomorrow")),
         ),
     }
     assert plan.missing_intervals == [
@@ -1850,7 +1854,7 @@ def test_disable_restatement(make_snapshot, mocker: MockerFixture):
     # Restatements should still be supported when in dev.
     plan = PlanBuilder(context_diff, schema_differ, is_dev=True, restate_models=['"a"']).build()
     assert plan.restatements == {
-        snapshot.snapshot_id: (to_timestamp(plan.start), to_timestamp(to_date("today")))
+        snapshot.snapshot_id: (to_timestamp(plan.start), to_timestamp(to_date("tomorrow")))
     }
 
     # We don't want to restate a disable_restatement model if it is unpaused since that would be mean we are violating
@@ -2755,6 +2759,7 @@ def test_restate_production_model_in_dev(make_snapshot, mocker: MockerFixture):
     )
 
 
+@time_machine.travel("2025-02-23 15:00:00 UTC")
 def test_restate_daily_to_monthly(make_snapshot, mocker: MockerFixture):
     snapshot_a = make_snapshot(
         SqlModel(
@@ -2846,10 +2851,10 @@ def test_restate_daily_to_monthly(make_snapshot, mocker: MockerFixture):
         end="2025-02-20",
     ).build()
 
-    # b is invalid because it's monthly and the date range is partial
-    # c is invalid because it only depends on b which is not restated
     assert plan.restatements == {
-        snapshot_a.snapshot_id: (1739577600000, 1740096000000),
-        snapshot_d.snapshot_id: (1739577600000, 1740096000000),
-        snapshot_e.snapshot_id: (1739577600000, 1740096000000),
+        snapshot_a.snapshot_id: (1739577600000, 1740355200000),
+        snapshot_b.snapshot_id: (1738368000000, 1740787200000),
+        snapshot_c.snapshot_id: (1739577600000, 1740355200000),
+        snapshot_d.snapshot_id: (1739577600000, 1740355200000),
+        snapshot_e.snapshot_id: (1739577600000, 1740355200000),
     }

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -370,6 +370,7 @@ def test_missing_intervals(snapshot: Snapshot):
     assert snapshot.missing_intervals("2020-01-03 00:00:01", "2020-01-05 00:00:02") == []
     assert snapshot.missing_intervals("2020-01-03 00:00:01", "2020-01-07 00:00:02") == [
         (to_timestamp("2020-01-06"), to_timestamp("2020-01-07")),
+        (to_timestamp("2020-01-07"), to_timestamp("2020-01-08")),
     ]
 
 
@@ -1548,12 +1549,12 @@ def test_inclusive_exclusive_monthly(make_snapshot):
 
     assert snapshot.inclusive_exclusive("2023-01-01", "2023-07-01") == (
         to_timestamp("2023-01-01"),
-        to_timestamp("2023-07-01"),
+        to_timestamp("2023-08-01"),
     )
 
     assert snapshot.inclusive_exclusive("2023-01-01", "2023-07-06") == (
         to_timestamp("2023-01-01"),
-        to_timestamp("2023-07-01"),
+        to_timestamp("2023-08-01"),
     )
 
     assert snapshot.inclusive_exclusive("2023-01-01", "2023-07-31") == (

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -708,7 +708,7 @@ def test_missing_interval_smaller_than_interval_unit(make_snapshot):
     ]
 
 
-def test_remove_intervals(snapshot: Snapshot):
+def test_remove_intervals(snapshot):
     snapshot.add_interval("2020-01-01", "2020-01-01")
     snapshot.remove_interval(snapshot.get_removal_interval("2020-01-01", "2020-01-01"))
     assert snapshot.intervals == []


### PR DESCRIPTION
if your partial restate a daily model -> monthly, (2024-02-15, 2024-02-20), get_removal_interval returned an interval where start > end. this ensures get_removal_interval only returns valid intervals.