### PR TITLE
Chore: show only one of direct/indirect/metadata update in console summary

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -984,13 +984,13 @@ class TerminalConsole(Console):
                     )
                 elif context_diff.indirectly_modified(name):
                     indirect.add(f"[indirect]{display_name}")
-
-                if context_diff.metadata_updated(name):
+                elif context_diff.metadata_updated(name):
                     metadata.add(
                         f"[metadata]{display_name}"
                         if no_diff
                         else Syntax(f"{display_name}\n{context_diff.text_diff(name)}", "sql")
                     )
+
             if direct.children:
                 tree.add(direct)
             if indirect.children:

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -238,7 +238,7 @@ def test_diff(sushi_context, notebook, convert_all_html_output_to_text, get_all_
     assert len(output.outputs) == 2
     assert convert_all_html_output_to_text(output) == [
         "Differences from the `prod` environment:",
-        "Models:\n├── Directly Modified:\n│   └── sqlmesh_example.test\n└── Metadata Updated:\n    └── sqlmesh_example.test",
+        "Models:\n└── Directly Modified:\n    └── sqlmesh_example.test",
     ]
     assert get_all_html_output(output) == [
         str(
@@ -266,21 +266,12 @@ def test_diff(sushi_context, notebook, convert_all_html_output_to_text, get_all_
                         autoescape=False,
                     )
                 )
-                + "├── "
+                + "└── "
                 + str(
                     h(
                         "span",
                         {"style": "font-weight: bold"},
                         "Directly Modified:",
-                        autoescape=False,
-                    )
-                )
-                + "│   └── sqlmesh_example.test└── "
-                + str(
-                    h(
-                        "span",
-                        {"style": "font-weight: bold"},
-                        "Metadata Updated:",
                         autoescape=False,
                     )
                 )


### PR DESCRIPTION
When a model is both directly-modified and has a metadata update, we want to display only the former. On the other hand, if it's an indirectly-modified model with a metadata update, we want to show both because the model may not be rebuilt (e.g. if it's an indirectly-non-breaking change), but we still want to show the metadata update status ([example](https://github.com/user-attachments/assets/dcaa31cb-e238-4630-bfa1-59da4eee8ca7)).