### PR TITLE
Feat: print CLI messages when no physical layer or model evals occurred

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1303,7 +1303,7 @@ class TerminalConsole(Console):
         ):
             self._print(
                 Tree(
-                    f"[bold]Differences from the `{context_diff.create_from if context_diff.is_new_environment else context_diff.environment}` environment:\n"
+                    f"\n[bold]Differences from the `{context_diff.create_from if context_diff.is_new_environment else context_diff.environment}` environment:\n"
                 )
             )
 

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from enum import Enum
 import logging
 import typing as t
 from sqlglot import exp
@@ -31,6 +30,7 @@ from sqlmesh.core.snapshot.definition import (
     parent_snapshots_by_name,
 )
 from sqlmesh.core.state_sync import StateSync
+from sqlmesh.utils import CompletionStatus
 from sqlmesh.utils.concurrency import concurrent_apply_to_dag, NodeExecutionFailedError
 from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.date import (
@@ -46,24 +46,6 @@ SnapshotToIntervals = t.Dict[Snapshot, Intervals]
 # we store snapshot name instead of snapshots/snapshotids because pydantic
 # is extremely slow to hash. snapshot names should be unique within a dag run
 SchedulingUnit = t.Tuple[str, t.Tuple[Interval, int]]
-
-
-class CompletionStatus(Enum):
-    SUCCESS = "success"
-    FAILURE = "failure"
-    NOTHING_TO_DO = "nothing_to_do"
-
-    @property
-    def is_success(self) -> bool:
-        return self == CompletionStatus.SUCCESS
-
-    @property
-    def is_failure(self) -> bool:
-        return self == CompletionStatus.FAILURE
-
-    @property
-    def is_nothing_to_do(self) -> bool:
-        return self == CompletionStatus.NOTHING_TO_DO
 
 
 class Scheduler:

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -51,7 +51,7 @@ from sqlmesh.core.model import (
     ViewKind,
     CustomKind,
 )
-
+from sqlmesh.utils import CompletionStatus
 from sqlmesh.core.schema_diff import has_drop_alteration, get_dropped_column_names
 from sqlmesh.core.snapshot import (
     DeployabilityIndex,
@@ -287,10 +287,9 @@ class SnapshotEvaluator:
         snapshots: t.Dict[SnapshotId, Snapshot],
         deployability_index: t.Optional[DeployabilityIndex] = None,
         on_start: t.Optional[t.Callable] = None,
-        on_no_work: t.Optional[t.Callable] = None,
         on_complete: t.Optional[t.Callable[[SnapshotInfoLike], None]] = None,
         allow_destructive_snapshots: t.Optional[t.Set[str]] = None,
-    ) -> None:
+    ) -> CompletionStatus:
         """Creates a physical snapshot schema and table for the given collection of snapshots.
 
         Args:
@@ -298,9 +297,11 @@ class SnapshotEvaluator:
             snapshots: Mapping of snapshot ID to snapshot.
             deployability_index: Determines snapshots that are deployable in the context of this creation.
             on_start: A callback to initialize the snapshot creation progress bar.
-            on_no_work: A callback to call when no snapshots are to be created.
             on_complete: A callback to call on each successfully created snapshot.
             allow_destructive_snapshots: Set of snapshots that are allowed to have destructive schema changes.
+
+        Returns:
+            CompletionStatus: The status of the creation operation (success, failure, nothing to do).
         """
         snapshots_with_table_names = defaultdict(set)
         tables_by_gateway_and_schema: t.Dict[t.Union[str, None], t.Dict[exp.Table, set[str]]] = (
@@ -368,9 +369,7 @@ class SnapshotEvaluator:
                 target_deployability_flags[snapshot.name].sort()
 
         if not snapshots_to_create:
-            if on_no_work:
-                on_no_work("\n[green]SKIP: No physical layer updates to perform[/green]\n")
-            return
+            return CompletionStatus.NOTHING_TO_DO
         if on_start:
             on_start(len(snapshots_to_create))
 
@@ -385,6 +384,7 @@ class SnapshotEvaluator:
             on_complete=on_complete,
             allow_destructive_snapshots=allow_destructive_snapshots,
         )
