### PR TITLE
Feat!: Add support for concurrent table diff of multiple models

### DIFF
--- a/docs/guides/model_selection.md
+++ b/docs/guides/model_selection.md
@@ -2,7 +2,7 @@
 
 This guide describes how to select specific models to include in a SQLMesh plan, which can be useful when modifying a subset of the models in a SQLMesh project.
 
-Note: the selector syntax described below is also used for the SQLMesh `plan` [`--allow-destructive-model` selector](../concepts/plans.md#destructive-changes).
+Note: the selector syntax described below is also used for the SQLMesh `plan` [`--allow-destructive-model` selector](../concepts/plans.md#destructive-changes) and for the `table_diff` command to [diff a selection of models](./tablediff.md#diffing-multiple-models-across-environments).
 
 ## Background
 

--- a/docs/guides/model_selection.md
+++ b/docs/guides/model_selection.md
@@ -221,6 +221,81 @@ Models:
     └── sushi.customer_revenue_lifetime
 ```
 
+#### Select with tags
+
+If we specify the `--select-model` option with a tag selector like `"tag:reporting"`, all models with the "reporting" tag will be selected. Tags are case-insensitive and support wildcards:
+
+```bash
+❯ sqlmesh plan dev --select-model "tag:reporting*"
+New environment `dev` will be created from `prod`
+
+Differences from the `prod` environment:
+
+Models:
+├── Directly Modified:
+│   ├── sushi.daily_revenue
+│   └── sushi.monthly_revenue
+└── Indirectly Modified:
+    └── sushi.revenue_dashboard
+```
+
+#### Select with git changes
+
+The git-based selector allows you to select models whose files have changed compared to a target branch (default: main). This includes:
+- Untracked files (new files not in git)
+- Uncommitted changes in working directory
+- Committed changes different from the target branch
+
+For example:
+
+```bash
+❯ sqlmesh plan dev --select-model "git:feature"
+New environment `dev` will be created from `prod`
+
+Differences from the `prod` environment:
+
+Models:
+├── Directly Modified:
+│   └── sushi.items # Changed in feature branch
+└── Indirectly Modified:
+    ├── sushi.order_items
+    └── sushi.daily_revenue
+```
+
+You can also combine git selection with upstream/downstream indicators:
+
+```bash
+❯ sqlmesh plan dev --select-model "git:feature+"
+# Selects changed models and their downstream dependencies
+
+❯ sqlmesh plan dev --select-model "+git:feature"
+# Selects changed models and their upstream dependencies
+```
+
+#### Complex selections with logical operators
+
+The model selector supports combining multiple conditions using logical operators:
+
+- `&` (AND): Both conditions must be true
+- `|` (OR): Either condition must be true
+- `^` (NOT): Negates a condition
+
+For example:
+
+```bash
+❯ sqlmesh plan dev --select-model "(tag:finance & ^tag:deprecated)"
+# Selects models with finance tag that don't have deprecated tag
+
+❯ sqlmesh plan dev --select-model "(+model_a | model_b+)"
+# Selects model_a and its upstream deps OR model_b and its downstream deps
+
+❯ sqlmesh plan dev --select-model "(tag:finance & git:main)"
+# Selects changed models that also have the finance tag
+
+❯ sqlmesh plan dev --select-model "^(tag:test) & metrics.*"
+# Selects models in metrics schema that don't have the test tag
+```
+
 ### Backfill examples
 
 #### No backfill selection

--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -135,8 +135,8 @@ sqlmesh table_diff prod:dev --select-model "sqlmesh_example.*"
 
 When diffing multiple models, SQLMesh will:
 
-1. Show the models returned by the selector that exist in both environments, but have no differences
-2. Compare the models that have differences and display the data diff of each model
+1. Show the models returned by the selector that exist in both environments and have differences
+2. Compare these models and display the data diff of each model
 
 > Note: Models will only be data diffed if there's a breaking change that impacts them.
 

--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -135,69 +135,39 @@ sqlmesh table_diff prod:dev --select-model "sqlmesh_example.*"
 
 When diffing multiple models, SQLMesh will:
 
-1. Show the models returnes by the selector that exist in both environments, but have no differences
-2. Compare the models that have differences and display the table diff of each model
-
-The `--select-model` option supports a powerful selection syntax that lets you choose models using patterns, tags, dependencies and git status. For complete details, see the [model selection guide](./model_selection.md).
+1. Show the models returned by the selector that exist in both environments, but have no differences
+2. Compare the models that have differences and display the data diff of each model
 
 > Note: Models will only be data diffed if there's a breaking change that impacts them.
 
-Here are some common patterns you can use:
+The `--select-model` option supports a powerful selection syntax that lets you choose models using patterns, tags, dependencies and git status. For complete details, see the [model selection guide](./model_selection.md).
 
 > Note: Surround your selection pattern in single or double quotes. Ex: `'*'`, `"sqlmesh_example.*"`
 
-### Wildcard Patterns
-
-- `*` - All models in the project
-- `sqlmesh_example.*` - All models in the sqlmesh_example schema
-
-### Upstream/Downstream Selection
-
-- `+model_name` - Select the model and its upstream dependencies
-- `model_name+` - Select the model and its downstream dependencies
-- `+model_name+` - Select the model and both its upstream and downstream dependencies
-
-### Tag-based Selection
-
-- `tag:finance` - All models with the "finance" tag
-- `tag:reporting*` - All models with tags starting with "reporting"
-
-### Git-based Selection
-
-- `git:feature` - Select models whose files have changed compared to main branch, including:
-  - Untracked files (new files not in git)
-  - Uncommitted changes in working directory
-  - Committed changes different from main branch
-- `+git:feature` - Select changed models and their upstream dependencies
-- `git:feature+` - Select changed models and their downstream dependencies
-
-> Note: Git-based selection excludes deleted files and respects your `.gitignore` settings.
-
-### Logical Operators
-
-You can combine multiple selectors using logical operators:
-- `&` (AND): Both conditions must be true
-- `|` (OR): Either condition must be true
-- `^` (NOT): Negates a condition
-
-#### Complex Selection Examples
-
-- `(tag:finance & ^tag:deprecated)` - Models with finance tag that don't have deprecated tag
-- `(+model_a | model_b+)` - Model A and its upstream deps OR model B and its downstream deps
-- `(tag:finance & git:main)` - Changed models that also have the finance tag
-- `^(tag:test) & metrics.*` - Models in metrics schema that don't have the test tag
-
-### Multiple selectors
-
-You can also combine multiple selectors in a single command:
+Here are some common examples:
 
 ```bash
+# Select all models in a schema
+sqlmesh table_diff prod:dev -m "sqlmesh_example.*"
+
+# Select a model and its dependencies
+sqlmesh table_diff prod:dev -m "+model_name"  # include upstream deps
+sqlmesh table_diff prod:dev -m "model_name+"  # include downstream deps
+
+# Select models by tag
+sqlmesh table_diff prod:dev -m "tag:finance"
+
+# Select models with git changes
+sqlmesh table_diff prod:dev -m "git:feature"
+
+# Use logical operators for complex selections
+sqlmesh table_diff prod:dev -m "(metrics.* & ^tag:deprecated)"  # finance models that aren't deprecated
+
+# Combine multiple selectors
 sqlmesh table_diff prod:dev -m "tag:finance" -m "metrics.*_daily"
 ```
 
 When multiple selectors are provided, they are combined with OR logic, meaning a model matching any of the selectors will be included.
-
-All the standard table diff options like `--show-sample` work with multiple model diffing. The comparisons are executed concurrently for better performance when dealing with a large project or many models.
 
 > Note: All models being compared must have their `grain` defined that is unique and not null, as this is used to perform the join between the tables in the two environments.
 

--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -140,24 +140,30 @@ When diffing multiple models, SQLMesh will:
 
 The `--select-model` option supports a powerful selection syntax that lets you choose models using patterns, tags, dependencies and git status. For complete details, see the [model selection guide](./model_selection.md).
 
-> Note: models will only be data diffed if there's a breaking change that impacts them.
+> Note: Models will only be data diffed if there's a breaking change that impacts them.
 
 Here are some common patterns you can use:
-> Note: Surround your selection pattern in single or double quotes. Ex: '*', "sqlmesh_example.*"
+
+> Note: Surround your selection pattern in single or double quotes. Ex: `'*'`, `"sqlmesh_example.*"`
+
 ### Wildcard Patterns
+
 - `*` - All models in the project
 - `sqlmesh_example.*` - All models in the sqlmesh_example schema
 
 ### Upstream/Downstream Selection
+
 - `+model_name` - Select the model and its upstream dependencies
 - `model_name+` - Select the model and its downstream dependencies
 - `+model_name+` - Select the model and both its upstream and downstream dependencies
 
 ### Tag-based Selection
+
 - `tag:finance` - All models with the "finance" tag
 - `tag:reporting*` - All models with tags starting with "reporting"
 
 ### Git-based Selection
+
 - `git:feature` - Select models whose files have changed compared to main branch, including:
   - Untracked files (new files not in git)
   - Uncommitted changes in working directory
@@ -168,12 +174,14 @@ Here are some common patterns you can use:
 > Note: Git-based selection excludes deleted files and respects your `.gitignore` settings.
 
 ### Logical Operators
+
 You can combine multiple selectors using logical operators:
 - `&` (AND): Both conditions must be true
 - `|` (OR): Either condition must be true
 - `^` (NOT): Negates a condition
 
 #### Complex Selection Examples
+
 - `(tag:finance & ^tag:deprecated)` - Models with finance tag that don't have deprecated tag
 - `(+model_a | model_b+)` - Model A and its upstream deps OR model B and its downstream deps
 - `(tag:finance & git:main)` - Changed models that also have the finance tag

--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -140,8 +140,10 @@ When diffing multiple models, SQLMesh will:
 
 The `--select-model` option supports a powerful selection syntax that lets you choose models using patterns, tags, dependencies and git status. For complete details, see the [model selection guide](./model_selection.md).
 
-Here are some common patterns you can use:
+> Note: models will only be data diffed if there's a breaking change that impacts them.
 
+Here are some common patterns you can use:
+> Note: Surround your selection pattern in single or double quotes. Ex: '*', "sqlmesh_example.*"
 ### Wildcard Patterns
 - `*` - All models in the project
 - `sqlmesh_example.*` - All models in the sqlmesh_example schema
@@ -187,9 +189,9 @@ sqlmesh table_diff prod:dev -m "tag:finance" -m "metrics.*_daily"
 
 When multiple selectors are provided, they are combined with OR logic, meaning a model matching any of the selectors will be included.
 
-All the standard table diff options like `--show-sample` work with multiple model diffing. The comparisons are executed concurrently for better performance when dealing with a large of project or many models.
+All the standard table diff options like `--show-sample` work with multiple model diffing. The comparisons are executed concurrently for better performance when dealing with a large project or many models.
 
-> Note: All models being compared must have their `grain` defined, as this is used to perform the join between the tables in the two environments.
+> Note: All models being compared must have their `grain` defined that is unique and not null, as this is used to perform the join between the tables in the two environments.
 
 ## Diffing tables or views
 

--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -161,7 +161,7 @@ sqlmesh table_diff prod:dev -m "tag:finance"
 sqlmesh table_diff prod:dev -m "git:feature"
 
 # Use logical operators for complex selections
-sqlmesh table_diff prod:dev -m "(metrics.* & ^tag:deprecated)"  # finance models that aren't deprecated
+sqlmesh table_diff prod:dev -m "(metrics.* & ^tag:deprecated)"  # models in the metrics schema that aren't deprecated
 
 # Combine multiple selectors
 sqlmesh table_diff prod:dev -m "tag:finance" -m "metrics.*_daily"

--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -135,10 +135,8 @@ sqlmesh table_diff prod:dev --select-model "sqlmesh_example.*"
 
 When diffing multiple models, SQLMesh will:
 
-1. Show which models exist only in the source environment
-2. Show which models exist only in the target environment
-3. Show which models exist in both environments but have no differences
-4. Compare the models that have differences and display them
+1. Show the models returnes by the selector that exist in both environments, but have no differences
+2. Compare the models that have differences and display the table diff of each model
 
 The `--select-model` option supports a powerful selection syntax that lets you choose models using patterns, tags, dependencies and git status. For complete details, see the [model selection guide](./model_selection.md).
 

--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -135,8 +135,8 @@ sqlmesh table_diff prod:dev --select-model "sqlmesh_example.*"
 
 When diffing multiple models, SQLMesh will:
 
-1. Show the models returned by the selector that exist in both environments, but have no differences
-2. Compare the models that have differences and display the data diff of each model
+1. Show the models returned by the selector that exist in both environments and have differences
+2. Compare the models and display the data diff of each model
 
 > Note: Models will only be data diffed if there's a breaking change that impacts them.
 

--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -135,8 +135,8 @@ sqlmesh table_diff prod:dev --select-model "sqlmesh_example.*"
 
 When diffing multiple models, SQLMesh will:
 
-1. Show the models returned by the selector that exist in both environments and have differences
-2. Compare the models and display the data diff of each model
+1. Show the models returned by the selector that exist in both environments, but have no differences
+2. Compare the models that have differences and display the data diff of each model
 
 > Note: Models will only be data diffed if there's a breaking change that impacts them.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -529,7 +529,7 @@ Options:
 ```
 Usage: sqlmesh table_diff [OPTIONS] SOURCE:TARGET [MODEL]
 
-  Show the diff between two tables.
+  Show the diff between two tables or multiple models across two environments.
 
 Options:
   -o, --on TEXT            The column to join on. Can be specified multiple
@@ -548,6 +548,7 @@ Options:
   --temp-schema TEXT       Schema used for temporary tables. It can be
                            `CATALOG.SCHEMA` or `SCHEMA`. Default:
                            `sqlmesh_temp`
+  -m, --select-model TEXT  Select specific models to table diff.
   --help                   Show this message and exit.
 ```
 

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -293,7 +293,7 @@ Create a schema file containing external model schemas.
 %table_diff [--on [ON ...]] [--skip-columns [SKIP_COLUMNS ...]]
                 [--model MODEL] [--where WHERE] [--limit LIMIT]
                 [--show-sample] [--decimals DECIMALS] [--skip-grain-check]
-                [--temp-schema SCHEMA]
+                [--temp-schema SCHEMA] [--select-model [SELECT_MODEL ...]]
                 SOURCE:TARGET
 
 Show the diff between two tables.
@@ -320,6 +320,8 @@ options:
   --skip-grain-check    Disable the check for a primary key (grain) that is
                         missing or is not unique.
   --temp-schema SCHEMA  The schema to use for temporary tables.
+  --select-model <[SELECT_MODEL ...]>
+                        Select specific models to diff using a pattern.
 ```
 
 #### model

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -906,10 +906,11 @@ def table_diff(
 ) -> None:
     """Show the diff between two tables or a selection of models when they are specified."""
     source, target = source_to_target.split(":")
+    select_models = {model} if model else kwargs.pop("select_model", None)
     obj.table_diff(
         source=source,
         target=target,
-        model_or_snapshot=model,
+        select_models=select_models,
         **kwargs,
     )
 

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -892,27 +892,26 @@ def create_external_models(obj: Context, **kwargs: t.Any) -> None:
     type=str,
     help="Schema used for temporary tables. It can be `CATALOG.SCHEMA` or `SCHEMA`. Default: `sqlmesh_temp`",
 )
+@click.option(
+    "--select-model",
+    type=str,
+    multiple=True,
+    help="Select specific model that should be diffed.",
+)
 @click.pass_obj
 @error_handler
 @cli_analytics
 def table_diff(
     obj: Context, source_to_target: str, model: t.Optional[str], **kwargs: t.Any
 ) -> None:
-    """Show the diff between two tables or all impacted when no model is specified."""
+    """Show the diff between two tables or a selection of models when they are specified."""
     source, target = source_to_target.split(":")
-    if model:
-        obj.table_diff(
-            source=source,
-            target=target,
-            model_or_snapshot=model,
-            **kwargs,
-        )
-    else:
-        obj.table_diff_impacted_models(
-            source=source,
-            target=target,
-            **kwargs,
-        )
+    obj.table_diff(
+        source=source,
+        target=target,
+        model_or_snapshot=model,
+        **kwargs,
+    )
 
 
 @cli.command("rewrite")

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -894,6 +894,7 @@ def create_external_models(obj: Context, **kwargs: t.Any) -> None:
 )
 @click.option(
     "--select-model",
+    "-m",
     type=str,
     multiple=True,
     help="Select specific model that should be diffed.",

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -897,7 +897,7 @@ def create_external_models(obj: Context, **kwargs: t.Any) -> None:
     "-m",
     type=str,
     multiple=True,
-    help="Select specific model that should be diffed.",
+    help="Specify one or more models to data diff. Use wildcards to diff multiple models. Ex: '*' (all models with applied plan diffs), 'demo.model+' (this and downstream models), 'git:feature_branch' (models with direct modifications in this branch only)",
 )
 @click.pass_obj
 @error_handler

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -898,14 +898,21 @@ def create_external_models(obj: Context, **kwargs: t.Any) -> None:
 def table_diff(
     obj: Context, source_to_target: str, model: t.Optional[str], **kwargs: t.Any
 ) -> None:
