### PR TITLE
Fix: Fix logging, grain resolution and source/target object names in table_diff

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -49,7 +49,7 @@ if t.TYPE_CHECKING:
     from sqlglot.dialects.dialect import DialectType
     from sqlmesh.core.context_diff import ContextDiff
     from sqlmesh.core.plan import Plan, EvaluatablePlan, PlanBuilder, SnapshotIntervals
-    from sqlmesh.core.table_diff import RowDiff, SchemaDiff
+    from sqlmesh.core.table_diff import TableDiff, RowDiff, SchemaDiff
 
     LayoutWidget = t.TypeVar("LayoutWidget", bound=t.Union[widgets.VBox, widgets.HBox])
 
@@ -291,6 +291,10 @@ class Console(abc.ABC):
         """Stop loading for the given id."""
 
     @abc.abstractmethod
+    def show_table_diff_summary(self, table_diff: TableDiff) -> None:
+        """Display information about the tables being diffed and how they are being joined"""
+
+    @abc.abstractmethod
     def show_schema_diff(self, schema_diff: SchemaDiff) -> None:
         """Show table schema diff."""
 
@@ -461,6 +465,9 @@ class NoopConsole(Console):
         return uuid.uuid4()
 
     def loading_stop(self, id: uuid.UUID) -> None:
+        pass
+
+    def show_table_diff_summary(self, table_diff: TableDiff) -> None:
         pass
 
     def show_schema_diff(self, schema_diff: SchemaDiff) -> None:
@@ -1280,6 +1287,44 @@ class TerminalConsole(Console):
     def loading_stop(self, id: uuid.UUID) -> None:
         self.loading_status[id].stop()
         del self.loading_status[id]
+
+    def show_table_diff_summary(self, table_diff: TableDiff) -> None:
+        tree = Tree("\n[b]Table Diff")
+
+        if table_diff.model_name:
+            model = Tree("Model:")
+            model.add(f"[blue]{table_diff.model_name}[/blue]")
+
+            tree.add(model)
+
+            envs = Tree("Environment:")
+            source = Tree(
+                f"Source: [{self.TABLE_DIFF_SOURCE_BLUE}]{table_diff.source_alias}[/{self.TABLE_DIFF_SOURCE_BLUE}]"
+            )
+            envs.add(source)
+
+            target = Tree(f"Target: [green]{table_diff.target_alias}[/green]")
+            envs.add(target)
+
+            tree.add(envs)
+
+        tables = Tree("Tables:")
+
+        tables.add(
+            f"Source: [{self.TABLE_DIFF_SOURCE_BLUE}]{table_diff.source}[/{self.TABLE_DIFF_SOURCE_BLUE}]"
+        )
+        tables.add(f"Target: [green]{table_diff.target}[/green]")
+
+        tree.add(tables)
+
+        join = Tree("Join On:")
+        _, _, key_column_names = table_diff.key_columns
+        for col_name in key_column_names:
+            join.add(f"[yellow]{col_name}[/yellow]")
+
+        tree.add(join)
+
+        self._print(tree)
 
     def show_schema_diff(self, schema_diff: SchemaDiff) -> None:
         source_name = schema_diff.source

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1533,25 +1533,29 @@ class GenericContext(BaseContext, t.Generic[C]):
             if not target_env:
                 raise SQLMeshError(f"Could not find environment '{target}')")
 
+            # Compare the virtual layer instead of the physical layer because the virtual layer is guaranteed to point
+            # to the correct/active snapshot for the model in the specified environment, taking into account things like dev previews
             source = next(
                 snapshot for snapshot in source_env.snapshots if snapshot.name == model.fqn
-            ).table_name()
+            ).qualified_view_name.for_environment(source_env.naming_info, adapter.dialect)
+
             target = next(
                 snapshot for snapshot in target_env.snapshots if snapshot.name == model.fqn
-            ).table_name()
+            ).qualified_view_name.for_environment(target_env.naming_info, adapter.dialect)
+
             source_alias = source_env.name
             target_alias = target_env.name
 
             if not on:
-                for ref in model.all_references:
-                    if ref.unique:
-                        expr = ref.expression
-
-                        if isinstance(expr, exp.Tuple):
-                            on = [key.this.sql() for key in expr.expressions]
-                        else:
-                            # Handle a single Column or Paren expression
-                            on = [expr.this.sql()]
+                on = []
+                for expr in [ref.expression for ref in model.all_references if ref.unique]:
+                    if isinstance(expr, exp.Tuple):
+                        on.extend(
+                            [key.this.sql(dialect=adapter.dialect) for key in expr.expressions]
+                        )
+                    else:
+                        # Handle a single Column or Paren expression
+                        on.append(expr.this.sql(dialect=adapter.dialect))
 
         if not on:
             raise SQLMeshError(
@@ -1559,7 +1563,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             )
 
         table_diff = TableDiff(
-            adapter=adapter,
+            adapter=adapter.with_log_level(logger.getEffectiveLevel()),
             source=source,
             target=target,
             on=on,
@@ -1573,6 +1577,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             decimals=decimals,
         )
         if show:
+            self.console.show_table_diff_summary(table_diff)
             self.console.show_schema_diff(table_diff.schema_diff())
             self.console.show_row_diff(
                 table_diff.row_diff(temp_schema=temp_schema, skip_grain_check=skip_grain_check),

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -650,8 +650,19 @@ def test_table_diff(notebook, loaded_sushi_context, convert_all_html_output_to_t
 
     assert not output.stdout
     assert not output.stderr
-    assert len(output.outputs) == 4
+    assert len(output.outputs) == 5
     assert convert_all_html_output_to_text(output) == [
+        """Table Diff
+├── Model:
+│   └── sushi.top_waiters
+├── Environment:
+│   ├── Source: dev
+│   └── Target: prod
+├── Tables:
+│   ├── Source: memory.sushi__dev.top_waiters
+│   └── Target: memory.sushi.top_waiters
+└── Join On:
+    └── waiter_id""",
         """Schema Diff Between 'DEV' and 'PROD' environments for model 'sushi.top_waiters':
 └── Schemas match""",
         """Row Counts:


### PR DESCRIPTION
Prior to this PR, `table_diff` queries where not being written to the log file which made debugging table diff issues a lot harder.

Also, when a model was specified (instead of an explicit source / target table), the following issues occurred:
 - Only a single `grain` column was being resolved for the join key even if there were multiple columns
 - If the model was in a dev environment and the snapshot backing it was a dev preview, SQLMesh would generate the wrong table name and diff against the wrong table

This PR fixes the bugs and introduces the following changes:
 - Output a summary of exactly what is being compared / what SQLMesh resolved the model to so that the user can reason about the results
 - Resolve models to the virtual layer instead of the physical layer in order to run diffs because the virtual layer is always guaranteed to point to the latest/correct snapshot in the specified environment

New output section when a model is specified:
![Screenshot From 2025-02-28 16-02-22](https://github.com/user-attachments/assets/f4a61cfb-1af9-4048-8443-5f5f4b509a65)

New output section when just a set of tables and a join key are specified:
![Screenshot From 2025-02-28 16-06-37](https://github.com/user-attachments/assets/45efc8ad-e296-4f43-9c61-283d08fbfd58)

