### PR TITLE
fix(vscode): specify python requirement

### DIFF
--- a/vscode/extension/package.json
+++ b/vscode/extension/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "https://github.com/tobikodata/sqlmesh"
   },
+  "main": "./dist/extension.js",
   "icon": "assets/logo.png",
   "engines": {
     "vscode": "^1.98.0"
@@ -21,7 +22,9 @@
   "extensionKind": [
     "workspace"
   ],
-  "main": "./dist/extension.js",
+  "extensionDependencies": [
+    "ms-python.python"
+  ],
   "contributes": {
     "authentication": [
       {


### PR DESCRIPTION
when depending on the microsoft python extension to manage python environments as we do, as outlined here, you need to add the Microsoft python extension as an explicit dependency as explained here https://www.npmjs.com/package/@vscode/python-extension

without it you get weird start up bug where the extension doesn't fire off until the ms python extension starts