-    """Show the diff between two tables."""
+    """Show the diff between two tables or all impacted when no model is specified."""
     source, target = source_to_target.split(":")
-    obj.table_diff(
-        source=source,
-        target=target,
-        model_or_snapshot=model,
-        **kwargs,
-    )
+    if model:
+        obj.table_diff(
+            source=source,
+            target=target,
+            model_or_snapshot=model,
+            **kwargs,
+        )
+    else:
+        obj.table_diff_impacted_models(
+            source=source,
+            target=target,
+            **kwargs,
+        )
 
 
 @cli.command("rewrite")

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -684,7 +684,13 @@ class NoopConsole(Console):
         skip_grain_check: bool = False,
         temp_schema: t.Optional[str] = None,
     ) -> None:
-        pass
+        self.show_table_diff_summary(table_diff)
+        self.show_schema_diff(table_diff.schema_diff())
+        self.show_row_diff(
+            table_diff.row_diff(temp_schema=temp_schema, skip_grain_check=skip_grain_check),
+            show_sample=show_sample,
+            skip_grain_check=skip_grain_check,
+        )
 
     def show_table_diff_summary(self, table_diff: TableDiff) -> None:
         pass

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1990,7 +1990,8 @@ class TerminalConsole(Console):
         """Display information about which tables are identical and which are diffed"""
 
         if (
-            len(models_no_diff) < self.TABLE_DIFF_MODELS_DISPLAY_THRESHOLD
+            models_no_diff
+            and len(models_no_diff) < self.TABLE_DIFF_MODELS_DISPLAY_THRESHOLD
             or self.verbosity == Verbosity.VERY_VERBOSE
         ):
             m_tree = Tree("\n[b]Models without changes:")

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -250,8 +250,6 @@ class TableDiffConsole(abc.ABC):
     @abc.abstractmethod
     def show_table_diff_details(
         self,
-        models_in_source: t.List[str],
-        models_in_target: t.List[str],
         models_no_diff: t.List[str],
         models_to_diff: t.List[str],
     ) -> None:
