### PR TITLE
Fix: Refreshing snapshot intervals for uncategorized snapshots when state is stored in databricks

### DIFF
--- a/sqlmesh/core/state_sync/db/interval.py
+++ b/sqlmesh/core/state_sync/db/interval.py
@@ -142,7 +142,7 @@ class IntervalState:
         if not snapshots:
             return []
 
-        _, intervals = self._get_snapshot_intervals(snapshots)
+        _, intervals = self._get_snapshot_intervals([s for s in snapshots if s.version])
         for s in snapshots:
             s.intervals = []
             s.dev_intervals = []

--- a/tests/core/engine_adapter/integration/config.yaml
+++ b/tests/core/engine_adapter/integration/config.yaml
@@ -118,8 +118,6 @@ gateways:
       database: {{ env_var('SNOWFLAKE_DATABASE') }}
       user: {{ env_var('SNOWFLAKE_USER') }}
       password: {{ env_var('SNOWFLAKE_PASSWORD') }}
-    state_connection:
-      type: duckdb
 
   inttest_databricks:
     connection:
@@ -128,8 +126,6 @@ gateways:
       server_hostname: {{ env_var('DATABRICKS_SERVER_HOSTNAME') }}
       http_path: {{ env_var('DATABRICKS_HTTP_PATH') }}
       access_token: {{ env_var('DATABRICKS_ACCESS_TOKEN') }}
-    state_connection:
-      type: duckdb
 
   inttest_redshift:
     connection:
@@ -138,16 +134,12 @@ gateways:
       user: {{ env_var('REDSHIFT_USER') }}
       password: {{ env_var('REDSHIFT_PASSWORD') }}
       database: {{ env_var('REDSHIFT_DATABASE') }}
-    state_connection:
-      type: duckdb
 
   inttest_bigquery:
     connection:
       type: bigquery
       method: service-account
       keyfile: {{ env_var('BIGQUERY_KEYFILE') }}
-    state_connection:
-      type: duckdb
 
   inttest_clickhouse_cloud:
     connection:


### PR DESCRIPTION
Closes #4081