### PR TITLE
Fix: sqlmesh_tests package version

### DIFF
--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -19,6 +19,7 @@ build-backend = "setuptools.build_meta"
 sqlmesh_tests = ""
 
 [tool.setuptools_scm]
+root = "../"
 version_file = "_version.py"
 fallback_version = "0.0.0"
 local_scheme = "no-local-version"


### PR DESCRIPTION
`make publish-tests` is [currently failing](https://app.circleci.com/pipelines/github/TobikoData/sqlmesh/19015/workflows/79c69494-f26c-42fb-a4db-da81f6edff4e/jobs/177088)

The cause appears to be that the version is not picked up correctly. This PR configures `setuptools_scm` in `tests/pyproject.toml` to use the parent directory when figuring out the version.

Running `make package-tests` now produces a tests package with the correct version, however I cant test the actual publish because I don't have credentials