### PR TITLE
fix: pass multithreaded with log level

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -140,6 +140,7 @@ class EngineAdapter:
         self._register_comments = register_comments
         self._pre_ping = pre_ping
         self._pretty_sql = pretty_sql
+        self._multithreaded = multithreaded
 
     def with_log_level(self, level: int) -> EngineAdapter:
         adapter = self.__class__(
@@ -150,6 +151,7 @@ class EngineAdapter:
             execute_log_level=level,
             register_comments=self._register_comments,
             null_connection=True,
+            multithreaded=self._multithreaded,
             **self._extra_config,
         )
 

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -45,7 +45,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
 
     def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
         super().__init__(*args, **kwargs)
-        self._set_spark_engine_adapter_if_needed(kwargs.get("multithreaded", False))
+        self._set_spark_engine_adapter_if_needed()
 
     @classmethod
     def can_access_spark_session(cls, disable_spark_session: bool) -> bool:
@@ -92,7 +92,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
     def is_spark_session_connection(self) -> bool:
         return isinstance(self.connection, SparkSessionConnection)
 
-    def _set_spark_engine_adapter_if_needed(self, multithreaded: bool) -> None:
+    def _set_spark_engine_adapter_if_needed(self) -> None:
         self._spark_engine_adapter = None
 
         if not self._use_spark_session or self.is_spark_session_connection:
@@ -117,7 +117,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
             partial(connection, spark=spark, catalog=catalog),
             default_catalog=catalog,
             execute_log_level=self._execute_log_level,
-            multithreaded=multithreaded,
+            multithreaded=self._multithreaded,
             sql_gen_kwargs=self._sql_gen_kwargs,
             register_comments=self._register_comments,
             pre_ping=self._pre_ping,


### PR DESCRIPTION
This fix was needed: https://github.com/TobikoData/sqlmesh/pull/4162

The problem is if a `with_log_level` call happened then it would not include the `multithreaded` argument and therefore the spark session class would be created as single threaded which is not expected. 