### PR TITLE
Fix: Make dialect in dbt init noncompulsory again

### DIFF
--- a/docs/integrations/dbt.md
+++ b/docs/integrations/dbt.md
@@ -41,7 +41,7 @@ Learn more about [SQLMesh installation and extras here](../installation.md#insta
 Prepare an existing dbt project to be run by SQLMesh by executing the `sqlmesh init` command *within the dbt project root directory* and with the `dbt` template option:
 
 ```bash
-$ sqlmesh init -t dbt <dialect> # e.g. sqlmesh init -t dbt snowflake
+$ sqlmesh init -t dbt
 ```
 
 SQLMesh will use the data warehouse connection target in your dbt project `profiles.yml` file. The target can be changed at any time.

--- a/sqlmesh/cli/example_project.py
+++ b/sqlmesh/cli/example_project.py
@@ -28,7 +28,13 @@ def _gen_config(
     start: t.Optional[str],
     template: ProjectTemplate,
 ) -> str:
-    if not settings:
+    connection_settings = (
+        settings
+        or """      type: duckdb
+      database: db.db"""
+    )
+
+    if not settings and template != ProjectTemplate.DBT:
         doc_link = "https://sqlmesh.readthedocs.io/en/stable/integrations/engines{engine_link}"
         engine_link = ""
 
@@ -69,8 +75,6 @@ def _gen_config(
             "      # https://sqlmesh.readthedocs.io/en/stable/reference/configuration/#connections\n"
             f"      # {doc_link.format(engine_link=engine_link)}\n{connection_settings}"
         )
-    else:
-        connection_settings = settings
 
     default_configs = {
         ProjectTemplate.DEFAULT: f"""gateways:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1614,3 +1614,24 @@ def test_state_import_local(runner: CliRunner, tmp_path: Path) -> None:
     assert result.exit_code == 1
     assert "State file is marked as not importable" in result.output
     assert "Aborting" in result.output
+
+
+def test_dbt_init(tmp_path):
+    # The dbt init project doesn't require a dialect
+    init_example_project(tmp_path, dialect=None, template=ProjectTemplate.DBT)
+
+    config_path = tmp_path / "config.py"
+    assert config_path.exists()
+
+    with open(config_path) as file:
+        config = file.read()
+
+    assert (
+        config
+        == """from pathlib import Path
+
+from sqlmesh.dbt.loader import sqlmesh_config
+
+config = sqlmesh_config(Path(__file__).parent)
+"""
+    )


### PR DESCRIPTION
This fixes a regression with the init command for dbt projects which didn't work without a dialect.