### PR TITLE
Feat: Add a janitor configuration that allows to warn instead of failing if it fails to delete an expired environment schema / view 

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -104,6 +104,16 @@ Formatting settings for the `sqlmesh format` command and UI.
 | `append_newline`      | Whether to append a newline to the end of the file (Default: False)                            | boolean |    N     |
 | `no_rewrite_casts`    | Preserve the existing casts, without rewriting them to use the :: syntax. (Default: False)                  | boolean |    N     |
 
+
+## Janitor
+
+Configuration for the `sqlmesh janitor` command.
+
+| Option                   | Description                                                                                                                | Type    | Required |
+|--------------------------|----------------------------------------------------------------------------------------------------------------------------|:-------:|:--------:|
+| `warn_on_delete_failure` | Whether to warn instead of erroring if the janitor fails to delete the expired environment schema / views (Default: False) | boolean | N        |
+
+
 ## UI
 
 SQLMesh UI settings.

--- a/sqlmesh/core/config/janitor.py
+++ b/sqlmesh/core/config/janitor.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import typing as t
+
+from sqlmesh.core.config.base import BaseConfig
+
+
+class JanitorConfig(BaseConfig):
+    """The configuration for the janitor.
+
+    Args:
+        warn_on_delete_failure: Whether to warn instead of erroring if the janitor fails to delete the expired environment schema / views.
+    """
+
+    warn_on_delete_failure: bool = False

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -25,6 +25,7 @@ from sqlmesh.core.config.connection import (
 from sqlmesh.core.config.feature_flag import FeatureFlag
 from sqlmesh.core.config.format import FormatConfig
 from sqlmesh.core.config.gateway import GatewayConfig
+from sqlmesh.core.config.janitor import JanitorConfig
 from sqlmesh.core.config.migration import MigrationConfig
 from sqlmesh.core.config.model import ModelDefaultsConfig
 from sqlmesh.core.config.naming import NameInferenceConfig as NameInferenceConfig
@@ -128,6 +129,7 @@ class Config(BaseConfig):
     before_all: t.Optional[t.List[str]] = None
     after_all: t.Optional[t.List[str]] = None
     linter: LinterConfig = LinterConfig()
+    janitor: JanitorConfig = JanitorConfig()
 
     _FIELD_UPDATE_STRATEGY: t.ClassVar[t.Dict[str, UpdateStrategy]] = {
         "gateways": UpdateStrategy.NESTED_UPDATE,

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -2292,6 +2292,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             default_adapter=self.engine_adapter,
             engine_adapters=self.engine_adapters,
             environments=expired_environments,
+            warn_on_delete_failure=self.config.janitor.warn_on_delete_failure,
             console=self.console,
         )
 

--- a/sqlmesh/core/state_sync/common.py
+++ b/sqlmesh/core/state_sync/common.py
@@ -26,6 +26,7 @@ def cleanup_expired_views(
     default_adapter: EngineAdapter,
     engine_adapters: t.Dict[str, EngineAdapter],
     environments: t.List[Environment],
+    warn_on_delete_failure: bool = False,
     console: t.Optional[Console] = None,
 ) -> None:
     expired_schema_environments = [
@@ -66,9 +67,11 @@ def cleanup_expired_views(
             if console:
                 console.update_cleanup_progress(schema.sql(dialect=engine_adapter.dialect))
         except Exception as e:
-            raise SQLMeshError(
-                f"Failed to drop the expired environment schema '{schema}': {e}"
-            ) from e
+            message = f"Failed to drop the expired environment schema '{schema}': {e}"
+            if warn_on_delete_failure:
+                logger.warning(message)
+            else:
+                raise SQLMeshError(message) from e
 
     # Drop the views for the expired environments
     for engine_adapter, expired_view in {
@@ -87,9 +90,11 @@ def cleanup_expired_views(
             if console:
                 console.update_cleanup_progress(expired_view)
         except Exception as e:
-            raise SQLMeshError(
-                f"Failed to drop the expired environment view '{expired_view}': {e}"
-            ) from e
+            message = f"Failed to drop the expired environment view '{expired_view}': {e}"
+            if warn_on_delete_failure:
+                logger.warning(message)
+            else:
+                raise SQLMeshError(message) from e
 
 
 def transactional() -> t.Callable[[t.Callable], t.Callable]:


### PR DESCRIPTION
This allows users to restore the janitor's previous behavior.