### PR TITLE
Fix!: dont wrap macro vars and str replacements in intervals

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -1035,6 +1035,12 @@ def extend_sqlglot() -> None:
                 MacroDef,
             )
 
+        generator.UNWRAPPED_INTERVAL_VALUES = (
+            *generator.UNWRAPPED_INTERVAL_VALUES,
+            MacroStrReplace,
+            MacroVar,
+        )
+
     _override(Parser, _parse_select)
     _override(Parser, _parse_statement)
     _override(Parser, _parse_join)

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -260,6 +260,8 @@ ON_VIRTUAL_UPDATE_END;"""
 
 def test_macro_format():
     assert parse_one("@EACH(ARRAY(1,2), x -> x)").sql() == "@EACH(ARRAY(1, 2), x -> x)"
+    assert parse_one("INTERVAL @x DAY").sql() == "INTERVAL @x DAY"
+    assert parse_one("INTERVAL @'@{bar}' DAY").sql() == "INTERVAL @'@{bar}' DAY"
 
 
 def test_format_body_macros():


### PR DESCRIPTION
Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1743582978860569