### PR TITLE
Fix: metadata status should not overwrite non-metadata status of used macro

### DIFF
--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -74,7 +74,7 @@ def make_python_env(
                 # If this macro has been seen before as a non-metadata macro, prioritize that
                 used_macros[name] = (
                     macros[name],
-                    used_macros.get(name, (None, is_metadata))[1],
+                    used_macros.get(name, (None, is_metadata))[1] and is_metadata,
                 )
                 if name == c.VAR:
                     args = macro_func_or_var.this.expressions
@@ -92,7 +92,7 @@ def make_python_env(
                     # If this macro has been seen before as a non-metadata macro, prioritize that
                     used_macros[name] = (
                         macros[name],
-                        used_macros.get(name, (None, is_metadata))[1],
+                        used_macros.get(name, (None, is_metadata))[1] and is_metadata,
                     )
                 elif name in variables:
                     used_variables.add(name)

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -8824,6 +8824,9 @@ def test_macros_referenced_in_metadata_statements_and_properties_are_metadata_on
             non_zero_c1,
             unique_values(columns := @m2()),
           ),
+          physical_properties (
+            random_prop = @random_prop_macro()
+          ),
         );
 
         SELECT
@@ -8836,6 +8839,7 @@ def test_macros_referenced_in_metadata_statements_and_properties_are_metadata_on
         ON_VIRTUAL_UPDATE_BEGIN;
 
         @bla();
+        @random_prop_macro();
 
         ON_VIRTUAL_UPDATE_END;
 
@@ -8879,6 +8883,10 @@ def zero_metadata(evaluator):
 
 @macro()
 def non_metadata_macro(evaluator):
+    return 1
+
+@macro()
+def random_prop_macro(evaluator):
     return 1"""
 
     test_macros = tmp_path / "macros/test_macros.py"
@@ -8927,7 +8935,7 @@ def test_signal_always_true(batch, arg1, arg2):
 
     python_env = model.python_env
 
-    assert len(python_env) == 12
+    assert len(python_env) == 13
     assert (python_env.get("test_signal_always_true") or empty_executable).is_metadata
     assert (python_env.get("bar") or empty_executable).is_metadata
     assert (python_env.get("m1") or empty_executable).is_metadata
@@ -8945,6 +8953,7 @@ def test_signal_always_true(batch, arg1, arg2):
     # is true for zero_alt, which is referenced in the non_zero_c1 audit.
     assert not (python_env.get("zero_alt") or empty_executable).is_metadata
     assert not (python_env.get("non_metadata_macro") or empty_executable).is_metadata
+    assert not (python_env.get("random_prop_macro") or empty_executable).is_metadata
 
 
 def test_scd_type_2_full_history_restatement():


### PR DESCRIPTION
Noticed this somehow slipped through my testing, but I managed to reproduce an erroneous behavior locally.

Given this model:

```
MODEL (
  name test,
  kind FULL,
  physical_properties (
    foo = @foo()
  ),
);

SELECT
  1 AS c;

ON_VIRTUAL_UPDATE_BEGIN;

SELECT @foo() AS foo;

ON_VIRTUAL_UPDATE_END;
```

and this macro:

```python
from sqlmesh import macro

@macro()
def foo(evaluator):
    return 1
```

Current main branch serializes `foo` as metadata-only:

```
D .mode ascii
D select snapshot -> 'node' -> 'python_env' from sqlmesh._snapshots;
(("snapshot" -> 'node') -> 'python_env')
{"foo":{"payload":"def foo(evaluator):\n    return 1","kind":"definition","name":"foo","path":"macros/macro.py","is_metadata":true}}
```