### PR TITLE
Fix: Columns should be sourced from the target table and not the temporary merge table

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -611,7 +611,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
             if columns_to_types is None or columns_to_types[
                 partition_column.name
             ] == exp.DataType.build("unknown"):
-                columns_to_types = self.columns(temp_table_name)
+                columns_to_types = self.columns(table_name)
 
             partition_type_sql = columns_to_types[partition_column.name].sql(dialect=self.dialect)
 

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -116,9 +116,7 @@ def test_insert_overwrite_by_partition_query_unknown_column_types(
         },
     )
 
-    columns_mock.assert_called_once_with(
-        exp.to_table(f"test_schema.__temp_test_table_{temp_table_id}")
-    )
+    columns_mock.assert_called_once_with(table_name)
 
     sql_calls = _to_sql_calls(execute_mock)
     assert sql_calls == [


### PR DESCRIPTION
The temporary table may include additional columns returned by the query that are not present in the target table. Sourcing column-to-types from the temporary table may make the schema inconsistent with the actual table into which the data is inserted.