### PR TITLE
fix make ui commands

### DIFF
--- a/web/Dockerfile.api
+++ b/web/Dockerfile.api
@@ -2,7 +2,7 @@ FROM python:3.11
 
 WORKDIR /sqlmesh
 
-COPY setup.py setup.py
+COPY pyproject.toml pyproject.toml
 COPY sqlmesh/_version.py sqlmesh/_version.py
 
 RUN pip install -e .[dev,web]


### PR DESCRIPTION
It seems like `make ui-up` has been broken since #3953. I've updated `web/Dockerfile.api` to reflect migrating from `setup.py` to `pyproject.toml`.

The command is currently failing for me with:

```
 => ERROR [generate-openapi-spec 3/5] COPY setup.py setup.py                                                                                   0.0s
 => ERROR [api 3/5] COPY setup.py setup.py                                                                                                     0.0s
```