### PR TITLE
Fix!: MotherDuck Concurrency 

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -9,6 +9,7 @@ import re
 import typing as t
 from enum import Enum
 from functools import partial, lru_cache
+from urllib.parse import urlencode
 
 import pydantic
 from pydantic import Field
@@ -383,16 +384,16 @@ class MotherDuckConnectionConfig(BaseDuckDBConnectionConfig):
 
         connection_str = "md:"
 
-        query_params = []
-        query_params.append(f"custom_user_agent=SQLMesh/{__version__}")
+        query_params = {}
+        query_params["custom_user_agent"] = f"SQLMesh/{__version__}"
         if self.database:
             # Attach single MD database instead of all databases on the account
             connection_str += self.database
-            query_params.append("attach_mode=single")
+            query_params["attach_mode"] = "single"
         if self.token:
-            query_params.append(f"motherduck_token={self.token}")
+            query_params["motherduck_token"] = self.token
 
-        connection_str += f"?{'&'.join(query_params)}"
+        connection_str += f"?{urlencode(query_params)}"
 
         return {"database": connection_str}
 

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -381,14 +381,20 @@ class MotherDuckConnectionConfig(BaseDuckDBConnectionConfig):
         """kwargs that are for execution config only"""
         from sqlmesh import __version__
 
-        custom_user_agent_config = {"custom_user_agent": f"SQLMesh/{__version__}"}
         connection_str = "md:"
+
+        query_params = []
+        query_params.append(f"custom_user_agent=SQLMesh/{__version__}")
         if self.database:
             # Attach single MD database instead of all databases on the account
-            connection_str += f"{self.database}?attach_mode=single"
+            connection_str += self.database
+            query_params.append("attach_mode=single")
         if self.token:
-            connection_str += f"{'&' if self.database else '?'}motherduck_token={self.token}"
-        return {"database": connection_str, "config": custom_user_agent_config}
+            query_params.append(f"motherduck_token={self.token}")
+        
+        connection_str += f"?{'&'.join(query_params)}"
+
+        return {"database": connection_str}
 
 
 class DuckDBConnectionConfig(BaseDuckDBConnectionConfig):

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -391,7 +391,7 @@ class MotherDuckConnectionConfig(BaseDuckDBConnectionConfig):
             query_params.append("attach_mode=single")
         if self.token:
             query_params.append(f"motherduck_token={self.token}")
-        
+
         connection_str += f"?{'&'.join(query_params)}"
 
         return {"database": connection_str}


### PR DESCRIPTION
Addresses #4096: Since `custom_user_agent_config` is a dict it is unhashable and `ThreadLocalConnectionPool` fails when instantiating connections. This only happens when `concurrent_tasks > 1`.

This is not a regression test for this included in the PR because `ThreadLocalConnectionPool` is forcing authentication to MotherDuck. 