### PR TITLE
Fix!: serialize blueprint variables separately to leverage AST

### DIFF
--- a/sqlmesh/core/constants.py
+++ b/sqlmesh/core/constants.py
@@ -76,6 +76,8 @@ REQUIREMENTS = "sqlmesh-requirements.lock"
 DEFAULT_SCHEMA = "default"
 
 SQLMESH_VARS = "__sqlmesh__vars__"
+SQLMESH_BLUEPRINT_VARS = "__sqlmesh__blueprint__vars__"
+
 VAR = "var"
 GATEWAY = "gateway"
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -253,6 +253,7 @@ class ExecutionContext(BaseContext):
         default_dialect: t.Optional[str] = None,
         default_catalog: t.Optional[str] = None,
         variables: t.Optional[t.Dict[str, t.Any]] = None,
+        blueprint_variables: t.Optional[t.Dict[str, t.Any]] = None,
     ):
         self.snapshots = snapshots
         self.deployability_index = deployability_index
@@ -260,6 +261,7 @@ class ExecutionContext(BaseContext):
         self._default_catalog = default_catalog
         self._default_dialect = default_dialect
         self._variables = variables or {}
+        self._blueprint_variables = blueprint_variables or {}
 
     @property
     def default_dialect(self) -> t.Optional[str]:
@@ -288,7 +290,15 @@ class ExecutionContext(BaseContext):
         """Returns a variable value."""
         return self._variables.get(var_name.lower(), default)
 
-    def with_variables(self, variables: t.Dict[str, t.Any]) -> ExecutionContext:
+    def blueprint_var(self, var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
+        """Returns a blueprint variable value."""
+        return self._blueprint_variables.get(var_name.lower(), default)
+
+    def with_variables(
+        self,
+        variables: t.Dict[str, t.Any],
+        blueprint_variables: t.Optional[t.Dict[str, t.Any]] = None,
+    ) -> ExecutionContext:
         """Returns a new ExecutionContext with additional variables."""
         return ExecutionContext(
             self._engine_adapter,
@@ -297,6 +307,7 @@ class ExecutionContext(BaseContext):
             self._default_dialect,
             self._default_catalog,
             variables=variables,
+            blueprint_variables=blueprint_variables,
         )
 
 

--- a/sqlmesh/core/model/decorator.py
+++ b/sqlmesh/core/model/decorator.py
@@ -122,6 +122,7 @@ class model(registry_decorator):
         default_catalog: t.Optional[str] = None,
         variables: t.Optional[t.Dict[str, t.Any]] = None,
         infer_names: t.Optional[bool] = False,
+        blueprint_variables: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> Model:
         """Get the model registered by this function."""
         env: t.Dict[str, t.Any] = {}
@@ -155,6 +156,7 @@ class model(registry_decorator):
             path=path,
             dialect=dialect,
             default_catalog=default_catalog,
+            blueprint_variables=blueprint_variables,
         )
 
         rendered_name = rendered_fields["name"]
@@ -193,6 +195,7 @@ class model(registry_decorator):
             "macros": macros,
             "jinja_macros": jinja_macros,
             "audit_definitions": audit_definitions,
