### PR TITLE
Fix: Skip project loading when running the 'invalidate' CLI command

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -20,7 +20,14 @@ from sqlmesh.utils.errors import MissingDependencyError
 
 logger = logging.getLogger(__name__)
 
-SKIP_LOAD_COMMANDS = ("create_external_models", "migrate", "rollback", "run", "environments")
+SKIP_LOAD_COMMANDS = (
+    "create_external_models",
+    "migrate",
+    "rollback",
+    "run",
+    "environments",
+    "invalidate",
+)
 SKIP_CONTEXT_COMMANDS = ("init", "ui")
 
 


### PR DESCRIPTION
Loaded project is not necessary to invalidate an environment and adds to runtime unnecessarily.