### PR TITLE
Fix: Forward-only models can't be categorized manually

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1625,6 +1625,8 @@ class TerminalConsole(Console):
             self._show_categorized_snapshots(plan, default_catalog)
 
         for snapshot in plan.uncategorized:
+            if snapshot.is_model and snapshot.model.forward_only:
+                continue
             if not no_diff:
                 self.show_sql(plan.context_diff.text_diff(snapshot.name))
             tree = Tree(


### PR DESCRIPTION
The user should not be able to categorize forward-only into BREAKING or NON-BREAKING. There are a few important invariants that rely on the fact that forward-only models are always categorized as forward-only.