### PR TITLE
Fix: Enable unit testing in Python models with upstream tables

### DIFF
--- a/sqlmesh/core/test/context.py
+++ b/sqlmesh/core/test/context.py
@@ -39,8 +39,12 @@ class TestExecutionContext(ExecutionContext):
     @cached_property
     def _model_tables(self) -> t.Dict[str, str]:
         """Returns a mapping of model names to tables."""
+
+        # Include upstream dependencies to ensure they can be resolved during test execution
         return {
-            name: self._test._test_fixture_table(name).sql() for name, model in self._models.items()
+            name: self._test._test_fixture_table(name).sql()
+            for model in self._models.values()
+            for name in [model.name, *model.depends_on]
         }
 
     def with_variables(


### PR DESCRIPTION
This update allows Python models to be unit tested when they contain non-SQLMesh models, fixes:  #3891 

Given the following test with `ext_table` an upstream table:
```yaml
test_python_model:
  model: test_model
  inputs:
    ext_table:
      - id: 1
      - id: 2
  outputs:
    query:
      - id: 1
      - id: 2
```
and this python_model which uses `ext_table`:
```python
@model(
    "test_model",
    columns={"id": "int"},
)
def entrypoint(context, *args, **kwargs):
    table_ref = context.resolve_table("ext_table")
    return context.fetchdf(f"SELECT id FROM {table_ref}")
```
Previously resolving the table in the test would return the actual table name, preventing fixture-based mocking. This instead extends the testing table mapping to map not only sqlmesh models, but upstream references as well, instead of the actual table to the corresponding test fixture tables.