### PR TITLE
Chore: remove debug flags from migration testing script

### DIFF
--- a/.circleci/test_migration.sh
+++ b/.circleci/test_migration.sh
@@ -36,6 +36,6 @@ make install-dev
 
 # Migrate and make sure the diff is empty
 pushd $SUSHI_DIR
-SQLMESH_DEBUG=1 sqlmesh --gateway $GATEWAY_NAME migrate
-SQLMESH_DEBUG=1 sqlmesh --gateway $GATEWAY_NAME diff prod
+sqlmesh --gateway $GATEWAY_NAME migrate
+sqlmesh --gateway $GATEWAY_NAME diff prod
 popd


### PR DESCRIPTION
When the migration script detects a diff and fails, we no longer see it because of these flags:

![image](https://github.com/user-attachments/assets/9d3f5dfa-6999-414c-b6f5-77f66a21f4dc)
