### PR TITLE
feat(vscode): better errors for missing sqlmesh_lsp

### DIFF
--- a/vscode/extension/eslint.config.mjs
+++ b/vscode/extension/eslint.config.mjs
@@ -16,6 +16,7 @@ export default tseslint.config(
   },
   {
     rules: {
+      'no-fallthrough': 'error',
       '@typescript-eslint/switch-exhaustiveness-check': 'error',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-explicit-any': 'off',

--- a/vscode/extension/src/utilities/errors.ts
+++ b/vscode/extension/src/utilities/errors.ts
@@ -9,6 +9,16 @@ import { traceInfo } from './common/log'
 export type ErrorType =
   | { type: 'generic'; message: string }
   | { type: 'not_signed_in' }
+  | { type: 'sqlmesh_lsp_not_found' }
+  // sqlmesh_lsp_dependencies_missing is used when the sqlmesh_lsp is found but the lsp extras are missing.
+  | SqlmeshLspDependenciesMissingError
+
+interface SqlmeshLspDependenciesMissingError {
+  type: 'sqlmesh_lsp_dependencies_missing'
+  is_missing_pygls: boolean
+  is_missing_lsprotocol: boolean
+  is_tobiko_cloud: boolean
+}
 
 /**
  * Handles the case where the user is not signed in to Tobiko Cloud.
@@ -24,5 +34,42 @@ export const handleNotSginedInError = async (
   )
   if (result === 'Sign In') {
     await signIn(authProvider)()
+  }
+}
+
+/**
+ * Handles the case where the sqlmesh_lsp is not found.
+ */
+export const handleSqlmeshLspNotFoundError = async (): Promise<void> => {
+  traceInfo('handleSqlmeshLspNotFoundError')
+  await window.showErrorMessage(
+    'SQLMesh LSP not found, please check installation',
+  )
+}
+
+/**
+ * Handles the case where the sqlmesh_lsp is found but the lsp extras are missing.
+ */
+export const handleSqlmeshLspDependenciesMissingError = async (
+  error: SqlmeshLspDependenciesMissingError,
+): Promise<void> => {
+  traceInfo('handleSqlmeshLspDependenciesMissingError')
+  if (error.is_tobiko_cloud) {
+    await window.showErrorMessage(
+      'LSP dependencies missing, make sure to include `lsp` in the `extras` section of your `tcloud.yaml` file.',
+    )
+  } else {
+    const install = await window.showErrorMessage(
+      'LSP dependencies missing, make sure to install `sqlmesh[lsp]`.',
+      'Install',
+    )
+    if (install === 'Install') {
+      const terminal = window.createTerminal({
+        name: 'SQLMesh LSP Install',
+        hideFromUser: false,
+      })
+      terminal.show()
+      terminal.sendText("pip install 'sqlmesh[lsp]'", false)
+    }
   }
 }


### PR DESCRIPTION
Handle the cases where 

- `sqlmesh_lsp` is not present 
- `pygls` and `lsprotocol` are not present, recommend installing `sqlmesh[lsp]`

![Screenshot 2025-04-30 at 22 47 06](https://github.com/user-attachments/assets/10b4f76c-83bc-4d1b-ac6f-af142e38a748)
