### PR TITLE
Fix: make dialect regex more robust

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -761,7 +761,7 @@ def text_diff(
 
 
 DIALECT_PATTERN = re.compile(
-    r"(model|audit).*?\(.*?dialect[^a-z,]+([a-z]*|,)", re.IGNORECASE | re.DOTALL
+    r"(model|audit).*?\(.*?dialect\s+'?([a-z]*)", re.IGNORECASE | re.DOTALL
 )
 
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -4071,6 +4071,9 @@ def test_model_dialect_name():
     )
     assert "name `project-1`.`db`.`tbl1`" in model.render_definition()[0].sql(dialect="bigquery")
 
+    # This used to fail due to the dialect regex picking up `DIALECT_TEST` as the model's dialect
+    expressions = d.parse("MODEL(name DIALECT_TEST.foo); SELECT 1")
+
 
 def test_model_allow_partials():
     expressions = d.parse(


### PR DESCRIPTION
Fixes #3916

The new regex says: "If I see a `dialect`, ensure there's at least one whitespace, then [a-zA-Z]*, optionally wrapped in single quotes to allow stuff like `'duckdb'` (we have some tests for this ...).