### PR TITLE
Fix(snowflake): Support cloning transient tables for dev previews

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -890,6 +890,8 @@ class EngineAdapter:
         """
         if not self.SUPPORTS_CLONING:
             raise NotImplementedError(f"Engine does not support cloning: {type(self)}")
+
+        kwargs.pop("rendered_physical_properties", None)
         self.execute(
             exp.Create(
                 this=exp.to_table(target_table_name),

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -830,7 +830,12 @@ class SnapshotEvaluator:
                 )
 
                 try:
-                    adapter.clone_table(target_table_name, snapshot.table_name(), replace=True)
+                    adapter.clone_table(
+                        target_table_name,
+                        snapshot.table_name(),
+                        replace=True,
+                        rendered_physical_properties=rendered_physical_properties,
+                    )
                     alter_expressions = adapter.get_alter_expressions(
                         target_table_name, tmp_table_name
                     )

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -1503,6 +1503,7 @@ def test_create_clone_in_dev(mocker: MockerFixture, adapter_mock, make_snapshot)
         f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev",
         f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}",
         replace=True,
+        rendered_physical_properties={},
     )
 
     adapter_mock.get_alter_expressions.assert_called_once_with(
@@ -1601,6 +1602,7 @@ def test_drop_clone_in_dev_when_migration_fails(mocker: MockerFixture, adapter_m
         f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev",
         f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}",
         replace=True,
+        rendered_physical_properties={},
     )
 
     adapter_mock.get_alter_expressions.assert_called_once_with(


### PR DESCRIPTION
This is an update for snowflake to support cloning transient tables for dev previews fixes: #4079 

When planning a new environment that results in the creation of a dev preview, creating a cloned table doesn't account for the physical properties. This ensures that if the source table is transient we account for it and clone using the correct `CREATE TRANSIENT TABLE` syntax.