### PR TITLE
Fix!: Type inference for BQ engine adapter

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -232,9 +232,10 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
         """Fetches column names and types for the target table."""
 
         def dtype_to_sql(
-            dtype: t.Optional[StandardSqlDataType], field: t.Optional[bigquery.SchemaField] = None
+            dtype: t.Optional[StandardSqlDataType], field: bigquery.SchemaField
         ) -> str:
             assert dtype
+            assert field
 
             kind = dtype.type_kind
             assert kind
@@ -242,21 +243,21 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
             # Not using the enum value to preserve compatibility with older versions
             # of the BigQuery library.
             if kind.name == "ARRAY":
-                return f"ARRAY<{dtype_to_sql(dtype.array_element_type)}>"
+                return f"ARRAY<{dtype_to_sql(dtype.array_element_type, field)}>"
             if kind.name == "STRUCT":
                 struct_type = dtype.struct_type
                 assert struct_type
                 fields = ", ".join(
-                    f"{field.name} {dtype_to_sql(field.type)}" for field in struct_type.fields
+                    f"{struct_field.name} {dtype_to_sql(struct_field.type, nested_field)}"
+                    for struct_field, nested_field in zip(struct_type.fields, field.fields)
                 )
                 return f"STRUCT<{fields}>"
             if kind.name == "TYPE_KIND_UNSPECIFIED":
-                if not field:
-                    return "UNKNOWN"
-
                 field_type = field.field_type
 
                 if field_type == "RANGE":
+                    # If the field is a RANGE then `range_element_type` should be set to
+                    # one of `"DATE"`, `"DATETIME"` or `"TIMESTAMP"`.
                     return f"RANGE<{field.range_element_type.element_type}>"
 
                 return field_type


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/3978

In the BigQuery engine adapter, type inference for the fields happens through `to_standard_sql()`; However, it seems like the types that do not belong to stanard SQL are not handled properly (e.g RANGE or JSON, see https://github.com/TobikoData/sqlmesh/commit/4951ff9b539c42242050617869127764d120cf6d) and are instead marked as `TYPE_KIND_UNSPECIFIED`. 

This PR adds a fallback for these types and instead uses `field.field_type`, as was used [before](https://github.com/TobikoData/sqlmesh/pull/1089/files):

```SQL
MODEL (name vaggelis.test);

SELECT 
 RANGE('01-01-1900'::DATE, '01-01-1902'::DATE) AS my_range, 
 JSON '{"id": 10}' AS foo;
```

```Python3
>>> bq_adapter.columns("vaggelis.test");
{'my_range': DataType(
  this=Type.RANGE,
  expressions=[
    DataType(this=Type.DATE, nested=False)],
  nested=True), 'foo': DataType(this=Type.JSON, nested=False)}
```

