### PR TITLE
Fix: Account for array types when showing sample in table diff

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -2044,8 +2044,6 @@ class TerminalConsole(Console):
 
 def _cells_match(x: t.Any, y: t.Any) -> bool:
     """Helper function to compare two cells and returns true if they're equal, handling array objects."""
-    if x is None or y is None:
-        return x == y
 
     # Convert array-like objects to list for consistent comparison
     def _normalize(val: t.Any) -> t.Any:

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1908,7 +1908,7 @@ class TerminalConsole(Console):
                     # Filter to retain non identical-valued rows
                     column_table = column_table[
                         column_table.apply(
-                            lambda row: _compare_df_cells(row[source_column], row[target_column]),
+                            lambda row: not _cells_match(row[source_column], row[target_column]),
                             axis=1,
                         )
                     ]
@@ -2042,23 +2042,16 @@ class TerminalConsole(Console):
             self.log_warning(msg)
 
 
-def _compare_df_cells(x: t.Any, y: t.Any) -> bool:
-    """Helper function to compare two cells and returns true if they're not equal, handling array objects."""
+def _cells_match(x: t.Any, y: t.Any) -> bool:
+    """Helper function to compare two cells and returns true if they're equal, handling array objects."""
     if x is None or y is None:
-        return x != y
+        return x == y
 
-    # Convert any array-like object to list for consistent comparison
-    def to_list(val: t.Any) -> t.Any:
-        return list(val) if isinstance(val, (pd.Series, np.ndarray, list, tuple, set)) else val
+    # Convert array-like objects to list for consistent comparison
+    def _normalize(val: t.Any) -> t.Any:
+        return list(val) if isinstance(val, (pd.Series, np.ndarray)) else val
 
-    x = to_list(x)
-    y = to_list(y)
-    if isinstance(x, list) and isinstance(y, list):
-        if len(x) != len(y):
-            return True
-        return any(a != b for a, b in zip(x, y))
-
-    return x != y
+    return _normalize(x) == _normalize(y)
 
 
 def add_to_layout_widget(target_widget: LayoutWidget, *widgets: widgets.Widget) -> LayoutWidget:

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -70,6 +70,7 @@ class RowDiff(PydanticModel, frozen=True):
     source_alias: t.Optional[str] = None
     target_alias: t.Optional[str] = None
     model_name: t.Optional[str] = None
+    decimals: int = 3
 
     @property
     def source_count(self) -> int:
@@ -576,5 +577,6 @@ class TableDiff:
                     source_alias=self.source_alias,
                     target_alias=self.target_alias,
                     model_name=self.model_name,
+                    decimals=self.decimals,
                 )
         return self._row_diff

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -431,7 +431,7 @@ def test_tables_and_grain_inferred_from_model(sushi_context_fixed_date: Context)
 
 
 @pytest.mark.slow
-def test_data_diff_array(sushi_context_fixed_date):
+def test_data_diff_array_dict(sushi_context_fixed_date):
     engine_adapter = sushi_context_fixed_date.engine_adapter
 
     engine_adapter.ctas(
@@ -440,6 +440,7 @@ def test_data_diff_array(sushi_context_fixed_date):
             {
                 "key": [1, 2, 3],
                 "value": [np.array([51.2, 4.5678]), np.array([2.31, 12.2]), np.array([5.0])],
+                "dict": [{"key1": 10, "key2": 20, "key3": 30}, {"key1": 10}, {}],
             }
         ),
     )
@@ -454,6 +455,7 @@ def test_data_diff_array(sushi_context_fixed_date):
                     np.array([2.31, 12.2, 3.6, 1.9]),
                     np.array([5.0]),
                 ],
+                "dict": [{"key1": 10, "key2": 13}, {"key1": 10}, {}],
             }
         ),
     )
@@ -487,6 +489,7 @@ Row Counts:
 COMMON ROWS column comparison stats:
        pct_match
 value  33.333333
+dict   66.666667
 
 
 COMMON ROWS sample data differences:
@@ -497,6 +500,12 @@ Column: value
 │ 1   │ [51.2, 4.5678] │ [51.2, 4.5679]         │
 │ 2   │ [2.31, 12.2]   │ [2.31, 12.2, 3.6, 1.9] │
 └─────┴────────────────┴────────────────────────┘
+Column: dict
+┏━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┓
+┃ key ┃ DEV                         ┃ PROD               ┃
+┡━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━┩
+│ 1   │ {key1=10, key2=20, key3=30} │ {key1=10, key2=13} │
+└─────┴─────────────────────────────┴────────────────────┘
 """
 
     stripped_output = strip_ansi_codes(output)


### PR DESCRIPTION
This update improves the filtering approach in table diff when displaying the diff samples for a column, which failed to properly handle array types before.

As part of this also decimal values are now correctly aligned by propagating the decimal precision in row diff to properly display them in the sample. Also added helper methods (`capture_console_output` and `create_test_console`) so we can verify in tests the exact output of console methods from now on.