@@ -719,8 +717,6 @@ class NoopConsole(Console):
 
     def show_table_diff_details(
         self,
-        models_in_source: t.List[str],
-        models_in_target: t.List[str],
         models_no_diff: t.List[str],
         models_to_diff: t.List[str],
     ) -> None:
@@ -1987,24 +1983,10 @@ class TerminalConsole(Console):
 
     def show_table_diff_details(
         self,
-        models_in_source: t.List[str],
-        models_in_target: t.List[str],
         models_no_diff: t.List[str],
         models_to_diff: t.List[str],
     ) -> None:
         """Display information about which tables are identical and which are diffed"""
-
-        if models_in_source:
-            m_tree = Tree("\n[b]Models only in source environment:")
-            for m in models_in_source:
-                m_tree.add(f"[{self.TABLE_DIFF_SOURCE_BLUE}]{m}[/{self.TABLE_DIFF_SOURCE_BLUE}]")
-            self._print(m_tree)
-
-        if models_in_target:
-            m_tree = Tree("\n[b]Models only in target environment:")
-            for m in models_in_target:
-                m_tree.add(f"[{self.TABLE_DIFF_TARGET_GREEN}]{m}[/{self.TABLE_DIFF_TARGET_GREEN}]")
-            self._print(m_tree)
 
         if models_no_diff:
             m_tree = Tree("\n[b]Models without changes:")

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -317,7 +317,6 @@ class Console(
     with them when their input is needed."""
 
     INDIRECTLY_MODIFIED_DISPLAY_THRESHOLD = 10
-    TABLE_DIFF_MODELS_DISPLAY_THRESHOLD = 5
 
     @abc.abstractmethod
     def start_plan_evaluation(self, plan: EvaluatablePlan) -> None:

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -250,9 +250,10 @@ class TableDiffConsole(abc.ABC):
     @abc.abstractmethod
     def show_table_diff_details(
         self,
+        models_no_diff: t.List[str],
         models_to_diff: t.List[str],
     ) -> None:
-        """Display information about which tables are going to be diffed"""
+        """Display information about which tables are identical and which are diffed"""
 
     @abc.abstractmethod
     def show_table_diff_summary(self, table_diff: TableDiff) -> None:
@@ -716,6 +717,7 @@ class NoopConsole(Console):
 
     def show_table_diff_details(
         self,
+        models_no_diff: t.List[str],
         models_to_diff: t.List[str],
     ) -> None:
         pass
@@ -1981,9 +1983,16 @@ class TerminalConsole(Console):
 
     def show_table_diff_details(
         self,
+        models_no_diff: t.List[str],
         models_to_diff: t.List[str],
     ) -> None:
-        """Display information about which tables are going to be diffed"""
+        """Display information about which tables are identical and which are diffed"""
+
+        if models_no_diff:
+            m_tree = Tree("\n[b]Models without changes:")
+            for m in models_no_diff:
+                m_tree.add(f"[{self.TABLE_DIFF_SOURCE_BLUE}]{m}[/{self.TABLE_DIFF_SOURCE_BLUE}]")
+            self._print(m_tree)
 
         if models_to_diff:
             m_tree = Tree("\n[b]Models to compare:")

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -250,10 +250,9 @@ class TableDiffConsole(abc.ABC):
     @abc.abstractmethod
     def show_table_diff_details(
         self,
-        models_no_diff: t.List[str],
         models_to_diff: t.List[str],
     ) -> None:
-        """Display information about which tables are identical and which are diffed"""
+        """Display information about which tables are going to be diffed"""
 
     @abc.abstractmethod
     def show_table_diff_summary(self, table_diff: TableDiff) -> None:
@@ -718,7 +717,6 @@ class NoopConsole(Console):
 
     def show_table_diff_details(
         self,
-        models_no_diff: t.List[str],
         models_to_diff: t.List[str],
     ) -> None:
         pass
@@ -1984,20 +1982,9 @@ class TerminalConsole(Console):
 
     def show_table_diff_details(
         self,
-        models_no_diff: t.List[str],
         models_to_diff: t.List[str],
     ) -> None:
-        """Display information about which tables are identical and which are diffed"""
-
-        if (
-            models_no_diff
-            and len(models_no_diff) < self.TABLE_DIFF_MODELS_DISPLAY_THRESHOLD
-            or self.verbosity == Verbosity.VERY_VERBOSE
-        ):
-            m_tree = Tree("\n[b]Models without changes:")
-            for m in models_no_diff:
-                m_tree.add(f"[{self.TABLE_DIFF_SOURCE_BLUE}]{m}[/{self.TABLE_DIFF_SOURCE_BLUE}]")
-            self._print(m_tree)
+        """Display information about which tables are going to be diffed"""
 
         if models_to_diff:
             m_tree = Tree("\n[b]Models to compare:")

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -2139,7 +2139,6 @@ class TerminalConsole(Console):
                 self.console.print(f"\n[b][green]{target_name} ONLY[/green] sample rows:[/b]")
                 self.console.print(row_diff.t_sample.to_string(index=False), end="\n\n")
 
-
     def show_table_diff(
         self,
         table_diffs: t.List[TableDiff],

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -250,10 +250,9 @@ class TableDiffConsole(abc.ABC):
     @abc.abstractmethod
     def show_table_diff_details(
         self,
-        models_no_diff: t.List[str],
         models_to_diff: t.List[str],
     ) -> None:
-        """Display information about which tables are identical and which are diffed"""
+        """Display information about which tables are going to be diffed"""
 
     @abc.abstractmethod
     def show_table_diff_summary(self, table_diff: TableDiff) -> None:
@@ -717,7 +716,6 @@ class NoopConsole(Console):
 
     def show_table_diff_details(
         self,
-        models_no_diff: t.List[str],
         models_to_diff: t.List[str],
     ) -> None:
         pass
@@ -1983,16 +1981,9 @@ class TerminalConsole(Console):
 
     def show_table_diff_details(
         self,
-        models_no_diff: t.List[str],
         models_to_diff: t.List[str],
     ) -> None:
-        """Display information about which tables are identical and which are diffed"""
-
-        if models_no_diff:
-            m_tree = Tree("\n[b]Models without changes:")
-            for m in models_no_diff:
-                m_tree.add(f"[{self.TABLE_DIFF_SOURCE_BLUE}]{m}[/{self.TABLE_DIFF_SOURCE_BLUE}]")
-            self._print(m_tree)
+        """Display information about which tables are going to be diffed"""
 
         if models_to_diff:
             m_tree = Tree("\n[b]Models to compare:")

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -318,6 +318,7 @@ class Console(
     with them when their input is needed."""
 
     INDIRECTLY_MODIFIED_DISPLAY_THRESHOLD = 10
+    TABLE_DIFF_MODELS_DISPLAY_THRESHOLD = 5
 
     @abc.abstractmethod
     def start_plan_evaluation(self, plan: EvaluatablePlan) -> None:
@@ -1988,7 +1989,10 @@ class TerminalConsole(Console):
     ) -> None:
         """Display information about which tables are identical and which are diffed"""
 
