### PR TITLE
Feat(BigQuery): Add support for column descriptions in nested fields

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -308,16 +308,16 @@ workflows:
           matrix:
             parameters:
               engine:
-                # - snowflake
-                # - databricks
-                # - redshift
+                - snowflake
+                - databricks
+                - redshift
                 - bigquery
-                # - clickhouse-cloud
-                # - athena
-          # filters:
-          #  branches:
-          #    only:
-          #      - main
+                - clickhouse-cloud
+                - athena
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -308,16 +308,16 @@ workflows:
           matrix:
             parameters:
               engine:
-                - snowflake
-                - databricks
-                - redshift
+                # - snowflake
+                # - databricks
+                # - redshift
                 - bigquery
-                - clickhouse-cloud
-                - athena
-          filters:
-           branches:
-             only:
-               - main
+                # - clickhouse-cloud
+                # - athena
+          # filters:
+          #  branches:
+          #    only:
+          #      - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -679,7 +679,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
                                 comment, self.MAX_COLUMN_COMMENT_LENGTH
                             )
                         else:
-                            fields = field.get("fields", [])
+                            fields = field.get("fields") or []
 
             # An "etag" is BQ versioning metadata that changes when an object is updated/modified. `update_table`
             # compares the etags of the table object passed to it and the remote table, erroring if the etags
@@ -802,6 +802,8 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
         ) -> exp.DataType:
             column_expressions = []
             for column_def in col_type.expressions:
+                # The is expected to always be true, but this check is included as a
+                # precautionary measure in case of an unexpected edge case
                 if isinstance(column_def, exp.ColumnDef):
                     column = self._build_column_def(
                         col_name=column_def.name,

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -802,7 +802,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
         ) -> exp.DataType:
             column_expressions = []
             for column_def in col_type.expressions:
-                # The is expected to always be true, but this check is included as a
+                # This is expected to  be true, but this check is included as a
                 # precautionary measure in case of an unexpected edge case
                 if isinstance(column_def, exp.ColumnDef):
                     column = self._build_column_def(

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -238,7 +238,7 @@ class ModelMeta(_Node):
             vs = vs.expressions
 
         raw_col_descriptions = (
-            vs if isinstance(vs, dict) else {v.this.name: v.expression.name for v in vs}
+            vs if isinstance(vs, dict) else {v.this.sql(dialect): v.expression.name for v in vs}
         )
 
         col_descriptions = {

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -238,7 +238,9 @@ class ModelMeta(_Node):
             vs = vs.expressions
 
         raw_col_descriptions = (
-            vs if isinstance(vs, dict) else {v.this.sql(dialect): v.expression.name for v in vs}
+            vs
+            if isinstance(vs, dict)
+            else {".".join([part.this for part in v.this.parts]): v.expression.name for v in vs}
         )
 
         col_descriptions = {

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -681,30 +681,16 @@ def test_nested_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerF
 
     nested_columns_to_types = {
         "record with space": exp.DataType.build(
-            "STRUCT<"
-            "'int_field': INT, "
-            "'record_field': STRUCT<"
-            "'sub_record_field': STRUCT<"
-            "'nest_array': ARRAY<INT64>"
-            ">>>"
+            "STRUCT<`int_field` INT, `record_field` STRUCT<`sub_record_field` STRUCT<`nest_array` ARRAY<INT64>>>>",
+            dialect="bigquery",
         ),
         "repeated_record": exp.DataType.build(
-            "ARRAY<STRUCT<"
-            "'nested_repeated_record': ARRAY<STRUCT<"
-            "'int_field': INT, "
-            "'array_field': ARRAY<INT64>, "
-            "'struct_field with space': STRUCT<"
-            "'nested_field': INT"
-            ">>>"
-            ">>>"
+            "ARRAY<STRUCT<`nested_repeated_record` ARRAY<STRUCT<`int_field` INT, `array_field` ARRAY<INT64>, `struct_field with space` STRUCT<`nested_field` INT>>>>",
+            dialect="bigquery",
         ),
         "same_name_": exp.DataType.build(
-            "ARRAY<STRUCT<"
-            "'same_name_': ARRAY<STRUCT<"
-            "'same_name_': STRUCT<"
-            "'same_name_': INT"
-            ">>>"
-            ">>>"
+            "ARRAY<STRUCT<`same_name_` ARRAY<STRUCT<`same_name_` STRUCT<`same_name_` INT>>>>",
+            dialect="bigquery",
         ),
     }
 
@@ -721,7 +707,6 @@ def test_nested_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerF
         "repeated_record.nested_repeated_record.struct_field with space": "Nested Repeated Struct Field",
         "repeated_record.nested_repeated_record.struct_field with space.nested_field": "Nested Repeated Record Nested Field",
         "same_name_": "Level 1",
-        "same_name_.same_name_": "Level 2",
         "same_name_.same_name_.same_name_": "Level 3",
         "same_name_.same_name_.same_name_.same_name_": "4" * allowed_column_comment_length + "X",
     }
@@ -765,8 +750,7 @@ def test_nested_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerF
         "`same_name_` ARRAY<STRUCT<"
         "`same_name_` STRUCT<"
         f"`same_name_` INT64 OPTIONS (description='{'4' * allowed_column_comment_length}')> "
-        "OPTIONS (description='Level 3')>> "
-        "OPTIONS (description='Level 2')>> "
+        "OPTIONS (description='Level 3')>>>> "
         "OPTIONS (description='Level 1'))"
     )
 
@@ -793,8 +777,7 @@ def test_nested_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerF
         "`same_name_` ARRAY<STRUCT<"
         "`same_name_` STRUCT<"
         f"`same_name_` INT64 OPTIONS (description='{'4' * allowed_column_comment_length}')> "
-        "OPTIONS (description='Level 3')>> "
-        "OPTIONS (description='Level 2')>> "
+        "OPTIONS (description='Level 3')>>>> "
         "OPTIONS (description='Level 1'))"
         " AS SELECT CAST(`record with space` AS STRUCT<`int_field` INT64, `record_field` STRUCT<`sub_record_field` STRUCT<`nest_array` ARRAY<INT64>>>>) AS `record with space`, "
         "CAST(`repeated_record` AS ARRAY<STRUCT<`nested_repeated_record` ARRAY<STRUCT<`int_field` INT64, `array_field` ARRAY<INT64>, `struct_field with space` STRUCT<`nested_field` INT64>>>>>) AS `repeated_record`, "


### PR DESCRIPTION
This PR introduces support for column descriptions in nested types in BigQuery, closes #3854 

The syntax follows BigQuery's conventions for nested and repeated columns, using dots to indicate the appropriate level of nesting:

```sql
MODEL (
  name schema.record_model,
  column_descriptions(
    id = "Unique identifier for the event",
    repeated_record.sub_repeated_record.sub_field = "Sub-field within nested repeated record",
    record.nested_record.field = "Field within nested record",
    record.nested_record.array = "Array of integers",
    repeated_record.sub_repeated_record = "Nested repeated record",
    record.nested_record = "Nested record"
  )
);

SELECT
  id,
  [STRUCT([STRUCT(sub_field AS sub_field)] AS sub_repeated_record)] AS repeated_record,
  STRUCT(
    STRUCT([2, 3] AS array, field AS field) AS nested_record
  ) AS record
FROM
  schema.seed_model;
```

The column definitions are built using the helper method `_build_column_def`, which is applied recursively in the BigQuery adapter to handle the RECORD and REPEATED RECORD columns. For views which are registered in `_create_column_comments` we traverse the fields and apply comments at each appropriate level.