### PR TITLE
Fix!: Change how `partitioned_by` is parsed so that partition expressions with specialized AST nodes are captured

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -134,7 +134,7 @@ jobs:
             - v1-nm-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install packages
-          command: npm ci
+          command: npm ci 
       - save_cache:
           key: v1-nm-cache-{{ checksum "package-lock.json" }}
           paths:
@@ -277,10 +277,10 @@ workflows:
                 - bigquery
                 - clickhouse-cloud
                 - athena
-          #filters:
-          # branches:
-          #   only:
-          #     - main
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_cicd_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -134,7 +134,7 @@ jobs:
             - v1-nm-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install packages
-          command: npm ci 
+          command: npm ci
       - save_cache:
           key: v1-nm-cache-{{ checksum "package-lock.json" }}
           paths:
@@ -277,10 +277,10 @@ workflows:
                 - bigquery
                 - clickhouse-cloud
                 - athena
-          filters:
-           branches:
-             only:
-               - main
+          #filters:
+          # branches:
+          #   only:
+          #     - main
       - trigger_private_tests:
           requires:
             - style_and_cicd_tests

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -610,6 +610,12 @@ def _create_parser(expression_type: t.Type[exp.Expression], table_keys: t.List[s
                     value = self.expression(ModelKind, this=kind.value, expressions=props)
             elif key == "expression":
                 value = self._parse_conjunction()
+            elif key == "partitioned_by":
+                partitioned_by = self._parse_partitioned_by()
+                if isinstance(partitioned_by.this, exp.Schema):
+                    value = exp.tuple_(*partitioned_by.this.expressions)
+                else:
+                    value = partitioned_by.this
             else:
                 value = self._parse_bracket(self._parse_field(any_token=True))
 

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -39,6 +39,7 @@ from sqlmesh.utils.pydantic import (
     field_validator,
     list_of_fields_validator,
     model_validator,
+    get_dialect,
 )
 
 if t.TYPE_CHECKING:
@@ -182,12 +183,20 @@ class ModelMeta(_Node):
     def _partition_and_cluster_validator(
         cls, v: t.Any, info: ValidationInfo
     ) -> t.List[exp.Expression]:
-        if isinstance(v, list) and info.field_name == "partitioned_by_":
+        if (
+            isinstance(v, list)
+            and all(isinstance(i, str) for i in v)
+            and info.field_name == "partitioned_by_"
+        ):
             # this branch gets hit when we are deserializing from json because `partitioned_by` is stored as a List[str]
+            # however, we should only invoke this if the list contains strings because this validator is also
+            # called by Python models which might pass a List[exp.Expression]
             string_to_parse = (
                 f"({','.join(v)})"  # recreate the (a, b, c) part of "partitioned_by (a, b, c)"
             )
-            parsed = parse_one(string_to_parse, into=exp.PartitionedByProperty)
+            parsed = parse_one(
+                string_to_parse, into=exp.PartitionedByProperty, dialect=get_dialect(info)
+            )
             v = parsed.this.expressions if isinstance(parsed.this, exp.Schema) else v
 
         expressions = list_of_fields_validator(v, info.data)

--- a/sqlmesh/migrations/v0081_update_partitioned_by.py
+++ b/sqlmesh/migrations/v0081_update_partitioned_by.py
@@ -1,0 +1,91 @@
+"""Remove superfluous exp.Paren references from partitioned_by"""
+
+import json
+
+import pandas as pd
+from sqlglot import exp
+
+from sqlmesh.utils.migration import index_text_type
+from sqlmesh.utils.migration import blob_text_type
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    index_type = index_text_type(engine_adapter.dialect)
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+
+    new_snapshots = []
+    updated = False
+
+    for (
+        name,
+        identifier,
+        version,
+        snapshot,
+        kind_name,
+        updated_ts,
+        unpaused_ts,
+        ttl_ms,
+        unrestorable,
+    ) in engine_adapter.fetchall(
+        exp.select(
+            "name",
+            "identifier",
+            "version",
+            "snapshot",
+            "kind_name",
+            "updated_ts",
+            "unpaused_ts",
+            "ttl_ms",
+            "unrestorable",
+        ).from_(snapshots_table),
+        quote_identifiers=True,
+    ):
+        parsed_snapshot = json.loads(snapshot)
+
+        if partitioned_by := parsed_snapshot["node"].get("partitioned_by"):
+            new_partitioned_by = []
+            for item in partitioned_by:
+                # rewrite '(foo)' to 'foo'
+                if item.startswith("(") and item.endswith(")"):
+                    item = item[1:-1]
+                    updated = True
+                new_partitioned_by.append(item)
+            parsed_snapshot["node"]["partitioned_by"] = new_partitioned_by
+
+        new_snapshots.append(
+            {
+                "name": name,
+                "identifier": identifier,
+                "version": version,
+                "snapshot": json.dumps(parsed_snapshot),
+                "kind_name": kind_name,
+                "updated_ts": updated_ts,
+                "unpaused_ts": unpaused_ts,
+                "ttl_ms": ttl_ms,
+                "unrestorable": unrestorable,
+            }
+        )
+
+    if new_snapshots and updated:
+        engine_adapter.delete_from(snapshots_table, "TRUE")
+        blob_type = blob_text_type(engine_adapter.dialect)
+
+        engine_adapter.insert_append(
+            snapshots_table,
+            pd.DataFrame(new_snapshots),
+            columns_to_types={
+                "name": exp.DataType.build(index_type),
+                "identifier": exp.DataType.build(index_type),
+                "version": exp.DataType.build(index_type),
+                "snapshot": exp.DataType.build(blob_type),
+                "kind_name": exp.DataType.build(index_type),
+                "updated_ts": exp.DataType.build("bigint"),
+                "unpaused_ts": exp.DataType.build("bigint"),
+                "ttl_ms": exp.DataType.build("bigint"),
+                "unrestorable": exp.DataType.build("boolean"),
+            },
+        )

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1978,19 +1978,22 @@ def test_plan_audit_intervals(tmp_path: pathlib.Path, capsys, caplog):
         )
     )
 
