### PR TITLE
fix: properly share engine adapter config to spark engine adapter

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -311,16 +311,16 @@ workflows:
           matrix:
             parameters:
               engine:
-                - snowflake
+#                - snowflake
                 - databricks
-                - redshift
-                - bigquery
-                - clickhouse-cloud
-                - athena
-          filters:
-           branches:
-             only:
-               - main
+#                - redshift
+#                - bigquery
+#                - clickhouse-cloud
+#                - athena
+#          filters:
+#           branches:
+#             only:
+#               - main
       - trigger_private_tests:
           requires:
             - style_and_cicd_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -311,16 +311,16 @@ workflows:
           matrix:
             parameters:
               engine:
-#                - snowflake
+                - snowflake
                 - databricks
-#                - redshift
-#                - bigquery
-#                - clickhouse-cloud
-#                - athena
-#          filters:
-#           branches:
-#             only:
-#               - main
+                - redshift
+                - bigquery
+                - clickhouse-cloud
+                - athena
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_cicd_tests

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -45,7 +45,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
 
     def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
         super().__init__(*args, **kwargs)
-        self._set_spark_engine_adapter_if_needed()
+        self._set_spark_engine_adapter_if_needed(kwargs.get("multithreaded", False))
 
     @classmethod
     def can_access_spark_session(cls, disable_spark_session: bool) -> bool:
@@ -92,7 +92,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
     def is_spark_session_connection(self) -> bool:
         return isinstance(self.connection, SparkSessionConnection)
 
-    def _set_spark_engine_adapter_if_needed(self) -> None:
+    def _set_spark_engine_adapter_if_needed(self, multithreaded: bool) -> None:
         self._spark_engine_adapter = None
 
         if not self._use_spark_session or self.is_spark_session_connection:
@@ -117,6 +117,11 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
             partial(connection, spark=spark, catalog=catalog),
             default_catalog=catalog,
             execute_log_level=self._execute_log_level,
+            multithreaded=multithreaded,
+            sql_gen_kwargs=self._sql_gen_kwargs,
+            register_comments=self._register_comments,
+            pre_ping=self._pre_ping,
+            pretty_sql=self._pretty_sql,
         )
 
     @property


### PR DESCRIPTION
Prior to this PR, if a Databricks engine adapter was created as multithreaded then the spark engine adapter created internally was single threaded. Therefore the threads would potentially collide and attempt to share common resources. The main issue was `_last_df` which stores the last result which could then be shared across the threads. Also went ahead and reviewed the other kwargs that seems to make sense to pass into the spark engine adapter. 