### PR TITLE
Fix: Migration of indirect non-breaking views

### DIFF
--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -143,7 +143,9 @@ class BuiltInPlanEvaluator(PlanEvaluator):
                 deployability_index_for_evaluation,
                 circuit_breaker=circuit_breaker,
             )
-            promotion_result = self._promote(plan, snapshots, before_promote_snapshots)
+            promotion_result = self._promote(
+                plan, snapshots, before_promote_snapshots, deployability_index_for_creation
+            )
             self._backfill(
                 plan,
                 snapshots_by_name,
@@ -301,6 +303,7 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         plan: EvaluatablePlan,
         snapshots: t.Dict[SnapshotId, Snapshot],
         no_gaps_snapshot_names: t.Optional[t.Set[str]] = None,
+        deployability_index: t.Optional[DeployabilityIndex] = None,
     ) -> PromotionResult:
         """Promote a plan.
 
@@ -320,7 +323,8 @@ class BuiltInPlanEvaluator(PlanEvaluator):
                 self.snapshot_evaluator.migrate(
                     [s for s in snapshots.values() if s.is_paused],
                     snapshots,
-                    plan.allow_destructive_models,
+                    allow_destructive_snapshots=plan.allow_destructive_models,
+                    deployability_index=deployability_index,
                 )
             except NodeExecutionFailedError as ex:
                 raise PlanError(str(ex.__cause__) if ex.__cause__ else str(ex))

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -854,13 +854,11 @@ class SnapshotEvaluator:
         adapter: EngineAdapter,
         deployability_index: DeployabilityIndex,
     ) -> None:
-        if not snapshot.is_paused or not snapshot.is_model:
-            return
-
-        needs_migration = snapshot.model.forward_only or not deployability_index.is_representative(
-            snapshot
-        )
-        if not needs_migration:
+        if (
+            not snapshot.is_paused
+            or not snapshot.is_model
+            or deployability_index.is_representative(snapshot)
+        ):
             return
 
         target_table_name = snapshot.table_name()

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -57,7 +57,6 @@ from sqlmesh.core.snapshot import (
     DeployabilityIndex,
     Intervals,
     Snapshot,
-    SnapshotChangeCategory,
     SnapshotId,
     SnapshotInfoLike,
     SnapshotTableCleanupTask,
@@ -390,6 +389,7 @@ class SnapshotEvaluator:
         target_snapshots: t.Iterable[Snapshot],
         snapshots: t.Dict[SnapshotId, Snapshot],
         allow_destructive_snapshots: t.Set[str] = set(),
+        deployability_index: t.Optional[DeployabilityIndex] = None,
     ) -> None:
         """Alters a physical snapshot table to match its snapshot's schema for the given collection of snapshots.
 
@@ -397,8 +397,9 @@ class SnapshotEvaluator:
             target_snapshots: Target snapshots.
             snapshots: Mapping of snapshot ID to snapshot.
             allow_destructive_snapshots: Set of snapshots that are allowed to have destructive schema changes.
+            deployability_index: Determines snapshots that are deployable in the context of this evaluation.
         """
-
+        deployability_index = deployability_index or DeployabilityIndex.all_deployable()
         with self.concurrent_context():
             concurrent_apply_to_snapshots(
                 target_snapshots,
@@ -407,6 +408,7 @@ class SnapshotEvaluator:
                     snapshots,
                     allow_destructive_snapshots,
                     self._get_adapter(s.model_gateway),
+                    deployability_index,
                 ),
                 self.ddl_concurrent_tasks,
             )
@@ -850,13 +852,13 @@ class SnapshotEvaluator:
         snapshots: t.Dict[SnapshotId, Snapshot],
         allow_destructive_snapshots: t.Set[str],
         adapter: EngineAdapter,
+        deployability_index: DeployabilityIndex,
     ) -> None:
         if not snapshot.is_paused or not snapshot.is_model:
             return
 
-        needs_migration = snapshot.model.forward_only or snapshot.change_category in (
-            SnapshotChangeCategory.FORWARD_ONLY,
-            SnapshotChangeCategory.INDIRECT_NON_BREAKING,
+        needs_migration = snapshot.model.forward_only or not deployability_index.is_representative(
+            snapshot
         )
         if not needs_migration:
             return


### PR DESCRIPTION
This ensures that deployable physical views are available for non-breaking snapshots when migrating downstream indirect non-breaking child view.