### PR TITLE
Fix: Always support start_* / end_* macros in pre- / post- statements

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -584,7 +584,7 @@ class _Model(ModelMeta, frozen=True):
                 path=self._path,
                 jinja_macro_registry=self.jinja_macros,
                 python_env=self.python_env,
-                only_execution_time=self.kind.only_execution_time,
+                only_execution_time=False,
                 default_catalog=self.default_catalog,
                 model_fqn=self.fqn,
             )


### PR DESCRIPTION
Previously, whether the `start_*` / `end_*` macros were supported in pre- or post-statements depended on the model kind. For example, they were not supported if the model was of kind VIEW or FULL. This change ensures that these macros are always available in pre- and post-statements