### PR TITLE
Feat: improve blueprint loading performance

### DIFF
--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -97,7 +97,7 @@ class model(registry_decorator):
     ) -> t.List[Model]:
         return create_models_from_blueprints(
             gateway=self.kwargs.get("gateway"),
-            blueprints=self.kwargs.get("blueprints"),
+            blueprints=self.kwargs.pop("blueprints", None),
             get_variables=get_variables,
             loader=self.model,
             path=path,

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1935,7 +1935,8 @@ def load_sql_based_models(
         if prop.name == "gateway":
             gateway = prop.args["value"]
         elif prop.name == "blueprints":
-            blueprints = prop.args["value"]
+            # We pop the `blueprints` here to avoid walking large lists when rendering the meta
+            blueprints = prop.pop().args["value"]
 
     if isinstance(blueprints, d.MacroFunc):
         rendered_blueprints = render_expression(
@@ -2362,9 +2363,6 @@ def _create_model(
     variables: t.Optional[t.Dict[str, t.Any]] = None,
     **kwargs: t.Any,
 ) -> Model:
-    # blueprints are not really part of the model meta, so we pop it off here before validation kicks in
-    kwargs.pop("blueprints", None)
-
     _validate_model_fields(klass, {"name", *kwargs} - {"grain", "table_properties"}, path)
 
     for prop in PROPERTIES:


### PR DESCRIPTION
Loading blueprints is suboptimal today, because the `blueprints (...)` property is needlessly preserved in the `Model` expression until very late in the loading stage (`_create_model`).

This leads to performance issues when rendering the `MODEL (...)` block to resolve macro calls, because we're traversing very big ASTs that unnecessarily carry the whole blueprint list with them.

We only need to extract the blueprints variables from `blueprints`, so it can be dropped earlier. This PR makes this change.