### PR TITLE
Fix: determine SnapshotTableInfo equality with fingerprint only

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -481,6 +481,12 @@ class SnapshotTableInfo(PydanticModel, SnapshotInfoMixin, frozen=True):
     def __lt__(self, other: SnapshotTableInfo) -> bool:
         return self.name < other.name
 
+    def __eq__(self, other: t.Any) -> bool:
+        return isinstance(other, SnapshotTableInfo) and self.fingerprint == other.fingerprint
+
+    def __hash__(self) -> int:
+        return hash((self.__class__, self.name, self.fingerprint))
+
     def table_name(self, is_deployable: bool = True) -> str:
         """Full table name pointing to the materialized location of the snapshot.
 

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -1035,6 +1035,48 @@ def test_fingerprint_virtual_properties(model: Model, parent_model: Model):
     assert updated_fingerprint.data_hash == fingerprint.data_hash
 
 
+def test_tableinfo_equality():
+    snapshot_a = SnapshotTableInfo(
+        name="test_schema.a",
+        fingerprint=SnapshotFingerprint(data_hash="1", metadata_hash="1"),
+        version="test_version",
+        physical_schema="test_physical_schema",
+        parents=[],
+        dev_table_suffix="dev",
+    )
+
+    snapshot_b = SnapshotTableInfo(
+        name="test_schema.b",
+        fingerprint=SnapshotFingerprint(data_hash="1", metadata_hash="1"),
+        version="test_version",
+        physical_schema="test_physical_schema",
+        parents=[],
+        dev_table_suffix="dev",
+    )
+
+    snapshot_c = SnapshotTableInfo(
+        name="test_schema.c",
+        fingerprint=SnapshotFingerprint(data_hash="1", metadata_hash="1"),
+        version="test_version",
+        physical_schema="test_physical_schema",
+        parents=[snapshot_a.snapshot_id, snapshot_b.snapshot_id],
+        dev_table_suffix="dev",
+    )
+
+    # parents in different order than snapshot_c
+    snapshot_c2 = SnapshotTableInfo(
+        name="test_schema.c",
+        fingerprint=SnapshotFingerprint(data_hash="1", metadata_hash="1"),
+        version="test_version",
+        physical_schema="test_physical_schema",
+        parents=[snapshot_b.snapshot_id, snapshot_a.snapshot_id],
+        dev_table_suffix="dev",
+    )
+
+    assert snapshot_c is not snapshot_c2
+    assert snapshot_c == snapshot_c2
+
+
 def test_stamp(model: Model):
     original_fingerprint = fingerprint_from_node(model, nodes={})
 


### PR DESCRIPTION
The view promotion logic determines what snapshots have been added based on equality between `SnapshotTableInfo` objects. 

In some cases, two snapshots' table infos may be functionally identical but have their parent node lists ordered differently. When this occurs, we incorrectly determine that they are not the same snapshot.

This PR overrides the `SnapshotTableInfo` `__eq__` method to determine equality based solely on the snapshot fingerprint. All other similar comparisons in the code already use fingerprint.