### PR TITLE
Feat: Improve the cli before all after all diff and include python env

### DIFF
--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -16,7 +16,8 @@ from sqlmesh.core.model.common import (
     default_catalog_validator,
     depends_on_validator,
     expression_validator,
-    python_env_payloads,
+    sort_python_env,
+    sorted_python_env_payloads,
 )
 from sqlmesh.core.model.common import make_python_env, single_value_or_tuple
 from sqlmesh.core.node import _Node
@@ -237,7 +238,7 @@ class StandaloneAudit(_Node, AuditMixin):
     @property
     def sorted_python_env(self) -> t.List[t.Tuple[str, Executable]]:
         """Returns the python env sorted by executable kind and then var name."""
-        return sorted(self.python_env.items(), key=lambda x: (x[1].kind, x[0]))
+        return sort_python_env(self.python_env)
 
     @property
     def data_hash(self) -> str:
@@ -338,7 +339,7 @@ class StandaloneAudit(_Node, AuditMixin):
         jinja_expressions = []
         python_expressions = []
         if include_python:
-            python_env = d.PythonCode(expressions=python_env_payloads(self.sorted_python_env))
+            python_env = d.PythonCode(expressions=sorted_python_env_payloads(self.python_env))
             if python_env.expressions:
                 python_expressions.append(python_env)
 

--- a/sqlmesh/core/audit/definition.py
+++ b/sqlmesh/core/audit/definition.py
@@ -16,6 +16,7 @@ from sqlmesh.core.model.common import (
     default_catalog_validator,
     depends_on_validator,
     expression_validator,
+    python_env_payloads,
 )
 from sqlmesh.core.model.common import make_python_env, single_value_or_tuple
 from sqlmesh.core.node import _Node
@@ -337,12 +338,7 @@ class StandaloneAudit(_Node, AuditMixin):
         jinja_expressions = []
         python_expressions = []
         if include_python:
-            python_env = d.PythonCode(
-                expressions=[
-                    v.payload if v.is_import or v.is_definition else f"{k} = {v.payload}"
-                    for k, v in self.sorted_python_env
-                ]
-            )
+            python_env = d.PythonCode(expressions=python_env_payloads(self.sorted_python_env))
             if python_env.expressions:
                 python_expressions.append(python_env)
 

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1311,9 +1311,9 @@ class TerminalConsole(Console):
             self._print(f"[bold]Requirements:\n{context_diff.requirements_diff()}")
 
         if context_diff.has_environment_statements_changes:
