### PR TITLE
Chore!: bump sqlglot[rs] to v26.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "rich[jupyter]",
         "ruamel.yaml",
         "setuptools; python_version>='3.12'",
-        "sqlglot[rs]~=26.6.0",
+        "sqlglot[rs]~=26.8.0",
         "tenacity",
         "time-machine",
     ],

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1428,7 +1428,6 @@ class SqlModel(_Model):
                 this_query,
                 matchings=[(previous_query, this_query)],
                 delta_only=True,
-                copy=False,
                 dialect=self.dialect if self.dialect == previous.dialect else None,
             )
         inserted_expressions = {e.expression for e in edits if isinstance(e, Insert)}

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -921,7 +921,7 @@ def test_date_spine(assert_exp_eq, dialect, date_part):
                     CAST('2022-01-01' AS DATE),
                     CAST('2024-12-31' AS DATE),
                     INTERVAL '{interval}'
-                ) AS value
+                ) AS _t(value)
         ) AS _exploded(date_{date_part})
         """
     elif dialect == "spark":


### PR DESCRIPTION
The generation for brackets in DuckDB [changed](https://github.com/tobymao/sqlglot/commit/466c839c2cfc94b398dd619b738df165f2876cdb) after v26.6.0, in order to support the latest semantics, [introduced in v1.2.0](https://duckdb.org/2025/02/05/announcing-duckdb-120.html#breaking-changes).

In order to allow folks to use both the old and the new semantics, we introduced a new dialect setting that controls the version of the dialect, e.g. `dialect="duckdb, version=1.1.0"`.

Dialect settings aren't properly supported in SQLMesh right now, because we hard code dialect strings in various places, but most importantly in the engine adapters:

https://github.com/TobikoData/sqlmesh/blob/5fb2c818a720a823d3f8ef45d047bb33f92376fc/sqlmesh/core/engine_adapter/bigquery.py#L62

This means that even if someone includes some settings in the config's default dialect, I expect that they won't be used when generating ASTs within the adapter module, e.g. when executing code, which can lead to issues.

Granted, only the DuckDB dialect is affected by this change, so perhaps this doesn't need to be a blocker for merging this PR, assuming that we can suggest upgrading DuckDB to the latest version as a workaround. But it may be an issue for other dialects in the future, so I'll leave this be for a while until we discuss how we want to solve this internally.

EDIT: we discussed this internally and concluded that roundtripping DuckDB SQL should work regardless of the version. The issue would only arise if someone wanted to transpile _to_ duckdb and the version of the latter was <v1.2.0. This tradeoff is fine for now, happy to revisit this if needed.