### PR TITLE
Fix: Allow deserialization of models using custom materializations 

### DIFF
--- a/examples/custom_materializations/custom_materializations/custom_kind.py
+++ b/examples/custom_materializations/custom_materializations/custom_kind.py
@@ -4,19 +4,15 @@ import typing as t
 
 from sqlmesh import CustomMaterialization, CustomKind, Model
 from sqlmesh.utils.pydantic import validate_string
-from pydantic import field_validator
 
 if t.TYPE_CHECKING:
     from sqlmesh import QueryOrDF
 
 
 class ExtendedCustomKind(CustomKind):
-    custom_property: t.Optional[str] = None
-
-    @field_validator("custom_property", mode="before")
-    @classmethod
-    def _validate_custom_property(cls, v: t.Any) -> str:
-        return validate_string(v)
+    @property
+    def custom_property(self) -> str:
+        return validate_string(self.materialization_properties.get("custom_property"))
 
 
 class CustomFullWithCustomKindMaterialization(CustomMaterialization[ExtendedCustomKind]):

--- a/examples/sushi/models/latest_order.sql
+++ b/examples/sushi/models/latest_order.sql
@@ -2,7 +2,9 @@ MODEL (
   name sushi.latest_order,
   kind CUSTOM (
     materialization 'custom_full_with_custom_kind',
-    custom_property 'sushi!!!'
+    materialization_properties (
+      custom_property = 'sushi!!!'
+    )
   ),
   cron '@daily'
 );

--- a/pytest.ini
+++ b/pytest.ini
@@ -39,6 +39,8 @@ markers =
     trino_delta: test for Trino (Delta connector)
 addopts = -n 0 --dist=loadgroup
 
+asyncio_default_fixture_loop_scope = session
+
 # Set this to True to enable logging during tests
 log_cli = False
 log_cli_format = %(asctime)s.%(msecs)03d %(filename)s:%(lineno)d %(levelname)s %(message)s

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -32,7 +32,14 @@ from sqlmesh.core.model.common import (
     single_value_or_tuple,
 )
 from sqlmesh.core.model.meta import ModelMeta, FunctionCall
-from sqlmesh.core.model.kind import ModelKindName, SeedKind, ModelKind, FullKind, create_model_kind
+from sqlmesh.core.model.kind import (
+    ModelKindName,
+    SeedKind,
+    ModelKind,
+    FullKind,
+    create_model_kind,
+    CustomKind,
+)
 from sqlmesh.core.model.seed import CsvSeedReader, Seed, create_seed
 from sqlmesh.core.renderer import ExpressionRenderer, QueryRenderer
 from sqlmesh.core.signal import SignalRegistry
@@ -978,6 +985,12 @@ class _Model(ModelMeta, frozen=True):
                     "Query validation can only be enabled for SQL models",
                     self._path,
                 )
+
+        if isinstance(self.kind, CustomKind):
+            from sqlmesh.core.snapshot.evaluator import get_custom_materialization_type_or_raise
+
+            # Will raise if the custom materialization points to an invalid class
+            get_custom_materialization_type_or_raise(self.kind.materialization)
 
     def is_breaking_change(self, previous: Model) -> t.Optional[bool]:
         """Determines whether this model is a breaking change in relation to the `previous` model.

--- a/tests/integrations/github/cicd/fixtures.py
+++ b/tests/integrations/github/cicd/fixtures.py
@@ -3,7 +3,7 @@ import typing as t
 import pytest
 from pytest_mock.plugin import MockerFixture
 
-from sqlmesh.core.console import set_console, MarkdownConsole
+from sqlmesh.core.console import set_console, get_console, MarkdownConsole
 from sqlmesh.integrations.github.cicd.config import GithubCICDBotConfig
 from sqlmesh.integrations.github.cicd.controller import (
     GithubController,
@@ -57,7 +57,7 @@ def make_pull_request_review() -> t.Callable:
 
 
 @pytest.fixture
-def make_controller(mocker: MockerFixture) -> t.Callable:
+def make_controller(mocker: MockerFixture, copy_to_temp_path: t.Callable) -> t.Callable:
     from github import Github
 
     def _make_function(
@@ -81,17 +81,25 @@ def make_controller(mocker: MockerFixture) -> t.Callable:
                 "sqlmesh.integrations.github.cicd.controller.GithubController.bot_config",
                 bot_config,
             )
-        set_console(MarkdownConsole())
-        return GithubController(
-            paths=["examples/sushi"],
-            token="abc",
-            event=(
-                GithubEvent.from_path(event_path)
-                if isinstance(event_path, str)
-                else GithubEvent.from_obj(event_path)
-            ),
-            client=client,
-        )
+
+        paths = copy_to_temp_path("examples/sushi")
+
+        orig_console = get_console()
+        try:
+            set_console(MarkdownConsole())
+
+            return GithubController(
+                paths=paths,
+                token="abc",
+                event=(
+                    GithubEvent.from_path(event_path)
+                    if isinstance(event_path, str)
+                    else GithubEvent.from_obj(event_path)
+                ),
+                client=client,
+            )
+        finally:
+            set_console(orig_console)
 
     return _make_function
 


### PR DESCRIPTION
Allow deserialization of models using custom materializations _without the custom materialization classes being present_.

This essentially moves the `kind` validation for custom materializations into `Model.validate_definition()`, which gets called after everything is loaded.

This means that components that just need to coerce Snapshots into JSON and back without doing anything special can continue to do so without needing the custom materialization classes loaded (since these would typically exist in an external library).

Only the components that evaluate the snapshots will need the custom materialization classes available in the Python environment.

This PR also rolls back the ability for CustomKind subclasses to define persistent properties outside of `materialization_properties`. The problem with that approach was that it forced the CustomKind subclasses (arbitrary user code) to be available in the Python environment of any context that touches a Snapshot, including state migration because it can affect how model fingerprints are calculated.

The downside of reverting this is that once again leveraging the project-level `time_column_format` property within a custom materialization becomes a problem. I've solved it by saving the value onto the `Model` in a private field and then when `validate_definition()` is called, re-applying it by calling `self.set_time_format()`