-        if models_no_diff:
+        if (
+            len(models_no_diff) < self.TABLE_DIFF_MODELS_DISPLAY_THRESHOLD
+            or self.verbosity == Verbosity.VERY_VERBOSE
+        ):
             m_tree = Tree("\n[b]Models without changes:")
             for m in models_no_diff:
                 m_tree.add(f"[{self.TABLE_DIFF_SOURCE_BLUE}]{m}[/{self.TABLE_DIFF_SOURCE_BLUE}]")

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -197,7 +197,7 @@ class EnvironmentsConsole(abc.ABC):
 
 
 class DifferenceConsole(abc.ABC):
-    """Console for displaying environment differences"""
+    """Console for displaying differences"""
 
     @abc.abstractmethod
     def show_environment_difference_summary(
@@ -216,6 +216,20 @@ class DifferenceConsole(abc.ABC):
         no_diff: bool = True,
     ) -> None:
         """Displays a summary of differences for the given models."""
+
+    @abc.abstractmethod
+    def show_table_diff_summary(self, table_diff: TableDiff) -> None:
+        """Display information about the tables being diffed and how they are being joined"""
+
+    @abc.abstractmethod
+    def show_schema_diff(self, schema_diff: SchemaDiff) -> None:
+        """Show table schema diff."""
+
+    @abc.abstractmethod
+    def show_row_diff(
+        self, row_diff: RowDiff, show_sample: bool = True, skip_grain_check: bool = False
+    ) -> None:
+        """Show table summary diff."""
 
 
 class BaseConsole(abc.ABC):
