### PR TITLE
Fix: single blueprint edge case

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1862,7 +1862,7 @@ def _extract_blueprint_variables(
 ) -> t.Dict[str, str]:
     if not blueprint:
         return {}
-    if isinstance(blueprint, exp.Paren):
+    if isinstance(blueprint, (exp.Paren, exp.PropertyEQ)):
         blueprint = blueprint.unnest()
         return {blueprint.left.name: blueprint.right.sql(dialect=dialect)}
     if isinstance(blueprint, (exp.Tuple, exp.Array)):

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -8327,6 +8327,31 @@ def gen_blueprints(evaluator):
     assert '"memory"."customer2"."some_table"' in ctx.models
 
 
+def test_single_blueprint(tmp_path: Path) -> None:
+    init_example_project(tmp_path, dialect="duckdb", template=ProjectTemplate.EMPTY)
+
+    single_blueprint = tmp_path / "models/single_blueprint.sql"
+    single_blueprint.parent.mkdir(parents=True, exist_ok=True)
+    single_blueprint.write_text(
+        """
+        MODEL (
+          name @single_blueprint.some_table,
+          kind FULL,
+          blueprints ((single_blueprint := bar))
+        );
+
+        SELECT 1 AS c
+        """
+    )
+
+    ctx = Context(
+        config=Config(model_defaults=ModelDefaultsConfig(dialect="duckdb")), paths=tmp_path
+    )
+
+    assert len(ctx.models) == 1
+    assert '"memory"."bar"."some_table"' in ctx.models
+
+
 @time_machine.travel("2020-01-01 00:00:00 UTC")
 def test_dynamic_date_spine_model(assert_exp_eq):
     @macro()


### PR DESCRIPTION
This model fails in main currently:

```sql
MODEL (
  name @foo.some_table,
  kind FULL,
  blueprints ((
      foo := bar
  ))
);

SELECT
  1 AS c
```

With the following error:

```
Error: Failed to load model definition at 'playground/models/test.sql'.
Expected a key-value mapping for the blueprint value, got 'foo := bar' instead at 'playground/models/test.sql'
```

This PR addresses this.