### PR TITLE
Fix: Add custom exception for macro evaluation errors

### DIFF
--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -228,7 +228,9 @@ class BaseExpressionRenderer:
             try:
                 macro_evaluator.evaluate(definition)
             except Exception as ex:
-                raise_config_error(f"Failed to evaluate macro '{definition}'. {ex}", self._path)
+                raise_config_error(
+                    f"Failed to evaluate macro '{definition}'.\n\n{ex}\n", self._path
+                )
 
         resolved_expressions: t.List[t.Optional[exp.Expression]] = []
 
@@ -237,7 +239,7 @@ class BaseExpressionRenderer:
                 transformed_expressions = ensure_list(macro_evaluator.transform(expression))
             except Exception as ex:
                 raise_config_error(
-                    f"Failed to resolve macros for\n{expression.sql(dialect=self._dialect, pretty=True)}\n{ex}",
+                    f"Failed to resolve macros for\n\n{expression.sql(dialect=self._dialect, pretty=True)}\n\n{ex}\n",
                     self._path,
                 )
 

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -554,12 +554,16 @@ def format_evaluated_code_exception(
     tb: t.List[str] = []
     indent = ""
 
+    skip_patterns = re.compile(
+        r"Traceback \(most recent call last\):|"
+        r'File ".*?core/model/definition\.py|'
+        r'File ".*?core/snapshot/definition\.py|'
+        r'File ".*?core/macros\.py|'
+        r'File ".*?inspect\.py'
+    )
+
     for error_line in format_exception(exception):
-        traceback_match = error_line.startswith("Traceback (most recent call last):")
-        model_def_match = re.search('File ".*?core/model/definition.py', error_line)
-        snapshot_def_match = re.search('File ".*?core/snapshot/definition.py', error_line)
-        core_macros_match = re.search('File ".*?core/macros.py', error_line)
-        if traceback_match or model_def_match or snapshot_def_match or core_macros_match:
+        if skip_patterns.search(error_line):
             continue
 
         error_match = re.search("^.*?Error: ", error_line)


### PR DESCRIPTION
Handle MacroEval errors similar to pythonmodel and signal evaluation errors that we want to catch.