### PR TITLE
Fix: Make jinja_macros optional for environment statements

### DIFF
--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -219,7 +219,7 @@ class EnvironmentStatements(PydanticModel):
     before_all: t.List[str]
     after_all: t.List[str]
     python_env: t.Dict[str, Executable]
-    jinja_macros: JinjaMacroRegistry = JinjaMacroRegistry()
+    jinja_macros: t.Optional[JinjaMacroRegistry] = None
 
 
 def execute_environment_statements(

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -437,7 +437,7 @@ def render_statements(
                     expression,
                     dialect,
                     [],
-                    jinja_macro_registry=jinja_macros or JinjaMacroRegistry(),
+                    jinja_macro_registry=jinja_macros or None,
                     python_env=python_env,
                     default_catalog=default_catalog,
                     quote_identifiers=False,

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -437,7 +437,7 @@ def render_statements(
                     expression,
                     dialect,
                     [],
-                    jinja_macro_registry=jinja_macros or None,
+                    jinja_macro_registry=jinja_macros,
                     python_env=python_env,
                     default_catalog=default_catalog,
                     quote_identifiers=False,


### PR DESCRIPTION
Make jinja_macros optional for environment statements to ensure they don't cause extra diffs when running plan in latest versions of pydantic ( > 2.10 ).