+            "blueprint_variables": blueprint_variables,
             **rendered_fields,
         }
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -52,6 +52,7 @@ from sqlmesh.utils.jinja import JinjaMacroRegistry, extract_macro_references_and
 from sqlmesh.utils.pydantic import PydanticModel, PRIVATE_FIELDS
 from sqlmesh.utils.metaprogramming import (
     Executable,
+    SqlValue,
     build_env,
     prepare_env,
     serialize_env,
@@ -1749,8 +1750,10 @@ class PythonModel(_Model):
         variables = env.get(c.SQLMESH_VARS, {})
         variables.update(kwargs.pop("variables", {}))
 
-        blueprint_variables = env.get(c.SQLMESH_BLUEPRINT_VARS, {})
-
+        blueprint_variables = {
+            k: d.parse_one(v.sql, dialect=self.dialect) if isinstance(v, SqlValue) else v
+            for k, v in env.get(c.SQLMESH_BLUEPRINT_VARS, {}).items()
+        }
         try:
             kwargs = {
                 **variables,

--- a/sqlmesh/core/test/context.py
+++ b/sqlmesh/core/test/context.py
@@ -26,6 +26,7 @@ class TestExecutionContext(ExecutionContext):
         default_dialect: t.Optional[str] = None,
         default_catalog: t.Optional[str] = None,
         variables: t.Optional[t.Dict[str, t.Any]] = None,
+        blueprint_variables: t.Optional[t.Dict[str, t.Any]] = None,
     ):
         self._engine_adapter = engine_adapter
         self._models = models
@@ -33,6 +34,7 @@ class TestExecutionContext(ExecutionContext):
         self._default_catalog = default_catalog
         self._default_dialect = default_dialect
         self._variables = variables or {}
+        self._blueprint_variables = variables or {}
 
     @cached_property
     def _model_tables(self) -> t.Dict[str, str]:
@@ -41,7 +43,11 @@ class TestExecutionContext(ExecutionContext):
             name: self._test._test_fixture_table(name).sql() for name, model in self._models.items()
         }
 
-    def with_variables(self, variables: t.Dict[str, t.Any]) -> TestExecutionContext:
+    def with_variables(
+        self,
+        variables: t.Dict[str, t.Any],
+        blueprint_variables: t.Optional[t.Dict[str, t.Any]] = None,
+    ) -> TestExecutionContext:
         """Returns a new TestExecutionContext with additional variables."""
         return TestExecutionContext(
             self._engine_adapter,
@@ -50,4 +56,5 @@ class TestExecutionContext(ExecutionContext):
             self._default_dialect,
             self._default_catalog,
             variables=variables,
+            blueprint_variables=blueprint_variables,
         )

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -11,6 +11,7 @@ import sys
 import textwrap
 import types
 import typing as t
+from dataclasses import dataclass
 from enum import Enum
 from numbers import Number
 from pathlib import Path
@@ -349,6 +350,13 @@ def build_env(
     walk(obj, name)
 
 
+@dataclass
+class SqlValue:
+    """A SQL string representing a generated SQLGlot AST."""
+
+    sql: str
+
+
 class ExecutableKind(str, Enum):
     """The kind of of executable. The order of the members is used when serializing the python model to text."""
 
@@ -490,11 +498,12 @@ def prepare_env(
         python_env.items(), key=lambda item: 0 if item[1].is_import else 1
     ):
         if executable.is_value:
-            env[name] = ast.literal_eval(executable.payload)
+            env[name] = eval(executable.payload)
         else:
             exec(executable.payload, env)
             if executable.alias and executable.name:
                 env[executable.alias] = env[executable.name]
+
     return env
 
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -64,7 +64,7 @@ from sqlmesh.core.snapshot import Snapshot, SnapshotChangeCategory
 from sqlmesh.utils.date import TimeLike, to_datetime, to_ds, to_timestamp
 from sqlmesh.utils.errors import ConfigError, SQLMeshError, LinterError
 from sqlmesh.utils.jinja import JinjaMacroRegistry, MacroInfo, MacroExtractor
-from sqlmesh.utils.metaprogramming import Executable
+from sqlmesh.utils.metaprogramming import Executable, SqlValue
 from sqlmesh.core.macros import RuntimeStage
 from tests.utils.test_helpers import use_terminal_console
 
@@ -8200,6 +8200,7 @@ from sqlmesh import model
 )
 def entrypoint(context, *args, **kwargs):
     x_var = context.var("x")
