### PR TITLE
Fix: Avoid concurrent dialect patching in model testing

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -530,9 +530,7 @@ class ModelTest(unittest.TestCase):
         import time_machine
 
         lock_ctx: AbstractContextManager = (
-            self.CONCURRENT_RENDER_LOCK
-            if (self.concurrency and self._execution_time)
-            else nullcontext()
+            self.CONCURRENT_RENDER_LOCK if self.concurrency else nullcontext()
         )
         time_ctx: AbstractContextManager = nullcontext()
         dialect_patch_ctx: AbstractContextManager = nullcontext()

--- a/sqlmesh/core/test/result.py
+++ b/sqlmesh/core/test/result.py
@@ -100,7 +100,8 @@ class ModelTextTestResult(unittest.TextTestResult):
         for test_case, failure in failures:
             stream.writeln(unittest.TextTestResult.separator1)
             stream.writeln(f"FAIL: {test_case}")
-            stream.writeln(f"{test_case.shortDescription()}")
+            if test_description := test_case.shortDescription():
+                stream.writeln(test_description)
             stream.writeln(unittest.TextTestResult.separator2)
             stream.writeln(failure)
 

--- a/sqlmesh/core/test/runner.py
+++ b/sqlmesh/core/test/runner.py
@@ -120,6 +120,9 @@ def run_tests(
         default_catalog_dialect=default_catalog_dialect,
     )
 
+    # Ensure workers are not greater than the number of tests
+    num_workers = min(len(model_test_metadata) or 1, default_test_connection.concurrent_tasks)
+
     def _run_single_test(
         metadata: ModelTestMetadata, engine_adapter: EngineAdapter
     ) -> t.Optional[ModelTextTestResult]:
@@ -132,6 +135,7 @@ def run_tests(
             path=metadata.path,
             default_catalog=default_catalog,
             preserve_fixtures=preserve_fixtures,
+            concurrency=num_workers > 1,
         )
 
         if not test:
@@ -158,9 +162,6 @@ def run_tests(
         return result
 
     test_results = []
-
-    # Ensure workers are not greater than the number of tests
-    num_workers = min(len(model_test_metadata) or 1, default_test_connection.concurrent_tasks)
 
     start_time = time.perf_counter()
     try:

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -2370,3 +2370,74 @@ test_example_full_model2:
     # Case 3: The "new_test.yaml::test_example_full_model2" should amount to a single subtest
     results = context.test(tests=[f"{test_file}::test_example_full_model2"])
     assert len(results.successes) == 1
+
+
+def test_freeze_time_concurrent(tmp_path: Path) -> None:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+
+    for model_name in ["sql_model", "py_model"]:
+        for i in range(5):
+            test_2019 = tmp_path / "tests" / f"test_2019_{model_name}_{i}.yaml"
+            test_2019.write_text(
+                f"""
+    test_2019_{model_name}_{i}:
+      model: {model_name}
+      vars:
+        execution_time: '2019-12-01'
+      outputs:
+        query:
+          rows:
+            - col_exec_ds_time: '2019-12-01'
+              col_current_date: '2019-12-01'
+              """
+            )
+
+            test_2025 = tmp_path / "tests" / f"test_2025_{model_name}_{i}.yaml"
+            test_2025.write_text(
+                f"""
+    test_2025_{model_name}_{i}:
+      model: {model_name}
+      vars:
+        execution_time: '2025-12-01'
+      outputs:
+        query:
+          rows:
+            - col_exec_ds_time: '2025-12-01'
+              col_current_date: '2025-12-01'
+              """
+            )
+
+    ctx = Context(
+        paths=tmp_path,
+        config=Config(default_test_connection=DuckDBConnectionConfig(concurrent_tasks=8)),
+    )
+
+    @model(
+        "py_model",
+        columns={"col_exec_ds_time": "timestamp_ntz", "col_current_date": "timestamp_ntz"},
+    )
+    def execute(context, start, end, execution_time, **kwargs):
+        datetime_now_utc = datetime.datetime.now(tz=datetime.timezone.utc)
+
+        context.engine_adapter.execute(exp.select("CURRENT_DATE()"))
+        current_date = context.engine_adapter.cursor.fetchone()[0]
+
+        return pd.DataFrame(
+            [{"col_exec_ds_time": datetime_now_utc, "col_current_date": current_date}]
+        )
+
+    python_model = model.get_registry()["py_model"].model(module_path=Path("."), path=Path("."))
+
+    ctx.upsert_model(
+        _create_model(
+            meta="MODEL(NAME sql_model)",
+            query="SELECT @execution_ds::timestamp_ntz AS col_exec_ds_time, current_date()::date AS col_current_date",
+            default_catalog=ctx.default_catalog,
+        )
+    )
+
+    ctx.upsert_model(python_model)
+
+    results = ctx.test()
+    assert len(results.successes) == 20


### PR DESCRIPTION
To [freeze time](https://sqlmesh.readthedocs.io/en/latest/concepts/tests/#freezing-time) through `execution_time` in unit tests we essentially patch the SQLGlot dialects globally to generate any `CURRENT_<date/time>()` reference as a cast at the specified time & type.

This works fine if tests are run sequentially but runs into race conditions in concurrent execution. This PR:

- Replaces the global patching for SQL models by instead transforming the corresponding AST nodes before generation

- Locks the global patching for Python models using the runner's `lock`; This is required because Python models can execute any SQL statement, so the patching is indeed necessary to cover that globally.
 