@@ -423,20 +437,6 @@ class Console(
     @abc.abstractmethod
     def loading_stop(self, id: uuid.UUID) -> None:
         """Stop loading for the given id."""
-
-    @abc.abstractmethod
-    def show_table_diff_summary(self, table_diff: TableDiff) -> None:
-        """Display information about the tables being diffed and how they are being joined"""
-
-    @abc.abstractmethod
-    def show_schema_diff(self, schema_diff: SchemaDiff) -> None:
-        """Show table schema diff."""
-
-    @abc.abstractmethod
-    def show_row_diff(
-        self, row_diff: RowDiff, show_sample: bool = True, skip_grain_check: bool = False
-    ) -> None:
-        """Show table summary diff."""
 
 
 class NoopConsole(Console):
@@ -697,6 +697,7 @@ class TerminalConsole(Console):
     """A rich based implementation of the console."""
 
     TABLE_DIFF_SOURCE_BLUE = "#0248ff"
+    TABLE_DIFF_TARGET_GREEN = "green"
 
     def __init__(
         self,
@@ -1544,38 +1545,57 @@ class TerminalConsole(Console):
                 )
             tree.add(self._limit_model_names(removed_tree, self.verbosity))
         if modified_snapshot_ids:
-            direct = Tree("[bold][direct]Directly Modified:")
-            indirect = Tree("[bold][indirect]Indirectly Modified:")
-            metadata = Tree("[bold][metadata]Metadata Updated:")
-            for s_id in modified_snapshot_ids:
-                name = s_id.name
-                display_name = context_diff.snapshots[s_id].display_name(
-                    environment_naming_info,
-                    default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None,
-                    dialect=self.dialect,
-                )
-                if context_diff.directly_modified(name):
-                    direct.add(
-                        f"[direct]{display_name}"
-                        if no_diff
-                        else Syntax(f"{display_name}\n{context_diff.text_diff(name)}", "sql")
-                    )
-                elif context_diff.indirectly_modified(name):
-                    indirect.add(f"[indirect]{display_name}")
-                elif context_diff.metadata_updated(name):
-                    metadata.add(
-                        f"[metadata]{display_name}"
-                        if no_diff
-                        else Syntax(f"{display_name}\n{context_diff.text_diff(name)}", "sql")
-                    )
+            tree = self._add_modified_models(
+                context_diff,
+                modified_snapshot_ids,
+                tree,
+                environment_naming_info,
+                default_catalog,
+                no_diff,
+            )
 
-            if direct.children:
-                tree.add(direct)
-            if indirect.children:
-                tree.add(self._limit_model_names(indirect, self.verbosity))
-            if metadata.children:
-                tree.add(metadata)
         self._print(tree)
+
+    def _add_modified_models(
+        self,
+        context_diff: ContextDiff,
+        modified_snapshot_ids: t.Set[SnapshotId],
+        tree: Tree,
+        environment_naming_info: EnvironmentNamingInfo,
+        default_catalog: t.Optional[str] = None,
+        no_diff: bool = True,
+    ) -> Tree:
+        direct = Tree("[bold][direct]Directly Modified:")
+        indirect = Tree("[bold][indirect]Indirectly Modified:")
+        metadata = Tree("[bold][metadata]Metadata Updated:")
+        for s_id in modified_snapshot_ids:
+            name = s_id.name
+            display_name = context_diff.snapshots[s_id].display_name(
+                environment_naming_info,
+                default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None,
+                dialect=self.dialect,
+            )
+            if context_diff.directly_modified(name):
+                direct.add(
+                    f"[direct]{display_name}"
+                    if no_diff
+                    else Syntax(f"{display_name}\n{context_diff.text_diff(name)}", "sql")
+                )
+            elif context_diff.indirectly_modified(name):
+                indirect.add(f"[indirect]{display_name}")
+            elif context_diff.metadata_updated(name):
+                metadata.add(
+                    f"[metadata]{display_name}"
+                    if no_diff
+                    else Syntax(f"{display_name}\n{context_diff.text_diff(name)}", "sql")
+                )
+        if direct.children:
+            tree.add(direct)
+        if indirect.children:
+            tree.add(self._limit_model_names(indirect, self.verbosity))
+        if metadata.children:
+            tree.add(metadata)
+        return tree
 
     def _show_options_after_categorization(
         self,
@@ -1897,7 +1917,9 @@ class TerminalConsole(Console):
             )
             envs.add(source)
 
-            target = Tree(f"Target: [green]{table_diff.target_alias}[/green]")
+            target = Tree(
+                f"Target: [{self.TABLE_DIFF_TARGET_GREEN}]{table_diff.target_alias}[/{self.TABLE_DIFF_TARGET_GREEN}]"
+            )
             envs.add(target)
 
             tree.add(envs)
@@ -1907,7 +1929,9 @@ class TerminalConsole(Console):
         tables.add(
             f"Source: [{self.TABLE_DIFF_SOURCE_BLUE}]{table_diff.source}[/{self.TABLE_DIFF_SOURCE_BLUE}]"
         )
-        tables.add(f"Target: [green]{table_diff.target}[/green]")
+        tables.add(
+            f"Target: [{self.TABLE_DIFF_TARGET_GREEN}]{table_diff.target}[/{self.TABLE_DIFF_TARGET_GREEN}]"
+        )
 
         tree.add(tables)
 
@@ -1928,7 +1952,7 @@ class TerminalConsole(Console):
         if schema_diff.target_alias:
             target_name = schema_diff.target_alias.upper()
 
-        first_line = f"\n[b]Schema Diff Between '[{self.TABLE_DIFF_SOURCE_BLUE}]{source_name}[/{self.TABLE_DIFF_SOURCE_BLUE}]' and '[green]{target_name}[/green]'"
+        first_line = f"\n[b]Schema Diff Between '[{self.TABLE_DIFF_SOURCE_BLUE}]{source_name}[/{self.TABLE_DIFF_SOURCE_BLUE}]' and '[{self.TABLE_DIFF_TARGET_GREEN}]{target_name}[/{self.TABLE_DIFF_TARGET_GREEN}]'"
         if schema_diff.model_name:
             first_line = (
                 first_line + f" environments for model '[blue]{schema_diff.model_name}[/blue]'"
@@ -2032,7 +2056,7 @@ class TerminalConsole(Console):
 
                 column_styles = {
                     source_name: self.TABLE_DIFF_SOURCE_BLUE,
-                    target_name: "green",
+                    target_name: self.TABLE_DIFF_TARGET_GREEN,
                 }
 
                 for column, [source_column, target_column] in columns.items():
@@ -2643,23 +2667,11 @@ class MarkdownConsole(CaptureTerminalConsole):
             no_diff: Hide the actual SQL differences.
         """
         added_snapshots = {context_diff.snapshots[s_id] for s_id in context_diff.added}
-        added_snapshot_models = {s for s in added_snapshots if s.is_model}
-        if added_snapshot_models:
+        if added_snapshots:
             self._print("\n**Added Models:**")
-            added_models = sorted(added_snapshot_models)
-            list_length = len(added_models)
-            if (
-                self.verbosity < Verbosity.VERY_VERBOSE
-                and list_length > self.INDIRECTLY_MODIFIED_DISPLAY_THRESHOLD
-            ):
-                self._print(added_models[0])
-                self._print(f"- `.... {list_length - 2} more ....`\n")
-                self._print(added_models[-1])
-            else:
-                for snapshot in added_models:
-                    self._print(
-                        f"- `{snapshot.display_name(environment_naming_info, default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None, dialect=self.dialect)}`"
-                    )
+            self._print_models_with_threshold(
+                environment_naming_info, {s for s in added_snapshots if s.is_model}, default_catalog
+            )
 
         added_snapshot_audits = {s for s in added_snapshots if s.is_audit}
         if added_snapshot_audits:
@@ -2670,23 +2682,13 @@ class MarkdownConsole(CaptureTerminalConsole):
                 )
 
         removed_snapshot_table_infos = set(context_diff.removed_snapshots.values())
-        removed_model_snapshot_table_infos = {s for s in removed_snapshot_table_infos if s.is_model}
-        if removed_model_snapshot_table_infos:
+        if removed_snapshot_table_infos:
             self._print("\n**Removed Models:**")
-            removed_models = sorted(removed_model_snapshot_table_infos)
-            list_length = len(removed_models)
-            if (
-                self.verbosity < Verbosity.VERY_VERBOSE
-                and list_length > self.INDIRECTLY_MODIFIED_DISPLAY_THRESHOLD
-            ):
-                self._print(removed_models[0])
-                self._print(f"- `.... {list_length - 2} more ....`\n")
-                self._print(removed_models[-1])
-            else:
-                for snapshot_table_info in removed_models:
-                    self._print(
-                        f"- `{snapshot_table_info.display_name(environment_naming_info, default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None, dialect=self.dialect)}`"
-                    )
+            self._print_models_with_threshold(
+                environment_naming_info,
+                {s for s in removed_snapshot_table_infos if s.is_model},
+                default_catalog,
+            )
 
         removed_audit_snapshot_table_infos = {s for s in removed_snapshot_table_infos if s.is_audit}
         if removed_audit_snapshot_table_infos:
@@ -2700,48 +2702,72 @@ class MarkdownConsole(CaptureTerminalConsole):
             current_snapshot for current_snapshot, _ in context_diff.modified_snapshots.values()
         }
         if modified_snapshots:
-            directly_modified = []
-            indirectly_modified = []
-            metadata_modified = []
-            for snapshot in modified_snapshots:
-                if context_diff.directly_modified(snapshot.name):
-                    directly_modified.append(snapshot)
-                elif context_diff.indirectly_modified(snapshot.name):
-                    indirectly_modified.append(snapshot)
-                elif context_diff.metadata_updated(snapshot.name):
-                    metadata_modified.append(snapshot)
-            if directly_modified:
-                self._print("\n**Directly Modified:**")
-                for snapshot in sorted(directly_modified):
-                    self._print(
-                        f"- `{snapshot.display_name(environment_naming_info, default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None, dialect=self.dialect)}`"
-                    )
-                    if not no_diff:
-                        self._print(f"```diff\n{context_diff.text_diff(snapshot.name)}\n```")
-            if indirectly_modified:
-                self._print("\n**Indirectly Modified:**")
-                indirectly_modified = sorted(indirectly_modified)
-                modified_length = len(indirectly_modified)
-                if (
-                    self.verbosity < Verbosity.VERY_VERBOSE
-                    and modified_length > self.INDIRECTLY_MODIFIED_DISPLAY_THRESHOLD
-                ):
-                    self._print(
-                        f"- `{indirectly_modified[0].display_name(environment_naming_info, default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None, dialect=self.dialect)}`\n"
-                        f"- `.... {modified_length - 2} more ....`\n"
-                        f"- `{indirectly_modified[-1].display_name(environment_naming_info, default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None, dialect=self.dialect)}`"
-                    )
-                else:
-                    for snapshot in indirectly_modified:
-                        self._print(
-                            f"- `{snapshot.display_name(environment_naming_info, default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None, dialect=self.dialect)}`"
-                        )
-            if metadata_modified:
-                self._print("\n**Metadata Updated:**")
-                for snapshot in sorted(metadata_modified):
-                    self._print(
-                        f"- `{snapshot.display_name(environment_naming_info, default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None, dialect=self.dialect)}`"
-                    )
+            self._print_modified_models(
+                context_diff, modified_snapshots, environment_naming_info, default_catalog, no_diff
+            )
+
+    def _print_models_with_threshold(
+        self,
+        environment_naming_info: EnvironmentNamingInfo,
+        snapshot_table_infos: t.Set[SnapshotInfoLike],
+        default_catalog: t.Optional[str] = None,
+    ) -> None:
+        models = sorted(snapshot_table_infos)
+        list_length = len(models)
+        if (
+            self.verbosity < Verbosity.VERY_VERBOSE
+            and list_length > self.INDIRECTLY_MODIFIED_DISPLAY_THRESHOLD
+        ):
+            self._print(
+                f"- `{models[0].display_name(environment_naming_info, default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None, dialect=self.dialect)}`"
+            )
+            self._print(f"- `.... {list_length - 2} more ....`\n")
+            self._print(
+                f"- `{models[-1].display_name(environment_naming_info, default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None, dialect=self.dialect)}`"
+            )
+        else:
+            for snapshot_table_info in models:
+                self._print(
+                    f"- `{snapshot_table_info.display_name(environment_naming_info, default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None, dialect=self.dialect)}`"
+                )
+
+    def _print_modified_models(
+        self,
+        context_diff: ContextDiff,
+        modified_snapshots: t.Set[Snapshot],
+        environment_naming_info: EnvironmentNamingInfo,
+        default_catalog: t.Optional[str] = None,
+        no_diff: bool = True,
+    ) -> None:
+        directly_modified = []
+        indirectly_modified = []
+        metadata_modified = []
+        for snapshot in modified_snapshots:
+            if context_diff.directly_modified(snapshot.name):
+                directly_modified.append(snapshot)
+            elif context_diff.indirectly_modified(snapshot.name):
+                indirectly_modified.append(snapshot)
+            elif context_diff.metadata_updated(snapshot.name):
+                metadata_modified.append(snapshot)
+        if directly_modified:
+            self._print("\n**Directly Modified:**")
+            for snapshot in sorted(directly_modified):
+                self._print(
+                    f"- `{snapshot.display_name(environment_naming_info, default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None, dialect=self.dialect)}`"
+                )
+                if not no_diff:
+                    self._print(f"```diff\n{context_diff.text_diff(snapshot.name)}\n```")
+        if indirectly_modified:
+            self._print("\n**Indirectly Modified:**")
+            self._print_models_with_threshold(
+                environment_naming_info, set(indirectly_modified), default_catalog
+            )
+        if metadata_modified:
+            self._print("\n**Metadata Updated:**")
+            for snapshot in sorted(metadata_modified):
+                self._print(
+                    f"- `{snapshot.display_name(environment_naming_info, default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None, dialect=self.dialect)}`"
+                )
 
     def _show_missing_dates(self, plan: Plan, default_catalog: t.Optional[str]) -> None:
         """Displays the models with missing dates."""

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -197,7 +197,7 @@ class EnvironmentsConsole(abc.ABC):
 
 
 class DifferenceConsole(abc.ABC):
-    """Console for displaying differences"""
+    """Console for displaying environment differences"""
 
     @abc.abstractmethod
     def show_environment_difference_summary(
@@ -216,6 +216,10 @@ class DifferenceConsole(abc.ABC):
         no_diff: bool = True,
     ) -> None:
         """Displays a summary of differences for the given models."""
+
+
+class TableDiffConsole(abc.ABC):
+    """Console for displaying table differences"""
 
     @abc.abstractmethod
     def show_table_diff(
@@ -308,6 +312,7 @@ class Console(
     JanitorConsole,
     EnvironmentsConsole,
     DifferenceConsole,
+    TableDiffConsole,
     BaseConsole,
     abc.ABC,
 ):

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1659,7 +1659,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             decimals=decimals,
         )
         if show:
-            self._show_table_diff(
+            self.console.show_table_diff(
                 table_diff=table_diff,
                 show_sample=show_sample,
                 skip_grain_check=skip_grain_check,
@@ -1667,31 +1667,6 @@ class GenericContext(BaseContext, t.Generic[C]):
             )
 
         return table_diff
-
-    def _show_table_diff(
-        self,
-        table_diff: TableDiff,
-        show_sample: bool = True,
-        skip_grain_check: bool = False,
-        temp_schema: t.Optional[str] = None,
-    ) -> None:
-        """Display the table diff between two tables.
-
-        Args:
-            table_diff: The TableDiff object containing schema and summary differences
-            show_sample: Show the sample dataframe in the console. Requires show=True.
-            skip_grain_check: Skip check for rows that contain null or duplicate grains.
-            temp_schema: The schema to use for temporary tables.
-
-        """
-
-        self.console.show_table_diff_summary(table_diff)
-        self.console.show_schema_diff(table_diff.schema_diff())
-        self.console.show_row_diff(
-            table_diff.row_diff(temp_schema=temp_schema, skip_grain_check=skip_grain_check),
-            show_sample=show_sample,
-            skip_grain_check=skip_grain_check,
-        )
 
     def _concurrent_table_diff(
         self,
@@ -1797,7 +1772,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             for _, (current_snapshot, _) in context_diff.modified_snapshots.items()
         }
         if modified_snapshot_ids:
-            results = self._concurrent_table_diff(
+            table_diffs = self._concurrent_table_diff(
                 modified_snapshot_ids=modified_snapshot_ids,
                 source=source,
                 target=target,
@@ -1813,14 +1788,10 @@ class GenericContext(BaseContext, t.Generic[C]):
                 temp_schema=temp_schema,
             )
             if show:
-                for result in results:
-                    self._show_table_diff(
-                        table_diff=result,
-                        show_sample=show_sample,
-                        skip_grain_check=skip_grain_check,
-                        temp_schema=temp_schema,
-                    )
-            return results
+                self.console.show_impacted_tables_diff(
+                    table_diffs, show_sample, skip_grain_check, temp_schema
+                )
+            return table_diffs
         return []
 
     @python_api_analytics

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1625,7 +1625,6 @@ class GenericContext(BaseContext, t.Generic[C]):
             models_to_diff: t.List[
                 t.Tuple[Model, EngineAdapter, str, str, t.Optional[t.List[str] | exp.Condition]]
             ] = []
-            models_no_diff: t.List[str] = []
             models_without_grain: t.List[Model] = []
             source_snapshots_to_name = {
                 snapshot.name: snapshot for snapshot in source_env.snapshots
@@ -1657,15 +1656,12 @@ class GenericContext(BaseContext, t.Generic[C]):
                         models_to_diff.append((model, adapter, source, target, model_on))
                         if not model_on:
                             models_without_grain.append(model)
-                    else:
-                        models_no_diff.append(model_fqn)
-
-            self.console.show_table_diff_details(
-                models_no_diff,
-                [model[0].name for model in models_to_diff],
-            )
 
             if models_to_diff:
+                self.console.show_table_diff_details(
+                    [model[0].name for model in models_to_diff],
+                )
+
                 if models_without_grain:
                     model_names = "\n".join(
                         f"─ {model.name} \n  at '{model._path}'" for model in models_without_grain

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1624,7 +1624,6 @@ class GenericContext(BaseContext, t.Generic[C]):
             models_to_diff: t.List[
                 t.Tuple[Model, EngineAdapter, str, str, t.Optional[t.List[str] | exp.Condition]]
             ] = []
-            models_no_diff: t.List[str] = []
             models_without_grain: t.List[Model] = []
             source_snapshots_to_name = {
                 snapshot.name: snapshot for snapshot in source_env.snapshots
@@ -1656,12 +1655,9 @@ class GenericContext(BaseContext, t.Generic[C]):
                         models_to_diff.append((model, adapter, source, target, model_on))
                         if not model_on:
                             models_without_grain.append(model)
-                    else:
-                        models_no_diff.append(model_fqn)
 
             if models_to_diff:
                 self.console.show_table_diff_details(
-                    models_no_diff,
                     [model[0].name for model in models_to_diff],
                 )
                 if models_without_grain:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1625,8 +1625,6 @@ class GenericContext(BaseContext, t.Generic[C]):
             models_to_diff: t.List[
                 t.Tuple[Model, EngineAdapter, str, str, t.Optional[t.List[str] | exp.Condition]]
             ] = []
-            models_in_source: t.List[str] = []
-            models_in_target: t.List[str] = []
             models_no_diff: t.List[str] = []
             models_without_grain: t.List[Model] = []
             source_snapshots_to_name = {
@@ -1642,11 +1640,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 source_snapshot = source_snapshots_to_name.get(model.fqn)
                 target_snapshot = target_snapshots_to_name.get(model.fqn)
 
-                if source_snapshot is None and target_snapshot:
-                    models_in_source.append(model_fqn)
-                elif target_snapshot is None and source_snapshot:
-                    models_in_target.append(model_fqn)
-                elif target_snapshot and source_snapshot:
+                if target_snapshot and source_snapshot:
                     if (
                         source_snapshot.fingerprint.data_hash
                         != target_snapshot.fingerprint.data_hash
@@ -1667,8 +1661,6 @@ class GenericContext(BaseContext, t.Generic[C]):
                         models_no_diff.append(model_fqn)
 
             self.console.show_table_diff_details(
-                models_in_source,
-                models_in_target,
                 models_no_diff,
                 [model[0].name for model in models_to_diff],
             )

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1647,25 +1647,9 @@ class GenericContext(BaseContext, t.Generic[C]):
                         target = target_snapshot.qualified_view_name.for_environment(
                             target_env.naming_info, adapter.dialect
                         )
-
-                        model_on = []
-                        if not on:
-                            for expr in [
-                                ref.expression for ref in model.all_references if ref.unique
-                            ]:
-                                if isinstance(expr, exp.Tuple):
-                                    model_on.extend(
-                                        [
-                                            key.this.sql(dialect=adapter.dialect)
-                                            for key in expr.expressions
-                                        ]
-                                    )
-                                else:
-                                    # Handle a single Column or Paren expression
-                                    model_on.append(expr.this.sql(dialect=adapter.dialect))
-
-                        models_to_diff.append((model, adapter, source, target, on or model_on))
-                        if not (on or model_on):
+                        model_on = on or model.on
+                        models_to_diff.append((model, adapter, source, target, model_on))
+                        if not model_on:
                             models_without_grain.append(model)
                     else:
                         models_no_diff.append(model_fqn)

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1660,12 +1660,11 @@ class GenericContext(BaseContext, t.Generic[C]):
                     else:
                         models_no_diff.append(model_fqn)
 
-            self.console.show_table_diff_details(
-                models_no_diff,
-                [model[0].name for model in models_to_diff],
-            )
-
             if models_to_diff:
+                self.console.show_table_diff_details(
+                    models_no_diff,
+                    [model[0].name for model in models_to_diff],
+                )
                 if models_without_grain:
                     model_names = "\n".join(
                         f"─ {model.name} \n  at '{model._path}'" for model in models_without_grain

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1611,11 +1611,10 @@ class GenericContext(BaseContext, t.Generic[C]):
                 raise SQLMeshError(f"Could not find environment '{source}'")
             if not target_env:
                 raise SQLMeshError(f"Could not find environment '{target}'")
-
+            criteria = ", ".join(f"'{c}'" for c in select_models)
             try:
                 selected_models = self._new_selector().expand_model_selections(select_models)
                 if not selected_models:
-                    criteria = ", ".join(f"'{c}'" for c in select_models)
                     self.console.log_status_update(
                         f"No models matched the selection criteria: {criteria}"
                     )
@@ -1701,6 +1700,10 @@ class GenericContext(BaseContext, t.Generic[C]):
                 except:
                     self.console.stop_table_diff_progress(success=False)
                     raise
+            else:
+                self.console.log_status_update(
+                    f"No models contain differences with the selection criteria: {criteria}"
+                )
 
         else:
             table_diffs = [

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1588,7 +1588,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             on: The join condition, table aliases must be "s" and "t" for source and target.
                 If omitted, the table's grain will be used.
             skip_columns: The columns to skip when computing the table diff.
-            select_models: The modelσ or snapshotσ to use when environments are passed in.
+            select_models: The models or snapshots to use when environments are passed in.
             where: An optional where statement to filter results.
             limit: The limit of the sample dataframe.
             show: Show the table diff output in the console.

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1696,7 +1696,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 except:
                     self.console.stop_table_diff_progress(success=False)
                     raise
-            else:
+            elif selected_models:
                 self.console.log_status_update(
                     f"No models contain differences with the selection criteria: {criteria}"
                 )

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1613,7 +1613,9 @@ class GenericContext(BaseContext, t.Generic[C]):
             if not target_env:
                 raise SQLMeshError(f"Could not find environment '{target}'")
 
-            modified_snapshots: t.Set[ModelOrSnapshot] = { model_or_snapshot } if model_or_snapshot else set()
+            modified_snapshots: t.Set[ModelOrSnapshot] = (
+                {model_or_snapshot} if model_or_snapshot else set()
+            )
             if select_model:
                 models_to_diff = self._new_selector().expand_model_selections(select_model)
                 target_snapshots = {

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1625,6 +1625,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             models_to_diff: t.List[
                 t.Tuple[Model, EngineAdapter, str, str, t.Optional[t.List[str] | exp.Condition]]
             ] = []
+            models_no_diff: t.List[str] = []
             models_without_grain: t.List[Model] = []
             source_snapshots_to_name = {
                 snapshot.name: snapshot for snapshot in source_env.snapshots
@@ -1656,12 +1657,15 @@ class GenericContext(BaseContext, t.Generic[C]):
                         models_to_diff.append((model, adapter, source, target, model_on))
                         if not model_on:
                             models_without_grain.append(model)
+                    else:
+                        models_no_diff.append(model_fqn)
+
+            self.console.show_table_diff_details(
+                models_no_diff,
+                [model[0].name for model in models_to_diff],
+            )
 
             if models_to_diff:
-                self.console.show_table_diff_details(
-                    [model[0].name for model in models_to_diff],
-                )
-
                 if models_without_grain:
                     model_names = "\n".join(
                         f"─ {model.name} \n  at '{model._path}'" for model in models_without_grain

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -451,6 +451,20 @@ class ModelMeta(_Node):
         ]
 
     @property
+    def on(self) -> t.List[str]:
+        """The grains to be used as join condition in table_diff."""
+
+        on: t.List[str] = []
+        for expr in [ref.expression for ref in self.all_references if ref.unique]:
+            if isinstance(expr, exp.Tuple):
+                on.extend([key.this.sql(dialect=self.dialect) for key in expr.expressions])
+            else:
+                # Handle a single Column or Paren expression
+                on.append(expr.this.sql(dialect=self.dialect))
+
+        return on
+
+    @property
     def managed_columns(self) -> t.Dict[str, exp.DataType]:
         return getattr(self.kind, "managed_columns", {})
 

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -690,7 +690,7 @@ class SQLMeshMagics(Magics):
         "--select-model",
         type=str,
         nargs="*",
-        help="Select specific model changes that should be included in the plan.",
+        help="Specify one or more models to data diff. Use wildcards to diff multiple models. Ex: '*' (all models with applied plan diffs), 'demo.model+' (this and downstream models), 'git:feature_branch' (models with direct modifications in this branch only)",
     )
     @argument(
         "--skip-grain-check",

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -687,6 +687,12 @@ class SQLMeshMagics(Magics):
         help="The number of decimal places to keep when comparing floating point columns. Default: 3",
     )
     @argument(
+        "--select-model",
+        type=str,
+        nargs="*",
+        help="Select specific model changes that should be included in the plan.",
+    )
+    @argument(
         "--skip-grain-check",
         action="store_true",
         help="Disable the check for a primary key (grain) that is missing or is not unique.",
@@ -700,12 +706,13 @@ class SQLMeshMagics(Magics):
         """
         args = parse_argstring(self.table_diff, line)
         source, target = args.source_to_target.split(":")
+        select_models = {args.model} if args.model else args.select_model or None
         context.table_diff(
             source=source,
             target=target,
             on=args.on,
             skip_columns=args.skip_columns,
-            model_or_snapshot=args.model,
+            select_models=select_models,
             where=args.where,
             limit=args.limit,
             show_sample=args.show_sample,

--- a/sqlmesh/utils/git.py
+++ b/sqlmesh/utils/git.py
@@ -27,7 +27,23 @@ class GitClient:
         return [(base_path / o).absolute() for o in self._execute(commands).split("\n") if o]
 
     def _execute(self, commands: t.List[str]) -> str:
-        result = subprocess.run(["git"] + commands, cwd=self._work_dir, stdout=subprocess.PIPE)
+        result = subprocess.run(
+            ["git"] + commands,
+            cwd=self._work_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        # If the Git command failed, extract and raise the error message in the console
+        if result.returncode != 0:
+            stderr_output = result.stderr.decode("utf-8").strip()
+            error_message = next(
+                (line for line in stderr_output.splitlines() if line.lower().startswith("fatal:")),
+                stderr_output,
+            )
+            raise RuntimeError(f"Git error: {error_message}")
+
         return result.stdout.decode("utf-8").strip()
 
     @cached_property

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -110,7 +110,7 @@ def test_data_diff(sushi_context_fixed_date, capsys, caplog):
         source="source_dev",
         target="target_dev",
         on=exp.condition("s.customer_id = t.customer_id AND s.event_date = t.event_date"),
-        model_or_snapshot="sushi.customer_revenue_by_day",
+        select_models={"sushi.customer_revenue_by_day"},
     )
 
     # verify queries were actually logged to the log file, this helps immensely with debugging
@@ -291,7 +291,7 @@ def test_grain_check(sushi_context_fixed_date):
         source="source_dev",
         target="target_dev",
         on=["'key_1'", "key_2"],
-        model_or_snapshot="SUSHI.GRAIN_ITEMS",
+        select_models={"memory.sushi*"},
         skip_grain_check=False,
     )
 
@@ -420,7 +420,7 @@ def test_tables_and_grain_inferred_from_model(sushi_context_fixed_date: Context)
     sushi_context_fixed_date.plan(environment="unit_test", auto_apply=True, include_unmodified=True)
 
     table_diff = sushi_context_fixed_date.table_diff(
-        source="unit_test", target="prod", model_or_snapshot="sushi.waiter_revenue_by_day"
+        source="unit_test", target="prod", select_models={"sushi.waiter_revenue_by_day"}
     )
     assert isinstance(table_diff, TableDiff)
     assert table_diff.source == "memory.sushi__unit_test.waiter_revenue_by_day"

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -422,7 +422,7 @@ def test_tables_and_grain_inferred_from_model(sushi_context_fixed_date: Context)
     table_diff = sushi_context_fixed_date.table_diff(
         source="unit_test", target="prod", model_or_snapshot="sushi.waiter_revenue_by_day"
     )
-
+    assert isinstance(table_diff, TableDiff)
     assert table_diff.source == "memory.sushi__unit_test.waiter_revenue_by_day"
     assert table_diff.target == "memory.sushi.waiter_revenue_by_day"
 

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -111,7 +111,7 @@ def test_data_diff(sushi_context_fixed_date, capsys, caplog):
         target="target_dev",
         on=exp.condition("s.customer_id = t.customer_id AND s.event_date = t.event_date"),
         select_models={"sushi.customer_revenue_by_day"},
-    )
+    )[0]
 
     # verify queries were actually logged to the log file, this helps immensely with debugging
     console_output = capsys.readouterr()
