### PR TITLE
Feat: Adds support for macros in model_defaults and conditional properties

### DIFF
--- a/docs/concepts/macros/macro_variables.md
+++ b/docs/concepts/macros/macro_variables.md
@@ -134,3 +134,4 @@ SQLMesh provides two other predefined variables used to modify model behavior ba
     * Can be used in model definitions when SQLGlot cannot fully parse a statement and you need to reference the model's underlying physical table directly.
     * Can be passed as an argument to macros that access or interact with the underlying physical table.
 * @this_env - A string value containing the name of the current [environment](../environments.md). Only available in [`before_all` and `after_all` statements](../../guides/configuration.md#before_all-and-after_all-statements), as well as in macros invoked within them.
+* @model_kind_name - A string value containing the name of the current model kind. Intended to be used in scenarios where you need to control the [physical properties in model defaults](../../reference/model_configuration.md#model-defaults).

--- a/docs/reference/model_configuration.md
+++ b/docs/reference/model_configuration.md
@@ -107,6 +107,34 @@ To override `partition_expiration_days`, add a new `creatable_type` property and
     )
     ```
 
+You can also use the `@model_kind_name` variable to fine-tune control over `physical_properties` in `model_defaults`. This holds the current model's kind name and is useful for conditionally assigning a property. For example, to disable `creatable_type` for your project's `VIEW` kind models:
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    model_defaults:
+      dialect: snowflake
+      start: 2022-01-01
+      physical_properties:
+        creatable_type: "@IF(@model_kind_name != 'VIEW', 'TRANSIENT', NULL)"
+    ```
+
+=== "Python"
+
+    ```python linenums="1"
+    from sqlmesh.core.config import Config, ModelDefaultsConfig
+
+    config = Config(
+      model_defaults=ModelDefaultsConfig(
+        dialect="snowflake",
+        start="2022-01-01",
+        physical_properties={
+          "creatable_type": "@IF(@model_kind_name != 'VIEW', 'TRANSIENT', NULL)",
+        },
+      ),
+    )
+    ```
+
 
 The SQLMesh project-level `model_defaults` key supports the following options, described in the [general model properties](#general-model-properties) table above:
 

--- a/sqlmesh/core/config/model.py
+++ b/sqlmesh/core/config/model.py
@@ -10,8 +10,6 @@ from sqlmesh.core.model.kind import (
     model_kind_validator,
     on_destructive_change_validator,
 )
-from sqlmesh.core.node import IntervalUnit
-from sqlmesh.utils.date import TimeLike
 from sqlmesh.core.model.meta import FunctionCall
 from sqlmesh.utils.pydantic import field_validator
 
@@ -48,7 +46,7 @@ class ModelDefaultsConfig(BaseConfig):
     dialect: t.Optional[str] = None
     cron: t.Optional[str] = None
     owner: t.Optional[str] = None
-    start: t.Optional[TimeLike] = None
+    start: t.Optional[t.Any] = None
     table_format: t.Optional[str] = None
     storage_format: t.Optional[str] = None
     on_destructive_change: t.Optional[OnDestructiveChange] = None
@@ -56,10 +54,10 @@ class ModelDefaultsConfig(BaseConfig):
     virtual_properties: t.Optional[t.Dict[str, t.Any]] = None
     session_properties: t.Optional[t.Dict[str, t.Any]] = None
     audits: t.Optional[t.List[FunctionCall]] = None
-    optimize_query: t.Optional[bool] = None
-    allow_partials: t.Optional[bool] = None
-    interval_unit: t.Optional[IntervalUnit] = None
-    enabled: t.Optional[bool] = None
+    optimize_query: t.Optional[t.Any] = None
+    allow_partials: t.Optional[t.Any] = None
+    interval_unit: t.Optional[t.Any] = None
+    enabled: t.Optional[t.Any] = None
 
     _model_kind_validator = model_kind_validator
     _on_destructive_change_validator = on_destructive_change_validator

--- a/sqlmesh/core/config/model.py
+++ b/sqlmesh/core/config/model.py
@@ -11,6 +11,7 @@ from sqlmesh.core.model.kind import (
     on_destructive_change_validator,
 )
 from sqlmesh.core.model.meta import FunctionCall
+from sqlmesh.core.node import IntervalUnit
 from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.pydantic import field_validator
 
@@ -55,10 +56,10 @@ class ModelDefaultsConfig(BaseConfig):
     virtual_properties: t.Optional[t.Dict[str, t.Any]] = None
     session_properties: t.Optional[t.Dict[str, t.Any]] = None
     audits: t.Optional[t.List[FunctionCall]] = None
-    optimize_query: t.Optional[t.Any] = None
-    allow_partials: t.Optional[t.Any] = None
-    interval_unit: t.Optional[t.Any] = None
-    enabled: t.Optional[t.Any] = None
+    optimize_query: t.Optional[t.Union[str, bool]] = None
+    allow_partials: t.Optional[t.Union[str, bool]] = None
+    interval_unit: t.Optional[t.Union[str, IntervalUnit]] = None
+    enabled: t.Optional[t.Union[str, bool]] = None
 
     _model_kind_validator = model_kind_validator
     _on_destructive_change_validator = on_destructive_change_validator

--- a/sqlmesh/core/config/model.py
+++ b/sqlmesh/core/config/model.py
@@ -11,6 +11,7 @@ from sqlmesh.core.model.kind import (
     on_destructive_change_validator,
 )
 from sqlmesh.core.model.meta import FunctionCall
+from sqlmesh.utils.date import TimeLike
 from sqlmesh.utils.pydantic import field_validator
 
 
@@ -46,7 +47,7 @@ class ModelDefaultsConfig(BaseConfig):
     dialect: t.Optional[str] = None
     cron: t.Optional[str] = None
     owner: t.Optional[str] = None
-    start: t.Optional[t.Any] = None
+    start: t.Optional[TimeLike] = None
     table_format: t.Optional[str] = None
     storage_format: t.Optional[str] = None
     on_destructive_change: t.Optional[OnDestructiveChange] = None

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -18,6 +18,7 @@ from sqlmesh.core.model.definition import (
     create_sql_model,
     create_models_from_blueprints,
     get_model_name,
+    parse_defaults_properties,
     render_meta_fields,
     render_model_defaults,
 )
@@ -174,6 +175,8 @@ class model(registry_decorator):
             if defaults
             else {}
         )
+
+        rendered_defaults = parse_defaults_properties(rendered_defaults, dialect=dialect)
 
         common_kwargs = {
             "defaults": rendered_defaults,

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -19,6 +19,7 @@ from sqlmesh.core.model.definition import (
     create_models_from_blueprints,
     get_model_name,
     render_meta_fields,
+    render_model_defaults,
 )
 from sqlmesh.core.model.kind import ModelKindName, _ModelKind
 from sqlmesh.utils import registry_decorator, DECORATOR_RETURN_TYPE
@@ -159,8 +160,23 @@ class model(registry_decorator):
         if isinstance(rendered_name, exp.Expression):
             rendered_fields["name"] = rendered_name.sql(dialect=dialect)
 
+        rendered_defaults = (
+            render_model_defaults(
+                defaults=defaults,
+                module_path=module_path,
+                macros=macros,
+                jinja_macros=jinja_macros,
+                variables=variables,
+                path=path,
+                dialect=dialect,
+                default_catalog=default_catalog,
+            )
+            if defaults
+            else {}
+        )
+
         common_kwargs = {
-            "defaults": defaults,
+            "defaults": rendered_defaults,
             "path": path,
             "time_column_format": time_column_format,
             "python_env": serialize_env(env, path=module_path),

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2278,7 +2278,7 @@ def create_python_model(
         }
 
     used_variables = {k: v for k, v in (variables or {}).items() if k in referenced_variables}
-    if variables:
+    if used_variables:
         python_env[c.SQLMESH_VARS] = Executable.value(used_variables)
 
     return _create_model(

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -661,7 +661,6 @@ class _Model(ModelMeta, frozen=True):
         def _render(expression: exp.Expression) -> exp.Expression | None:
             # note: we use the _statement_renderer instead of _create_renderer because it sets model_fqn which
             # in turn makes @this_model available in the evaluation context
-            render_kwargs["model_kind_name"] = self.kind.name
             rendered_exprs = self._statement_renderer(
                 exp.maybe_parse(expression.this)
                 if isinstance(expression, exp.Literal)

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2012,9 +2012,10 @@ def load_sql_based_model(
     unrendered_merge_filter = None
 
     for prop in meta.expressions:
+        # Macro functions that programmaticaly generate the key-value pair properties should be rendered
+        # This is needed in the odd case where a macro shares the name of one of the properties
+        # eg `@session_properties()` Test: `test_macros_in_model_statement` Reference PR: #2574
         if isinstance(prop, d.MacroFunc):
-            # Macro functions that programmaticaly generate the property key-value pair should be rendered
-            # See: https://github.com/TobikoData/sqlmesh/pull/2574 Test: test_macros_in_model_statement
             continue
 
         prop_name = prop.name.lower()

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -664,12 +664,7 @@ class _Model(ModelMeta, frozen=True):
         def _render(expression: exp.Expression) -> exp.Expression | None:
             # note: we use the _statement_renderer instead of _create_renderer because it sets model_fqn which
             # in turn makes @this_model available in the evaluation context
-            rendered_exprs = self._statement_renderer(
-                exp.maybe_parse(expression.this, dialect=self.dialect)
-                if isinstance(expression, exp.Literal)
-                and (d.SQLMESH_MACRO_PREFIX in expression.this)
-                else expression
-            ).render(**render_kwargs)
+            rendered_exprs = self._statement_renderer(expression).render(**render_kwargs)
 
             # Warn instead of raising for cases where a property is conditionally assigned
             if not rendered_exprs or rendered_exprs[0].sql().lower() in {"none", "null"}:

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2696,6 +2696,19 @@ def render_model_defaults(
         default_catalog=default_catalog,
     )
 
+    # Validate defaults that have macros are rendered to boolean
+    for boolean in {"optimize_query", "allow_partials", "enabled"}:
+        if var := rendered_defaults.get(boolean):
+            if not isinstance(var, (exp.Boolean, bool)):
+                raise ConfigError(f"Expected boolean for '{var}', got '{type(var)}' instead")
+
+    # Validate the 'interval_unit' if present is an Interval Unit
+    if (var := rendered_defaults.get("interval_unit")) and isinstance(var, str):
+        try:
+            rendered_defaults["interval_unit"] = IntervalUnit(var)
+        except ValueError as e:
+            raise ConfigError(f"Invalid interval unit: {var}") from e
+
     return rendered_defaults
 
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2276,9 +2276,9 @@ def create_python_model(
             for dep in t.cast(t.List[exp.Expression], depends_on_rendered)[0].expressions
         }
 
-    variables = {k: v for k, v in (variables or {}).items() if k in referenced_variables}
+    used_variables = {k: v for k, v in (variables or {}).items() if k in referenced_variables}
     if variables:
-        python_env[c.SQLMESH_VARS] = Executable.value(variables)
+        python_env[c.SQLMESH_VARS] = Executable.value(used_variables)
 
     return _create_model(
         PythonModel,

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2067,6 +2067,8 @@ def load_sql_based_model(
         else {}
     )
 
+    rendered_defaults = parse_defaults_properties(rendered_defaults, dialect=dialect)
+
     # Extract the query and any pre/post statements
     query_or_seed_insert, pre_statements, post_statements, on_virtual_update, inline_audits = (
         _split_sql_model_statements(expressions[1:], path, dialect=dialect)
@@ -2694,13 +2696,19 @@ def render_model_defaults(
         default_catalog=default_catalog,
     )
 
+    return rendered_defaults
+
+
+def parse_defaults_properties(
+    defaults: t.Dict[str, t.Any], dialect: DialectType
+) -> t.Dict[str, t.Any]:
     for prop in PROPERTIES:
-        if default_properties := rendered_defaults.get(prop):
+        if default_properties := defaults.get(prop):
             for key, value in default_properties.items():
                 if isinstance(key, str) and d.SQLMESH_MACRO_PREFIX in str(value):
-                    rendered_defaults[prop][key] = exp.maybe_parse(value, dialect=dialect)
+                    defaults[prop][key] = exp.maybe_parse(value, dialect=dialect)
 
-    return rendered_defaults
+    return defaults
 
 
 def render_expression(

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -60,7 +60,7 @@ from sqlmesh.utils.metaprogramming import (
 
 if t.TYPE_CHECKING:
     from sqlglot.dialects.dialect import DialectType
-    from sqlmesh.core._typing import Self, TableName
+    from sqlmesh.core._typing import Self, TableName, SessionProperties
     from sqlmesh.core.context import ExecutionContext
     from sqlmesh.core.engine_adapter import EngineAdapter
     from sqlmesh.core.engine_adapter._typing import QueryOrDF
@@ -71,14 +71,15 @@ if t.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+PROPERTIES = {"physical_properties", "session_properties", "virtual_properties"}
+
 RUNTIME_RENDERED_MODEL_FIELDS = {
     "audits",
     "signals",
     "description",
     "cron",
-    "physical_properties",
     "merge_filter",
-}
+} | PROPERTIES
 
 
 class _Model(ModelMeta, frozen=True):
@@ -657,12 +658,14 @@ class _Model(ModelMeta, frozen=True):
             raise SQLMeshError(f"Expected one expression but got {len(rendered_exprs)}")
         return rendered_exprs[0].transform(d.replace_merge_table_aliases)
 
-    def render_physical_properties(self, **render_kwargs: t.Any) -> t.Dict[str, exp.Expression]:
+    def render_properties(
+        self, properties: t.Dict[str, exp.Expression] | SessionProperties, **render_kwargs: t.Any
+    ) -> t.Dict[str, t.Any]:
         def _render(expression: exp.Expression) -> exp.Expression | None:
             # note: we use the _statement_renderer instead of _create_renderer because it sets model_fqn which
             # in turn makes @this_model available in the evaluation context
             rendered_exprs = self._statement_renderer(
-                exp.maybe_parse(expression.this)
+                exp.maybe_parse(expression.this, dialect=self.dialect)
                 if isinstance(expression, exp.Literal)
                 and (d.SQLMESH_MACRO_PREFIX in expression.this)
                 else expression
@@ -683,8 +686,19 @@ class _Model(ModelMeta, frozen=True):
             return rendered_exprs[0]
 
         return {
-            k: rendered for k, v in self.physical_properties.items() if (rendered := _render(v))
+            k: rendered
+            for k, v in properties.items()
+            if (rendered := (_render(v) if isinstance(v, exp.Expression) else v))
         }
+
+    def render_physical_properties(self, **render_kwargs: t.Any) -> t.Dict[str, t.Any]:
+        return self.render_properties(properties=self.physical_properties, **render_kwargs)
+
+    def render_virtual_properties(self, **render_kwargs: t.Any) -> t.Dict[str, t.Any]:
+        return self.render_properties(properties=self.virtual_properties, **render_kwargs)
+
+    def render_session_properties(self, **render_kwargs: t.Any) -> t.Dict[str, t.Any]:
+        return self.render_properties(properties=self.session_properties, **render_kwargs)
 
     def _create_renderer(self, expression: exp.Expression) -> ExpressionRenderer:
         return ExpressionRenderer(
@@ -1998,8 +2012,20 @@ def load_sql_based_model(
     unrendered_merge_filter = None
 
     for prop in meta.expressions:
+        if isinstance(prop, d.MacroFunc):
+            # Macro functions that programmaticaly generate the property key-value pair should be rendered
+            # See: https://github.com/TobikoData/sqlmesh/pull/2574 Test: test_macros_in_model_statement
+            continue
+
         prop_name = prop.name.lower()
-        if prop_name in ("signals", "audits", "physical_properties"):
+        if (
+            prop_name
+            in {
+                "signals",
+                "audits",
+            }
+            | PROPERTIES
+        ):
             unrendered_properties[prop_name] = prop.args.get("value")
         elif (
             prop.name.lower() == "kind"
@@ -2029,6 +2055,21 @@ def load_sql_based_model(
         raise
 
     rendered_meta = rendered_meta_exprs[0]
+
+    rendered_defaults = (
+        render_model_defaults(
+            defaults=defaults,
+            module_path=module_path,
+            macros=macros,
+            jinja_macros=jinja_macros,
+            variables=variables,
+            path=path,
+            dialect=dialect,
+            default_catalog=default_catalog,
+        )
+        if defaults
+        else {}
+    )
 
     # Extract the query and any pre/post statements
     query_or_seed_insert, pre_statements, post_statements, on_virtual_update, inline_audits = (
@@ -2075,7 +2116,7 @@ def load_sql_based_model(
         pre_statements=pre_statements,
         post_statements=post_statements,
         on_virtual_update=on_virtual_update,
-        defaults=defaults,
+        defaults=rendered_defaults,
         path=path,
         module_path=module_path,
         macros=macros,
@@ -2311,11 +2352,7 @@ def _create_model(
 
     _validate_model_fields(klass, {"name", *kwargs} - {"grain", "table_properties"}, path)
 
-    for prop in [
-        "session_properties",
-        "physical_properties",
-        "virtual_properties",
-    ]:
+    for prop in PROPERTIES:
         kwargs[prop] = _resolve_properties((defaults or {}).get(prop), kwargs.get(prop))
 
     dialect = dialect or ""
@@ -2347,10 +2384,12 @@ def _create_model(
         statements.extend(kwargs["post_statements"])
     if "on_virtual_update" in kwargs:
         statements.extend(kwargs["on_virtual_update"])
-    if physical_properties := kwargs.get("physical_properties"):
-        # to allow variables like @gateway to be used in physical_properties
-        # since rendering shifted from load time to run time
-        statements.extend(physical_properties)
+
+    # to allow variables like @gateway to be used in these properties
+    # since rendering shifted from load time to run time
+    for property_name in PROPERTIES:
+        if property_values := kwargs.get(property_name):
+            statements.extend(property_values)
 
     jinja_macro_references, used_variables = extract_macro_references_and_variables(
         *(gen(e) for e in statements)
@@ -2582,9 +2621,7 @@ def render_meta_fields(
     default_catalog: t.Optional[str],
 ) -> t.Dict[str, t.Any]:
     def render_field_value(value: t.Any) -> t.Any:
-        if isinstance(value, exp.Expression) or (
-            isinstance(value, str) and d.SQLMESH_MACRO_PREFIX in value
-        ):
+        if isinstance(value, exp.Expression) or (isinstance(value, str) and "@" in value):
             expression = exp.maybe_parse(value, dialect=dialect)
             rendered_expr = render_expression(
                 expression=expression,
@@ -2596,15 +2633,15 @@ def render_meta_fields(
                 dialect=dialect,
                 default_catalog=default_catalog,
             )
-            if rendered_expr is None:
-                raise SQLMeshError(
-                    f"Failed to render model attribute `{fields['name']}` at `{path}`\n"
-                    f"'{expression.sql(dialect=dialect)}' must return an expression"
+            # Warn instead of raising for cases where an attribute is conditionally assigned
+            if not rendered_expr or rendered_expr[0].sql().lower() in {"none", "null"}:
+                logger.warning(
+                    f"Rendering '{expression.sql(dialect=dialect)}' did not return an expression"
                 )
+                return None
             if len(rendered_expr) != 1:
                 raise SQLMeshError(
-                    f"Failed to render model attribute `{fields['name']}` at `{path}`.\n"
-                    f"`{expression.sql(dialect=dialect)}` must return one result, but got {len(rendered_expr)}"
+                    f"Rendering `{expression.sql(dialect=dialect)}` must return one result, but got {len(rendered_expr)}"
                 )
             return rendered_expr[0]
 
@@ -2614,15 +2651,60 @@ def render_meta_fields(
         field = field_info.alias or field_name
         if field not in RUNTIME_RENDERED_MODEL_FIELDS and (field_value := fields.get(field)):
             if isinstance(field_value, dict):
-                for key in list(field_value.keys()):
-                    if key not in RUNTIME_RENDERED_MODEL_FIELDS:
-                        fields[field][key] = render_field_value(field_value[key])
+                rendered_dict = {}
+                for key, value in field_value.items():
+                    if key in RUNTIME_RENDERED_MODEL_FIELDS:
+                        rendered_dict[key] = value
+                    elif rendered := render_field_value(value):
+                        rendered_dict[key] = rendered
+                if rendered_dict:
+                    fields[field] = rendered_dict
+                else:
+                    fields.pop(field)
             elif isinstance(field_value, list):
-                fields[field] = [render_field_value(value) for value in field_value]
+                if rendered_list := [
+                    rendered for value in field_value if (rendered := render_field_value(value))
+                ]:
+                    fields[field] = rendered_list
+                else:
+                    fields.pop(field)
             else:
-                fields[field] = render_field_value(field_value)
+                if rendered_field := render_field_value(field_value):
+                    fields[field] = rendered_field
+                else:
+                    fields.pop(field)
 
     return fields
+
+
+def render_model_defaults(
+    defaults: t.Dict[str, t.Any],
+    module_path: Path,
+    path: Path,
+    jinja_macros: t.Optional[JinjaMacroRegistry],
+    macros: t.Optional[MacroRegistry],
+    dialect: DialectType,
+    variables: t.Optional[t.Dict[str, t.Any]],
+    default_catalog: t.Optional[str],
+) -> t.Dict[str, t.Any]:
+    rendered_defaults = render_meta_fields(
+        fields=defaults,
+        module_path=module_path,
+        macros=macros,
+        jinja_macros=jinja_macros,
+        variables=variables,
+        path=path,
+        dialect=dialect,
+        default_catalog=default_catalog,
+    )
+
+    for prop in PROPERTIES:
+        if default_properties := rendered_defaults.get(prop):
+            for key, value in default_properties.items():
+                if isinstance(key, str) and d.SQLMESH_MACRO_PREFIX in str(value):
+                    rendered_defaults[prop][key] = exp.maybe_parse(value, dialect=dialect)
+
+    return rendered_defaults
 
 
 def render_expression(

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -110,14 +110,16 @@ class BaseExpressionRenderer:
 
         this_model = kwargs.pop("this_model", None)
 
+        this_snapshot = (snapshots or {}).get(self._model_fqn) if self._model_fqn else None
         if not this_model and self._model_fqn:
-            this_snapshot = (snapshots or {}).get(self._model_fqn)
             this_model = self._resolve_table(
                 self._model_fqn,
                 snapshots={self._model_fqn: this_snapshot} if this_snapshot else None,
                 deployability_index=deployability_index,
                 table_mapping=table_mapping,
             )
+        if this_snapshot and (kind := this_snapshot.model_kind_name):
+            kwargs["model_kind_name"] = kind.name
 
         expressions = [self._expression]
 

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -667,7 +667,9 @@ class SnapshotEvaluator:
                     physical_properties=rendered_physical_properties,
                 )
 
-        with adapter.transaction(), adapter.session(snapshot.model.session_properties):
+        with adapter.transaction(), adapter.session(
+            snapshot.model.render_session_properties(**render_statements_kwargs)
+        ):
             wap_id: t.Optional[str] = None
             if (
                 table_name
@@ -766,7 +768,9 @@ class SnapshotEvaluator:
             deployability_index=deployability_index,
         )
 
-        with adapter.transaction(), adapter.session(snapshot.model.session_properties):
+        with adapter.transaction(), adapter.session(
+            snapshot.model.render_session_properties(**create_render_kwargs)
+        ):
             rendered_physical_properties = snapshot.model.render_physical_properties(
                 **create_render_kwargs
             )
@@ -886,7 +890,9 @@ class SnapshotEvaluator:
                 runtime_stage=RuntimeStage.CREATING,
                 deployability_index=deployability_index,
             )
-            with adapter.transaction(), adapter.session(snapshot.model.session_properties):
+            with adapter.transaction(), adapter.session(
+                snapshot.model.render_session_properties(**render_kwargs)
+            ):
                 self._execute_create(
                     snapshot=snapshot,
                     table_name=target_table_name,
@@ -917,12 +923,6 @@ class SnapshotEvaluator:
             view_name = snapshot.qualified_view_name.for_environment(
                 environment_naming_info, dialect=adapter.dialect
             )
-            _evaluation_strategy(snapshot, adapter).promote(
-                table_name=table_name,
-                view_name=view_name,
-                model=snapshot.model,
-                environment=environment_naming_info.name,
-            )
             render_kwargs: t.Dict[str, t.Any] = dict(
                 start=start,
                 end=end,
@@ -932,6 +932,13 @@ class SnapshotEvaluator:
                 deployability_index=deployability_index,
                 table_mapping=table_mapping,
                 runtime_stage=RuntimeStage.PROMOTING,
+            )
+            _evaluation_strategy(snapshot, adapter).promote(
+                table_name=table_name,
+                view_name=view_name,
+                model=snapshot.model,
+                environment=environment_naming_info.name,
+                **render_kwargs,
             )
             adapter.execute(snapshot.model.render_on_virtual_update(**render_kwargs))
 
@@ -1371,7 +1378,7 @@ class PromotableStrategy(EvaluationStrategy):
             exp.select("*").from_(table_name, dialect=self.adapter.dialect),
             table_description=model.description if is_prod else None,
             column_descriptions=model.column_descriptions if is_prod else None,
-            view_properties=model.virtual_properties,
+            view_properties=model.render_virtual_properties(**kwargs),
         )
 
     def demote(self, view_name: str, **kwargs: t.Any) -> None:

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -1373,12 +1373,22 @@ class PromotableStrategy(EvaluationStrategy):
     ) -> None:
         is_prod = environment == c.PROD
         logger.info("Updating view '%s' to point at table '%s'", view_name, table_name)
+        render_kwargs: t.Dict[str, t.Any] = dict(
+            start=kwargs.get("start"),
+            end=kwargs.get("end"),
+            execution_time=kwargs.get("execution_time"),
+            engine_adapter=kwargs.get("engine_adapter"),
+            snapshots=kwargs.get("snapshots"),
+            deployability_index=kwargs.get("deployability_index"),
+            table_mapping=kwargs.get("table_mapping"),
+            runtime_stage=kwargs.get("runtime_stage"),
+        )
         self.adapter.create_view(
             view_name,
             exp.select("*").from_(table_name, dialect=self.adapter.dialect),
             table_description=model.description if is_prod else None,
             column_descriptions=model.column_descriptions if is_prod else None,
-            view_properties=model.render_virtual_properties(**kwargs),
+            view_properties=model.render_virtual_properties(**render_kwargs),
         )
 
     def demote(self, view_name: str, **kwargs: t.Any) -> None:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -3930,6 +3930,39 @@ def test_model_defaults_macros_python_model(make_snapshot):
     }
 
 
+@pytest.mark.parametrize(
+    "optimize_query, enabled, allow_partials, interval_unit, expected_error",
+    [
+        ("string", "string", "string", "string", r"^Expected boolean for*"),
+        (True, "string", "string", "string", r"^Expected boolean for*"),
+        (True, True, "string", "string", r"^Expected boolean for*"),
+        (True, True, True, "string", r"^Invalid interval unitr*"),
+    ],
+)
+def test_model_defaults_validations(
+    optimize_query, enabled, allow_partials, interval_unit, expected_error
+):
+    model_defaults = ModelDefaultsConfig(
+        optimize_query=optimize_query,
+        enabled=enabled,
+        allow_partials=allow_partials,
+        interval_unit=interval_unit,
+    )
+
+    with pytest.raises(ConfigError, match=expected_error):
+        load_sql_based_model(
+            d.parse(
+                """
+            MODEL (
+                name test_schema.test_model,
+            );
+            SELECT a FROM tbl;
+            """,
+            ),
+            defaults=model_defaults.dict(),
+        )
+
+
 def test_model_session_properties(sushi_context):
     assert sushi_context.models['"memory"."sushi"."items"'].session_properties == {
         "string_prop": "some_value",

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -3737,7 +3737,6 @@ def test_model_defaults_macros(make_snapshot):
     model_defaults = ModelDefaultsConfig(
         table_format="@IF(@gateway = 'dev', 'iceberg', NULL)",
         storage_format="@IF(@gateway = 'local', 'parquet', NULL)",
-        validate_query="@IF(@gateway = 'dev', True, False)",
         optimize_query="@IF(@gateway = 'dev', True, False)",
         enabled="@IF(@gateway = 'dev', True, False)",
         allow_partials="@IF(@gateway = 'local', True, False)",
@@ -3780,7 +3779,6 @@ def test_model_defaults_macros(make_snapshot):
 
     # Validate rendering of model defaults
     assert model.optimize_query
-    assert model.validate_query
     assert model.enabled
     assert model.start == "1 month ago"
     assert not model.allow_partials
@@ -3840,7 +3838,6 @@ def test_model_defaults_macros_python_model(make_snapshot):
         },
         "table_format": "@IF(@gateway = 'local', 'iceberg', NULL)",
         "storage_format": "@IF(@gateway = 'dev', 'parquet', NULL)",
-        "validate_query": "@IF(@gateway = 'local', True, False)",
         "optimize_query": "@IF(@gateway = 'local', True, False)",
         "enabled": "@IF(@gateway = 'local', True, False)",
         "allow_partials": "@IF(@gateway = 'local', True, False)",
@@ -3870,9 +3867,8 @@ def test_model_defaults_macros_python_model(make_snapshot):
         variables={"gateway": "local", "create_type": "SECURE"},
     )
 
-    # Even if in the project wide defaults these are ignored for python models
+    # Even if in the project wide defaults this is ignored for python models
     assert not m.optimize_query
-    assert not m.validate_query
 
     # Validate rendering of model defaults
     assert m.enabled


### PR DESCRIPTION
This update adds: 

- Macro support in `model_defaults` attributes.
- The ability to conditionally enable these, as well as for `physical_properties`, `session_properties`, `virtual_properties`.  
- For `session_properties`, `virtual_properties` rendering is now moved to runtime to align with `physical_properties`. 
- Introduces the `model_kind_name` macro variable, which holds the name of the current model kind.

This macro is intended for example to disable from `physical_properties` the `creatable_type` for your project's VIEW-type models and set it to `TRANSIENT` for the rest of the model kinds, by having in `model_defaults`:

```yaml
model_defaults:
  dialect: snowflake
  start: 2022-01-01
  physical_properties:
    creatable_type: "@IF(@model_kind_name != 'VIEW', 'TRANSIENT', NULL)"
```