### PR TITLE
Fix: Handle macros in model properties when formatting

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -635,7 +635,7 @@ def _props_sql(self: Generator, expressions: t.List[exp.Expression]) -> str:
 
     for i, prop in enumerate(expressions):
         if isinstance(prop, MacroFunc):
-            sql = self.indent(f"{self.sql(prop, comment=False)}")
+            sql = self.indent(self.sql(prop, comment=False))
         else:
             sql = self.indent(f"{prop.name} {self.sql(prop, 'value')}")
 

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -634,7 +634,10 @@ def _props_sql(self: Generator, expressions: t.List[exp.Expression]) -> str:
     size = len(expressions)
 
     for i, prop in enumerate(expressions):
-        sql = self.indent(f"{prop.name} {self.sql(prop, 'value')}")
+        if isinstance(prop, MacroFunc):
+            sql = self.indent(f"{self.sql(prop, comment=False)}")
+        else:
+            sql = self.indent(f"{prop.name} {self.sql(prop, 'value')}")
 
         if i < size - 1:
             sql += ","

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -26,6 +26,7 @@ def test_format_model_expressions():
      a,
      (b, c) as d,
      ),  -- c
+       @macro_prop_with_comment(proper := 'foo'), -- k
      audits [
     not_null(columns=[
       foo_id,
@@ -91,6 +92,7 @@ def test_format_model_expressions():
   name a.b, /* a */
   kind FULL, /* b */
   references (a, (b, c) AS d), /* c */
+  @macro_prop_with_comment(proper := 'foo'), /* k */
   audits ARRAY(
     NOT_NULL(
       columns = ARRAY(
@@ -269,7 +271,7 @@ def test_format_body_macros():
         format_model_expressions(
             parse(
                 """
-    Model ( name foo );
+    Model ( name foo , @macro_dialect(), @properties_macro(prop_1 := 'max', prop_2 := 33));
     @WITH(TRUE) x AS (SELECT 1)
     SELECT col::int
     FROM foo
@@ -281,7 +283,9 @@ def test_format_body_macros():
             )
         )
         == """MODEL (
-  name foo
+  name foo,
+  @macro_dialect(),
+  @properties_macro(prop_1 := 'max', prop_2 := 33)
 );
 
 @WITH(TRUE) x AS (


### PR DESCRIPTION
This fixes an issue in formatting [model meta properties that have macro functions](https://github.com/TobikoData/sqlmesh/pull/2574) by handling them in `_props_sql` to account for macro funcs. 

Relevant slack thread: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1744698810151999?thread_ts=1741243847.726999&cid=C044BRE5W4S