-    ctx.plan(
+    plan = ctx.plan(
         environment="dev", auto_apply=True, no_prompts=True, start="2025-02-01", end="2025-02-01"
     )
 
+    date_snapshot = next(s for s in plan.new_snapshots if "date_example" in s.name)
+    timestamp_snapshot = next(s for s in plan.new_snapshots if "timestamp_example" in s.name)
+
     # Case 1: The timestamp audit should be in the inclusive range ['2025-02-01 00:00:00', '2025-02-01 23:59:59.999999']
     assert (
-        """SELECT COUNT(*) FROM (SELECT ("timestamp_id") AS "timestamp_id" FROM (SELECT * FROM "sqlmesh__sqlmesh_audit"."sqlmesh_audit__timestamp_example__2797548448" AS "sqlmesh_audit__timestamp_example__2797548448" WHERE "timestamp_id" BETWEEN CAST('2025-02-01 00:00:00' AS TIMESTAMP) AND CAST('2025-02-01 23:59:59.999999' AS TIMESTAMP)) AS "_q_0" WHERE TRUE GROUP BY ("timestamp_id") HAVING COUNT(*) > 1) AS "audit\""""
+        f"""SELECT COUNT(*) FROM (SELECT ("timestamp_id") AS "timestamp_id" FROM (SELECT * FROM "sqlmesh__sqlmesh_audit"."sqlmesh_audit__timestamp_example__{timestamp_snapshot.version}" AS "sqlmesh_audit__timestamp_example__{timestamp_snapshot.version}" WHERE "timestamp_id" BETWEEN CAST('2025-02-01 00:00:00' AS TIMESTAMP) AND CAST('2025-02-01 23:59:59.999999' AS TIMESTAMP)) AS "_q_0" WHERE TRUE GROUP BY ("timestamp_id") HAVING COUNT(*) > 1) AS "audit\""""
         in caplog.text
     )
 
     # Case 2: The date audit should be in the inclusive range ['2025-02-01', '2025-02-01']
     assert (
-        """SELECT COUNT(*) FROM (SELECT ("date_id") AS "date_id" FROM (SELECT * FROM "sqlmesh__sqlmesh_audit"."sqlmesh_audit__date_example__4100277424" AS "sqlmesh_audit__date_example__4100277424" WHERE "date_id" BETWEEN CAST('2025-02-01' AS DATE) AND CAST('2025-02-01' AS DATE)) AS "_q_0" WHERE TRUE GROUP BY ("date_id") HAVING COUNT(*) > 1) AS "audit\""""
+        f"""SELECT COUNT(*) FROM (SELECT ("date_id") AS "date_id" FROM (SELECT * FROM "sqlmesh__sqlmesh_audit"."sqlmesh_audit__date_example__{date_snapshot.version}" AS "sqlmesh_audit__date_example__{date_snapshot.version}" WHERE "date_id" BETWEEN CAST('2025-02-01' AS DATE) AND CAST('2025-02-01' AS DATE)) AS "_q_0" WHERE TRUE GROUP BY ("date_id") HAVING COUNT(*) > 1) AS "audit\""""
         in caplog.text
     )
 


### PR DESCRIPTION
This addresses issue #4090 

Prior to this PR, a partition expression in a `MODEL` block like:
```
MODEL (
 ...,
 partitioned_by (bucket(4, a), colb)
);
```

would be parsed into an `exp.Anonymous` node. SQLGlot gained support for `exp.PartitionedByBucket` (and `exp.PartitionedByTruncate`) in order to handle Iceberg transforms in a first class manner.

This is important because Athena inexplicably expects the arguments on the partition transforms to be in a different order depending on if the query is a `CREATE TABLE` or a `CTAS`.

This PR changes the `partitioned_by` property to be parsed with the SQLGlot `_parse_partitioned_by` parser instead of the fallback `_parse_bracket(_parse_field)` parser so that the correct AST nodes are created.

This has the effect of standardizing the parsing of this property.

This *change is breaking* because previously a single item was parsed as `exp.Paren` instead of `exp.Tuple` which meant it wasn't unpacked in the Pydantic field validator and ended up getting nested in the `partitioned_by` list.

Given the following model:
```
MODEL (
  name sqlmesh_audit.date_example,
  kind full,
  partitioned_by (date_id)
);
SELECT DATE('2025-02-01') as date_id
```

Before this change, `partitioned_by` looked like:
```
>>> model.partitioned_by
[Paren(
  this=Column(
    this=Identifier(this='date_id', quoted=True)))]
```

After this change, `partitioned_by` looks like:
```
>>> model.partitioned_by
[Column(
  this=Identifier(this='date_id', quoted=True))]
```

That is - the superfluous `exp.Paren` has been removed