### PR TITLE
IPython display import from core deprecated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "dateparser",
         "hyperscript>=0.1.0",
         "importlib-metadata; python_version<'3.12'",
+        "ipython>=7.14",
         "ipywidgets",
         "jinja2",
         "pandas",

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from copy import deepcopy
 
 from hyperscript import h
-from IPython.core.display import display
 from IPython.core.magic import (
     Magics,
     cell_magic,
@@ -17,6 +16,7 @@ from IPython.core.magic import (
     magics_class,
 )
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
+from IPython.display import display
 from IPython.utils.process import arg_split
 from rich.jupyter import JupyterRenderable
 


### PR DESCRIPTION
> DeprecationWarning: Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython.display

Does as the deprecation warning suggest, and puts lower bound in ipython version.

---

This turned into an error in IPython 9:

>   File "/opt/venv/lib/python3.13/site-packages/sqlmesh/magics.py", line 11, in <module>
    from IPython.core.display import display
ImportError: cannot import name 'display' from 'IPython.core.display' (/opt/venv/lib/python3.13/site-packages/IPython/core/display.py)

