### PR TITLE
Fix: When initialising multiple connections pass concurrent tasks

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -109,8 +109,12 @@ class ConnectionConfig(abc.ABC, BaseConfig):
         """A function that validates the connection configuration"""
         return self.create_engine_adapter().ping
 
-    def create_engine_adapter(self, register_comments_override: bool = False) -> EngineAdapter:
+    def create_engine_adapter(
+        self, register_comments_override: bool = False, concurrent_tasks: t.Optional[int] = None
+    ) -> EngineAdapter:
         """Returns a new instance of the Engine Adapter."""
+        if concurrent_tasks:
+            self.concurrent_tasks = concurrent_tasks
         return self._engine_adapter(
             self._connection_factory_with_kwargs,
             multithreaded=self.concurrent_tasks > 1,
@@ -284,7 +288,9 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
 
         return init
 
-    def create_engine_adapter(self, register_comments_override: bool = False) -> EngineAdapter:
+    def create_engine_adapter(
+        self, register_comments_override: bool = False, concurrent_tasks: t.Optional[int] = None
+    ) -> EngineAdapter:
         """Checks if another engine adapter has already been created that shares a catalog that points to the same data
         file. If so, it uses that same adapter instead of creating a new one. As a result, any additional configuration
         associated with the new adapter will be ignored."""
@@ -315,7 +321,9 @@ class BaseDuckDBConnectionConfig(ConnectionConfig):
             logger.info(f"Creating new DuckDB adapter for data files: {masked_files}")
         else:
             logger.info("Creating new DuckDB adapter for in-memory database")
-        adapter = super().create_engine_adapter(register_comments_override)
+        adapter = super().create_engine_adapter(
+            register_comments_override, concurrent_tasks=concurrent_tasks
+        )
         for data_file in data_files:
             key = data_file if isinstance(data_file, str) else data_file.path
             BaseDuckDBConnectionConfig._data_file_to_adapter[key] = adapter

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -113,11 +113,11 @@ class ConnectionConfig(abc.ABC, BaseConfig):
         self, register_comments_override: bool = False, concurrent_tasks: t.Optional[int] = None
     ) -> EngineAdapter:
         """Returns a new instance of the Engine Adapter."""
-        if concurrent_tasks:
-            self.concurrent_tasks = concurrent_tasks
+
+        concurrent_tasks = concurrent_tasks or self.concurrent_tasks
         return self._engine_adapter(
             self._connection_factory_with_kwargs,
-            multithreaded=self.concurrent_tasks > 1,
+            multithreaded=concurrent_tasks > 1,
             default_catalog=self.get_catalog(),
             cursor_init=self._cursor_init,
             register_comments=register_comments_override or self.register_comments,

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -82,10 +82,10 @@ class _EngineAdapterStateSyncSchedulerConfig(SchedulerConfig):
                     + f"multi threaded mode with {warehouse_connection.concurrent_tasks} concurrent tasks."
                     + " This can cause SQLMesh to hang. Overriding the duckdb state connection config to use multi threaded mode."
                 )
-                # this triggers multithreaded mode and has to happen before the engine adapter is created below
-                state_connection.concurrent_tasks = warehouse_connection.concurrent_tasks
 
-        engine_adapter = state_connection.create_engine_adapter()
+        engine_adapter = state_connection.create_engine_adapter(
+            concurrent_tasks=warehouse_connection.concurrent_tasks
+        )
         if state_connection.is_forbidden_for_state_sync:
             raise ConfigError(
                 f"The {engine_adapter.DIALECT.upper()} engine cannot be used to store SQLMesh state - please specify a different `state_connection` engine."

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -82,10 +82,10 @@ class _EngineAdapterStateSyncSchedulerConfig(SchedulerConfig):
                     + f"multi threaded mode with {warehouse_connection.concurrent_tasks} concurrent tasks."
                     + " This can cause SQLMesh to hang. Overriding the duckdb state connection config to use multi threaded mode."
                 )
+                # this triggers multithreaded mode and has to happen before the engine adapter is created below
+                state_connection.concurrent_tasks = warehouse_connection.concurrent_tasks
 
