### PR TITLE
Fix: error if python model has SEED kind

### DIFF
--- a/docs/concepts/audits.md
+++ b/docs/concepts/audits.md
@@ -92,7 +92,7 @@ Alternatively, you can apply specific audits globally by including them in the m
 
 ```sql linenums="1"
 model_defaults:
-  audits: 
+  audits:
     - assert_positive_order_ids
     - does_not_exceed_threshold(column := id, threshold := 1000)
 ```
@@ -277,7 +277,7 @@ This example asserts that column `name` has a value of 'Hamachi', 'Unagi', or 'S
 MODEL (
   name sushi.items,
   audits (
-    accepted_values(column := name, is_in=('Hamachi', 'Unagi', 'Sake'))
+    accepted_values(column := name, is_in := ('Hamachi', 'Unagi', 'Sake'))
   )
 );
 ```

--- a/docs/concepts/models/managed_models.md
+++ b/docs/concepts/models/managed_models.md
@@ -7,6 +7,10 @@ For supported engines, we expose this functionality through Managed models. This
 
 Due to this, managed models would typically be built off an [External Model](./external_models.md) rather than another SQLMesh model. Since SQLMesh already ensures that models it's tracking are kept up to date, the main benefit of managed models comes when they read from external tables that arent tracked by SQLMesh.
 
+!!! warning "Not supported in Python models"
+
+    Python models do not support the `MANAGED` [model kind](./model_kinds.md) - use a SQL model isntead.
+
 ## Difference from materialized views
 The difference between an Managed model and a materialized view is down to semantics and in some engines there is no difference.
 
@@ -36,7 +40,7 @@ Therefore, we try to not create managed tables unnecessarily. For example, in [f
 
 !!! warning
     Due to the use of normal tables for dev previews, it is possible to write a query that uses features that are available to normal tables in the target engine but not managed tables. This could result in a scenario where a plan works in a dev environment but fails when deployed to production.
-    
+
     We believe the cost savings are worth it, however please [reach out](https://tobikodata.com/slack) if this causes problems for you.
 
 ## Supported Engines

--- a/docs/concepts/models/model_kinds.md
+++ b/docs/concepts/models/model_kinds.md
@@ -334,7 +334,10 @@ The `VIEW` kind is different, because no data is actually written during model e
 
 **Note:** `VIEW` is the default model kind if kind is not specified.
 
+**Note:** Python models do not support the `VIEW` model kind - use a SQL model instead.
+
 **Note:** With this kind, the model's query is evaluated every time the model is referenced in a downstream query. This may incur undesirable compute cost and time in cases where the model's query is compute-intensive, or when the model is referenced in many downstream queries.
+
 
 This example specifies a `VIEW` model kind:
 ```sql linenums="1" hl_lines="3"
@@ -372,6 +375,8 @@ Embedded models are a way to share common logic between different models of othe
 
 There are no data assets (tables or views) associated with `EMBEDDED` models in the data warehouse. Instead, an `EMBEDDED` model's query is injected directly into the query of each downstream model that references it, as a subquery.
 
+**Note:** Python models do not support the `EMBEDDED` model kind - use a SQL model instead.
+
 This example specifies a `EMBEDDED` model kind:
 ```sql linenums="1" hl_lines="3"
 MODEL (
@@ -386,6 +391,8 @@ FROM db.employees;
 
 ## SEED
 The `SEED` model kind is used to specify [seed models](./seed_models.md) for using static CSV datasets in your SQLMesh project.
+
+**Note:** Python models do not support the `SEED` model kind - use a SQL model instead.
 
 ## SCD Type 2
 
@@ -885,6 +892,8 @@ The EXTERNAL model kind is used to specify [external models](./external_models.m
 !!! warning
 
     Managed models are still under development and the API / semantics may change as support for more engines is added
+
+**Note:** Python models do not support the `MANAGED` model kind - use a SQL model instead.
 
 The `MANAGED` model kind is used to create models where the underlying database engine manages the data lifecycle.
 

--- a/docs/concepts/models/python_models.md
+++ b/docs/concepts/models/python_models.md
@@ -4,6 +4,16 @@ Although SQL is a powerful tool, some use cases are better handled by Python. Fo
 
 SQLMesh has first-class support for models defined in Python; there are no restrictions on what can be done in the Python model as long as it returns a Pandas or Spark DataFrame instance.
 
+
+!!! info "Unsupported model kinds"
+
+    Python models do not support these [model kinds](./model_kinds.md) - use a SQL model instead.
+
+    * `VIEW`
+    * `SEED`
+    * `MANAGED`
+    * `EMBEDDED`
+
 ## Definition
 
 To create a Python model, add a new file with the `*.py` extension to the `models/` directory. Inside the file, define a function named `execute`. For example:

--- a/docs/concepts/models/seed_models.md
+++ b/docs/concepts/models/seed_models.md
@@ -14,6 +14,10 @@ Seed models are a good fit for static datasets that change infrequently or not a
 * Names of national holidays and their dates
 * A static list of identifiers that should be excluded
 
+!!! warning "Not supported in Python models"
+
+    Python models do not support the `SEED` [model kind](./model_kinds.md) - use a SQL model instead.
+
 ## Creating a seed model
 
 Similar to [SQL models](./sql_models.md), `SEED` models are defined in files with the `.sql` extension in the `models/` directory of the SQLMesh project.
@@ -209,11 +213,11 @@ MODEL (
   )
 );
 
-ON_VIRTUAL_UPDATE_BEGIN; 
+ON_VIRTUAL_UPDATE_BEGIN;
 GRANT SELECT ON VIEW @this_model TO ROLE dev_role;
-JINJA_STATEMENT_BEGIN;     
+JINJA_STATEMENT_BEGIN;
 GRANT SELECT ON VIEW {{ this_model }} TO ROLE admin_role;
-JINJA_END;  
+JINJA_END;
 ON_VIRTUAL_UPDATE_END;
 ```
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1701,7 +1701,7 @@ class PythonModel(_Model):
 
         if self.kind and not self.kind.supports_python_models:
             raise SQLMeshError(
-                f"Cannot create Python model '{self.name}' as the '{self.kind.name}' kind doesnt support Python models"
+                f"Cannot create Python model '{self.name}' as the '{self.kind.name}' kind doesn't support Python models"
             )
 
     def render(

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -649,6 +649,10 @@ class SeedKind(_ModelKind):
     def metadata_hash_values(self) -> t.List[t.Optional[str]]:
         return [*super().metadata_hash_values, str(self.batch_size)]
 
+    @property
+    def supports_python_models(self) -> bool:
+        return False
+
 
 class FullKind(_ModelKind):
     name: t.Literal[ModelKindName.FULL] = ModelKindName.FULL

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -6859,7 +6859,7 @@ def test_managed_kind_python():
 
     with pytest.raises(
         SQLMeshError,
-        match=r".*Cannot create Python model.*the 'MANAGED' kind doesnt support Python models",
+        match=r".*Cannot create Python model.*the 'MANAGED' kind doesn't support Python models",
     ):
         model.get_registry()["test_managed_python_model"].model(
             module_path=Path("."),


### PR DESCRIPTION
- Add SEED kind property `supports_python_models=False`
- Clarify in docs which model kinds are/aren't supported for Py models