### PR TITLE
Fix: Fail the plan command if the selector expression doesn't return any models

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1341,6 +1341,13 @@ class GenericContext(BaseContext, t.Generic[C]):
         if restate_models is not None:
             expanded_restate_models = model_selector.expand_model_selections(restate_models)
 
+        if (restate_models is not None and not expanded_restate_models) or (
+            backfill_models is not None and not backfill_models
+        ):
+            raise PlanError(
+                "Selector did not return any models. Please check your model selection and try again."
+            )
+
         snapshots = self._snapshots(models_override)
         context_diff = self._context_diff(
             environment or c.PROD,

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -47,7 +47,7 @@ from sqlmesh.utils.date import (
     to_timestamp,
     yesterday_ds,
 )
-from sqlmesh.utils.errors import ConfigError, SQLMeshError, LinterError
+from sqlmesh.utils.errors import ConfigError, SQLMeshError, LinterError, PlanError
 from sqlmesh.utils.metaprogramming import Executable
 from tests.utils.test_helpers import use_terminal_console
 from tests.utils.test_filesystem import create_temp_file
@@ -1786,3 +1786,23 @@ def test_model_linting(tmp_path: pathlib.Path, sushi_context) -> None:
     )
 
     sushi_context.upsert_model(model5)
+
+
+def test_plan_selector_expression_no_match(sushi_context: Context) -> None:
+    with pytest.raises(
+        PlanError,
+        match="Selector did not return any models. Please check your model selection and try again.",
+    ):
+        sushi_context.plan("dev", select_models=["*missing*"])
+
+    with pytest.raises(
+        PlanError,
+        match="Selector did not return any models. Please check your model selection and try again.",
+    ):
+        sushi_context.plan("dev", backfill_models=["*missing*"])
+
+    with pytest.raises(
+        PlanError,
+        match="Selector did not return any models. Please check your model selection and try again.",
+    ):
+        sushi_context.plan("prod", restate_models=["*missing*"])

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -779,15 +779,17 @@ def test_restate_models(sushi_context_pre_scheduling: Context):
         '"memory"."sushi"."waiter_revenue_by_day"',
     }
 
-    plan = sushi_context_pre_scheduling.plan(restate_models=["unknown_model"], no_prompts=True)
-    assert not plan.has_changes
-    assert not plan.restatements
-    assert plan.models_to_backfill is None
+    with pytest.raises(
+        PlanError,
+        match="Selector did not return any models. Please check your model selection and try again.",
+    ):
+        sushi_context_pre_scheduling.plan(restate_models=["unknown_model"], no_prompts=True)
 
-    plan = sushi_context_pre_scheduling.plan(restate_models=["tag:unknown_tag"], no_prompts=True)
-    assert not plan.has_changes
-    assert not plan.restatements
-    assert plan.models_to_backfill is None
+    with pytest.raises(
+        PlanError,
+        match="Selector did not return any models. Please check your model selection and try again.",
+    ):
+        sushi_context_pre_scheduling.plan(restate_models=["tag:unknown_tag"], no_prompts=True)
 
     plan = sushi_context_pre_scheduling.plan(restate_models=["raw.demographics"], no_prompts=True)
     assert not plan.has_changes


### PR DESCRIPTION
To prevent unexpected behavior and confusing errors we should fail the plan immediately if we discover that the selector expressions provided by the user don't return any models.