### PR TITLE
Fix: Make sure backfill is not triggered for models downstream of met…adata changes

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1473,7 +1473,9 @@ class DeployabilityIndex(PydanticModel, frozen=True):
             )
             if this_deployable:
                 snapshot = snapshots[node]
-                is_forward_only_model = snapshot.is_model and snapshot.model.forward_only
+                is_forward_only_model = (
+                    snapshot.is_model and snapshot.model.forward_only and not snapshot.is_metadata
+                )
                 has_auto_restatement = (
                     snapshot.is_model and snapshot.model.auto_restatement_cron is not None
                 )

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -197,7 +197,7 @@ def test_render_sql_model(sushi_context, assert_exp_eq, copy_to_temp_path: t.Cal
 def test_render_non_deployable_parent(sushi_context, assert_exp_eq, copy_to_temp_path: t.Callable):
     model = sushi_context.get_model("sushi.waiter_revenue_by_day")
     forward_only_kind = model.kind.copy(update={"forward_only": True})
-    model = model.copy(update={"kind": forward_only_kind})
+    model = model.copy(update={"kind": forward_only_kind, "stamp": "trigger forward-only change"})
     sushi_context.upsert_model(model)
     sushi_context.plan("dev", no_prompts=True, auto_apply=True)
 

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -2033,11 +2033,11 @@ def test_deployability_index_categorized_forward_only_model(make_snapshot):
 
     snapshot_a = make_snapshot(model_a)
     snapshot_a.previous_versions = snapshot_a_old.all_versions
-    snapshot_a.categorize_as(SnapshotChangeCategory.METADATA)
+    snapshot_a.categorize_as(SnapshotChangeCategory.FORWARD_ONLY)
 
     snapshot_b = make_snapshot(SqlModel(name="b", query=parse_one("SELECT 1")))
     snapshot_b.parents = (snapshot_a.snapshot_id,)
-    snapshot_b.categorize_as(SnapshotChangeCategory.METADATA)
+    snapshot_b.categorize_as(SnapshotChangeCategory.FORWARD_ONLY)
 
     deployability_index = DeployabilityIndex.create(
         {s.snapshot_id: s for s in [snapshot_a, snapshot_b]}


### PR DESCRIPTION
Scenario:
1. DAG: A -> B (forward-only) -> C
2. User makes a metadata change to A
3. Plan shows that C needs backfilling

The issue occurred because B got categorized as `FORWARD_ONLY` instead of `METADATA` which lead to C being treated as non-deployable. Provide its dev intervals were empty (since it itself wasnt forward-only and therefore didn't inherit production intervals), the planner concluded that backfill was necessray.

This fix ensures that B in the example above is categorized as `METADATA` (which is more accurate anyway) and so C subsequently is treated as both deployable and representative. 