### PR TITLE
Fix: Plan application should succeeed even when the snapshot query in state is unrenderable

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -2144,6 +2144,8 @@ class GenericContext(BaseContext, t.Generic[C]):
     def clear_caches(self) -> None:
         for path in self.configs:
             rmtree(path / c.CACHE)
+        if isinstance(self.state_sync, CachingStateSync):
+            self.state_sync.clear_cache()
 
     def export_state(
         self,

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1337,7 +1337,11 @@ class SqlModel(_Model):
         if self.columns_to_types_ is not None:
             self._columns_to_types = self.columns_to_types_
         elif self._columns_to_types is None:
-            query = self._query_renderer.render()
+            try:
+                query = self._query_renderer.render()
+            except Exception:
+                logger.exception("Failed to render query for model %s", self.fqn)
+                return None
 
             if query is None:
                 return None

--- a/sqlmesh/core/state_sync/cache.py
+++ b/sqlmesh/core/state_sync/cache.py
@@ -143,3 +143,6 @@ class CachingStateSync(DelegatingStateSync):
     ) -> None:
         self.snapshot_cache.clear()
         self.state_sync.unpause_snapshots(snapshots, unpaused_dt)
+
+    def clear_cache(self) -> None:
+        self.snapshot_cache.clear()


### PR DESCRIPTION
Otherwise, it's impossible to repair the target environment after upgrade which caused the existing snapshots to be unrenderable.