### PR TITLE
Chore: improve error message when data type missing from column

### DIFF
--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -205,7 +205,10 @@ class ModelMeta(_Node):
 
         if isinstance(v, exp.Schema):
             for column in v.expressions:
-                expr = column.args["kind"]
+                expr = column.args.get("kind")
+                if not isinstance(expr, exp.DataType):
+                    raise ConfigError(f"Missing data type for column '{column.name}'.")
+
                 expr.meta["dialect"] = dialect
                 columns_to_types[normalize_identifiers(column, dialect=dialect).name] = expr
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -7943,3 +7943,21 @@ def test_seed_dont_coerce_na_into_null(tmp_path):
     assert model.seed is not None
     assert len(model.seed.content) > 0
     assert next(model.render(context=None)).to_dict() == {"code": {0: "NA"}}
+
+
+def test_missing_column_data_in_columns_key():
+    expressions = d.parse(
+        """
+        MODEL (
+            name db.seed,
+            kind SEED (
+              path '../seeds/waiter_names.csv',
+            ),
+            columns (
+              culprit, other_column double,
+            )
+        );
+    """
+    )
+    with pytest.raises(ConfigError, match="Missing data type for column 'culprit'."):
+        load_sql_based_model(expressions, path=Path("./examples/sushi/models/test_model.sql"))


### PR DESCRIPTION
The current UX when a column type is missing in the `columns` key is not great:

```
$ pytest tests/core/test_model.py::test_missing_column_data_in_columns_key
...
>               expr = column.args["kind"]
E               KeyError: 'kind'

sqlmesh/core/model/meta.py:208: KeyError
...
```