### PR TITLE
Fix: update sushi.marketing so it does not check scd time column types

### DIFF
--- a/examples/sushi/models/marketing.sql
+++ b/examples/sushi/models/marketing.sql
@@ -20,7 +20,5 @@ FROM
         customer_id: 'int',
         status: 'text',
         updated_at: 'timestamp',
-        valid_from: 'timestamp',
-        valid_to: 'timestamp',
     }
 )

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -250,7 +250,7 @@ def test_model_union_query(sushi_context, assert_exp_eq):
         """SELECT
   CAST("marketing"."customer_id" AS INT) AS "customer_id",
   CAST("marketing"."status" AS TEXT) AS "status",
-  CAST("marketing"."updated_at" AS TIMESTAMP) AS "updated_at",
+  CAST("marketing"."updated_at" AS TIMESTAMPNTZ) AS "updated_at",
   CAST("marketing"."valid_from" AS TIMESTAMP) AS "valid_from",
   CAST("marketing"."valid_to" AS TIMESTAMP) AS "valid_to"
 FROM "memory"."sushi"."marketing" AS "marketing"
@@ -258,7 +258,7 @@ UNION ALL
 SELECT
   CAST("marketing"."customer_id" AS INT) AS "customer_id",
   CAST("marketing"."status" AS TEXT) AS "status",
-  CAST("marketing"."updated_at" AS TIMESTAMP) AS "updated_at",
+  CAST("marketing"."updated_at" AS TIMESTAMPNTZ) AS "updated_at",
   CAST("marketing"."valid_from" AS TIMESTAMP) AS "valid_from",
   CAST("marketing"."valid_to" AS TIMESTAMP) AS "valid_to"
 FROM "memory"."sushi"."marketing" AS "marketing"


### PR DESCRIPTION
This [commit](https://github.com/tobymao/sqlglot/commit/69146842d005ae0edecbd7f6f842f648ae0622e7) changed how DuckDB parses `DATETIME` and `TIMESTAMP`; these types are now not timezone-aware.

The marketing sushi model started failing due to this change, because there's an assertion about its columns & their types. The catch is that the "expected" types for `valid_from` and `valid_to` in this mapping are parsed using DuckDB, so the resulting `DataType` instances are different than the actual ones:

```
# Expected
('valid_from', DataType(this=Type.TIMESTAMPNTZ, nested=False)),
('valid_to', DataType(this=Type.TIMESTAMPNTZ, nested=False))

# Actual
('valid_from', DataType(this=Type.TIMESTAMP, nested=False)),
('valid_to', DataType(this=Type.TIMESTAMP, nested=False))
```

Here's where the SCD2 types are constructed: https://github.com/TobikoData/sqlmesh/blob/cdd97c51a14eb1f4441228a6cbd479fd77587849/sqlmesh/core/model/kind.py#L674

Just putting this here for discussion, but not sure yet if we should change the above `DataType.build` call in the SCD kind's `time_data_type` to build a `TIMESTAMPNTZ` instead.