### PR TITLE
Feat: Enable Iceberg support for Snowflake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ on_tag_filter: &on_tag_filter
       only: /^v.+/
 
 orbs:
-  path-filtering: circleci/path-filtering@1.1.0
+  path-filtering: circleci/path-filtering@1.2.0
 
 jobs:
   vscode-extension-setup:
@@ -116,6 +116,7 @@ workflows:
             pytest.ini|setup.cfg|setup.py python true
             \.circleci/.*|Makefile|\.pre-commit-config\.yaml common true
             vscode/extensions/.* vscode true
+          tag: "3.9"
 
       - vscode-extension-setup:
           <<: *on_main_or_tag_filter

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -134,7 +134,7 @@ jobs:
             - v1-nm-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install packages
-          command: npm ci
+          command: npm ci 
       - save_cache:
           key: v1-nm-cache-{{ checksum "package-lock.json" }}
           paths:
@@ -272,15 +272,15 @@ workflows:
             parameters:
               engine:
                 - snowflake
-                # - databricks
-                # - redshift
-                # - bigquery
-                # - clickhouse-cloud
-                # - athena
-          #filters:
-          # branches:
-          #   only:
-          #     - main
+                - databricks
+                - redshift
+                - bigquery
+                - clickhouse-cloud
+                - athena
+          filters:
+           branches:
+             only:
+               - main
       - trigger_private_tests:
           requires:
             - style_and_cicd_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -134,7 +134,7 @@ jobs:
             - v1-nm-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install packages
-          command: npm ci 
+          command: npm ci
       - save_cache:
           key: v1-nm-cache-{{ checksum "package-lock.json" }}
           paths:
@@ -272,15 +272,15 @@ workflows:
             parameters:
               engine:
                 - snowflake
-                - databricks
-                - redshift
-                - bigquery
-                - clickhouse-cloud
-                - athena
-          filters:
-           branches:
-             only:
-               - main
+                # - databricks
+                # - redshift
+                # - bigquery
+                # - clickhouse-cloud
+                # - athena
+          #filters:
+          # branches:
+          #   only:
+          #     - main
       - trigger_private_tests:
           requires:
             - style_and_cicd_tests

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -263,7 +263,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
             table_properties = {k.upper(): v for k, v in table_properties.items()}
             # if we are creating a non-dynamic table; remove any properties that are only valid for dynamic tables
             # this is necessary because we create "normal" tables from the same managed model definition for dev previews and the "normal" tables dont support these parameters
-            if table_kind and "DYNAMIC" not in table_kind:
+            if "DYNAMIC" not in (table_kind or "").upper():
                 for prop in {"WAREHOUSE", "TARGET_LAG", "REFRESH_MODE", "INITIALIZE"}:
                     table_properties.pop(prop, None)
 

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -2098,6 +2098,7 @@ class EngineManagedStrategy(MaterializableStrategy):
                 table_properties=kwargs.get("physical_properties", model.physical_properties),
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
+                table_format=model.table_format,
             )
         elif not is_table_deployable:
             # Only create the dev preview table as a normal table.
@@ -2134,6 +2135,7 @@ class EngineManagedStrategy(MaterializableStrategy):
                 table_properties=kwargs.get("physical_properties", model.physical_properties),
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
+                table_format=model.table_format,
             )
         elif not is_snapshot_deployable:
             # Snapshot isnt deployable; update the preview table instead

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -3367,6 +3367,7 @@ def test_create_managed(adapter_mock, make_snapshot, mocker: MockerFixture):
         table_properties=model.physical_properties,
         table_description=model.description,
         column_descriptions=model.column_descriptions,
+        table_format=None,
     )
 
 


### PR DESCRIPTION
Addresses issue #3829 

Prior to this, `table_format iceberg` was ignored by the Snowflake adapter.

It now checks for this property and uses it to trigger `CREATE ICEBERG TABLE` statements instead of normal `CREATE TABLE` statements