### PR TITLE
fix: include stacktrace in signal eval error message

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -39,7 +39,12 @@ from sqlmesh.utils.date import (
     yesterday,
 )
 from sqlmesh.utils.errors import SQLMeshError, SignalEvalError
-from sqlmesh.utils.metaprogramming import prepare_env, print_exception
+from sqlmesh.utils.metaprogramming import (
+    prepare_env,
+    print_exception,
+    format_evaluated_code_exception,
+    Executable,
+)
 from sqlmesh.utils.hashing import hash_data
 from sqlmesh.utils.pydantic import PydanticModel, field_validator
 
@@ -962,6 +967,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
                     env[signal_name],
                     intervals,
                     context,
+                    python_env=python_env,
                     dialect=self.model.dialect,
                     path=self.model._path,
                     kwargs=kwargs,
@@ -2153,6 +2159,7 @@ def _check_ready_intervals(
     check: t.Callable,
     intervals: Intervals,
     context: ExecutionContext,
+    python_env: t.Dict[str, Executable],
     dialect: DialectType = None,
     path: Path = Path(),
     kwargs: t.Optional[t.Dict] = None,
@@ -2172,7 +2179,7 @@ def _check_ready_intervals(
                 context=context,
             )
         except Exception as ex:
-            raise SignalEvalError("Error evaluating signal") from ex
+            raise SignalEvalError(format_evaluated_code_exception(ex, python_env))
 
         if isinstance(ready_intervals, bool):
             if not ready_intervals:

--- a/sqlmesh/utils/errors.py
+++ b/sqlmesh/utils/errors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import traceback
 import typing as t
 from enum import auto
 from pathlib import Path

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -539,7 +539,9 @@ def format_evaluated_code_exception(
     for error_line in format_exception(exception):
         traceback_match = error_line.startswith("Traceback (most recent call last):")
         model_def_match = re.search('File ".*?core/model/definition.py', error_line)
-        if traceback_match or model_def_match:
+        snapshot_def_match = re.search('File ".*?core/snapshot/definition.py', error_line)
+        core_macros_match = re.search('File ".*?core/macros.py', error_line)
+        if traceback_match or model_def_match or snapshot_def_match or core_macros_match:
             continue
 
         error_match = re.search("^.*?Error: ", error_line)

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -2499,7 +2499,10 @@ def test_contiguous_intervals():
 
 def test_check_ready_intervals(mocker: MockerFixture):
     def assert_always_signal(intervals):
-        assert _check_ready_intervals(lambda _: True, intervals, mocker.Mock()) == intervals
+        assert (
+            _check_ready_intervals(lambda _: True, intervals, mocker.Mock(), mocker.Mock())
+            == intervals
+        )
 
     assert_always_signal([])
     assert_always_signal([(0, 1)])
@@ -2507,7 +2510,9 @@ def test_check_ready_intervals(mocker: MockerFixture):
     assert_always_signal([(0, 1), (2, 3)])
 
     def assert_never_signal(intervals):
-        assert _check_ready_intervals(lambda _: False, intervals, mocker.Mock()) == []
+        assert (
+            _check_ready_intervals(lambda _: False, intervals, mocker.Mock(), mocker.Mock()) == []
+        )
 
     assert_never_signal([])
     assert_never_signal([(0, 1)])
@@ -2515,7 +2520,7 @@ def test_check_ready_intervals(mocker: MockerFixture):
     assert_never_signal([(0, 1), (2, 3)])
 
     def assert_empty_signal(intervals):
-        assert _check_ready_intervals(lambda _: [], intervals, mocker.Mock()) == []
+        assert _check_ready_intervals(lambda _: [], intervals, mocker.Mock(), mocker.Mock()) == []
 
     assert_empty_signal([])
     assert_empty_signal([(0, 1)])
@@ -2532,7 +2537,7 @@ def test_check_ready_intervals(mocker: MockerFixture):
     ):
         mock = mocker.Mock()
         mock.side_effect = [to_intervals(r) for r in ready]
-        _check_ready_intervals(mock, intervals, mocker.Mock()) == expected
+        _check_ready_intervals(mock, intervals, mocker.Mock(), mocker.Mock()) == expected
 
     assert_check_intervals([], [], [])
     assert_check_intervals([(0, 1)], [[]], [])
@@ -2571,15 +2576,14 @@ def test_check_ready_intervals(mocker: MockerFixture):
         [[(0, 1)], [(3, 4)]],
         [(0, 1), (3, 4)],
     )
-    with pytest.raises(SignalEvalError) as excinfo:
+
+    with pytest.raises(SignalEvalError):
         _check_ready_intervals(
             lambda _: (_ for _ in ()).throw(MemoryError("Some exception")),
             [(0, 1), (1, 2)],
             mocker.Mock(),
+            mocker.Mock(),
         )
-
-    assert isinstance(excinfo.value.__cause__, MemoryError)
-    assert str(excinfo.value.__cause__) == "Some exception"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Use the `format_evaluated_code_exception` to properly format the exception for the python env. 