### PR TITLE
Fix: Resolution of this_model within macros of on_virtual_update

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -452,8 +452,6 @@ class _Model(ModelMeta, frozen=True):
         engine_adapter: t.Optional[EngineAdapter] = None,
         **kwargs: t.Any,
     ) -> t.List[exp.Expression]:
-        if "this_model" not in kwargs:
-            kwargs["this_model"] = self.fully_qualified_table
         return self._render_statements(
             self.on_virtual_update,
             start=start,

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -386,6 +386,7 @@ class ExpressionRenderer(BaseExpressionRenderer):
                 execution_time=execution_time,
                 snapshots=snapshots,
                 deployability_index=deployability_index,
+                table_mapping=table_mapping,
                 **kwargs,
             )
         except ParsetimeAdapterCallError:

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -932,9 +932,6 @@ class SnapshotEvaluator:
                 deployability_index=deployability_index,
                 table_mapping=table_mapping,
                 runtime_stage=RuntimeStage.PROMOTING,
-                this_model=snapshot.qualified_view_name.table_for_environment(
-                    environment_naming_info, dialect=adapter.dialect
-                ),
             )
             _evaluation_strategy(snapshot, adapter).promote(
                 table_name=table_name,

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -932,6 +932,9 @@ class SnapshotEvaluator:
                 deployability_index=deployability_index,
                 table_mapping=table_mapping,
                 runtime_stage=RuntimeStage.PROMOTING,
+                this_model=snapshot.qualified_view_name.table_for_environment(
+                    environment_naming_info, dialect=adapter.dialect
+                ),
             )
             _evaluation_strategy(snapshot, adapter).promote(
                 table_name=table_name,

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1875,10 +1875,13 @@ def create_log_view(evaluator, view_name):
     log_schema = context.fetchdf("select * from log_schema").to_dict()
 
     # Validate that within macro for this_model we resolve to the environment-specific view
-    assert log_view["fqn_this_model"][0] == "memory.db__dev.test_view_macro_this_model"
+    assert (
+        log_view["fqn_this_model"][0]
+        == '"db__dev"."test_view_macro_this_model" /* memory.db.test_view_macro_this_model */'
+    )
 
     # Validate that from the macro evaluator this_model we get the environment-specific fqn
-    assert log_view["evaluator_this_model"][0] == '"memory"."db__dev"."test_view_macro_this_model"'
+    assert log_view["evaluator_this_model"][0] == '"db__dev"."test_view_macro_this_model"'
 
     # Validate the schema is retrieved using resolve_template for the environment-specific schema
     assert log_schema["my_schema"][0] == "db__dev"

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1813,3 +1813,72 @@ def test_plan_selector_expression_no_match(sushi_context: Context) -> None:
         match="Selector did not return any models. Please check your model selection and try again.",
     ):
         sushi_context.plan("prod", restate_models=["*missing*"])
+
+
+def test_plan_on_virtual_update_this_model_in_macro(tmp_path: pathlib.Path):
+    models_dir = pathlib.Path("models")
+    macros_dir = pathlib.Path("macros")
+    dialect = "duckdb"
+
+    config = Config(
+        model_defaults=ModelDefaultsConfig(dialect=dialect),
+    )
+
+    model_file = """
+MODEL(
+  name db.test_view_macro_this_model,
+  kind full,
+);
+
+
+SELECT 1 AS cola;
+
+ON_VIRTUAL_UPDATE_BEGIN;
+CREATE OR REPLACE TABLE log_schema AS SELECT @resolve_template('@{schema_name}') as my_schema;
+@create_log_view(@this_model);
+ON_VIRTUAL_UPDATE_END;
+
+    """
+
+    create_temp_file(
+        tmp_path,
+        pathlib.Path(models_dir, "db", "test_view_macro_this_model.sql"),
+        model_file,
+    )
+
+    create_temp_file(
+        tmp_path,
+        pathlib.Path(macros_dir, "create_log_view.py"),
+        """
+from sqlmesh.core.macros import macro
+
+@macro()
+def create_log_view(evaluator, view_name):
+    return f"CREATE OR REPLACE TABLE log_view AS SELECT '{view_name}' as fqn_this_model,  '{evaluator.this_model}' as evaluator_this_model;"
+""",
+    )
+
+    context = Context(paths=tmp_path, config=config)
+    context.plan(environment="dev", auto_apply=True, no_prompts=True)
+
+    model = context.get_model("db.test_view_macro_this_model")
+    assert (
+        model.on_virtual_update[0].sql(dialect=dialect)
+        == "CREATE OR REPLACE TABLE log_schema AS SELECT @resolve_template('@{schema_name}') AS my_schema"
+    )
+    assert model.on_virtual_update[1].sql(dialect=dialect) == "@create_log_view(@this_model)"
+
+    snapshot = context.get_snapshot("db.test_view_macro_this_model")
+    assert snapshot and snapshot.version
+
+    log_view = context.fetchdf("select * from log_view").to_dict()
+    log_schema = context.fetchdf("select * from log_schema").to_dict()
+
+    # Validate that within macro for this_model we resolve to the environment-specific view
+    assert log_view["fqn_this_model"][0] == "memory.db__dev.test_view_macro_this_model"
+
+    # Validate that from the macro evaluator this_model we get the environment-specific fqn
+    assert log_view["evaluator_this_model"][0] == '"memory"."db__dev"."test_view_macro_this_model"'
+
+    # Validate the schema is retrieved using resolve_template for the environment-specific schema
+    assert log_schema["my_schema"][0] == "db__dev"

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -7898,7 +7898,6 @@ def test_model_on_virtual_update(make_snapshot: t.Callable):
 
     parent_snapshot = make_snapshot(parent)
     parent_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