+    assert context.blueprint_var("blueprint").startswith("gw")
     return pd.DataFrame({"x": [x_var]})"""
     )
     blueprint_pysql = tmp_path / "models" / "blueprint_sql.py"
@@ -8218,6 +8219,7 @@ from sqlmesh import model
 )
 def entrypoint(evaluator):
     x_var = evaluator.var("x")
+    assert evaluator.blueprint_var("blueprint", default="").startswith("gw")
     return f'SELECT {x_var} AS x'"""
     )
 
@@ -8231,11 +8233,21 @@ def entrypoint(evaluator):
 
     for model_name in ("test_model_sql", "test_model_pydf", "test_model_pysql"):
         for gateway_no in range(1, 3):
-            model = models.get(f'"db"."gw{gateway_no}"."{model_name}"')
+            blueprint_value = f"gw{gateway_no}"
 
+            model = models.get(f'"db"."{blueprint_value}"."{model_name}"')
             assert model is not None
             assert "blueprints" not in model.all_fields()
-            assert model.python_env.get(c.SQLMESH_VARS) == Executable.value({"x": gateway_no})
+
+            python_env = model.python_env
+            serialized_blueprint = (
+                SqlValue(sql=blueprint_value) if model_name == "test_model_sql" else blueprint_value
+            )
+            assert python_env.get(c.SQLMESH_VARS) == Executable.value({"x": gateway_no})
+            assert python_env.get(c.SQLMESH_BLUEPRINT_VARS) == Executable.value(
+                {"blueprint": serialized_blueprint}
+            )
+
             assert context.fetchdf(f"from {model.fqn}").to_dict() == {"x": {0: gateway_no}}
 
     multi_variable_blueprint_example = tmp_path / "models" / "multi_variable_blueprint_example.sql"
@@ -8245,15 +8257,17 @@ def entrypoint(evaluator):
         MODEL (
           name @{customer}.my_table,
           blueprints (
-            (customer := customer1, foo := 'bar'),
-            (customer := customer2, foo := qux),
+            (customer := customer1, customer_field := 'bar'),
+            (customer := customer2, customer_field := qux),
           ),
           kind FULL
         );
 
         SELECT
-          @VAR('foo') AS foo,
-        FROM @VAR('customer').my_source
+          @customer_field AS foo,
+          @{customer_field} AS foo2,
+          @BLUEPRINT_VAR('customer_field') AS foo3,
+        FROM @{customer}.my_source
         """
     )
 
@@ -8264,23 +8278,29 @@ def entrypoint(evaluator):
     assert len(models) == 8
 
     customer1_model = models.get('"db"."customer1"."my_table"')
-
     assert customer1_model is not None
-    assert customer1_model.python_env.get(c.SQLMESH_VARS) == Executable.value(
-        {"customer": "customer1", "foo": "'bar'"}
+
+    customer1_python_env = customer1_model.python_env
+    assert customer1_python_env.get(c.SQLMESH_VARS) is None
+    assert customer1_python_env.get(c.SQLMESH_BLUEPRINT_VARS) == Executable.value(
+        {"customer": SqlValue(sql="customer1"), "customer_field": SqlValue(sql="'bar'")}
     )
+
     assert t.cast(exp.Expression, customer1_model.render_query()).sql() == (
-        """SELECT '''bar''' AS "foo" FROM "db"."customer1"."my_source" AS "my_source\""""
+        """SELECT 'bar' AS "foo", "bar" AS "foo2", 'bar' AS "foo3" FROM "db"."customer1"."my_source" AS "my_source\""""
     )
 
     customer2_model = models.get('"db"."customer2"."my_table"')
-
     assert customer2_model is not None
