### PR TITLE
Fix: Support on-virtual-update statements in sqlmesh format

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -646,7 +646,9 @@ def _props_sql(self: Generator, expressions: t.List[exp.Expression]) -> str:
 
 def _on_virtual_update_sql(self: Generator, expressions: t.List[exp.Expression]) -> str:
     statements = "".join(
-        f"{self.sql(expression)}{';' if not isinstance(expression, JinjaStatement) else ''}{'\n'}"
+        f"{self.sql(expression)}\n"
+        if isinstance(expression, JinjaStatement)
+        else f"{self.sql(expression)};\n"
         for expression in expressions
     )
     return f"{ON_VIRTUAL_UPDATE_BEGIN};\n{statements}{ON_VIRTUAL_UPDATE_END};"

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -644,6 +644,14 @@ def _props_sql(self: Generator, expressions: t.List[exp.Expression]) -> str:
     return "\n".join(props)
 
 
+def _on_virtual_update_sql(self: Generator, expressions: t.List[exp.Expression]) -> str:
+    statements = "".join(
+        f"{self.sql(expression)}{';' if not isinstance(expression, JinjaStatement) else ''}{'\n'}"
+        for expression in expressions
+    )
+    return f"{ON_VIRTUAL_UPDATE_BEGIN};\n{statements}{ON_VIRTUAL_UPDATE_END};"
+
+
 def _sqlmesh_ddl_sql(self: Generator, expression: Model | Audit | Metric, name: str) -> str:
     return "\n".join([f"{name} (", _props_sql(self, expression.expressions), ")"])
 
@@ -1004,6 +1012,7 @@ def extend_sqlglot() -> None:
                     JinjaQuery: lambda self, e: f"{JINJA_QUERY_BEGIN};\n{e.name}\n{JINJA_END};",
                     JinjaStatement: lambda self,
                     e: f"{JINJA_STATEMENT_BEGIN};\n{e.name}\n{JINJA_END};",
+                    VirtualUpdateStatement: lambda self, e: _on_virtual_update_sql(self, e),
                     MacroDef: lambda self, e: f"@DEF({self.sql(e.this)}, {self.sql(e.expression)})",
                     MacroFunc: _macro_func_sql,
                     MacroStrReplace: lambda self, e: f"@{self.sql(e.this)}",

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -651,7 +651,7 @@ def _on_virtual_update_sql(self: Generator, expressions: t.List[exp.Expression])
         else f"{self.sql(expression)};"
         for expression in expressions
     )
-    return f"{ON_VIRTUAL_UPDATE_BEGIN};\n{statements}{ON_VIRTUAL_UPDATE_END};"
+    return f"{ON_VIRTUAL_UPDATE_BEGIN};\n{statements}\n{ON_VIRTUAL_UPDATE_END};"
 
 
 def _sqlmesh_ddl_sql(self: Generator, expression: Model | Audit | Metric, name: str) -> str:

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -645,10 +645,10 @@ def _props_sql(self: Generator, expressions: t.List[exp.Expression]) -> str:
 
 
 def _on_virtual_update_sql(self: Generator, expressions: t.List[exp.Expression]) -> str:
-    statements = "".join(
-        f"{self.sql(expression)}\n"
+    statements = "\n".join(
+        self.sql(expression)
         if isinstance(expression, JinjaStatement)
-        else f"{self.sql(expression)};\n"
+        else f"{self.sql(expression)};"
         for expression in expressions
     )
     return f"{ON_VIRTUAL_UPDATE_BEGIN};\n{statements}{ON_VIRTUAL_UPDATE_END};"


### PR DESCRIPTION
This update addresses the issue with formatting models containing ON_VIRTUAL_UPDATE statements when running `sqlmesh format`, fixes: #3996 