### PR TITLE
fix: correctly have scd models depend on past

### DIFF
--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -131,14 +131,14 @@ class ModelKindMixin:
     @property
     def full_history_restatement_only(self) -> bool:
         """Whether or not this model only supports restatement of full history."""
-        return self.model_kind_name in (
-            ModelKindName.INCREMENTAL_UNMANAGED,
-            ModelKindName.INCREMENTAL_BY_UNIQUE_KEY,
-            ModelKindName.INCREMENTAL_BY_PARTITION,
-            ModelKindName.SCD_TYPE_2,
-            ModelKindName.MANAGED,
-            ModelKindName.FULL,
-            ModelKindName.VIEW,
+        return (
+            self.is_incremental_unmanaged
+            or self.is_incremental_by_unique_key
+            or self.is_incremental_by_partition
+            or self.is_scd_type_2
+            or self.is_managed
+            or self.is_full
+            or self.is_view
         )
 
     @property

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -8665,3 +8665,10 @@ def test_data_hash_unchanged_when_column_type_uses_default_dialect():
 
     # int == int64 in bigquery
     assert model.data_hash == deserialized_model.data_hash
+
+
+def test_scd_type_2_full_history_restatement():
+    assert ModelKindName.SCD_TYPE_2.full_history_restatement_only is True
+    assert ModelKindName.SCD_TYPE_2_BY_TIME.full_history_restatement_only is True
+    assert ModelKindName.SCD_TYPE_2_BY_COLUMN.full_history_restatement_only is True
+    assert ModelKindName.INCREMENTAL_BY_TIME_RANGE.full_history_restatement_only is False


### PR DESCRIPTION
`ModelKindName.SCD_TYPE_2` is a legacy model kind name that represents an SCD Type 2 by time model. So the prior logic said that only legacy SCD Type 2 by time models had full history restatements when the intention was for all of them to have it. 