-            self._print(
-                f"[bold]Environment statements:\n{context_diff.environment_statements_diff()}"
-            )
+            self._print("[bold]Environment statements:\n")
+            for changes in context_diff.environment_statements_diff():
+                self._print(changes)
 
         self._show_summary_tree_for(
             context_diff,
@@ -2463,7 +2463,9 @@ class MarkdownConsole(CaptureTerminalConsole):
             self._print(f"Requirements:\n{context_diff.requirements_diff()}")
 
         if context_diff.has_environment_statements_changes:
-            self._print(f"Environment statements:\n{context_diff.environment_statements_diff()}")
+            self._print("[bold]Environment statements:\n")
+            for changes in context_diff.environment_statements_diff():
+                self._print(changes)
 
         added_snapshots = {context_diff.snapshots[s_id] for s_id in context_diff.added}
         added_snapshot_models = {s for s in added_snapshots if s.is_model}
@@ -2976,7 +2978,9 @@ class DebuggerTerminalConsole(TerminalConsole):
             self._write(f"Requirements:\n{context_diff.requirements_diff()}")
 
         if context_diff.has_environment_statements_changes:
-            self._write(f"Environment statements:\n{context_diff.environment_statements_diff()}")
+            self._write("Environment statements:\n")
+            for changes in context_diff.environment_statements_diff():
+                self._write(changes)
 
         for added in context_diff.new_snapshots:
             self._write(f"  Added: {added}")

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1312,8 +1312,8 @@ class TerminalConsole(Console):
 
         if context_diff.has_environment_statements_changes:
             self._print("[bold]Environment statements:\n")
-            for changes in context_diff.environment_statements_diff():
-                self._print(changes)
+            for type, diff in context_diff.environment_statements_diff():
+                self._print(Syntax(diff, type, line_numbers=False))
 
         self._show_summary_tree_for(
             context_diff,
@@ -2464,8 +2464,8 @@ class MarkdownConsole(CaptureTerminalConsole):
 
         if context_diff.has_environment_statements_changes:
             self._print("[bold]Environment statements:\n")
-            for changes in context_diff.environment_statements_diff():
-                self._print(changes)
+            for _, diff in context_diff.environment_statements_diff():
+                self._print(diff)
 
         added_snapshots = {context_diff.snapshots[s_id] for s_id in context_diff.added}
         added_snapshot_models = {s for s in added_snapshots if s.is_model}
@@ -2979,8 +2979,8 @@ class DebuggerTerminalConsole(TerminalConsole):
 
         if context_diff.has_environment_statements_changes:
             self._write("Environment statements:\n")
-            for changes in context_diff.environment_statements_diff():
-                self._write(changes)
+            for _, diff in context_diff.environment_statements_diff():
+                self._write(diff)
 
         for added in context_diff.new_snapshots:
             self._write(f"  Added: {added}")

--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -368,7 +368,11 @@ class ContextDiff(PydanticModel):
             if previous == current:
                 return None
 
-            diff_text = f"=== {attribute if not attribute == PYTHON_ENV else "dependencies"} ===\n"
+            diff_text = (
+                f"=== {attribute} ===\n"
+                if not attribute == PYTHON_ENV
+                else "=== dependencies ===\n"
+            )
 
             diff_lines = list(ndiff(previous, current))
             if any(line.startswith(("-", "+")) for line in diff_lines):

--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -352,11 +352,16 @@ def depends_on(cls: t.Type, v: t.Any, info: ValidationInfo) -> t.Optional[t.Set[
     return v
 
 
-def python_env_payloads(sorted_python_env: t.List[t.Tuple[str, Executable]]) -> t.List[str]:
+def sort_python_env(python_env: t.Dict[str, Executable]) -> t.List[t.Tuple[str, Executable]]:
+    """Returns the python env sorted."""
+    return sorted(python_env.items(), key=lambda x: (x[1].kind, x[0]))
+
+
+def sorted_python_env_payloads(python_env: t.Dict[str, Executable]) -> t.List[str]:
     """Returns the payloads of the sorted python env."""
     return [
         v.payload if v.is_import or v.is_definition else f"{k} = {v.payload}"
-        for k, v in sorted_python_env
+        for k, v in sort_python_env(python_env)
     ]
 
 

--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -352,6 +352,14 @@ def depends_on(cls: t.Type, v: t.Any, info: ValidationInfo) -> t.Optional[t.Set[
     return v
 
 
+def python_env_payloads(sorted_python_env: t.List[t.Tuple[str, Executable]]) -> t.List[str]:
+    """Returns the payloads of the sorted python env."""
+    return [
+        v.payload if v.is_import or v.is_definition else f"{k} = {v.payload}"
+        for k, v in sorted_python_env
+    ]
+
+
 expression_validator: t.Callable = field_validator(
     "query",
     "expressions_",

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -29,8 +29,8 @@ from sqlmesh.core.model.common import (
     expression_validator,
     make_python_env,
     parse_dependencies,
-    python_env_payloads,
     single_value_or_tuple,
+    sorted_python_env_payloads,
 )
 from sqlmesh.core.model.meta import ModelMeta, FunctionCall
 from sqlmesh.core.model.kind import (
@@ -258,7 +258,7 @@ class _Model(ModelMeta, frozen=True):
         jinja_expressions = []
         python_expressions = []
         if include_python:
-            python_env = d.PythonCode(expressions=python_env_payloads(self.sorted_python_env))
+            python_env = d.PythonCode(expressions=sorted_python_env_payloads(self.python_env))
             if python_env.expressions:
                 python_expressions.append(python_env)
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -29,6 +29,7 @@ from sqlmesh.core.model.common import (
     expression_validator,
     make_python_env,
     parse_dependencies,
+    python_env_payloads,
     single_value_or_tuple,
 )
 from sqlmesh.core.model.meta import ModelMeta, FunctionCall
@@ -257,12 +258,7 @@ class _Model(ModelMeta, frozen=True):
         jinja_expressions = []
         python_expressions = []
         if include_python:
-            python_env = d.PythonCode(
-                expressions=[
-                    v.payload if v.is_import or v.is_definition else f"{k} = {v.payload}"
-                    for k, v in self.sorted_python_env
-                ]
-            )
+            python_env = d.PythonCode(expressions=python_env_payloads(self.sorted_python_env))
             if python_env.expressions:
                 python_expressions.append(python_env)
 

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -3024,12 +3024,12 @@ def test_plan_environment_statements_diff(make_snapshot):
     output = console_output.getvalue()
     stripped = strip_ansi_codes(output)
     expected_output = (
-        "=== before_all ===\n"
+        "before_all:\n"
         "  + CREATE OR REPLACE TABLE table_1 AS SELECT 1\n"
         "  + @test_macro()\n\n"
-        "=== after_all ===\n"
+        "after_all:\n"
         "  + CREATE OR REPLACE TABLE table_2 AS SELECT 2\n\n"
-        "=== dependencies ===\n"
+        "dependencies:\n"
         "  + def test_macro(evaluator):\n"
         "    return 'one'"
     )

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -3019,22 +3019,18 @@ def test_plan_environment_statements_diff(make_snapshot):
     assert context_diff.has_environment_statements_changes
 
     console_output, terminal_console = create_test_console()
-
-    for stmt in context_diff.environment_statements_diff():
-        terminal_console._print(stmt)
+    for _, diff in context_diff.environment_statements_diff():
+        terminal_console._print(diff)
     output = console_output.getvalue()
     stripped = strip_ansi_codes(output)
-
     expected_output = (
-        "=== before_all ===                                                              \n"
-        "  + CREATE OR REPLACE TABLE table_1 AS SELECT 1                                 \n"
-        "  + @test_macro()                                                               \n"
-        "                                                                                \n"
-        "=== after_all ===                                                               \n"
-        "  + CREATE OR REPLACE TABLE table_2 AS SELECT 2                                 \n"
-        "                                                                                \n"
-        "=== dependencies ===                                                            \n"
-        "  + def test_macro(evaluator):                                                  \n"
+        "=== before_all ===\n"
+        "  + CREATE OR REPLACE TABLE table_1 AS SELECT 1\n"
+        "  + @test_macro()\n\n"
+        "=== after_all ===\n"
+        "  + CREATE OR REPLACE TABLE table_2 AS SELECT 2\n\n"
+        "=== dependencies ===\n"
+        "  + def test_macro(evaluator):\n"
         "    return 'one'"
     )
     assert stripped == expected_output


### PR DESCRIPTION
This update adds the Python dependencies to the `before all` / `after all` diff and aims to improve the formatting using the Syntax library for consistency with the rest of the diffs. This adds syntax highlighting for Python code in the dependencies section and accordingly for SQL in the statements.

<img width="883" alt="Screenshot 2025-04-14 at 12 23 24" src="https://github.com/user-attachments/assets/9364e7b7-f0fa-4049-8c71-bdea0926ee1a" />

