### PR TITLE
Fix: python serialization edge case

### DIFF
--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -89,9 +89,8 @@ def func_globals(func: t.Callable) -> t.Dict[str, t.Any]:
         for var in (
             arg_globals + list(_code_globals(code)) + decorator_vars(func, root_node=root_node)
         ):
-            ref = func.__globals__.get(var)
-            if ref:
-                variables[var] = ref
+            if var in func.__globals__:
+                variables[var] = func.__globals__[var]
 
         if func.__closure__:
             for var, value in zip(code.co_freevars, func.__closure__):

--- a/tests/utils/test_metaprogramming.py
+++ b/tests/utils/test_metaprogramming.py
@@ -63,6 +63,7 @@ def test_print_exception(mocker: MockerFixture):
 X = 1
 Y = 2
 Z = 3
+W = 0
 
 my_lambda = lambda: print("z")  # noqa: E731
 
@@ -96,7 +97,7 @@ def other_func(a: int) -> int:
     pd.DataFrame([{"x": 1}])
     to_table("y")
     my_lambda()  # type: ignore
-    return X + a
+    return X + a + W
 
 
 def noop_metadata() -> None:
@@ -165,6 +166,7 @@ def test_func_globals() -> None:
     }
     assert func_globals(other_func) == {
         "X": 1,
+        "W": 0,
         "my_lambda": my_lambda,
         "pd": pd,
         "to_table": to_table,
@@ -212,7 +214,7 @@ def test_normalize_source() -> None:
     pd.DataFrame([{'x': 1}])
     to_table('y')
     my_lambda()
-    return X + a"""
+    return X + a + W"""
     )
 
 
@@ -256,6 +258,7 @@ def test_serialize_env() -> None:
         "X": Executable(payload="1", kind=ExecutableKind.VALUE),
         "Y": Executable(payload="2", kind=ExecutableKind.VALUE),
         "Z": Executable(payload="3", kind=ExecutableKind.VALUE),
+        "W": Executable(payload="0", kind=ExecutableKind.VALUE),
         "_GeneratorContextManager": Executable(
             payload="from contextlib import _GeneratorContextManager", kind=ExecutableKind.IMPORT
         ),
@@ -336,7 +339,7 @@ def test_context_manager():
     pd.DataFrame([{'x': 1}])
     to_table('y')
     my_lambda()
-    return X + a""",
+    return X + a + W""",
         ),
         "test_context_manager": Executable(
             payload="""@contextmanager


### PR DESCRIPTION
This PR addresses a bug in the Python code serialization logic. When walking objects and looking up function globals, we only add them to the environment if the fetched objects are not falsey, which leads to excluding falsey primitives such as `0`, `False` and `None`. A minimally-reproducible example for this is shown below:

```python
import pandas as pd
from sqlmesh import model

Z = 0

@model(name="foo", columns={"id": "int"})
def entrypoint(context, *args, **kwargs):
    return pd.DataFrame({"id": [Z]})

# Failed models
# 
#  "foo"
#
#    File 'models/test.py' (or imported file), line 2, in entrypoint
#        def entrypoint(context, *args, **kwargs):
#            return pd.DataFrame({'id': [Z]})
#          NameError: name 'Z' is not defined
#
# Error: Plan application failed.
```

No additional context here. I was simply playing around locally and came across this issue, so figured I'd fix it.