### PR TITLE
Chore: bump sqlglot to v26.16.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "requests",
     "rich[jupyter]",
     "ruamel.yaml",
-    "sqlglot[rs]~=26.16.0",
+    "sqlglot[rs]~=26.16.1",
     "tenacity",
     "time-machine",
     "json-stream"


### PR DESCRIPTION
@erindru with this you should have the `partitioned_by` parser for https://github.com/TobikoData/sqlmesh/pull/4224.