### PR TITLE
Feat: Enable INCREMENTAL_UNMANAGED models in native projects

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -594,6 +594,7 @@ def _create_parser(expression_type: t.Type[exp.Expression], table_keys: t.List[s
                         ModelKindName.INCREMENTAL_BY_TIME_RANGE,
                         ModelKindName.INCREMENTAL_BY_UNIQUE_KEY,
                         ModelKindName.INCREMENTAL_BY_PARTITION,
+                        ModelKindName.INCREMENTAL_UNMANAGED,
                         ModelKindName.SEED,
                         ModelKindName.VIEW,
                         ModelKindName.SCD_TYPE_2,

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -3003,6 +3003,42 @@ def test_incremental_unmanaged_validation():
     model.validate_definition()
 
 
+def test_incremental_unmanaged():
+    expr = d.parse(
+        """
+        MODEL (
+            name foo,
+            kind INCREMENTAL_UNMANAGED
+        );
+
+        SELECT x.a AS a FROM test.x AS x
+        """
+    )
+
+    model = load_sql_based_model(expressions=expr)
+
+    assert isinstance(model.kind, IncrementalUnmanagedKind)
+    assert not model.kind.insert_overwrite
+
+    expr = d.parse(
+        """
+        MODEL (
+            name foo,
+            kind INCREMENTAL_UNMANAGED (
+                insert_overwrite true
+            ),
+            partitioned_by a
+        );
+
+        SELECT x.a AS a FROM test.x AS x
+        """
+    )
+
+    model = load_sql_based_model(expressions=expr)
+    assert isinstance(model.kind, IncrementalUnmanagedKind)
+    assert model.kind.insert_overwrite
+
+
 def test_custom_interval_unit():
     assert (
         load_sql_based_model(


### PR DESCRIPTION
This PR exposes the `INCREMENTAL_UNMANAGED` model kind that was previously hidden from native projects because it was built to align with DBT's limited notion of incremental models and lacks a bunch of features such as being able to load data in batches.

However, it turns out it's the only model type we have currently that supports append-only tables