@@ -169,7 +169,7 @@ def test_data_diff_decimals(sushi_context_fixed_date):
         source="table_diff_source",
         target="table_diff_target",
         on=["key"],
-    )
+    )[0]
     assert diff.row_diff().full_match_count == 3
     assert diff.row_diff().partial_match_count == 0
 
@@ -178,7 +178,7 @@ def test_data_diff_decimals(sushi_context_fixed_date):
         target="table_diff_target",
         on=["key"],
         decimals=4,
-    )
+    )[0]
 
     row_diff = diff.row_diff()
     joined_sample_columns = row_diff.joined_sample.columns
@@ -293,7 +293,7 @@ def test_grain_check(sushi_context_fixed_date):
         on=["'key_1'", "key_2"],
         select_models={"memory.sushi*"},
         skip_grain_check=False,
-    )
+    )[0]
 
     row_diff = diff.row_diff()
     assert row_diff.full_match_count == 7
@@ -421,7 +421,7 @@ def test_tables_and_grain_inferred_from_model(sushi_context_fixed_date: Context)
 
     table_diff = sushi_context_fixed_date.table_diff(
         source="unit_test", target="prod", select_models={"sushi.waiter_revenue_by_day"}
-    )
+    )[0]
     assert isinstance(table_diff, TableDiff)
     assert table_diff.source == "memory.sushi__unit_test.waiter_revenue_by_day"
     assert table_diff.target == "memory.sushi.waiter_revenue_by_day"

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -644,7 +644,7 @@ def test_table_diff(notebook, loaded_sushi_context, convert_all_html_output_to_t
 
     assert len(output.outputs) == 1
     assert convert_all_html_output_to_text(output) == [
-        'Models without changes:\n└── "memory"."sushi"."top_waiters"'
+        "No models contain differences with the selection criteria: 'sushi.top_waiters'"
     ]
 
 

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -641,26 +641,11 @@ def test_table_diff(notebook, loaded_sushi_context, convert_all_html_output_to_t
 
     assert not output.stdout
     assert not output.stderr
-    assert len(output.outputs) == 5
+    assert len(output.outputs) == 1
+
     assert convert_all_html_output_to_text(output) == [
-        """Table Diff
-├── Model:
-│   └── sushi.top_waiters
-├── Environment:
-│   ├── Source: dev
-│   └── Target: prod
-├── Tables:
-│   ├── Source: memory.sushi__dev.top_waiters
-│   └── Target: memory.sushi.top_waiters
-└── Join On:
-    └── waiter_id""",
-        """Schema Diff Between 'DEV' and 'PROD' environments for model 'sushi.top_waiters':
-└── Schemas match""",
-        """Row Counts:
-└──  FULL MATCH: 8 rows (100.0%)""",
-        """COMMON ROWS column comparison stats:""",
-        """pct_match
-revenue      100.0""",
+        """Identical Tables
+└── memory.sushi__dev.top_waiters - memory.sushi.top_waiters""",
     ]
 
 

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -641,11 +641,27 @@ def test_table_diff(notebook, loaded_sushi_context, convert_all_html_output_to_t
 
     assert not output.stdout
     assert not output.stderr
-    assert len(output.outputs) == 1
+    assert len(output.outputs) == 5
 
     assert convert_all_html_output_to_text(output) == [
-        """Identical Tables
-└── memory.sushi__dev.top_waiters - memory.sushi.top_waiters""",
+                """Table Diff
+├── Model:
+│   └── sushi.top_waiters
+├── Environment:
+│   ├── Source: dev
+│   └── Target: prod
+├── Tables:
+│   ├── Source: memory.sushi__dev.top_waiters
+│   └── Target: memory.sushi.top_waiters
+└── Join On:
+    └── waiter_id""",
+        """Schema Diff Between 'DEV' and 'PROD' environments for model 'sushi.top_waiters':
+└── Schemas match""",
+        """Row Counts:
+└──  FULL MATCH: 8 rows (100.0%)""",
+        """COMMON ROWS column comparison stats:""",
+        """pct_match
+revenue      100.0""",
     ]
 
 

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -641,27 +641,10 @@ def test_table_diff(notebook, loaded_sushi_context, convert_all_html_output_to_t
 
     assert not output.stdout
     assert not output.stderr
-    assert len(output.outputs) == 5
 
+    assert len(output.outputs) == 1
     assert convert_all_html_output_to_text(output) == [
-        """Table Diff
-├── Model:
-│   └── sushi.top_waiters
-├── Environment:
-│   ├── Source: dev
-│   └── Target: prod
-├── Tables:
-│   ├── Source: memory.sushi__dev.top_waiters
-│   └── Target: memory.sushi.top_waiters
-└── Join On:
-    └── waiter_id""",
-        """Schema Diff Between 'DEV' and 'PROD' environments for model 'sushi.top_waiters':
-└── Schemas match""",
-        """Row Counts:
-└──  FULL MATCH: 8 rows (100.0%)""",
-        """COMMON ROWS column comparison stats:""",
-        """pct_match
-revenue      100.0""",
+        'Models without changes:\n└── "memory"."sushi"."top_waiters"'
     ]
 
 

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -644,7 +644,7 @@ def test_table_diff(notebook, loaded_sushi_context, convert_all_html_output_to_t
     assert len(output.outputs) == 5
 
     assert convert_all_html_output_to_text(output) == [
-                """Table Diff
+        """Table Diff
 ├── Model:
 │   └── sushi.top_waiters
 ├── Environment:

--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -520,8 +520,7 @@ def test_table_diff(client: TestClient, web_sushi_context: Context) -> None:
         },
     )
     assert response.status_code == 200
-    assert "schema_diff" in response.json()
-    assert "row_diff" in response.json()
+    assert response.json() == None
 
 
 def test_test(client: TestClient, web_sushi_context: Context) -> None:

--- a/web/server/api/endpoints/table_diff.py
+++ b/web/server/api/endpoints/table_diff.py
@@ -34,6 +34,7 @@ def get_table_diff(
         limit=limit,
         show=False,
     )
+    diff = diff[0] if isinstance(diff, list) else diff
     _schema_diff = diff.schema_diff()
     _row_diff = diff.row_diff(temp_schema=temp_schema)
     schema_diff = SchemaDiff(


### PR DESCRIPTION
This update extends using the table_diff command with `--select-model` to diff a subset or selection of SQLMesh models, fixes: #4198 

https://github.com/user-attachments/assets/7a2c817d-8743-4ddb-abda-cb9db04fbe26


For example with the downstream + to diff `items` and all models downstream of it:
`sqlmesh table_diff prod:dev sushi.items+`  

With the * wildcard to diff all models of a schema:
`sqlmesh table_diff prod:dev 'sushi.*'`  

Similarly with all the selectors: https://sqlmesh.readthedocs.io/en/latest/guides/model_selection/

- If the --show-sample flag is included, the output also includes sample rows. 
- If the engine supports it, it runs all the table diff concurrently.