### PR TITLE
Feat: Make this_env and views available in macros of before after all

### DIFF
--- a/docs/concepts/macros/macro_variables.md
+++ b/docs/concepts/macros/macro_variables.md
@@ -141,3 +141,4 @@ The following variables are also available in [`before_all` and `after_all` stat
 
 * @this_env - A string value containing the name of the current [environment](../environments.md).
 * @schemas - A list of the schema names of the [virtual layer](../../concepts/glossary.md#virtual-layer) of the current environment.
+* @views - A list of the views names of the [virtual layer](../../concepts/glossary.md#virtual-layer) of the current environment.

--- a/docs/concepts/macros/macro_variables.md
+++ b/docs/concepts/macros/macro_variables.md
@@ -141,4 +141,4 @@ The following variables are also available in [`before_all` and `after_all` stat
 
 * @this_env - A string value containing the name of the current [environment](../environments.md).
 * @schemas - A list of the schema names of the [virtual layer](../../concepts/glossary.md#virtual-layer) of the current environment.
-* @views - A list of the views names of the [virtual layer](../../concepts/glossary.md#virtual-layer) of the current environment.
+* @views - A list of the view names of the [virtual layer](../../concepts/glossary.md#virtual-layer) of the current environment.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1019,7 +1019,6 @@ For example, rather than using an `on_virtual_update` statement in each model to
 
 ```python linenums="1"
 from sqlmesh.core.macros import macro
-from sqlmesh.core.snapshot.definition import to_view_mapping
 
 @macro()
 def grant_select_privileges(evaluator):

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -500,21 +500,21 @@ class MacroEvaluator:
     def this_env(self) -> str:
         """Returns the name of the current environment in before after all."""
         if "this_env" not in self.locals:
-            raise SQLMeshError("Environment name is not available in this context")
+            raise SQLMeshError("Environment name is only available in before_all and after_all")
         return self.locals["this_env"]
 
     @property
     def schemas(self) -> t.List[str]:
         """Returns the schemas of the current environment in before after all macros."""
         if "schemas" not in self.locals:
-            raise SQLMeshError("Schemas are not available in this context")
+            raise SQLMeshError("Schemas are only available in before_all and after_all")
         return self.locals["schemas"]
 
     @property
     def views(self) -> t.List[str]:
         """Returns the views of the current environment in before after all macros."""
         if "views" not in self.locals:
-            raise SQLMeshError("Views are not available in this context")
+            raise SQLMeshError("Views are only available in before_all and after_all")
         return self.locals["views"]
 
     def var(self, var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -491,6 +491,26 @@ class MacroEvaluator:
         """Returns the gateway name."""
         return self.var(c.GATEWAY)
 
+    @property
+    def snapshots(self) -> t.Dict[str, Snapshot]:
+        """Returns the snapshots if available."""
+        return self._snapshots
+
+    @property
+    def this_env(self) -> t.Optional[str]:
+        """Returns the name of the current environment in before after all."""
+        return self.locals.get("this_env")
+
+    @property
+    def schemas(self) -> t.Optional[t.List[str]]:
+        """Returns the schemas of the current environment in before after all macros."""
+        return self.locals.get("schemas")
+
+    @property
+    def views(self) -> t.Optional[t.List[str]]:
+        """Returns the views of the current environment in before after all macros."""
+        return self.locals.get("views")
+
     def var(self, var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
         """Returns the value of the specified variable, or the default value if it doesn't exist."""
         return (self.locals.get(c.SQLMESH_VARS) or {}).get(var_name.lower(), default)

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -497,19 +497,25 @@ class MacroEvaluator:
         return self._snapshots
 
     @property
-    def this_env(self) -> t.Optional[str]:
+    def this_env(self) -> str:
         """Returns the name of the current environment in before after all."""
-        return self.locals.get("this_env")
+        if "this_env" not in self.locals:
+            raise SQLMeshError("Environment name is not available in this context")
+        return self.locals["this_env"]
 
     @property
-    def schemas(self) -> t.Optional[t.List[str]]:
+    def schemas(self) -> t.List[str]:
         """Returns the schemas of the current environment in before after all macros."""
-        return self.locals.get("schemas")
+        if "schemas" not in self.locals:
+            raise SQLMeshError("Schemas are not available in this context")
+        return self.locals["schemas"]
 
     @property
-    def views(self) -> t.Optional[t.List[str]]:
+    def views(self) -> t.List[str]:
         """Returns the views of the current environment in before after all macros."""
-        return self.locals.get("views")
+        if "views" not in self.locals:
+            raise SQLMeshError("Views are not available in this context")
+        return self.locals["views"]
 
     def var(self, var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
         """Returns the value of the specified variable, or the default value if it doesn't exist."""

--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -110,17 +110,23 @@ class BaseExpressionRenderer:
         if environment_naming_info is not None:
             kwargs["this_env"] = getattr(environment_naming_info, "name")
             if snapshots:
-                schemas = set(
-                    [
-                        s.qualified_view_name.schema_for_environment(
-                            environment_naming_info, dialect=self._dialect
+                schemas, views = set(), []
+                for snapshot in snapshots.values():
+                    if snapshot.is_model and not snapshot.is_symbolic:
+                        schemas.add(
+                            snapshot.qualified_view_name.schema_for_environment(
+                                environment_naming_info, dialect=self._dialect
+                            )
                         )
-                        for s in snapshots.values()
-                        if s.is_model and not s.is_symbolic
-                    ]
-                )
+                        views.append(
+                            snapshot.display_name(
+                                environment_naming_info, self._default_catalog, self._dialect
+                            )
+                        )
                 if schemas:
                     kwargs["schemas"] = list(schemas)
+                if views:
+                    kwargs["views"] = views
 
         this_model = kwargs.pop("this_model", None)
 


### PR DESCRIPTION
This update adds the `this_env` variable in the macros for before all after all statements as well as `views` which provides all the views of the virtual layer to be able to easily for example grant rights on the views:
```python
@macro()
def grant_select_privileges(evaluator):
    if evaluator.views:
        return [
            f"GRANT SELECT ON VIEW {view_name} /* sqlglot.meta replace=false */ TO ROLE admin_role;"
            for view_name in evaluator.views
        ]
```

By including the comment `/* sqlglot.meta replace=false */`, you ensure that the evaluator does not replace the view name with the physical table name.