### PR TITLE
Fix: Put a lower bound on the cloud-sql-python-connector dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
             "dlt",
         ],
         "gcppostgres": [
-            "cloud-sql-python-connector[pg8000]",
+            "cloud-sql-python-connector[pg8000]>=1.8.0",
         ],
         "github": [
             "PyGithub~=2.5.0",


### PR DESCRIPTION
The changes in #3842 are not compatible with `cloud-sql-python-connector` versions below `1.8.0`.