+        return CompletionStatus.SUCCESS
 
     def _create_snapshots(
         self,

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -287,6 +287,7 @@ class SnapshotEvaluator:
         snapshots: t.Dict[SnapshotId, Snapshot],
         deployability_index: t.Optional[DeployabilityIndex] = None,
         on_start: t.Optional[t.Callable] = None,
+        on_no_work: t.Optional[t.Callable] = None,
         on_complete: t.Optional[t.Callable[[SnapshotInfoLike], None]] = None,
         allow_destructive_snapshots: t.Optional[t.Set[str]] = None,
     ) -> None:
@@ -297,6 +298,7 @@ class SnapshotEvaluator:
             snapshots: Mapping of snapshot ID to snapshot.
             deployability_index: Determines snapshots that are deployable in the context of this creation.
             on_start: A callback to initialize the snapshot creation progress bar.
+            on_no_work: A callback to call when no snapshots are to be created.
             on_complete: A callback to call on each successfully created snapshot.
             allow_destructive_snapshots: Set of snapshots that are allowed to have destructive schema changes.
         """
@@ -366,6 +368,8 @@ class SnapshotEvaluator:
                 target_deployability_flags[snapshot.name].sort()
 
         if not snapshots_to_create:
+            if on_no_work:
+                on_no_work("\n[green]SKIP: No physical layer updates to perform[/green]\n")
             return
         if on_start:
             on_start(len(snapshots_to_create))

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -16,7 +16,7 @@ import uuid
 from collections import defaultdict
 from contextlib import contextmanager
 from copy import deepcopy
-from enum import IntEnum
+from enum import IntEnum, Enum
 from functools import lru_cache, reduce, wraps
 from pathlib import Path
 
@@ -346,3 +346,21 @@ class Verbosity(IntEnum):
     DEFAULT = 0
     VERBOSE = 1
     VERY_VERBOSE = 2
+
+
+class CompletionStatus(Enum):
+    SUCCESS = "success"
+    FAILURE = "failure"
+    NOTHING_TO_DO = "nothing_to_do"
+
+    @property
+    def is_success(self) -> bool:
+        return self == CompletionStatus.SUCCESS
+
+    @property
+    def is_failure(self) -> bool:
+        return self == CompletionStatus.FAILURE
+
+    @property
+    def is_nothing_to_do(self) -> bool:
+        return self == CompletionStatus.NOTHING_TO_DO

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -154,10 +154,6 @@ def assert_plan_success(result, new_env="prod", from_env="prod") -> None:
     assert_backfill_success(result)
 
 
-def assert_virtual_update(result) -> None:
-    assert "Virtual Update executed" in result.output
-
-
 def test_version(runner, tmp_path):
     from sqlmesh import __version__ as SQLMESH_VERSION
 
@@ -275,7 +271,7 @@ def test_plan_skip_backfill(runner, tmp_path, flag):
         input="y\n",
     )
     assert result.exit_code == 0
-    assert_virtual_update(result)
+    assert_virtual_layer_updated(result)
     assert "Model batches executed" not in result.output
 
 
@@ -404,8 +400,9 @@ def test_plan_dev_create_from_virtual(runner, tmp_path):
     )
     assert result.exit_code == 0
     assert_new_env(result, "dev2", "dev", initialize=False)
+    assert "SKIP: No physical layer updates to perform" in result.output
+    assert "SKIP: No model batches to execute" in result.output
     assert_virtual_layer_updated(result)
-    assert_virtual_update(result)
 
 
 def test_plan_dev_create_from(runner, tmp_path):
@@ -542,7 +539,6 @@ def test_plan_dev_no_changes(runner, tmp_path):
     assert result.exit_code == 0
     assert_new_env(result, "dev", initialize=False)
     assert_virtual_layer_updated(result)
-    assert_virtual_update(result)
 
 
 def test_plan_nonbreaking(runner, tmp_path):


### PR DESCRIPTION
When a plan only performs a virtual update, no physical layer updates or model evaluations occur.

Currently, there is no CLI output indicating that the physical layer updates and model evaluations were skipped on purpose (the progress bars just don't appear).

This PR adds messages indicating that the physical layer updates and/or model evaluations were skipped:
- Physical: `SKIP: No physical layer updates to perform`
- Models: `SKIP: No model batches to execute`