### PR TITLE
Feat: Add model defaults support per gateway configuration

### DIFF
--- a/sqlmesh/core/config/gateway.py
+++ b/sqlmesh/core/config/gateway.py
@@ -4,6 +4,7 @@ import typing as t
 
 from sqlmesh.core import constants as c
 from sqlmesh.core.config.base import BaseConfig
+from sqlmesh.core.config.model import ModelDefaultsConfig
 from sqlmesh.core.config.common import variables_validator
 from sqlmesh.core.config.connection import (
     SerializableConnectionConfig,
@@ -34,6 +35,7 @@ class GatewayConfig(BaseConfig):
     scheduler: t.Optional[SchedulerConfig] = None
     state_schema: t.Optional[str] = c.SQLMESH
     variables: t.Dict[str, t.Any] = {}
+    model_defaults: t.Optional[ModelDefaultsConfig] = None
 
     _connection_config_validator = connection_config_validator
     _scheduler_config_validator = scheduler_config_validator

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -287,6 +287,11 @@ class Config(BaseConfig):
 
     @property
     def dialect(self) -> t.Optional[str]:
+        if self.default_gateway:
+            gateway_config = self.gateways[self.default_gateway]
+            if gateway_config.model_defaults:
+                return gateway_config.model_defaults.dialect
+
         return self.model_defaults.dialect
 
     @property

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -287,11 +287,6 @@ class Config(BaseConfig):
 
     @property
     def dialect(self) -> t.Optional[str]:
-        if self.default_gateway:
-            gateway_config = self.gateways[self.default_gateway]
-            if gateway_config.model_defaults:
-                return gateway_config.model_defaults.dialect
-
         return self.model_defaults.dialect
 
     @property

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -384,11 +384,11 @@ class GenericContext(BaseContext, t.Generic[C]):
         }
 
         if self.selected_gateway:
-            gw_model_defaults = self.config.gateways[self.selected_gateway]
-            if gw_model_defaults.model_defaults:
+            gw_model_defaults = self.config.gateways[self.selected_gateway].model_defaults
+            if gw_model_defaults:
                 # Merge global model defaults with the selected gateway's, if it's overriden
                 global_defaults = self.config.model_defaults.model_dump(exclude_unset=True)
-                gateway_defaults = gw_model_defaults.model_defaults.model_dump(exclude_unset=True)
+                gateway_defaults = gw_model_defaults.model_dump(exclude_unset=True)
 
                 self.config.model_defaults = ModelDefaultsConfig(
                     **{**global_defaults, **gateway_defaults}

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -850,3 +850,29 @@ def test_gcp_postgres_ip_and_scopes(tmp_path):
     assert conn.scopes[0] == "https://www.googleapis.com/auth/cloud-platform"
     assert conn.scopes[1] == "https://www.googleapis.com/auth/sqlservice.admin"
     assert conn.ip_type == "private"
+
+
+def test_gateway_model_defaults(tmp_path):
+    global_defaults = ModelDefaultsConfig(
+        dialect="snowflake", owner="foo", optimize_query=True, enabled=True, cron="@daily"
+    )
+    gateway_defaults = ModelDefaultsConfig(dialect="duckdb", owner="baz", optimize_query=False)
+
+    config = Config(
+        gateways={
+            "duckdb": GatewayConfig(
+                connection=DuckDBConnectionConfig(database="db.db"),
+                model_defaults=gateway_defaults,
+            )
+        },
+        model_defaults=global_defaults,
+        default_gateway="duckdb",
+    )
+
+    ctx = Context(paths=tmp_path, config=config, gateway="duckdb")
+
+    expected = ModelDefaultsConfig(
+        dialect="duckdb", owner="baz", optimize_query=False, enabled=True, cron="@daily"
+    )
+
+    assert ctx.config.model_defaults == expected

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1127,7 +1127,7 @@ def test_different_gateway_normalization_strategy(tmp_path: pathlib.Path):
     dialect = Dialect.get_or_raise(ctx.config.dialect)
 
     assert dialect == "snowflake"
-    assert dialect.normalization_strategy == NormalizationStrategy.CASE_INSENSITIVE
+    assert Snowflake.NORMALIZATION_STRATEGY == NormalizationStrategy.CASE_INSENSITIVE
 
     Snowflake.NORMALIZATION_STRATEGY = NormalizationStrategy.UPPERCASE
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1127,7 +1127,7 @@ def test_different_gateway_normalization_strategy(tmp_path: pathlib.Path):
     dialect = Dialect.get_or_raise(ctx.config.dialect)
 
     assert dialect == "snowflake"
-    assert Snowflake.NORMALIZATION_STRATEGY == NormalizationStrategy.CASE_INSENSITIVE
+    assert dialect.NORMALIZATION_STRATEGY == NormalizationStrategy.CASE_INSENSITIVE
 
     Snowflake.NORMALIZATION_STRATEGY = NormalizationStrategy.UPPERCASE
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1127,7 +1127,7 @@ def test_different_gateway_normalization_strategy(tmp_path: pathlib.Path):
     dialect = Dialect.get_or_raise(ctx.config.dialect)
 
     assert dialect == "snowflake"
-    assert dialect.NORMALIZATION_STRATEGY == NormalizationStrategy.CASE_INSENSITIVE
+    assert dialect.normalization_strategy == NormalizationStrategy.CASE_INSENSITIVE
 
     Snowflake.NORMALIZATION_STRATEGY = NormalizationStrategy.UPPERCASE
 


### PR DESCRIPTION
Users can employ different gateways on the same project:

```YAML
gateways:
  redshift:
      connection:
        type: redshift
        ...

  snowflake:
    connection:
      type: snowflake
      ...

default_gateway: snowflake

model_defaults:
  dialect: snowflake
  start: 2025-02-05
```

However, the models will be normalized at the `model_defaults.dialect` even if the `default_gateway` is set to a different engine, which can lead to issues / inefficiencies e.g Redshift's `INFORMATION_SCHEMA` stores the tables as lower-case, so with Snowflake's upper-case normalization we'll fail to find the tables/views. 

This PR adds support for `model_defaults` under gateways which override the global dialect, e.g:

```YAML
gateways:
  redshift:
      connection:
        type: redshift
        ...

      model_defaults:
        dialect: snowflake, normalization_strategy=case_insensitive
```

This enables the following behavior:

```Python3
# Snowflake dialect, Redshift gateway without model_defaults
❯ sqlmesh render vaggelis.test_model
[WARNING] The redshift engine is not recommended for storing SQLMesh state in production deployments. Please see 
https://sqlmesh.readthedocs.io/en/stable/guides/configuration/#state-connection for a list of recommended engines and more information.
SELECT                                                                                                                                              
  "COL" AS "COL"                                                                                                                                    
FROM "TBL" AS "TBL"  

# Snowflake dialect, Redshift gateway with model_defaults.dialect: snowflake, normalization_strategy=case_insensitive
❯ sqlmesh render vaggelis.test_model
[WARNING] The redshift engine is not recommended for storing SQLMesh state in production deployments. Please see 
https://sqlmesh.readthedocs.io/en/stable/guides/configuration/#state-connection for a list of recommended engines and more information.
SELECT                                                                                                                                              
  "col" AS "col"                                                                                                                                    
FROM "tbl" AS "tbl" 
```


