### PR TITLE
Fix: Enable prompts if the auto categorization was disabled in CLI

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1181,6 +1181,10 @@ class GenericContext(BaseContext, t.Generic[C]):
             diff_rendered=diff_rendered,
         )
 
+        if no_auto_categorization:
+            # Prompts are required if the auto categorization is disabled
+            no_prompts = False
+
         self.console.plan(
             plan_builder,
             auto_apply if auto_apply is not None else self.config.plan.auto_apply,


### PR DESCRIPTION
If the auto categorization was disabled via CLI, it's user's intent to enter change categories manually. In this case no_prompts can be enabled.