### PR TITLE
Fix: Direct breaking category should only impact direct children snapshot

### DIFF
--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -578,24 +578,22 @@ class PlanBuilder:
                     if mode == AutoCategorizationMode.FULL:
                         snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
         elif self._context_diff.indirectly_modified(snapshot.name):
-            all_upstream_categories = []
-            direct_parent_categories = []
+            all_upstream_categories = set()
+            direct_parent_categories = set()
 
             for p_id in dag.upstream(s_id):
                 parent = self._context_diff.snapshots.get(p_id)
 
                 if parent and self._is_new_snapshot(parent):
-                    all_upstream_categories.append(parent.change_category)
+                    all_upstream_categories.add(parent.change_category)
                     if p_id in snapshot.parents:
-                        direct_parent_categories.append(parent.change_category)
+                        direct_parent_categories.add(parent.change_category)
 
-            if not direct_parent_categories or any(
-                category.is_breaking or category.is_indirect_breaking
-                for category in direct_parent_categories
-                if category
+            if not direct_parent_categories or direct_parent_categories.intersection(
+                {SnapshotChangeCategory.BREAKING, SnapshotChangeCategory.INDIRECT_BREAKING}
             ):
                 snapshot.categorize_as(SnapshotChangeCategory.INDIRECT_BREAKING)
-            elif any(category.is_forward_only for category in all_upstream_categories if category):
+            elif SnapshotChangeCategory.FORWARD_ONLY in all_upstream_categories:
                 # FORWARD_ONLY must take precedence over INDIRECT_NON_BREAKING
                 snapshot.categorize_as(SnapshotChangeCategory.FORWARD_ONLY)
             else:

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -1746,7 +1746,7 @@ def test_indirectly_modified_forward_only_model(make_snapshot, mocker: MockerFix
 
     assert updated_snapshot_a.change_category == SnapshotChangeCategory.BREAKING
     assert updated_snapshot_b.change_category == SnapshotChangeCategory.FORWARD_ONLY
-    assert updated_snapshot_c.change_category == SnapshotChangeCategory.INDIRECT_BREAKING
+    assert updated_snapshot_c.change_category == SnapshotChangeCategory.FORWARD_ONLY
     assert updated_snapshot_d.change_category == SnapshotChangeCategory.INDIRECT_BREAKING
 
     deployability_index = DeployabilityIndex.create(


### PR DESCRIPTION
In a DAG that looks like `A -> B -> C`, if the user makes a `Breaking` change to `A` and a `Non-breaking` change to `B`, then `C` should be categorized as `Indirect Non-Breaking` rather than `Indirect Breaking`, as it was before this change.

At the same time, if `A` was categorized as `Forward-Only` and `B` as `Non-Breaking`, SQLMesh should prefer the `Forward-only` category for `C` over the `Indirect Non-Breaking` one.