### PR TITLE
Fix!: Pass the model dialect when computing a hash for the column types

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1051,7 +1051,7 @@ class _Model(ModelMeta, frozen=True):
 
         for column_name, column_type in (self.columns_to_types_ or {}).items():
             data.append(column_name)
-            data.append(column_type.sql())
+            data.append(column_type.sql(dialect=self.dialect))
 
         for key, value in (self.physical_properties or {}).items():
             data.append(key)

--- a/sqlmesh/migrations/v0077_fix_column_type_hash_calculation.py
+++ b/sqlmesh/migrations/v0077_fix_column_type_hash_calculation.py
@@ -1,0 +1,5 @@
+"""Use the model's dialect when calculating the hash for the column types."""
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    pass

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -8435,3 +8435,20 @@ def test_ignored_rules_serialization():
 
     deserialized_model = SqlModel.parse_raw(model_json)
     assert deserialized_model.dict() == model.dict()
+
+
+def test_data_hash_unchanged_when_column_type_uses_default_dialect():
+    model = create_sql_model(
+        "foo",
+        parse_one("SELECT * FROM bla"),
+        columns={"a": exp.DataType.build("int")},
+        dialect="bigquery",
+    )
+
+    deserialized_model = SqlModel.parse_raw(model.json())
+
+    assert model.columns_to_types_ == {"a": exp.DataType.build("int")}
+    assert deserialized_model.columns_to_types_ == {"a": exp.DataType.build("bigint")}
+
+    # int == int64 in bigquery
+    assert model.data_hash == deserialized_model.data_hash


### PR DESCRIPTION
Otherwise, there can be a mismatch between the hash computed using the original instance of a model and the deserialized one when the type is constructed using the default dialect. (eg. `exp.DataType.build("int")`).

Example:
```
In [6]: exp.DataType.build("int").sql("bigquery")
Out[6]: 'INT64'

In [7]: exp.DataType.build("int64", dialect="bigquery")
Out[7]: DataType(this=Type.BIGINT, nested=False)
```