### PR TITLE
Update dbt integration doc sqlmesh init command to avoid init error

### DIFF
--- a/docs/integrations/dbt.md
+++ b/docs/integrations/dbt.md
@@ -41,7 +41,7 @@ Learn more about [SQLMesh installation and extras here](../installation.md#insta
 Prepare an existing dbt project to be run by SQLMesh by executing the `sqlmesh init` command *within the dbt project root directory* and with the `dbt` template option:
 
 ```bash
-$ sqlmesh init -t dbt
+$ sqlmesh init -t dbt <dialect> # e.g. sqlmesh init -t dbt snowflake
 ```
 
 SQLMesh will use the data warehouse connection target in your dbt project `profiles.yml` file. The target can be changed at any time.


### PR DESCRIPTION
# Description

sqlmesh version: 0.170.1
engine: snowflake

When following the documentation [here](https://sqlmesh.readthedocs.io/en/stable/integrations/dbt/#reading-a-dbt-project) and running the command `sqlmesh init -t dbt`, keeps getting error like below:

```
Traceback (most recent call last):
  File "/home/venvs/sqlmesh_env/bin/sqlmesh", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/sqlmesh/cli/__init__.py", line 29, in wrapper
    return handler(sqlmesh_context, lambda: func(*args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/sqlmesh/cli/__init__.py", line 38, in _default_exception_handler
    return func()
           ^^^^^^
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/sqlmesh/cli/__init__.py", line 29, in <lambda>
    return handler(sqlmesh_context, lambda: func(*args, **kwargs))
                                            ^^^^^^^^^^^^^^^^^^^^^
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/sqlmesh/core/analytics/__init__.py", line 82, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/sqlmesh/cli/main.py", line 159, in init
    init_example_project(
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/sqlmesh/cli/example_project.py", line 287, in init_example_project
    _create_config(config_path, dialect, settings, start, template)
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/sqlmesh/cli/example_project.py", line 323, in _create_config
    project_config = _gen_config(dialect, settings, start, template)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/venvs/sqlmesh_env/lib/python3.11/site-packages/sqlmesh/cli/example_project.py", line 72, in _gen_config
    f"      # {doc_link.format(engine_link=engine_link)}\n{connection_settings}"
                                                           ^^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'connection_settings' where it is not associated with a value
(sqlmesh_env) FAIL: 1
```

After looking at the `example_project.py`, looks like it needs an engine name to be passed to a variable `dialect` - i.e. `sqlmesh init -t dbt athena/snowflake/mysql` - As long as the engine is in `CONNECTION_CONFIG_TO_TYPE`.

Therefore, by updating the documentation with the engine type, this command works as expected.

```
(sqlmesh_env) user@host: /home/sqlmesh_snowflake
➜   sqlmesh init -t dbt snowflake
**************The dialect is: snowflake
**************The CONNECTION_CONFIG_TO_TYPE is:
{
    'athena': <class 'sqlmesh.core.config.connection.AthenaConnectionConfig'>,
    'azuresql': <class 'sqlmesh.core.config.connection.AzureSQLConnectionConfig'>,
    'bigquery': <class 'sqlmesh.core.config.connection.BigQueryConnectionConfig'>,
    'clickhouse': <class 'sqlmesh.core.config.connection.ClickhouseConnectionConfig'>,
    'databricks': <class 'sqlmesh.core.config.connection.DatabricksConnectionConfig'>,
    'duckdb': <class 'sqlmesh.core.config.connection.DuckDBConnectionConfig'>,
    'gcp_postgres': <class 'sqlmesh.core.config.connection.GCPPostgresConnectionConfig'>,
    'mssql': <class 'sqlmesh.core.config.connection.MSSQLConnectionConfig'>,
    'motherduck': <class 'sqlmesh.core.config.connection.MotherDuckConnectionConfig'>,
    'mysql': <class 'sqlmesh.core.config.connection.MySQLConnectionConfig'>,
    'postgres': <class 'sqlmesh.core.config.connection.PostgresConnectionConfig'>,
    'redshift': <class 'sqlmesh.core.config.connection.RedshiftConnectionConfig'>,
    'risingwave': <class 'sqlmesh.core.config.connection.RisingwaveConnectionConfig'>,
    'snowflake': <class 'sqlmesh.core.config.connection.SnowflakeConnectionConfig'>,
    'spark': <class 'sqlmesh.core.config.connection.SparkConnectionConfig'>,
    'trino': <class 'sqlmesh.core.config.connection.TrinoConnectionConfig'>
}
```
