### PR TITLE
Fix: address staged file path edge case in snowflake parsing

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -500,6 +500,7 @@ def _parse_table_parts(
                 self._curr
                 and self._prev.token_type in (TokenType.L_PAREN, TokenType.R_PAREN)
                 and self._curr.text.upper() not in ("FILE_FORMAT", "PATTERN")
+                and not (table.args.get("format") or table.args.get("pattern"))
             )
         ):
             self._retreat(index)


### PR DESCRIPTION
The behavior today in main is as follows:

```sql
MODEL (
  name test_schema.@{table_name},
  kind FULL,
  blueprints (
    (table_name := "test_table", stage_path := 'foo'),
  )
);

SELECT * FROM @stage_path (file_format => 'bar') LIMIT 100
```

```
(.venv) ➜  sqlmesh render test_schema.test_table
Error: Failed to resolve macros for
SELECT
  *
FROM @stage_path(file_format => 'bar')
LIMIT 100
Macro 'stage_path' does not exist. at '.../playground/models/test_model.sql'
```

This is because the parsing is off:

```python
>>> from sqlmesh.core.dialect import parse_one
>>> parse_one("""
... SELECT
...   *
... FROM @stage_path (FILE_FORMAT => 'foo')
... LIMIT 100
... """, dialect="snowflake")
Select(
  expressions=[
    Star()],
  limit=Limit(
    expression=Literal(this=100, is_string=False)),
  from=From(
    this=Table(
      this=MacroFunc(
        this=Anonymous(
          this=stage_path,
          expressions=[
            Kwarg(
              this=Var(this=FILE_FORMAT),
              expression=Literal(this='foo', is_string=True))])))))
```

Notice the `MacroFunc` here. Instead, we want this to be a `StagedFilePath`, because we can't disambiguate it from Snowflake's stage file syntax.

Alternatively, if I change the variable reference to `@{stage_path}`, then it fails with "Expecting ). Line 9, Col: 43." (`=>` highlighted).