### PR TITLE
Feat(dbt): Add support for on-run-start and on-run-end hooks

### DIFF
--- a/docs/concepts/macros/macro_variables.md
+++ b/docs/concepts/macros/macro_variables.md
@@ -44,7 +44,7 @@ This example used one of SQLMesh's predefined variables, but you can also define
 
 We describe SQLMesh's predefined variables below; user-defined macro variables are discussed in the [SQLMesh macros](./sqlmesh_macros.md#user-defined-variables) and [Jinja macros](./jinja_macros.md#user-defined-variables) pages.
 
-## Predefined Variables
+## Predefined variables
 SQLMesh comes with predefined variables that can be used in your queries. They are automatically set by the SQLMesh runtime.
 
 Most predefined variables are related to time and use a combination of prefixes (start, end, etc.) and postfixes (date, ds, ts, etc.). They are described in the next section; [other predefined variables](#runtime-variables) are discussed in the following section.
@@ -120,7 +120,7 @@ All predefined temporal macro variables:
 
 ### Runtime variables
 
-SQLMesh provides two other predefined variables used to modify model behavior based on information available at runtime.
+SQLMesh provides additional predefined variables used to modify model behavior based on information available at runtime.
 
 * @runtime_stage - A string value denoting the current stage of the SQLMesh runtime. Typically used in models to conditionally execute pre/post-statements (learn more [here](../models/sql_models.md#optional-prepost-statements)). It returns one of these values:
     * 'loading' - The project is being loaded into SQLMesh's runtime context.
@@ -133,5 +133,11 @@ SQLMesh provides two other predefined variables used to modify model behavior ba
 * @this_model - A string value containing the name of the physical table the model view selects from. Typically used to create [generic audits](../audits.md#generic-audits). In the case of [on_virtual_update statements](../models/sql_models.md#optional-on-virtual-update-statements) it contains the qualified view name instead.
     * Can be used in model definitions when SQLGlot cannot fully parse a statement and you need to reference the model's underlying physical table directly.
     * Can be passed as an argument to macros that access or interact with the underlying physical table.
-* @this_env - A string value containing the name of the current [environment](../environments.md). Only available in [`before_all` and `after_all` statements](../../guides/configuration.md#before_all-and-after_all-statements), as well as in macros invoked within them.
 * @model_kind_name - A string value containing the name of the current model kind. Intended to be used in scenarios where you need to control the [physical properties in model defaults](../../reference/model_configuration.md#model-defaults).
+
+#### Before all and after all variables
+
+The following variables are also available in [`before_all` and `after_all` statements](../../guides/configuration.md#before_all-and-after_all-statements), as well as in macros invoked within them.
+
+* @this_env - A string value containing the name of the current [environment](../environments.md).
+* @schemas - A list of the schema names of the [virtual layer](../../concepts/glossary.md#virtual-layer) of the current environment.

--- a/docs/integrations/dbt.md
+++ b/docs/integrations/dbt.md
@@ -324,7 +324,6 @@ The dbt jinja methods that are not currently supported are:
 * selected_sources
 * adapter.expand_target_column_types
 * adapter.rename_relation
-* schemas
 * graph.nodes.values
 * graph.metrics.values
 

--- a/examples/multi_dbt/bronze/dbt_project.yml
+++ b/examples/multi_dbt/bronze/dbt_project.yml
@@ -19,3 +19,6 @@ require-dbt-version: [">=1.0.0", "<2.0.0"]
 models:
   start: "2024-01-01"
   +materialized: table
+
+on-run-start:
+  - 'CREATE TABLE IF NOT EXISTS analytic_stats (physical_table VARCHAR, evaluation_time VARCHAR);'

--- a/examples/multi_dbt/silver/dbt_project.yml
+++ b/examples/multi_dbt/silver/dbt_project.yml
@@ -19,3 +19,6 @@ require-dbt-version: [">=1.0.0", "<2.0.0"]
 models:
   start: "2024-01-01"
   +materialized: table
+
+on-run-end:
+  - '{{ store_schemas(schemas) }}'

--- a/examples/multi_dbt/silver/macros/store_schemas.sql
+++ b/examples/multi_dbt/silver/macros/store_schemas.sql
@@ -1,0 +1,3 @@
+{% macro store_schemas(schemas) %}
+    create or replace table schema_table as select {{schemas}} as all_schemas;
+{% endmacro %}

--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -14,6 +14,7 @@ from sqlmesh.core.renderer import render_statements
 from sqlmesh.core.snapshot import SnapshotId, SnapshotTableInfo, Snapshot
 from sqlmesh.utils import word_characters_only
 from sqlmesh.utils.date import TimeLike, now_timestamp
+from sqlmesh.utils.jinja import JinjaMacroRegistry
 from sqlmesh.utils.metaprogramming import Executable
 from sqlmesh.utils.pydantic import PydanticModel, field_validator
 
@@ -218,6 +219,7 @@ class EnvironmentStatements(PydanticModel):
     before_all: t.List[str]
     after_all: t.List[str]
     python_env: t.Dict[str, Executable]
+    jinja_macros: JinjaMacroRegistry = JinjaMacroRegistry()
 
 
 def execute_environment_statements(
@@ -239,6 +241,7 @@ def execute_environment_statements(
             dialect=adapter.dialect,
             default_catalog=default_catalog,
             python_env=statements.python_env,
+            jinja_macros=statements.jinja_macros,
             snapshots=snapshots,
             start=start,
             end=end,

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -110,8 +110,11 @@ class BaseExpressionRenderer:
             if snapshots and (
                 schemas := set(
                     [
-                        s.qualified_view_name.schema_for_environment(environment_naming_info)
+                        s.qualified_view_name.schema_for_environment(
+                            environment_naming_info, dialect=self._dialect
+                        )
                         for s in snapshots.values()
+                        if s.is_model and not s.is_symbolic
                     ]
                 )
             ):

--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -94,6 +94,9 @@ class ManifestHelper:
             self.project_path / c.CACHE, "jinja_calls"
         )
 
+        self._on_run_start: t.Optional[t.List[str]] = None
+        self._on_run_end: t.Optional[t.List[str]] = None
+
     def tests(self, package_name: t.Optional[str] = None) -> TestConfigs:
         self._load_all()
         return self._tests_per_package[package_name or self._project_name]
@@ -311,6 +314,11 @@ class ManifestHelper:
             )
 
         runtime_config = RuntimeConfig.from_parts(project, profile, args)
+
+        if runtime_config.on_run_start:
+            self._on_run_start = runtime_config.on_run_start
+        if runtime_config.on_run_end:
+            self._on_run_end = runtime_config.on_run_end
 
         self._project_name = project.project_name
 

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -314,7 +314,6 @@ def test_on_run_start_end(copy_to_temp_path):
     # The jinja macro should have resolved the schemas for this environment and generated corresponding statements
     assert sorted(rendered_after_all) == sorted(
         [
-            "CREATE OR REPLACE TABLE schema_table_raw__dev AS SELECT 'raw__dev' AS schema",
             "CREATE OR REPLACE TABLE schema_table_snapshots__dev AS SELECT 'snapshots__dev' AS schema",
             "CREATE OR REPLACE TABLE schema_table_sushi__dev AS SELECT 'sushi__dev' AS schema",
         ]

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -998,6 +998,16 @@ def test_dbt_version(sushi_test_project: Project):
 
 
 @pytest.mark.xdist_group("dbt_manifest")
+def test_dbt_on_run_start_end(sushi_test_project: Project):
+    context = sushi_test_project.context
+    assert context._manifest
+    assert context._manifest._on_run_start == [
+        "CREATE TABLE IF NOT EXISTS analytic_stats (physical_table VARCHAR, evaluation_time VARCHAR);"
+    ]
+    assert context._manifest._on_run_end == ["{{ create_tables(schemas) }}"]
+
+
+@pytest.mark.xdist_group("dbt_manifest")
 def test_parsetime_adapter_call(
     assert_exp_eq, sushi_test_project: Project, sushi_test_dbt_context: Context
 ):

--- a/tests/fixtures/dbt/sushi_test/dbt_project.yml
+++ b/tests/fixtures/dbt/sushi_test/dbt_project.yml
@@ -25,14 +25,14 @@ models:
     +materialized: table
     +pre-hook:
       - '{{ log("pre-hook") }}'
-    +post-hook: 
+    +post-hook:
       - '{{ log("post-hook") }}'
 
 seeds:
   sushi:
     +pre-hook:
       - '{{ log("pre-hook") }}'
-    +post-hook: 
+    +post-hook:
       - '{{ log("post-hook") }}'
 
 vars:
@@ -57,3 +57,9 @@ vars:
       value: 1
     - name: 'item2'
       value: 2
+
+
+on-run-start:
+  - 'CREATE TABLE IF NOT EXISTS analytic_stats (physical_table VARCHAR, evaluation_time VARCHAR);'
+on-run-end:
+  - '{{ create_tables(schemas) }}'

--- a/tests/fixtures/dbt/sushi_test/macros/create_tables.sql
+++ b/tests/fixtures/dbt/sushi_test/macros/create_tables.sql
@@ -1,0 +1,5 @@
+{% macro create_tables(schemas) %}
+    {% for schema in schemas %}
+        create or replace table schema_table_{{schema}} as select '{{schema}}' as schema;
+    {% endfor%}
+{% endmacro %}


### PR DESCRIPTION
This update adds support for dbt's [`on-run-start` and `on-run-end` hooks](https://docs.getdbt.com/reference/project-configs/on-run-start-on-run-end) which are defined in `dbt_project.yml`:

```yaml
on-run-start: sql-statement | [sql-statement]  
on-run-end: sql-statement | [sql-statement]  
```  

Internally, these are mapped to SQLMesh's [`before_all` and `after_all` statements](https://sqlmesh.readthedocs.io/en/stable/guides/configuration/?h=before#before_all-and-after_all-statements) 

---

As part of this update, the [`schemas`](https://docs.getdbt.com/reference/dbt-jinja-functions/schemas) variable is also supported, enabling to grant privileges as you would in dbt with a macro:  

```jinja
{% macro grant_usage_to_schemas(schemas, user) %}
  {% for schema in schemas %}
    GRANT USAGE ON SCHEMA {{ schema }} TO {{ user }};
  {% endfor %}
{% endmacro %}
```  

This macro can then be used in `on-run-end`:  

```yaml
on-run-end:
  - "{{ grant_usage_to_schemas(schemas, 'user') }}"
```  

---

This is also supported in native SQLMesh projects for `before_all` and `after_all` statements:  

```yaml
after_all:
  - "@grant_usage_to_role(@schemas, admin)"
```  

And by defining the corresponding macro:  

```python
from sqlmesh import macro

@macro()
def grant_usage_to_role(evaluator, schemas, role):
  if evaluator._environment_naming_info:
    return [
      f"GRANT USAGE ON SCHEMA {schema} TO {role};"
      for schema in schemas
    ]
```