### PR TITLE
feat: adds LinterContext

### DIFF
--- a/sqlmesh/core/linter/definition.py
+++ b/sqlmesh/core/linter/definition.py
@@ -11,6 +11,9 @@ from sqlmesh.core.model import Model
 from sqlmesh.core.linter.rule import Rule, RuleViolation
 from sqlmesh.core.console import LinterConsole, get_console
 
+if t.TYPE_CHECKING:
+    from sqlmesh.core.context import LinterContext
+
 
 def select_rules(all_rules: RuleSet, rule_names: t.Set[str]) -> RuleSet:
     if "all" in rule_names:
@@ -52,7 +55,7 @@ class Linter:
         return Linter(config.enabled, all_rules, rules, warn_rules)
 
     def lint_model(
-        self, model: Model, console: LinterConsole = get_console()
+        self, context: LinterContext, model: Model, console: LinterConsole = get_console()
     ) -> t.Tuple[bool, t.List[AnnotatedRuleViolation]]:
         if not self.enabled:
             return False, []
@@ -62,8 +65,8 @@ class Linter:
         rules = self.rules.difference(ignored_rules)
         warn_rules = self.warn_rules.difference(ignored_rules)
 
-        error_violations = rules.check_model(model)
-        warn_violations = warn_rules.check_model(model)
+        error_violations = rules.check_model(context, model)
+        warn_violations = warn_rules.check_model(context, model)
 
         all_violations: t.List[AnnotatedRuleViolation] = [
             AnnotatedRuleViolation(
@@ -96,11 +99,11 @@ class RuleSet(Mapping[str, type[Rule]]):
     def __init__(self, rules: Iterable[type[Rule]] = ()) -> None:
         self._underlying = {rule.name: rule for rule in rules}
 
-    def check_model(self, model: Model) -> t.List[RuleViolation]:
+    def check_model(self, context: LinterContext, model: Model) -> t.List[RuleViolation]:
         violations = []
 
         for rule in self._underlying.values():
-            violation = rule().check_model(model)
+            violation = rule(context).check_model(model)
 
             if violation:
                 violations.append(violation)

--- a/sqlmesh/core/linter/rule.py
+++ b/sqlmesh/core/linter/rule.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import abc
 
 from sqlmesh.core.model import Model
+from sqlmesh.utils.dag import DAG
 
 from typing import Type
 
 import typing as t
+
+if t.TYPE_CHECKING:
+    from sqlmesh.core.context import LinterContext, ModelOrSnapshot
 
 
 class _Rule(abc.ABCMeta):
@@ -19,6 +23,9 @@ class Rule(abc.ABC, metaclass=_Rule):
     """The base class for a rule."""
 
     name = "rule"
+
+    def __init__(self, context: LinterContext):
+        self.context = context
 
     @abc.abstractmethod
     def check_model(self, model: Model) -> t.Optional[RuleViolation]:
@@ -35,6 +42,13 @@ class Rule(abc.ABC, metaclass=_Rule):
 
     def __repr__(self) -> str:
         return self.name
+
+    def get_model(self, model: ModelOrSnapshot) -> t.Optional[Model]:
+        """Get the model by name."""
+        return self.context.get_model(model)
+
+    def get_dag(self) -> DAG:
+        return self.context.get_dag()
 
 
 class RuleViolation:


### PR DESCRIPTION
Adds a LinterContext to LinterRules.

One of the things my team realized with the new linter rules (awesome, btw) but we also wanted to get the context of a model and it's relation to other models in some contexts of linting rules. 

For example, we have a case where anything downstream of a specific model we'd like it to include a specific tag or set of tags. This is to force the correct labeling of some models that are derived from the lineage of some other model. 

Notes:
* I figured it was bad form to pass the _full_ context into the Rule.
* In order to prevent a breaking change (that forces the Rule to include a `context`) object, I expose the context via the two new methods on the `Rule` base class. I'd prefer, honestly, to just pass in the `context` object but that would force all current users to change their implementations. 