### PR TITLE
Perf: use table name reference directly instead of select * subquery …

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -527,7 +527,9 @@ class _Model(ModelMeta, frozen=True):
             deployability_index=deployability_index,
             **{
                 **audit.defaults,
-                "this_model": exp.select("*").from_(quoted_model_name).where(where).subquery(),
+                "this_model": exp.select("*").from_(quoted_model_name).where(where).subquery()
+                if where is not None
+                else quoted_model_name,
                 **kwargs,
             },  # type: ignore
         )

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -901,7 +901,7 @@ def test_audit_query_normalization():
     )
     assert (
         rendered_audit_query.sql("snowflake")
-        == """SELECT * FROM (SELECT * FROM "DB"."TEST_MODEL" AS "TEST_MODEL") AS "_Q_0" WHERE "A" IS NULL AND TRUE"""
+        == """SELECT * FROM "DB"."TEST_MODEL" AS "TEST_MODEL" WHERE "A" IS NULL AND TRUE"""
     )
 
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -2710,7 +2710,7 @@ def test_audit_wap(adapter_mock, make_snapshot):
     not_null_query = call_args[0][0][0]
     assert (
         not_null_query.sql(dialect="spark")
-        == "SELECT COUNT(*) FROM (SELECT * FROM (SELECT * FROM `spark_catalog`.`test_schema`.`test_table`.`branch_wap_test_wap_id` AS `branch_wap_test_wap_id`) AS `_q_0` WHERE `a` IS NULL AND TRUE) AS audit"
+        == "SELECT COUNT(*) FROM (SELECT * FROM `spark_catalog`.`test_schema`.`test_table`.`branch_wap_test_wap_id` AS `branch_wap_test_wap_id` WHERE `a` IS NULL AND TRUE) AS audit"
     )
 
     custom_audit_query = call_args[1][0][0]
@@ -2752,7 +2752,7 @@ def test_audit_with_datetime_macros(adapter_mock, make_snapshot):
     unique_combination_of_columns_query = call_args[0][0][0]
     assert (
         unique_combination_of_columns_query.sql(dialect="duckdb")
-        == """SELECT COUNT(*) FROM (SELECT "a" AS "a" FROM (SELECT * FROM "test_schema"."test_table" AS "test_table") AS "_q_0" WHERE '2020-01-01' <> '2020-01-01' GROUP BY "a" HAVING COUNT(*) > 1) AS audit"""
+        == """SELECT COUNT(*) FROM (SELECT "a" AS "a" FROM "test_schema"."test_table" AS "test_table" WHERE '2020-01-01' <> '2020-01-01' GROUP BY "a" HAVING COUNT(*) > 1) AS audit"""
     )
 
 


### PR DESCRIPTION
…in audit wo where.

Striaghtforward change which allows audits without where conditions added by the snapshot containing a `time_column` to reference the table directly which reduces reliance on black box engine optimizer behavior. 

Resolves #3990 