-    version = parent_snapshot.version
 
     model_snapshot = make_snapshot(model)
     model_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
@@ -7939,7 +7938,8 @@ def test_model_on_virtual_update(make_snapshot: t.Callable):
         rendered_on_virtual_update[3].sql()
         == "GRANT REFERENCES, SELECT ON FUTURE VIEWS IN DATABASE demo_db TO ROLE owner_name"
     )
-    assert rendered_on_virtual_update[4].sql() == f'"sqlmesh__default"."parent__{version}"'
+
+    assert rendered_on_virtual_update[4].sql() == '"default__dev"."parent"'
 
     # When replace=false the table should remain as is
     assert (

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -13,6 +13,7 @@ from sqlglot import exp, parse_one
 from sqlglot.errors import ParseError
 from sqlglot.schema import MappingSchema
 from sqlmesh.cli.example_project import init_example_project, ProjectTemplate
+from sqlmesh.core.environment import EnvironmentNamingInfo
 from sqlmesh.core.model.kind import TimeColumn, ModelKindName
 
 from sqlmesh import CustomMaterialization, CustomKind
@@ -7843,6 +7844,7 @@ def test_model_on_virtual_update(make_snapshot: t.Callable):
     def resolve_parent_name(evaluator, name):
         return evaluator.resolve_table(name.name)
 
+    dialect = "postgres"
     virtual_update_statements = """
         CREATE OR REPLACE VIEW test_view FROM demo_db.table;
         GRANT SELECT ON VIEW @this_model TO ROLE owner_name;
@@ -7869,7 +7871,8 @@ def test_model_on_virtual_update(make_snapshot: t.Callable):
 
         on_virtual_update_end;
 
-    """
+    """,
+        default_dialect=dialect,
     )
 
     parent_expressions = d.parse(
@@ -7886,11 +7889,12 @@ def test_model_on_virtual_update(make_snapshot: t.Callable):
         JINJA_END;
         ON_VIRTUAL_UPDATE_END;
 
-    """
+    """,
+        default_dialect=dialect,
     )
 
-    model = load_sql_based_model(expressions)
-    parent = load_sql_based_model(parent_expressions)
+    model = load_sql_based_model(expressions, dialect=dialect)
+    parent = load_sql_based_model(parent_expressions, dialect=dialect)
 
     parent_snapshot = make_snapshot(parent)
     parent_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
@@ -7899,12 +7903,14 @@ def test_model_on_virtual_update(make_snapshot: t.Callable):
     model_snapshot = make_snapshot(model)
     model_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
 
-    assert model.on_virtual_update == d.parse(virtual_update_statements)
+    assert model.on_virtual_update == d.parse(virtual_update_statements, default_dialect=dialect)
 
     assert parent.on_virtual_update == d.parse(
-        "JINJA_STATEMENT_BEGIN; GRANT SELECT ON VIEW {{this_model}} TO ROLE admin; JINJA_END;"
+        "JINJA_STATEMENT_BEGIN; GRANT SELECT ON VIEW {{this_model}} TO ROLE admin; JINJA_END;",
+        default_dialect=dialect,
     )
 
+    environment_naming_info = EnvironmentNamingInfo(name="dev")
     table_mapping = {model.fqn: "demo_db__dev.table", parent.fqn: "default__dev.parent"}
     snapshots = {
         parent_snapshot.name: parent_snapshot,
@@ -7912,7 +7918,11 @@ def test_model_on_virtual_update(make_snapshot: t.Callable):
     }
 
     rendered_on_virtual_update = model.render_on_virtual_update(
-        snapshots=snapshots, table_mapping=table_mapping
+        snapshots=snapshots,
+        table_mapping=table_mapping,
+        this_model=model_snapshot.qualified_view_name.table_for_environment(
+            environment_naming_info, dialect=dialect
+        ),
     )
 
     assert len(rendered_on_virtual_update) == 6
@@ -7920,9 +7930,10 @@ def test_model_on_virtual_update(make_snapshot: t.Callable):
         rendered_on_virtual_update[0].sql()
         == 'CREATE OR REPLACE VIEW "test_view" AS SELECT * FROM "demo_db__dev"."table" AS "table" /* demo_db.table */'
     )
+
     assert (
         rendered_on_virtual_update[1].sql()
-        == 'GRANT SELECT ON VIEW "demo_db__dev"."table" /* demo_db.table */ TO ROLE "owner_name"'
+        == 'GRANT SELECT ON VIEW "demo_db__dev"."table" TO ROLE "owner_name"'
     )
     assert (
         rendered_on_virtual_update[3].sql()
@@ -7937,12 +7948,16 @@ def test_model_on_virtual_update(make_snapshot: t.Callable):
     )
 
     rendered_parent_on_virtual_update = parent.render_on_virtual_update(
-        snapshots=snapshots, table_mapping=table_mapping
+        snapshots=snapshots,
+        table_mapping=table_mapping,
+        this_model=parent_snapshot.qualified_view_name.table_for_environment(
+            environment_naming_info, dialect=dialect
+        ),
     )
     assert len(rendered_parent_on_virtual_update) == 1
     assert (
         rendered_parent_on_virtual_update[0].sql()
-        == 'GRANT SELECT ON VIEW "default__dev"."parent" /* parent */ TO ROLE "admin"'
+        == 'GRANT SELECT ON VIEW "default__dev"."parent" TO ROLE "admin"'
     )
 
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -2919,6 +2919,10 @@ def test_create_pre_post_statements_python_model(
 def test_on_virtual_update_statements(mocker: MockerFixture, adapter_mock, make_snapshot):
     evaluator = SnapshotEvaluator(adapter_mock)
 
+    @macro()
+    def create_log_table(evaluator, view_name):
+        return f"CREATE OR REPLACE TABLE log_table AS SELECT '{view_name}' as fqn_this_model, '{evaluator.this_model}' as eval_this_model"
+
     model = load_sql_based_model(
         d.parse(
             """
@@ -2937,6 +2941,7 @@ def test_on_virtual_update_statements(mocker: MockerFixture, adapter_mock, make_
             GRANT SELECT ON VIEW test_schema.test_model TO ROLE admin;
             JINJA_END;
             GRANT REFERENCES, SELECT ON FUTURE VIEWS IN DATABASE demo_db TO ROLE owner_name;
+            @create_log_table(@this_model);
             ON_VIRTUAL_UPDATE_END;
 
             """
@@ -2986,6 +2991,12 @@ def test_on_virtual_update_statements(mocker: MockerFixture, adapter_mock, make_
     assert (
         on_virtual_update_calls[1].sql(dialect="postgres")
         == "GRANT REFERENCES, SELECT ON FUTURE VIEWS IN DATABASE demo_db TO ROLE owner_name"
+    )
+
+    # Validation that within the macro the environment specific view is used
+    assert (
+        on_virtual_update_calls[2].sql(dialect="postgres")
+        == 'CREATE OR REPLACE TABLE "log_table" AS SELECT \'test_schema__test_env.test_model\' AS "fqn_this_model", \'"test_schema__test_env"."test_model"\' AS "eval_this_model"'
     )
 
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -2996,7 +2996,7 @@ def test_on_virtual_update_statements(mocker: MockerFixture, adapter_mock, make_
     # Validation that within the macro the environment specific view is used
     assert (
         on_virtual_update_calls[2].sql(dialect="postgres")
-        == 'CREATE OR REPLACE TABLE "log_table" AS SELECT \'test_schema__test_env.test_model\' AS "fqn_this_model", \'"test_schema__test_env"."test_model"\' AS "eval_this_model"'
+        == 'CREATE OR REPLACE TABLE "log_table" AS SELECT \'"test_schema__test_env"."test_model" /* test_schema.test_model */\' AS "fqn_this_model", \'"test_schema__test_env"."test_model"\' AS "eval_this_model"'
     )
 
 


### PR DESCRIPTION
This update fixes an issue in `on_virtual_update` statements, ensuring `this_model` resolves to the environment-specific name, when used within `macro` functions. It does this by passing environment naming info to `table_for_environment` instead of using the `fully_qualified_table` from the model, which defaults to the production view.