### PR TITLE
Chore: bump sqlglot to v26.10.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "requests",
     "rich[jupyter]",
     "ruamel.yaml",
-    "sqlglot[rs]~=26.10.0",
+    "sqlglot[rs]~=26.10.1",
     "tenacity",
     "time-machine",
 ]


### PR DESCRIPTION
This should fix the CI, temporarily reverted the DuckDB timestamp/datetime parsing changes.