### PR TITLE
Fix: Expand the parent's model query during query rendering if the parent is not categorized

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -152,6 +152,7 @@ class EngineAdapter:
             register_comments=self._register_comments,
             null_connection=True,
             multithreaded=self._multithreaded,
+            pretty_sql=self._pretty_sql,
             **self._extra_config,
         )
 

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -317,7 +317,9 @@ class BaseExpressionRenderer:
                 **table_mapping,
             }
             expand = set(expand) | {
-                name for name, snapshot in snapshots.items() if snapshot.is_embedded
+                name
+                for name, snapshot in snapshots.items()
+                if snapshot.is_embedded or not snapshot.categorized
             }
 
             if expand:

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -317,10 +317,7 @@ class BaseExpressionRenderer:
                 **table_mapping,
             }
             expand = set(expand) | {
-                name
-                for name, snapshot in snapshots.items()
-                if snapshot.is_embedded
-                or (snapshot.is_model and snapshot.model.is_sql and not snapshot.categorized)
+                name for name, snapshot in snapshots.items() if snapshot.is_embedded
             }
 
             if expand:

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -319,7 +319,8 @@ class BaseExpressionRenderer:
             expand = set(expand) | {
                 name
                 for name, snapshot in snapshots.items()
-                if snapshot.is_embedded or not snapshot.categorized
+                if snapshot.is_embedded
+                or (snapshot.is_model and snapshot.model.is_sql and not snapshot.categorized)
             }
 
             if expand:

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1014,6 +1014,11 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
 
         self.change_category = category
 
+    @property
+    def categorized(self) -> bool:
+        """Whether the snapshot has been categorized."""
+        return self.change_category is not None and self.version is not None
+
     def table_name(self, is_deployable: bool = True) -> str:
         """Full table name pointing to the materialized location of the snapshot.
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1470,11 +1470,6 @@ def grant_usage_role(evaluator, schemas, role):
     context = Context(paths=tmp_path, config=config)
     snapshots = {s.name: s for s in context.snapshots.values()}
 
-    from sqlmesh.core.snapshot.definition import SnapshotChangeCategory
-
-    for s in snapshots.values():
-        s.categorize_as(SnapshotChangeCategory.BREAKING)
-
     environment_statements = context._environment_statements[0]
     before_all = environment_statements.before_all
     after_all = environment_statements.after_all
@@ -1501,7 +1496,6 @@ def grant_usage_role(evaluator, schemas, role):
         snapshots=snapshots,
         environment_naming_info=EnvironmentNamingInfo(name="prod"),
         runtime_stage=RuntimeStage.BEFORE_ALL,
-        engine_adapter=context.engine_adapter,
     )
 
     assert after_all_rendered == [

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -4598,7 +4598,7 @@ def test_multi(mocker):
     )
     assert (
         context.render("silver.d").sql()
-        == '''SELECT "c"."col_a" AS "col_a", 2 AS "two", 'repo_2' AS "dup" FROM "memory"."silver"."c" AS "c"'''
+        == '''SELECT "c"."col_a" AS "col_a", 2 AS "two", 'repo_2' AS "dup" FROM (SELECT DISTINCT "a"."col_a" AS "col_a" FROM (SELECT 1 AS "col_a", 'b' AS "col_b", 1 AS "one", 'repo_1' AS "dup") AS "a") AS "c"'''
     )
     context._new_state_sync().reset(default_catalog=context.default_catalog)
     plan = context.plan_builder().build()

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -4076,7 +4076,7 @@ def test_no_backfill_for_model_downstream_of_metadata_change(init_and_plan_conte
 
 
 @time_machine.travel("2023-01-08 15:00:00 UTC")
-def test_evaluate_of_uncategorized_snapshot(init_and_plan_context: t.Callable):
+def test_evaluate_uncategorized_snapshot(init_and_plan_context: t.Callable):
     context, plan = init_and_plan_context("examples/sushi")
     context.apply(plan)
 
@@ -4598,7 +4598,7 @@ def test_multi(mocker):
     )
     assert (
         context.render("silver.d").sql()
-        == '''SELECT "c"."col_a" AS "col_a", 2 AS "two", 'repo_2' AS "dup" FROM (SELECT DISTINCT "a"."col_a" AS "col_a" FROM (SELECT 1 AS "col_a", 'b' AS "col_b", 1 AS "one", 'repo_1' AS "dup") AS "a") AS "c"'''
+        == '''SELECT "c"."col_a" AS "col_a", 2 AS "two", 'repo_2' AS "dup" FROM "memory"."silver"."c" AS "c"'''
     )
     context._new_state_sync().reset(default_catalog=context.default_catalog)
     plan = context.plan_builder().build()


### PR DESCRIPTION
The uncategorized parent won’t have a physical table available, so if the user runs `evaluate` on a downstream child that relies on uncategorized upstream changes, the command will fail.

This update makes it so that uncategorized parents are inlined into the target model's query automatically during rendering.