### PR TITLE
fix(vscode): improve naming of lsp channel

### DIFF
--- a/vscode/extension/src/lsp/lsp.ts
+++ b/vscode/extension/src/lsp/lsp.ts
@@ -16,7 +16,7 @@ export class LSPClient implements Disposable {
 
     public async start(): Promise<Result<undefined, string>> {
         if (!outputChannel) {
-            outputChannel = window.createOutputChannel('sqlmesh_actual_lsp_implementation')
+            outputChannel = window.createOutputChannel('sqlmesh-lsp')
         }
 
         const sqlmesh = await sqlmesh_lsp_exec()
@@ -62,7 +62,7 @@ export class LSPClient implements Disposable {
             // }
         }
     
-        this.client = new LanguageClient('sqlmesh-lsp-example', 'SQLMesh Language Server', serverOptions, clientOptions)
+        this.client = new LanguageClient('sqlmesh-lsp', 'SQLMesh Language Server', serverOptions, clientOptions)
         await this.client.start()
         return ok(undefined)
     }


### PR DESCRIPTION
- makes the name that the lsp output is recorded much nicer from a demo name to something logical.

From 

<img width="249" alt="image" src="https://github.com/user-attachments/assets/0ef743db-d856-4f10-97c3-55590bf2304d" />

To 

`sqlmesh-lsp`