### PR TITLE
Fix: Pass runtime_stage and engine_adapter in environment_statements

### DIFF
--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -244,6 +244,8 @@ def execute_environment_statements(
             end=end,
             execution_time=execution_time,
             environment_naming_info=environment_naming_info,
+            runtime_stage=runtime_stage,
+            engine_adapter=adapter,
         )
     ]:
         with adapter.transaction():


### PR DESCRIPTION
This update  passes the  `runtime_stage` and `engine_adapter` in the `before_all` and `after_all` statements so that they can be used in macros called in these statements.