### PR TITLE
Fix: only drop LIMIT 0 in VarcharSizeWorkaroundMixin table creation

### DIFF
--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -297,11 +297,15 @@ class VarcharSizeWorkaroundMixin(EngineAdapter):
             and statement.expression.args["limit"].expression.this == "0"
         ):
             assert not isinstance(table_name_or_schema, exp.Schema)
+
             # redshift and mssql have a bug where CTAS statements have non determistic types. if a limit
             # is applied to a ctas statement, VARCHAR types default to 1 in some instances.
             select_statement = statement.expression.copy()
             for select_or_union in select_statement.find_all(exp.Select, exp.SetOperation):
-                select_or_union.set("limit", None)
+                limit = select_or_union.args.get("limit")
+                if limit is not None and limit.expression.this == "0":
+                    limit.pop()
+
                 select_or_union.set("where", None)
 
             temp_view_name = self._get_temp_table("ctas")


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/4048

The issue here was that we dropped `LIMIT` clauses even if the expression wasn't 0, but MSSQL requires it when an `ORDER` clause is present.

```
2025-03-28 01:32:52,704 - ThreadPoolExecutor-1_0 - sqlmesh.core.engine_adapter.base - INFO - Executing SQL: CREATE VIEW [__temp_ctas_r5u2t2m9] AS SELECT [a].[id] AS [id], [c].[test_value] AS [test_value] FROM [master].[dbo].[test_table] AS [a] OUTER APPLY (SELECT [b].[test_value] FROM [master].[dbo].[test_table_two] AS [b] ORDER BY [b].[test_value]) AS [c]; (base.py:2113)
2025-03-28 01:32:52,714 - MainThread - sqlmesh.core.plan.evaluator - INFO - Execution failed for node SnapshotId<"master"."dbo"."test_model": 3980861674> (evaluator.py:289)
Traceback (most recent call last):
  File "src/pymssql/_pymssql.pyx", line 459, in pymssql._pymssql.Cursor.execute
  File "src/pymssql/_mssql.pyx", line 1087, in pymssql._mssql.MSSQLConnection.execute_query
  File "src/pymssql/_mssql.pyx", line 1118, in pymssql._mssql.MSSQLConnection.execute_query
  File "src/pymssql/_mssql.pyx", line 1251, in pymssql._mssql.MSSQLConnection.format_and_run_query
  File "src/pymssql/_mssql.pyx", line 1789, in pymssql._mssql.check_cancel_and_raise
  File "src/pymssql/_mssql.pyx", line 1835, in pymssql._mssql.raise_MSSQLDatabaseException
pymssql._mssql.MSSQLDatabaseException: (1033, b'The ORDER BY clause is invalid in views, inline functions, derived tables, subqueries, and common table expressions, unless TOP, OFFSET or FOR XML is also specified.DB-Lib error message 20018, severity 15:\nGeneral SQL Server error: Check messages from the SQL Server\n')
```

I haven't checked if having `LIMIT x` with `x ≠ 0` in the query causes the same type inference bug in either Redshift or MSSQL. Not sure how that bug was reproduced, but happy to test it out if it's consistently reproduced and someone can share a model for me to run.