### PR TITLE
Fix!: exclude Semicolon expressions from model state

### DIFF
--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -262,7 +262,9 @@ def parse_expression(
 
     if isinstance(v, list):
         return [
-            d.parse_one(e, dialect=dialect) if not isinstance(e, exp.Expression) else e for e in v
+            e if isinstance(e, exp.Expression) else d.parse_one(e, dialect=dialect)
+            for e in v
+            if not isinstance(e, exp.Semicolon)
         ]
 
     if isinstance(v, str):

--- a/sqlmesh/migrations/v0082_warn_if_incorrectly_duplicated_statements.py
+++ b/sqlmesh/migrations/v0082_warn_if_incorrectly_duplicated_statements.py
@@ -1,0 +1,68 @@
+"""
+This script's goal is to warn users if there are two adjacent expressions in a SQL
+model that are equivalent.
+
+Context:
+
+We used to include `Semicolon` expressions in the model's state, which led to a bug
+where the expression preceding the semicolon would be duplicated in pre_statements
+or post_statements. For example, the query in the model below would be incorrectly
+included in its post_statements list:
+
+```
+MODEL (
+  name test
+);
+
+SELECT 1 AS c;
+
+-- foo
+```
+
+We now don't include `Semicolon` expressions in the model's state, which fixes this
+issue, but unfortunately migrating existing snapshots is not possible because we do
+not have a signal in state to detect whether an expression was incorrectly duplicated.
+
+If a SQL model suffered from this issue, then there would be two adjacent equivalent
+expressions in it, so we use that as a heuristic to warn the user accordingly.
+"""
+
+import json
+
+from sqlglot import exp
+
+from sqlmesh.core.console import get_console
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+
+    warning = (
+        "SQLMesh detected that it may not be able to fully migrate the state database. This should not impact "
+        "the migration process, but may result in unexpected changes being reported by the next `sqlmesh plan` "
+        "command. Please run `sqlmesh diff prod` after the migration has completed, before making any new "
+        "changes. If any unexpected changes are reported, consider running a forward-only plan to apply these "
+        "changes and avoid unnecessary backfills: sqlmesh plan prod --forward-only. "
+        "See https://sqlmesh.readthedocs.io/en/stable/concepts/plans/#forward-only-plans for more details.\n"
+    )
+
+    for (snapshot,) in engine_adapter.fetchall(
+        exp.select("snapshot").from_(snapshots_table), quote_identifiers=True
+    ):
+        parsed_snapshot = json.loads(snapshot)
+        node = parsed_snapshot["node"]
+
+        if node.get("source_type") == "sql":
+            expressions = [
+                *node.get("pre_statements", []),
+                node["query"],
+                *node.get("post_statements", []),
+            ]
+            for e1, e2 in zip(expressions, expressions[1:]):
+                if e1 == e2:
+                    get_console().log_warning(warning)
+                    return


### PR DESCRIPTION
Fixes #4252

I reproduced the issue locally by following the steps outlined in the above issue:

```python
>>> ctx.models['"db"."sqlmesh_example"."incremental_model"'].json()
'{"name":"sqlmesh_example.incremental_model","project":"","start":"2020-01-01","cron":"@daily","tags":[],"dialect":"duckdb","kind":{"name":"INCREMENTAL_BY_TIME_RANGE","on_destructive_change":"ERROR","dialect":"duckdb","forward_only":false,"disable_restatement":false,"time_column":{"column":"\\"event_date\\"","format":"%Y-%m-%d"},"partition_by_time_column":true},"partitioned_by":[],"clustered_by":[],"default_catalog":"db","audits":[],"grains":["(id, event_date)"],"references":[],"allow_partials":false,"signals":[],"enabled":true,"python_env":{},"jinja_macros":{"packages":{},"root_macros":{},"global_objs":{},"create_builtins_module":"sqlmesh.utils.jinja","top_level_packages":[]},"audit_definitions":{},"mapping_schema":{"\\"db\\"":{"\\"sqlmesh_example\\"":{"\\"seed_model\\"":{"id":"INT","item_id":"INT","event_date":"DATE"}}}},"extract_dependencies_from_query":true,"pre_statements":[],"post_statements":["SELECT\\n  id,\\n  item_id,\\n  event_date,\\nFROM\\n  sqlmesh_example.seed_model\\nWHERE\\n  event_date BETWEEN @start_date AND @end_date\\n;"],"on_virtual_update":[],"query":"SELECT\\n  id,\\n  item_id,\\n  event_date,\\nFROM\\n  sqlmesh_example.seed_model\\nWHERE\\n  event_date BETWEEN @start_date AND @end_date\\n;","source_type":"sql"}'
```

I observed that we hit [this line](https://github.com/TobikoData/sqlmesh/blob/c1ae64f6e13dee5ebf340ee2fee23e11f4acd01b/sqlmesh/core/dialect.py#L935) for the `Semicolon` expression and store the query's SQL in its `meta` dict. This explains the duplication of the model's query in the above serialized `post_statements` key.

My initial approach was to avoid setting `meta["sql"]` for `Semicolon` expressions, but then it occurred to me that we shouldn't be storing any `Semicolon` expressions in the model, because they can also affect the data/metadata hash.

I verified for the issue's examples that if I ran plan, removed the semicolon+comment, and then ran plan again then a diff was shown. This is because `Semicolon` is `gen`'d since it's in the `post_statements` list and we get back a `"SEMICOLON"` string in the `_data_hash_values`. I added a test for this.

I think we need a migration for this change. I'll take it to the finish line ~on Monday~ soon.