### PR TITLE
fix!: raise instead of warn on catalog mismatch

### DIFF
--- a/sqlmesh/core/engine_adapter/shared.py
+++ b/sqlmesh/core/engine_adapter/shared.py
@@ -11,7 +11,7 @@ from pydantic import Field
 from sqlglot import exp
 
 from sqlmesh.core.dialect import to_schema
-from sqlmesh.utils.errors import UnsupportedCatalogOperationError
+from sqlmesh.utils.errors import UnsupportedCatalogOperationError, SQLMeshError
 from sqlmesh.utils.pydantic import PydanticModel
 
 if t.TYPE_CHECKING:
@@ -328,8 +328,8 @@ def set_catalog(override_mapping: t.Optional[t.Dict[str, CatalogSupport]] = None
             container[key] = expression  # type: ignore
             if catalog_support.is_single_catalog_only:
                 if catalog_name != engine_adapter._default_catalog:
-                    logger.warning(
-                        f"{engine_adapter.dialect} requires that all catalog operations be against a single catalog: {engine_adapter._default_catalog}. Ignoring catalog: {catalog_name}"
+                    raise SQLMeshError(
+                        f"{engine_adapter.dialect} requires that all catalog operations be against a single catalog: {engine_adapter._default_catalog}. Provided catalog: {catalog_name}"
                     )
                 return func(*list_args, **kwargs)
             # Set the catalog name on the engine adapter if needed

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -28,6 +28,7 @@ from sqlmesh.core.plan import Plan
 from sqlmesh.core.snapshot import Snapshot, SnapshotChangeCategory
 from sqlmesh.utils.date import now, to_date, to_time_column
 from sqlmesh.core.table_diff import TableDiff
+from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.pydantic import PydanticModel
 from tests.conftest import SushiDataValidator
 from tests.core.engine_adapter.integration import (
@@ -335,8 +336,11 @@ def test_drop_schema_catalog(ctx: TestContext, caplog):
 
     schema = ctx.schema("drop_schema_catalog_test", catalog_name)
     if ctx.engine_adapter.catalog_support.is_single_catalog_only:
-        drop_schema_and_validate(schema)
-        assert "requires that all catalog operations be against a single catalog" in caplog.text
+        with pytest.raises(
+            SQLMeshError, match="requires that all catalog operations be against a single catalog"
+        ):
+            drop_schema_and_validate(schema)
+            create_objects_and_validate(schema)
         return
     drop_schema_and_validate(schema)
     create_objects_and_validate(schema)

--- a/tests/core/engine_adapter/test_postgres.py
+++ b/tests/core/engine_adapter/test_postgres.py
@@ -7,6 +7,7 @@ from sqlglot import exp, parse_one
 from sqlglot.helper import ensure_list
 
 from sqlmesh.core.engine_adapter import PostgresEngineAdapter
+from sqlmesh.utils.errors import SQLMeshError
 from tests.core.engine_adapter import to_sql_calls
 
 pytestmark = [pytest.mark.engine, pytest.mark.postgres]
@@ -53,15 +54,15 @@ def test_drop_schema(kwargs, expected, make_mocked_engine_adapter: t.Callable):
     assert to_sql_calls(adapter) == ensure_list(expected)
 
 
-def test_drop_schema_with_catalog(
-    make_mocked_engine_adapter: t.Callable, mocker: MockFixture, caplog
-):
+def test_drop_schema_with_catalog(make_mocked_engine_adapter: t.Callable, mocker: MockFixture):
     adapter = make_mocked_engine_adapter(PostgresEngineAdapter)
 
     adapter.get_current_catalog = mocker.MagicMock(return_value="other_catalog")
 
-    adapter.drop_schema("test_catalog.test_schema")
-    assert "requires that all catalog operations be against a single catalog" in caplog.text
+    with pytest.raises(
+        SQLMeshError, match="requires that all catalog operations be against a single catalog"
+    ):
+        adapter.drop_schema("test_catalog.test_schema")
 
 
 def test_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):


### PR DESCRIPTION
For engines that are single catalog only, like Redshift and Postgres, currently we will warn if we detect they seem to be doing a cross-catalog operation. This code is old and hasn't been an issue, but we hit a scenario where a user ran janitor and the janitor deleted something unexpectedly due to this being a warning.

Therefore changing this to raise instead. 