### PR TITLE
Fix!: Propagate gateway variables to model tests

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -2465,13 +2465,13 @@ class GenericContext(BaseContext, t.Generic[C]):
     def load_model_tests(
         self, tests: t.Optional[t.List[str]] = None, patterns: list[str] | None = None
     ) -> t.List[ModelTestMetadata]:
-        # If a set of tests is provided, use a single loader to load them
-        # Otherwise, gather all tests from all loaders/repos
+        # If a set of specific test path(s) are provided, we can use a single loader
+        # since it's not required to walk every tests/ folder in each repo
         loaders = [self._loaders[0]] if tests else self._loaders
 
         model_tests = []
         for loader in loaders:
-            model_tests.extend(loader._load_model_tests(tests=tests, patterns=patterns))
+            model_tests.extend(loader.load_model_tests(tests=tests, patterns=patterns))
 
         return model_tests
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1785,7 +1785,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         if verbosity >= Verbosity.VERBOSE:
             pd.set_option("display.max_columns", None)
 
-        test_meta = self._load_model_tests(tests=tests, patterns=match_patterns)
+        test_meta = self.load_model_tests(tests=tests, patterns=match_patterns)
 
         return run_tests(
             model_test_metadata=test_meta,
@@ -2462,7 +2462,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 "Linter detected errors in the code. Please fix them before proceeding."
             )
 
