### PR TITLE
fix(vscode): force extension to run on host

### DIFF
--- a/vscode/extension/package.json
+++ b/vscode/extension/package.json
@@ -17,6 +17,9 @@
   "activationEvents": [
     "onLanguage:sql"
   ],
+  "extensionKind": [
+    "workspace"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "authentication": [
@@ -42,9 +45,9 @@
         "description": "SQLMesh"
       },
       {
-          "command": "sqlmesh.signinSpecifyFlow",
-          "title": "Sign in to Tobiko Cloud (Specify Auth Flow)",
-          "description": "SQLMesh"
+        "command": "sqlmesh.signinSpecifyFlow",
+        "title": "Sign in to Tobiko Cloud (Specify Auth Flow)",
+        "description": "SQLMesh"
       },
       {
         "command": "sqlmesh.signout",


### PR DESCRIPTION
Best source of info is here: https://code.visualstudio.com/api/advanced-topics/remote-extensions#installing-a-development-version-of-your-extension

Essentially when you run an extension and you are in an environment where you are connecting vscode to a remote host, the extension can either run on vscode or on the remote host. Currently, in the above example, the extension would run on the host connected rather the one being connect to, this flag changes that. 