### PR TITLE
Fix: Merge source and target aliases resolution for multi part fqns

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -1361,10 +1361,10 @@ def replace_merge_table_aliases(expression: exp.Expression) -> exp.Expression:
     """
     from sqlmesh.core.engine_adapter.base import MERGE_SOURCE_ALIAS, MERGE_TARGET_ALIAS
 
-    if isinstance(expression, exp.Column):
-        if expression.table.lower() in ("target", "dbt_internal_dest", "__merge_target__"):
-            expression.set("table", exp.to_identifier(MERGE_TARGET_ALIAS))
-        elif expression.table.lower() in ("source", "dbt_internal_source", "__merge_source__"):
-            expression.set("table", exp.to_identifier(MERGE_SOURCE_ALIAS))
+    if isinstance(expression, exp.Column) and (first_part := expression.parts[0]):
+        if first_part.this.lower() in ("target", "dbt_internal_dest", "__merge_target__"):
+            first_part.replace(exp.to_identifier(MERGE_TARGET_ALIAS))
+        elif first_part.this.lower() in ("source", "dbt_internal_source", "__merge_source__"):
+            first_part.replace(exp.to_identifier(MERGE_SOURCE_ALIAS))
 
     return expression


### PR DESCRIPTION
This update fixes an issue in `when_matched` and `merge_filter` when dealing with multi-part fqns (e.g. `source.second_part.column` ), where the aliases for source and target weren't replaced. The `replace_merge_table_aliases` function now is checking for the first part of the column instead of the column's table and replaces that. This allows for cases like BigQuery's nested fields, which can have arbitrary lengths of parts, by resolving the first part of the name.

Related slack thread: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1740423499786879