### PR TITLE
Fix: State sync snapshot count() quoting

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -314,10 +314,10 @@ workflows:
                 - bigquery
                 - clickhouse-cloud
                 - athena
-          filters:
-           branches:
-             only:
-               - main
+          #filters:
+          # branches:
+          #   only:
+          #     - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -314,10 +314,10 @@ workflows:
                 - bigquery
                 - clickhouse-cloud
                 - athena
-          #filters:
-          # branches:
-          #   only:
-          #     - main
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_slow_tests

--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -14,6 +14,7 @@ from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.state_sync.db.utils import (
     snapshot_name_version_filter,
     snapshot_id_filter,
+    fetchone,
     fetchall,
     create_batches,
 )
@@ -385,7 +386,7 @@ class SnapshotState:
 
     def count(self) -> int:
         """Counts the number of snapshots in the state."""
-        result = self.engine_adapter.fetchone(exp.select("COUNT(*)").from_(self.snapshots_table))
+        result = fetchone(self.engine_adapter, exp.select("COUNT(*)").from_(self.snapshots_table))
         return result[0] if result else 0
 
     def clear_cache(self) -> None:


### PR DESCRIPTION
PR #3903 introduced a subtle bug where the snapshot count queries stopped being quoted. This meant that on engines like Snowflake, `_snapshots` was interpreted as `_SNAPSHOTS` which caused migration to fail.

This PR fixes the issue and adds a test to detect this in future