### PR TITLE
Add supported Python versions into development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -5,7 +5,7 @@ SQLMesh is licensed under [Apache 2.0](https://github.com/TobikoData/sqlmesh/blo
 * Docker
 * Docker Compose V2
 * OpenJDK >= 11
-* Python >= 3.8 < 3.13
+* Python >= 3.9 < 3.13
 
 ## Commands reference
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,6 +5,7 @@ SQLMesh is licensed under [Apache 2.0](https://github.com/TobikoData/sqlmesh/blo
 * Docker
 * Docker Compose V2
 * OpenJDK >= 11
+* Python >= 3.8 < 3.13
 
 ## Commands reference
 


### PR DESCRIPTION
This morning I cloned the repo, after spending some time thrashing around whilst trying to install the dev dependencies I realised that Apache Airflow does not support Python 3.13. I've added a line to the `development.md` doc to (hopefully) mitigate this issue for other people looking to get started with the repository.