-    def _load_model_tests(
+    def load_model_tests(
         self, tests: t.Optional[t.List[str]] = None, patterns: list[str] | None = None
     ) -> t.List[ModelTestMetadata]:
         # If a set of tests is provided, use a single loader to load them

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1785,17 +1785,10 @@ class GenericContext(BaseContext, t.Generic[C]):
         if verbosity >= Verbosity.VERBOSE:
             pd.set_option("display.max_columns", None)
 
-        # Merge the root variables with the gateway's variables
-        variables = {
-            **self.config.variables,
-            **self.config.get_gateway(self.selected_gateway).variables,
-        }
-
         test_meta = load_model_tests(
-            configs=self.configs,
+            loaders=self._loaders,
             tests=tests,
             patterns=match_patterns,
-            variables=variables,
         )
 
         return run_tests(

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -2465,9 +2465,12 @@ class GenericContext(BaseContext, t.Generic[C]):
     def _load_model_tests(
         self, tests: t.Optional[t.List[str]] = None, patterns: list[str] | None = None
     ) -> t.List[ModelTestMetadata]:
-        model_tests = []
+        # If a set of tests is provided, use a single loader to load them
+        # Otherwise, gather all tests from all loaders/repos
+        loaders = [self._loaders[0]] if tests else self._loaders
 
-        for loader in self._loaders:
+        model_tests = []
+        for loader in loaders:
             model_tests.extend(loader._load_model_tests(tests=tests, patterns=patterns))
 
         return model_tests

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1785,10 +1785,11 @@ class GenericContext(BaseContext, t.Generic[C]):
         if verbosity >= Verbosity.VERBOSE:
             pd.set_option("display.max_columns", None)
 
-        default_gateway = self.gateway or self.config.default_gateway_name
-
         # Merge the root variables with the gateway's variables
-        variables = {**self.config.variables, **self.config.get_gateway(default_gateway).variables}
+        variables = {
+            **self.config.variables,
+            **self.config.get_gateway(self.selected_gateway).variables,
+        }
 
         test_meta = load_model_tests(
             configs=self.configs,
@@ -1801,7 +1802,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             model_test_metadata=test_meta,
             models=self._models,
             config=self.config,
-            default_gateway=default_gateway,
+            selected_gateway=self.selected_gateway,
             dialect=self.default_dialect,
             verbosity=verbosity,
             preserve_fixtures=preserve_fixtures,

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -293,7 +293,7 @@ class Loader(abc.ABC):
         """Loads user linting rules"""
         return RuleSet()
 
-    def _load_model_tests(
+    def load_model_tests(
         self, tests: t.Optional[t.List[str]] = None, patterns: list[str] | None = None
     ) -> t.List[ModelTestMetadata]:
         """Loads YAML-based model tests"""
@@ -699,21 +699,21 @@ class SqlMeshLoader(Loader):
 
         return model_test_metadata
 
-    def _load_model_tests(
+    def load_model_tests(
         self, tests: t.Optional[t.List[str]] = None, patterns: list[str] | None = None
     ) -> t.List[ModelTestMetadata]:
         """Loads YAML-based model tests"""
-        test_meta: t.List[ModelTestMetadata] = []
+        test_meta_list: t.List[ModelTestMetadata] = []
 
         if tests:
             for test in tests:
                 filename, test_name = test.split("::", maxsplit=1) if "::" in test else (test, "")
 
-                test_file = self._load_model_test_file(Path(filename))
+                test_meta = self._load_model_test_file(Path(filename))
                 if test_name:
-                    test_meta.append(test_file[test_name])
+                    test_meta_list.append(test_meta[test_name])
                 else:
-                    test_meta.extend(test_file.values())
+                    test_meta_list.extend(test_meta.values())
         else:
             search_path = Path(self.config_path) / c.TESTS
 
@@ -727,12 +727,12 @@ class SqlMeshLoader(Loader):
                 ):
                     continue
 
-                test_meta.extend(self._load_model_test_file(yaml_file).values())
+                test_meta_list.extend(self._load_model_test_file(yaml_file).values())
 
         if patterns:
-            test_meta = filter_tests_by_patterns(test_meta, patterns)
+            test_meta_list = filter_tests_by_patterns(test_meta_list, patterns)
 
-        return test_meta
+        return test_meta_list
 
     class _Cache(CacheBase):
         def __init__(self, loader: SqlMeshLoader, config_path: Path):

--- a/sqlmesh/core/test/__init__.py
+++ b/sqlmesh/core/test/__init__.py
@@ -6,9 +6,7 @@ from sqlmesh.core.test.discovery import (
     filter_tests_by_patterns as filter_tests_by_patterns,
     get_all_model_tests as get_all_model_tests,
     load_model_test_file as load_model_test_file,
+    load_model_tests as load_model_tests,
 )
 from sqlmesh.core.test.result import ModelTextTestResult as ModelTextTestResult
-from sqlmesh.core.test.runner import (
-    run_model_tests as run_model_tests,
-    run_tests as run_tests,
-)
+from sqlmesh.core.test.runner import run_tests as run_tests

--- a/sqlmesh/core/test/__init__.py
+++ b/sqlmesh/core/test/__init__.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 from sqlmesh.core.test.definition import ModelTest as ModelTest, generate_test as generate_test
 from sqlmesh.core.test.discovery import (
     ModelTestMetadata as ModelTestMetadata,
-    filter_tests_by_patterns as filter_tests_by_patterns,
-    get_all_model_tests as get_all_model_tests,
-    load_model_test_file as load_model_test_file,
     load_model_tests as load_model_tests,
 )
 from sqlmesh.core.test.result import ModelTextTestResult as ModelTextTestResult

--- a/sqlmesh/core/test/__init__.py
+++ b/sqlmesh/core/test/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sqlmesh.core.test.definition import ModelTest as ModelTest, generate_test as generate_test
 from sqlmesh.core.test.discovery import (
     ModelTestMetadata as ModelTestMetadata,
-    load_model_tests as load_model_tests,
+    filter_tests_by_patterns as filter_tests_by_patterns,
 )
 from sqlmesh.core.test.result import ModelTextTestResult as ModelTextTestResult
 from sqlmesh.core.test.runner import run_tests as run_tests

--- a/sqlmesh/core/test/result.py
+++ b/sqlmesh/core/test/result.py
@@ -107,7 +107,6 @@ class ModelTextTestResult(unittest.TextTestResult):
         for _, error in errors:
             stream.writeln(unittest.TextTestResult.separator1)
             stream.writeln(f"ERROR: {error}")
-            stream.writeln(unittest.TextTestResult.separator2)
 
         # Output final report
         stream.writeln(unittest.TextTestResult.separator2)

--- a/sqlmesh/core/test/runner.py
+++ b/sqlmesh/core/test/runner.py
@@ -14,9 +14,6 @@ from sqlmesh.core.model import Model
 from sqlmesh.core.test.definition import ModelTest as ModelTest, generate_test as generate_test
 from sqlmesh.core.test.discovery import (
     ModelTestMetadata as ModelTestMetadata,
-    filter_tests_by_patterns as filter_tests_by_patterns,
-    get_all_model_tests as get_all_model_tests,
-    load_model_test_file as load_model_test_file,
 )
 from sqlmesh.core.config.connection import BaseDuckDBConnectionConfig
 

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -272,7 +272,7 @@ class SQLMeshMagics(Magics):
         if not args.test_name and not args.ls:
             raise MagicError("Must provide either test name or `--ls` to list tests")
 
-        test_meta = load_model_tests(loaders=context._loaders)
+        test_meta = load_model_tests(configs=context.configs, get_variables=context._get_variables)
 
         tests: t.Dict[str, t.Dict[str, ModelTestMetadata]] = defaultdict(dict)
         for model_test_metadata in test_meta:

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -272,7 +272,7 @@ class SQLMeshMagics(Magics):
         if not args.test_name and not args.ls:
             raise MagicError("Must provide either test name or `--ls` to list tests")
 
-        test_meta = context._load_model_tests()
+        test_meta = context.load_model_tests()
 
         tests: t.Dict[str, t.Dict[str, ModelTestMetadata]] = defaultdict(dict)
         for model_test_metadata in test_meta:

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -26,13 +26,12 @@ from IPython.utils.process import arg_split
 from rich.jupyter import JupyterRenderable
 from sqlmesh.cli.example_project import ProjectTemplate, init_example_project
 from sqlmesh.core import analytics
-from sqlmesh.core import constants as c
 from sqlmesh.core.config import load_configs
 from sqlmesh.core.console import create_console, set_console, configure_console
 from sqlmesh.core.context import Context
 from sqlmesh.core.dialect import format_model_expressions, parse
 from sqlmesh.core.model import load_sql_based_model
-from sqlmesh.core.test import ModelTestMetadata, get_all_model_tests
+from sqlmesh.core.test import ModelTestMetadata, load_model_tests
 from sqlmesh.utils import sqlglot_dialects, yaml, Verbosity
 from sqlmesh.utils.errors import MagicError, MissingContextException, SQLMeshError
 
@@ -273,15 +272,7 @@ class SQLMeshMagics(Magics):
         if not args.test_name and not args.ls:
             raise MagicError("Must provide either test name or `--ls` to list tests")
 
-        test_meta = []
-
-        for path, config in context.configs.items():
-            test_meta.extend(
-                get_all_model_tests(
-                    path / c.TESTS,
-                    ignore_patterns=config.ignore_patterns,
-                )
-            )
+        test_meta = load_model_tests(loaders=context._loaders)
 
         tests: t.Dict[str, t.Dict[str, ModelTestMetadata]] = defaultdict(dict)
         for model_test_metadata in test_meta:

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -31,7 +31,7 @@ from sqlmesh.core.console import create_console, set_console, configure_console
 from sqlmesh.core.context import Context
 from sqlmesh.core.dialect import format_model_expressions, parse
 from sqlmesh.core.model import load_sql_based_model
-from sqlmesh.core.test import ModelTestMetadata, load_model_tests
+from sqlmesh.core.test import ModelTestMetadata
 from sqlmesh.utils import sqlglot_dialects, yaml, Verbosity
 from sqlmesh.utils.errors import MagicError, MissingContextException, SQLMeshError
 
@@ -272,7 +272,7 @@ class SQLMeshMagics(Magics):
         if not args.test_name and not args.ls:
             raise MagicError("Must provide either test name or `--ls` to list tests")
 
-        test_meta = load_model_tests(configs=context.configs, get_variables=context._get_variables)
+        test_meta = context._load_model_tests()
 
         tests: t.Dict[str, t.Dict[str, ModelTestMetadata]] = defaultdict(dict)
         for model_test_metadata in test_meta:

--- a/sqlmesh/utils/yaml.py
+++ b/sqlmesh/utils/yaml.py
@@ -13,10 +13,6 @@ from sqlmesh.core.constants import VAR
 from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.jinja import ENVIRONMENT, create_var
 
-if t.TYPE_CHECKING:
-    from sqlmesh.core.config.loader import C
-
-
 JINJA_METHODS = {
     "env_var": lambda key, default=None: getenv(key, default),
 }
@@ -44,8 +40,7 @@ def load(
     render_jinja: bool = True,
     allow_duplicate_keys: bool = False,
     variables: t.Optional[t.Dict[str, t.Any]] = None,
-    config: t.Optional[C] = None,
-    get_variables: t.Callable[[t.Optional[C], t.Optional[str]], t.Dict[str, str]] | None = None,
+    get_variables: t.Callable[[t.Optional[str]], t.Dict[str, str]] | None = None,
 ) -> t.Dict:
     """Loads a YAML object from either a raw string or a file."""
     path: t.Optional[Path] = None
@@ -62,7 +57,7 @@ def load(
         gateway_line = GATEWAY_PATTERN.search(source)
         gateway = yaml.load(gateway_line.group(0))["gateway"] if gateway_line else None
 
-        variables = get_variables(config, gateway)
+        variables = get_variables(gateway)
 
     if render_jinja:
         source = ENVIRONMENT.from_string(source).render(

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -1619,7 +1619,7 @@ test_parameterized_model_names:
     # Case 2: Test gateway variables
     context.config = Config(
         gateways={
-            "main": GatewayConfig(connection=DuckDBConnectionConfig(), variables=variables),
+            "": GatewayConfig(connection=DuckDBConnectionConfig(), variables=variables),
         },
         model_defaults=ModelDefaultsConfig(dialect="duckdb"),
     )
@@ -1633,7 +1633,7 @@ test_parameterized_model_names:
     # Case 3: Test gateway variables overriding root variables
     context.config = Config(
         gateways={
-            "main": GatewayConfig(connection=DuckDBConnectionConfig(), variables=variables),
+            "": GatewayConfig(connection=DuckDBConnectionConfig(), variables=variables),
         },
         model_defaults=ModelDefaultsConfig(dialect="duckdb"),
         variables={"gold": "foo", "silver": "bar"},

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -2319,7 +2319,6 @@ def test_number_of_tests_found(tmp_path: Path) -> None:
         """
 test_example_full_model1:
   model: sqlmesh_example.full_model
-  description: This is an invalid test
   inputs:
     sqlmesh_example.incremental_model:
       rows:
@@ -2339,7 +2338,6 @@ test_example_full_model1:
         
 test_example_full_model2:
   model: sqlmesh_example.full_model
-  description: This is an invalid test
   inputs:
     sqlmesh_example.incremental_model:
       rows:

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -2363,7 +2363,7 @@ test_example_full_model2:
     results = context.test()
     assert len(results.successes) == 3
 
-    # Case 1: The "new_test.yaml" should amount to 2 subtests
+    # Case 2: The "new_test.yaml" should amount to 2 subtests
     results = context.test(tests=[f"{test_file}"])
     assert len(results.successes) == 2
 


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/4068

This PR addresses the following items:

- [Fix] https://github.com/TobikoData/sqlmesh/pull/4047 did not properly handle cases where the model doesn't exist, the errors should be caught

- [Fix] The testing module only takes `config.variables` into account; This is now extended to also use the selected gateway's variables

- [Refactor] The APIs for loading & running tests are fragmented into multiple points e.g `run_model_tests` and `run_tests`. To address that, this PR attempts to unify the test loading+running logic.