### PR TITLE
fix: allow_partial interval batching

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1785,9 +1785,7 @@ def expand_range(start_ts: int, end_ts: int, interval_unit: IntervalUnit) -> t.L
         ts = to_timestamp(croniter.get_next(estimate=True))
 
         if ts > end_ts:
-            if len(timestamps) > 1:
-                timestamps[-1] = end_ts
-            else:
+            if timestamps and timestamps[-1] != end_ts:
                 timestamps.append(end_ts)
             break
 

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -404,6 +404,11 @@ def test_missing_intervals_partial(make_snapshot):
     assert snapshot.missing_intervals(start, start, execution_time=start, ignore_cron=True) == []
     assert snapshot.missing_intervals(start, start, execution_time=end_ts, end_bounded=True) == []
 
+    assert snapshot.missing_intervals(start, to_timestamp("2023-01-02 12:00:00")) == [
+        (to_timestamp(start), to_timestamp("2023-01-02")),
+        (to_timestamp("2023-01-02"), to_timestamp("2023-01-02 12:00:00")),
+    ]
+
 
 def test_missing_intervals_end_bounded_with_lookback(make_snapshot):
     snapshot = make_snapshot(


### PR DESCRIPTION
partial intervals were getting lumped into the previous interval expanding the range, this makes it so that the previous complete interval is isolated and the partial is new. for example

missing_interval('2023-01-01', '2023-01-02 12:00:00') should result in 2 intervals, [2023-01-01, 2023-01-02], [2023-01-02, 2023-01-02 12:00:00], but before this fix you only got one [2023-01-01, 2023-01-02 12:00:00]

closes #3859