### PR TITLE
Chore: add pyarrow as a dependency for the databricks target

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ bigquery = [
 ]
 bigframes = ["bigframes>=1.32.0"]
 clickhouse = ["clickhouse-connect"]
-databricks = ["databricks-sql-connector"]
+databricks = ["databricks-sql-connector[pyarrow]"]
 dev = [
     "agate==1.7.1",
     "beautifulsoup4",


### PR DESCRIPTION
The `Databricks` adapter's `_fetch_native_df` method [relies on pyarrow's API](https://github.com/TobikoData/sqlmesh/blob/e2adfe3714b8c794cf348123e022304fd37119f9/sqlmesh/core/engine_adapter/databricks.py#L194). If `pyarrow` is missing, `fetchdf` breaks:

```python
>>> from sqlmesh import Context
>>> ctx = Context()
>>> ctx.fetchdf("select * from foo.bar")
[WARN] pyarrow is not installed by default since databricks-sql-connector 4.0.0,any arrow specific api (e.g. fetchmany_arrow) and cloud fetch will be disabled.If you need these features, please run pip install pyarrow or pip install databricks-sql-connector[pyarrow] to install
[WARN] Parameter '_user_agent_entry' is deprecated; use 'user_agent_entry' instead. This parameter will be removed in the upcoming releases.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/georgesittas/Downloads/test_env/.venv/lib/python3.11/site-packages/sqlmesh/core/context.py", line 223, in fetchdf
    return self.engine_adapter.fetchdf(query, quote_identifiers=quote_identifiers)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/georgesittas/Downloads/test_env/.venv/lib/python3.11/site-packages/sqlmesh/core/engine_adapter/databricks.py", line 202, in fetchdf
    df = self._fetch_native_df(query, quote_identifiers=quote_identifiers)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/georgesittas/Downloads/test_env/.venv/lib/python3.11/site-packages/sqlmesh/core/engine_adapter/databricks.py", line 194, in _fetch_native_df
    return self.cursor.fetchall_arrow().to_pandas()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ColumnTable' object has no attribute 'to_pandas'
```