### PR TITLE
make relative paths absolute first in the models endpoint

### DIFF
--- a/web/server/api/endpoints/models.py
+++ b/web/server/api/endpoints/models.py
@@ -124,7 +124,7 @@ def serialize_model(context: Context, model: Model, render_query: bool = False) 
     return models.Model(
         name=model.name,
         fqn=model.fqn,
-        path=str(model._path.relative_to(context.path)),
+        path=str(model._path.absolute().relative_to(context.path)),
         dialect=dialect,
         columns=columns,
         details=details,


### PR DESCRIPTION
We're having an issue with the UI where our model paths are relative, and the relative_to function fails. Not sure whether our venv is the issue, but calling absolute() first fixes the issue.

```
    raise ValueError("{!r} is not in the subpath of {!r}"
ValueError: '.' is not in the subpath of '/path/to/sqlmesh/repo' OR one path is relative and the other is absolute.
```