### PR TITLE
Fix: Create snapshot records before creating physical tables

### DIFF
--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -255,6 +255,11 @@ class BuiltInPlanEvaluator(PlanEvaluator):
             plan: The plan to source snapshots from.
             deployability_index: Indicates which snapshots are deployable in the context of this creation.
         """
+        self.state_sync.push_snapshots(plan.new_snapshots)
+        analytics.collector.on_snapshots_created(
+            new_snapshots=plan.new_snapshots, plan_id=plan.plan_id
+        )
+
         promoted_snapshot_ids = (
             set(plan.environment.promoted_snapshot_ids)
             if plan.environment.promoted_snapshot_ids is not None
@@ -300,11 +305,6 @@ class BuiltInPlanEvaluator(PlanEvaluator):
                     success=completion_status is not None and completion_status.is_success
                 )
 
-        self.state_sync.push_snapshots(plan.new_snapshots)
-
-        analytics.collector.on_snapshots_created(
-            new_snapshots=plan.new_snapshots, plan_id=plan.plan_id
-        )
         return completion_status
 
     def _promote(


### PR DESCRIPTION
A long time ago, we created physical tables eagerly and assumed that if a snapshot record existed, a corresponding physical table must also exist. That’s why the order of operations mattered a lot - the record could only be created after the physical table was successfully created.

This is no longer necessary, as physical tables are now created lazily, on demand, if they’re missing