### PR TITLE
Chore: Fix airflow tests

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -284,10 +284,10 @@ workflows:
       - airflow_docker_tests:
           requires:
             - style_and_cicd_tests
-          #filters:
-          #  branches:
-          #    only:
-          #      - main
+          filters:
+            branches:
+              only:
+                - main
       - engine_tests_docker:
           name: engine_<< matrix.engine >>
           matrix:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -157,8 +157,11 @@ jobs:
           name: Install envsubst
           command: sudo apt-get update && sudo apt-get install gettext-base
       - run:
-          name: Install ruamel.yaml
-          command: pip3 install ruamel.yaml==0.16.0
+          name: Setup python env
+          command: |
+            pip3 install --upgrade pip
+            pip3 install ruamel.yaml==0.16.0
+            python3 --version
       - run:
           name: Run Airflow slow tests
           command: make airflow-docker-test-with-env
@@ -281,10 +284,10 @@ workflows:
       - airflow_docker_tests:
           requires:
             - style_and_cicd_tests
-          filters:
-            branches:
-              only:
-                - main
+          #filters:
+          #  branches:
+          #    only:
+          #      - main
       - engine_tests_docker:
           name: engine_<< matrix.engine >>
           matrix:


### PR DESCRIPTION
The airflow tests are currently failing on main because the ancient version of pip was having trouble resolving dependencies and hanging.

Simply upgrading pip prior to setting up the python env seems to fix the issue