### PR TITLE
Chore: Refine environment statements cli output

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -282,7 +282,7 @@ class Console(LinterConsole, StateExporterConsole, StateImporterConsole, Janitor
         """Stop the environment migration progress."""
 
     @abc.abstractmethod
-    def show_model_difference_summary(
+    def show_difference_summary(
         self,
         context_diff: ContextDiff,
         environment_naming_info: EnvironmentNamingInfo,
@@ -552,7 +552,7 @@ class NoopConsole(Console):
     def stop_state_import(self, success: bool, input_file: Path) -> None:
         pass
 
-    def show_model_difference_summary(
+    def show_difference_summary(
         self,
         context_diff: ContextDiff,
         environment_naming_info: EnvironmentNamingInfo,
@@ -1326,7 +1326,7 @@ class TerminalConsole(Console):
             else:
                 self.log_error("State import failed!")
 
-    def show_model_difference_summary(
+    def show_difference_summary(
         self,
         context_diff: ContextDiff,
         environment_naming_info: EnvironmentNamingInfo,
@@ -1557,7 +1557,7 @@ class TerminalConsole(Console):
         """Get the user's change category for the directly modified models."""
         plan = plan_builder.build()
 
-        self.show_model_difference_summary(
+        self.show_difference_summary(
             plan.context_diff,
             plan.environment_naming_info,
             default_catalog=default_catalog,
@@ -2503,7 +2503,7 @@ class MarkdownConsole(CaptureTerminalConsole):
     def __init__(self, **kwargs: t.Any) -> None:
         super().__init__(**{**kwargs, "console": RichConsole(no_color=True)})
 
-    def show_model_difference_summary(
+    def show_difference_summary(
         self,
         context_diff: ContextDiff,
         environment_naming_info: EnvironmentNamingInfo,
@@ -3044,7 +3044,7 @@ class DebuggerTerminalConsole(TerminalConsole):
     def stop_env_migration_progress(self, success: bool = True) -> None:
         self._write(f"Stopping environment migration with success={success}")
 
-    def show_model_difference_summary(
+    def show_difference_summary(
         self,
         context_diff: ContextDiff,
         environment_naming_info: EnvironmentNamingInfo,

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1543,6 +1543,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             ),
             self.default_catalog,
             no_diff=not detailed,
+            show_environment_statements=detailed,
         )
         return context_diff.has_changes
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1533,18 +1533,22 @@ class GenericContext(BaseContext, t.Generic[C]):
         environment = environment or self.config.default_target_environment
         environment = Environment.sanitize_name(environment)
         context_diff = self._context_diff(environment)
-        self.console.show_difference_summary(
+        self.console.show_environment_difference_summary(
             context_diff,
-            EnvironmentNamingInfo.from_environment_catalog_mapping(
-                self.config.environment_catalog_mapping,
-                name=environment,
-                suffix_target=self.config.environment_suffix_target,
-                normalize_name=context_diff.normalize_environment_name,
-            ),
-            self.default_catalog,
             no_diff=not detailed,
-            show_environment_statements=detailed,
         )
+        if context_diff.has_changes:
+            self.console.show_model_difference_summary(
+                context_diff,
+                EnvironmentNamingInfo.from_environment_catalog_mapping(
+                    self.config.environment_catalog_mapping,
+                    name=environment,
+                    suffix_target=self.config.environment_suffix_target,
+                    normalize_name=context_diff.normalize_environment_name,
+                ),
+                self.default_catalog,
+                no_diff=not detailed,
+            )
         return context_diff.has_changes
 
     @python_api_analytics

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1533,7 +1533,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         environment = environment or self.config.default_target_environment
         environment = Environment.sanitize_name(environment)
         context_diff = self._context_diff(environment)
-        self.console.show_model_difference_summary(
+        self.console.show_difference_summary(
             context_diff,
             EnvironmentNamingInfo.from_environment_catalog_mapping(
                 self.config.environment_catalog_mapping,

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -461,12 +461,13 @@ class GithubController:
                 context_diff=plan.context_diff,
                 no_diff=False,
             )
-            self._console.show_model_difference_summary(
-                context_diff=plan.context_diff,
-                environment_naming_info=plan.environment_naming_info,
-                default_catalog=self._context.default_catalog,
-                no_diff=False,
-            )
+            if plan.context_diff.has_changes:
+                self._console.show_model_difference_summary(
+                    context_diff=plan.context_diff,
+                    environment_naming_info=plan.environment_naming_info,
+                    default_catalog=self._context.default_catalog,
+                    no_diff=False,
+                )
             difference_summary = self._console.consume_captured_output()
             self._console._show_missing_dates(plan, self._context.default_catalog)
             missing_dates = self._console.consume_captured_output()

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -457,7 +457,7 @@ class GithubController:
         try:
             # Clear out any output that might exist from prior steps
             self._console.clear_captured_outputs()
-            self._console.show_model_difference_summary(
+            self._console.show_difference_summary(
                 context_diff=plan.context_diff,
                 environment_naming_info=plan.environment_naming_info,
                 default_catalog=self._context.default_catalog,

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -457,12 +457,15 @@ class GithubController:
         try:
             # Clear out any output that might exist from prior steps
             self._console.clear_captured_outputs()
-            self._console.show_difference_summary(
+            self._console.show_environment_difference_summary(
+                context_diff=plan.context_diff,
+                no_diff=False,
+            )
+            self._console.show_model_difference_summary(
                 context_diff=plan.context_diff,
                 environment_naming_info=plan.environment_naming_info,
                 default_catalog=self._context.default_catalog,
                 no_diff=False,
-                show_environment_statements=True,
             )
             difference_summary = self._console.consume_captured_output()
             self._console._show_missing_dates(plan, self._context.default_catalog)

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -462,6 +462,7 @@ class GithubController:
                 environment_naming_info=plan.environment_naming_info,
                 default_catalog=self._context.default_catalog,
                 no_diff=False,
+                show_environment_statements=True,
             )
             difference_summary = self._console.consume_captured_output()
             self._console._show_missing_dates(plan, self._context.default_catalog)

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -287,7 +287,7 @@ def test_diff(sushi_context: Context, mocker: MockerFixture):
 
     sushi_context.upsert_model("sushi.customers", query=parse_one("select 1 as customer_id"))
     sushi_context.diff("test")
-    assert mock_console.show_model_difference_summary.called
+    assert mock_console.show_difference_summary.called
     assert success
 
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -287,7 +287,8 @@ def test_diff(sushi_context: Context, mocker: MockerFixture):
 
     sushi_context.upsert_model("sushi.customers", query=parse_one("select 1 as customer_id"))
     sushi_context.diff("test")
-    assert mock_console.show_difference_summary.called
+    assert mock_console.show_environment_difference_summary.called
+    assert mock_console.show_model_difference_summary.called
     assert success
 
 

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -3023,6 +3023,23 @@ def test_plan_environment_statements_diff(make_snapshot):
         terminal_console._print(diff)
     output = console_output.getvalue()
     stripped = strip_ansi_codes(output)
+
+    expected_output = (
+        "before_all:\n"
+        "  + CREATE OR REPLACE TABLE table_1 AS SELECT 1\n"
+        "  + @test_macro()\n\n"
+        "after_all:\n"
+        "  + CREATE OR REPLACE TABLE table_2 AS SELECT 2"
+    )
+    assert stripped == expected_output
+    console_output.close()
+
+    # Validate with python env included
+    console_output, terminal_console = create_test_console()
+    for _, diff in context_diff.environment_statements_diff(include_python_env=True):
+        terminal_console._print(diff)
+    output = console_output.getvalue()
+    stripped = strip_ansi_codes(output)
     expected_output = (
         "before_all:\n"
         "  + CREATE OR REPLACE TABLE table_1 AS SELECT 1\n"
@@ -3030,8 +3047,9 @@ def test_plan_environment_statements_diff(make_snapshot):
         "after_all:\n"
         "  + CREATE OR REPLACE TABLE table_2 AS SELECT 2\n\n"
         "dependencies:\n"
-        "  + def test_macro(evaluator):\n"
-        "    return 'one'"
+        "@@ -0,0 +1,2 @@\n\n"
+        "+def test_macro(evaluator):\n"
+        "+    return 'one'"
     )
     assert stripped == expected_output
     console_output.close()


### PR DESCRIPTION
This update revises the cli output of `before_all` `after_all` statements to 
- not include the python env differences on first plan
- use unidiff for it so that is in line with models instead of ndiff
- account for `--no-diff` flag and don't display the differences when its provided
- as part of this also decoupled `show_model_difference_summary`

<img width="1260" alt="Screenshot 2025-04-16 at 14 03 26" src="https://github.com/user-attachments/assets/e97690a9-5f39-4292-bcac-ab5d1cd8733a" />
