### PR TITLE
Chore: install extras modules before building API docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: "3.10"
   jobs:
     pre_build:
-      - pip install -e .
+      - pip install -e ".[athena,azuresql,bigframes,bigquery,clickhouse,databricks,dbt,dlt,gcppostgres,github,llm,mssql,mysql,mwaa,postgres,redshift,slack,snowflake,trino,web,risingwave]"
       - make api-docs
 
 mkdocs:


### PR DESCRIPTION
API docs were not built correctly for pages importing uninstalled modules.

This PR includes all non-dev extras in the module installation before building the API docs.