-        engine_adapter = state_connection.create_engine_adapter(
-            concurrent_tasks=warehouse_connection.concurrent_tasks
-        )
+        engine_adapter = state_connection.create_engine_adapter()
         if state_connection.is_forbidden_for_state_sync:
             raise ConfigError(
                 f"The {engine_adapter.DIALECT.upper()} engine cannot be used to store SQLMesh state - please specify a different `state_connection` engine."

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -2197,6 +2197,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         for gateway_name in self.config.gateways:
             if gateway_name != self.selected_gateway:
                 connection = self.config.get_connection(gateway_name)
+                connection.concurrent_tasks = self.concurrent_tasks
                 adapter = connection.create_engine_adapter()
                 self._engine_adapters[gateway_name] = adapter
         return self._engine_adapters

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -2197,8 +2197,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         for gateway_name in self.config.gateways:
             if gateway_name != self.selected_gateway:
                 connection = self.config.get_connection(gateway_name)
-                connection.concurrent_tasks = self.concurrent_tasks
-                adapter = connection.create_engine_adapter()
+                adapter = connection.create_engine_adapter(concurrent_tasks=self.concurrent_tasks)
                 self._engine_adapters[gateway_name] = adapter
         return self._engine_adapters
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -26,6 +26,7 @@ from sqlmesh.core.config.loader import (
 )
 from sqlmesh.core.context import Context
 from sqlmesh.core.engine_adapter.athena import AthenaEngineAdapter
+from sqlmesh.core.engine_adapter.bigquery import BigQueryEngineAdapter
 from sqlmesh.core.engine_adapter.redshift import RedshiftEngineAdapter
 from sqlmesh.core.notification_target import ConsoleNotificationTarget
 from sqlmesh.core.user import User
@@ -709,6 +710,10 @@ gateways:
             aws_secret_access_key: accesskey
             work_group: group
             s3_warehouse_location: s3://location
+    bigquery:
+        connection:
+            type: bigquery
+
 
 default_gateway: redshift
 
@@ -725,10 +730,52 @@ model_defaults:
     ctx = Context(paths=tmp_path, config=config)
 
     assert isinstance(ctx._connection_config, RedshiftConnectionConfig)
-    assert len(ctx.engine_adapters) == 2
+    assert len(ctx.engine_adapters) == 3
     assert isinstance(ctx.engine_adapters["athena"], AthenaEngineAdapter)
     assert isinstance(ctx.engine_adapters["redshift"], RedshiftEngineAdapter)
+    assert isinstance(ctx.engine_adapters["bigquery"], BigQueryEngineAdapter)
     assert ctx.engine_adapter == ctx._get_engine_adapter("redshift")
+
+    # The bigquery engine adapter should be have been set as multithreaded as well
+    assert ctx.engine_adapters["bigquery"]._multithreaded
+
+
+def test_multi_gateway_single_threaded_config(tmp_path):
+    config_path = tmp_path / "config_duck_athena.yaml"
+    with open(config_path, "w", encoding="utf-8") as fd:
+        fd.write(
+            """
+gateways:
+    duckdb:
+        connection:
+            type: duckdb
+            database: db.db
+    athena:
+        connection:
+            type: athena
+            aws_access_key_id: '1234'
+            aws_secret_access_key: accesskey
+            work_group: group
+            s3_warehouse_location: s3://location
+default_gateway: duckdb
+model_defaults:
+    dialect: duckdb
+        """
+        )
+
+    config = load_config_from_paths(
+        Config,
+        project_paths=[config_path],
+    )
+
+    ctx = Context(paths=tmp_path, config=config)
+    assert isinstance(ctx._connection_config, DuckDBConnectionConfig)
+    assert len(ctx.engine_adapters) == 2
+    assert ctx.engine_adapter == ctx._get_engine_adapter("duckdb")
+    assert isinstance(ctx.engine_adapters["athena"], AthenaEngineAdapter)
+
+    # In this case athena should use 1 concurrent task as the default gateway is duckdb
+    assert not ctx.engine_adapters["athena"]._multithreaded
 
 
 def test_trino_schema_location_mapping_syntax(tmp_path):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -26,7 +26,7 @@ from sqlmesh.core.config.loader import (
 )
 from sqlmesh.core.context import Context
 from sqlmesh.core.engine_adapter.athena import AthenaEngineAdapter
-from sqlmesh.core.engine_adapter.bigquery import BigQueryEngineAdapter
+from sqlmesh.core.engine_adapter.duckdb import DuckDBEngineAdapter
 from sqlmesh.core.engine_adapter.redshift import RedshiftEngineAdapter
 from sqlmesh.core.notification_target import ConsoleNotificationTarget
 from sqlmesh.core.user import User
@@ -710,10 +710,10 @@ gateways:
             aws_secret_access_key: accesskey
             work_group: group
             s3_warehouse_location: s3://location
-    bigquery:
+    duckdb:
         connection:
-            type: bigquery
-
+            type: duckdb
+            database: db.db
 
 default_gateway: redshift
 
@@ -733,11 +733,11 @@ model_defaults:
     assert len(ctx.engine_adapters) == 3
     assert isinstance(ctx.engine_adapters["athena"], AthenaEngineAdapter)
     assert isinstance(ctx.engine_adapters["redshift"], RedshiftEngineAdapter)
-    assert isinstance(ctx.engine_adapters["bigquery"], BigQueryEngineAdapter)
+    assert isinstance(ctx.engine_adapters["duckdb"], DuckDBEngineAdapter)
     assert ctx.engine_adapter == ctx._get_engine_adapter("redshift")
 
-    # The bigquery engine adapter should be have been set as multithreaded as well
-    assert ctx.engine_adapters["bigquery"]._multithreaded
+    # The duckdb engine adapter should be have been set as multithreaded as well
+    assert ctx.engine_adapters["duckdb"]._multithreaded
 
 
 def test_multi_gateway_single_threaded_config(tmp_path):


### PR DESCRIPTION
This update addresses an issue when the configured default gateway's concurrency (e.g. Athena with concurrent_tasks=4) differs from a model-specific gateway (e.g. BigQuery with concurrent_tasks=1) which is explicitly set in some of the models. In these cases, it leads to BigQuery not running in a multithreaded mode and failing to run concurrent jobs. 

The issue is that concurrent_tasks is passed to the snapshot evaluator, but the connection uses the gateway specific or default. This fix ensures that concurrent_tasks is passed to the connection as well to align all gateways for multithreaded use when applied.