-    assert customer2_model.python_env.get(c.SQLMESH_VARS) == Executable.value(
-        {"customer": "customer2", "foo": "qux"}
+
+    customer2_python_env = customer2_model.python_env
+    assert customer2_python_env.get(c.SQLMESH_VARS) is None
+    assert customer2_python_env.get(c.SQLMESH_BLUEPRINT_VARS) == Executable.value(
+        {"customer": SqlValue(sql="customer2"), "customer_field": SqlValue(sql="qux")}
     )
+
     assert t.cast(exp.Expression, customer2_model.render_query()).sql() == (
-        '''SELECT 'qux' AS "foo" FROM "db"."customer2"."my_source" AS "my_source"'''
+        '''SELECT "qux" AS "foo", "qux" AS "foo2", "qux" AS "foo3" FROM "db"."customer2"."my_source" AS "my_source"'''
     )
 
 
@@ -8350,6 +8370,39 @@ def test_single_blueprint(tmp_path: Path) -> None:
 
     assert len(ctx.models) == 1
     assert '"memory"."bar"."some_table"' in ctx.models
+
+
+def test_blueprinting_with_quotes(tmp_path: Path) -> None:
+    init_example_project(tmp_path, dialect="duckdb", template=ProjectTemplate.EMPTY)
+
+    template_with_quoted_vars = tmp_path / "models/template_with_quoted_vars.sql"
+    template_with_quoted_vars.parent.mkdir(parents=True, exist_ok=True)
+    template_with_quoted_vars.write_text(
+        """
+        MODEL (
+          name m.@{bp_var},
+          blueprints (
+            (bp_var := "a b"),
+            (bp_var := 'c d'),
+          ),
+        );
+
+        SELECT @bp_var AS c1, @{bp_var} AS c2
+        """
+    )
+
+    ctx = Context(
+        config=Config(model_defaults=ModelDefaultsConfig(dialect="duckdb")), paths=tmp_path
+    )
+    assert len(ctx.models) == 2
+
+    m1 = ctx.get_model('m."a b"', raise_if_missing=True)
+    m2 = ctx.get_model('m."c d"', raise_if_missing=True)
+
+    assert m1.name == 'm."a b"'
+    assert m2.name == 'm."c d"'
+    assert t.cast(exp.Query, m1.render_query()).sql() == '''SELECT "a b" AS "c1", "a b" AS "c2"'''
+    assert t.cast(exp.Query, m2.render_query()).sql() == '''SELECT 'c d' AS "c1", "c d" AS "c2"'''
 
 
 @time_machine.travel("2020-01-01 00:00:00 UTC")


### PR DESCRIPTION
Fixes #4017

Given a model like this:

```sql
MODEL (
  name m.@{foo},
  blueprints (
    (foo := "s p a c e s"),
    (foo := 'c'),
  ),
);

SELECT
  @foo AS col
```

The blueprint variables that contain quotes are incorrectly rendered today:

```python
from sqlmesh import Context
ctx = Context()
for fqn, model in ctx.models.items():
    print(f"Fully-qualified name: {fqn}, name: {model.name}, query: {model.render_query().sql()}")

# Fully-qualified name: "db"."m"."""s p a c e s""", name: m."""s p a c e s""", query: SELECT '"s p a c e s"' AS "col"
# Fully-qualified name: "db"."m"."'c'", name: m."'c'", query: SELECT '''c''' AS "col"
```

This PR addresses this bug with the help of [this commit](https://github.com/TobikoData/sqlmesh/commit/d0154902e646d3ef8bc758660018afc233108578), by changing the representation of the blueprint values: their values are now the parsed ASTs, and not the corresponding SQL strings. This behavior is more intuitive, because for example quoted identifiers will be correctly interpolated in contexts such as model names, without dropping the quotes.

Since SQLGlot expressions aren't serialized today, making this fix wasn't as simple as pushing the blueprint variables to the `SQLMESH_VARS` dict, since that only contains Python literals that can be `eval`'d on the fly without additional context, when hydrating the Python environment.

Additionally, we need to serialize blueprint values because if, e.g., a model query references them, then the raw SQL with the variable reference is serialized and we need to have the variable's payload at deserialization time to ensure the query can be properly rendered.

This led to a new dictionary in the python env. that will contain only the blueprint variables, so that we can unambiguously serialize them as strings that are produced by `sql(dialect=...)` and then deserialize them in the macro evaluator by parsing with the same dialect.