### PR TITLE
Fix(Redshift): Introduce flag to control the use of redshifts native operation or logical merge

### DIFF
--- a/docs/concepts/models/model_kinds.md
+++ b/docs/concepts/models/model_kinds.md
@@ -246,6 +246,16 @@ MODEL (
 * Snowflake
 * Spark
 
+In Redshift's case, to enable the use of the native `MERGE` statement, you need to pass the `merge_operation` flag in the connection and set it to `true`. It is disabled by default.
+
+```yaml linenums="1"
+gateways:
+  redshift:
+    connection:
+      type: redshift
+      merge_operation: true
+```
+
 Redshift supports only the `UPDATE` or `DELETE` actions for the `WHEN MATCHED` clause and does not allow multiple `WHEN MATCHED` expressions. For further information, refer to the [Redshift documentation](https://docs.aws.amazon.com/redshift/latest/dg/r_MERGE.html#r_MERGE-parameters).
 
 ### Merge Filter Expression

--- a/docs/integrations/engines/redshift.md
+++ b/docs/integrations/engines/redshift.md
@@ -32,6 +32,8 @@ pip install "sqlmesh[redshift]"
 | `is_serverless`         | If the Amazon Redshift cluster is serverless (Default: `False`)                                             |  bool  |    N     |
 | `serverless_acct_id`    | The account ID of the serverless cluster                                                                    | string |    N     |
 | `serverless_work_group` | The name of work group for serverless end point                                                             | string |    N     |
+| `merge_operation`         | Whether the incremental_by_unique_key model kind will use the native Redshift MERGE operation or SQLMesh's logical merge. (Default: `False`)           |  bool  |    N     |
+
 
 ## Airflow Scheduler
 **Engine Name:** `redshift`

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -1104,6 +1104,7 @@ class RedshiftConnectionConfig(ConnectionConfig):
         serverless_acct_id: The account ID of the serverless. Default value None
         serverless_work_group: The name of work group for serverless end point. Default value None.
         pre_ping: Whether or not to pre-ping the connection before starting a new transaction to ensure it is still alive.
+        merge_operation: Whether to use the Redshift merge operation instead of the SQLMesh logical merge.
     """
 
     user: t.Optional[str] = None
@@ -1127,6 +1128,7 @@ class RedshiftConnectionConfig(ConnectionConfig):
     is_serverless: t.Optional[bool] = None
     serverless_acct_id: t.Optional[str] = None
     serverless_work_group: t.Optional[str] = None
+    merge_operation: t.Optional[bool] = None
 
     concurrent_tasks: int = 4
     register_comments: bool = True
@@ -1169,6 +1171,10 @@ class RedshiftConnectionConfig(ConnectionConfig):
         from redshift_connector import connect
 
         return connect
+
+    @property
+    def _extra_engine_config(self) -> t.Dict[str, t.Any]:
+        return {"merge_operation": self.merge_operation}
 
 
 class PostgresConnectionConfig(ConnectionConfig):

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -14,6 +14,7 @@ from sqlmesh.core.engine_adapter.mixins import (
     NonTransactionalTruncateMixin,
     VarcharSizeWorkaroundMixin,
     RowDiffMixin,
+    logical_merge,
 )
 from sqlmesh.core.engine_adapter.shared import (
     CommentCreationView,
@@ -45,6 +46,7 @@ class RedshiftEngineAdapter(
     # Redshift doesn't support comments for VIEWs WITH NO SCHEMA BINDING (which we always use)
     COMMENT_CREATION_VIEW = CommentCreationView.UNSUPPORTED
     SUPPORTS_REPLACE_TABLE = False
+    MERGE_OPERATION = False
     SCHEMA_DIFFER = SchemaDiffer(
         parameterized_type_defaults={
             exp.DataType.build("VARBYTE", dialect=DIALECT).this: [(64000,)],
@@ -119,6 +121,12 @@ class RedshiftEngineAdapter(
             column_name: exp.DataType.build(data_type, dialect=self.dialect)
             for column_name, data_type in columns
         }
+
+    @property
+    def merge_operation(self) -> bool:
+        # Redshift supports the MERGE operation but we use the logical merge
+        # unless the user has opted in by setting merge_operation in the connection.
+        return self._extra_config.get("merge_operation") or self.MERGE_OPERATION
 
     @property
     def cursor(self) -> t.Any:
@@ -328,6 +336,36 @@ class RedshiftEngineAdapter(
             )
             for row in df.itertuples()
         ]
+
+    def merge(
+        self,
+        target_table: TableName,
+        source_table: QueryOrDF,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        unique_key: t.Sequence[exp.Expression],
+        when_matched: t.Optional[exp.Whens] = None,
+        merge_filter: t.Optional[exp.Expression] = None,
+    ) -> None:
+        if self.merge_operation:
+            # By default we use the logical merge unless the user has opted in
+            super().merge(
+                target_table=target_table,
+                source_table=source_table,
+                columns_to_types=columns_to_types,
+                unique_key=unique_key,
+                when_matched=when_matched,
+                merge_filter=merge_filter,
+            )
+        else:
+            logical_merge(
+                self,
+                target_table,
+                source_table,
+                columns_to_types,
+                unique_key,
+                when_matched=when_matched,
+                merge_filter=merge_filter,
+            )
 
     def _merge(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ from sqlmesh.core.config import BaseDuckDBConnectionConfig
 from sqlmesh.core.context import Context
 from sqlmesh.core.engine_adapter import MSSQLEngineAdapter, SparkEngineAdapter
 from sqlmesh.core.engine_adapter.base import EngineAdapter
+from sqlmesh.core.engine_adapter.redshift import RedshiftEngineAdapter
 from sqlmesh.core.environment import EnvironmentNamingInfo
 from sqlmesh.core import lineage
 from sqlmesh.core.macros import macro
@@ -464,6 +465,11 @@ def make_mocked_engine_adapter(mocker: MockerFixture) -> t.Callable:
             mocker.patch(
                 "sqlmesh.core.engine_adapter.mssql.MSSQLEngineAdapter.catalog_support",
                 new_callable=PropertyMock(return_value=CatalogSupport.REQUIRES_SET_CATALOG),
+            )
+        if isinstance(adapter, RedshiftEngineAdapter):
+            mocker.patch(
+                "sqlmesh.core.engine_adapter.redshift.RedshiftEngineAdapter.merge_operation",
+                new_callable=PropertyMock(return_value=True),
             )
         return adapter
 


### PR DESCRIPTION
This update modifies the default behaviour for the incremental_by_unique_key model to use SQLMesh's logical merge for Redshift, unless the user opts in to use the native Redshift MERGE operation.

To enable the native MERGE statement in Redshift, the user must set the merge_operation flag to true in the connection configuration. By default it is disabled.

Example configuration:
```yaml
gateways:
  redshift:
    connection:
      type: redshift
      merge_operation: true
```