### PR TITLE
feat: add custom exception for signal eval errors

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -38,7 +38,7 @@ from sqlmesh.utils.date import (
     validate_date_range,
     yesterday,
 )
-from sqlmesh.utils.errors import SQLMeshError
+from sqlmesh.utils.errors import SQLMeshError, SignalEvalError
 from sqlmesh.utils.metaprogramming import prepare_env, print_exception
 from sqlmesh.utils.hashing import hash_data
 from sqlmesh.utils.pydantic import PydanticModel, field_validator
@@ -2172,7 +2172,7 @@ def _check_ready_intervals(
                 context=context,
             )
         except Exception:
-            raise SQLMeshError("Error evaluating signal")
+            raise SignalEvalError("Error evaluating signal")
 
         if isinstance(ready_intervals, bool):
             if not ready_intervals:

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -2171,8 +2171,8 @@ def _check_ready_intervals(
                 provided_kwargs=(kwargs or {}),
                 context=context,
             )
-        except Exception:
-            raise SignalEvalError("Error evaluating signal")
+        except Exception as ex:
+            raise SignalEvalError("Error evaluating signal") from ex
 
         if isinstance(ready_intervals, bool):
             if not ready_intervals:
@@ -2180,10 +2180,10 @@ def _check_ready_intervals(
         elif isinstance(ready_intervals, list):
             for i in ready_intervals:
                 if i not in batch:
-                    raise SQLMeshError(f"Unknown interval {i} for signal")
+                    raise SignalEvalError(f"Unknown interval {i} for signal")
             batch = ready_intervals
         else:
-            raise SQLMeshError(f"Expected bool | list, got {type(ready_intervals)} for signal")
+            raise SignalEvalError(f"Expected bool | list, got {type(ready_intervals)} for signal")
 
         checked_intervals.extend((to_timestamp(start), to_timestamp(end)) for start, end in batch)
 

--- a/sqlmesh/utils/errors.py
+++ b/sqlmesh/utils/errors.py
@@ -181,6 +181,8 @@ class LinterError(SQLMeshError):
 
 
 class SignalEvalError(SQLMeshError):
+    """Errors when evaluating a signal that is because of a user mistake and not a SQLMesh bug."""
+
     pass
 
 

--- a/sqlmesh/utils/errors.py
+++ b/sqlmesh/utils/errors.py
@@ -180,6 +180,10 @@ class LinterError(SQLMeshError):
     pass
 
 
+class SignalEvalError(SQLMeshError):
+    pass
+
+
 def raise_config_error(
     msg: str,
     location: t.Optional[str | Path] = None,

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -2571,12 +2571,15 @@ def test_check_ready_intervals(mocker: MockerFixture):
         [[(0, 1)], [(3, 4)]],
         [(0, 1), (3, 4)],
     )
-    with pytest.raises(SignalEvalError):
+    with pytest.raises(SignalEvalError) as excinfo:
         _check_ready_intervals(
-            lambda _: (_ for _ in ()).throw(Exception("Some exception")),
+            lambda _: (_ for _ in ()).throw(MemoryError("Some exception")),
             [(0, 1), (1, 2)],
             mocker.Mock(),
         )
+
+    assert isinstance(excinfo.value.__cause__, MemoryError)
+    assert str(excinfo.value.__cause__) == "Some exception"
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -63,7 +63,7 @@ from sqlmesh.core.snapshot.definition import (
 )
 from sqlmesh.utils import AttributeDict
 from sqlmesh.utils.date import DatetimeRanges, to_date, to_datetime, to_timestamp
-from sqlmesh.utils.errors import SQLMeshError
+from sqlmesh.utils.errors import SQLMeshError, SignalEvalError
 from sqlmesh.utils.jinja import JinjaMacroRegistry, MacroInfo
 from sqlmesh.core.console import get_console
 
@@ -2571,6 +2571,12 @@ def test_check_ready_intervals(mocker: MockerFixture):
         [[(0, 1)], [(3, 4)]],
         [(0, 1), (3, 4)],
     )
+    with pytest.raises(SignalEvalError):
+        _check_ready_intervals(
+            lambda _: (_ for _ in ()).throw(Exception("Some exception")),
+            [(0, 1), (1, 2)],
+            mocker.Mock(),
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Signal evaluation errors are user errors that we want to properly catch