### PR TITLE
Fix: use MarkdownConsole in non-interactive contexts

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -248,7 +248,10 @@ For example, you might have a specific connection where your tests should run re
 
 ## Debug mode
 
-To enable debug mode set the `SQLMESH_DEBUG` environment variable to one of the following values: "1", "true", "t", "yes" or "y".
+Enable debug mode in one of two ways:
+
+- Pass the `--debug` flag between the CLI command and the subcommand. For example, `sqlmesh --debug plan`.
+- Set the `SQLMESH_DEBUG` environment variable to one of the following values: "1", "true", "t", "yes" or "y".
 
 Enabling this mode ensures that full backtraces are printed when using CLI. The default log level is set to `DEBUG` when this mode is enabled.
 
@@ -257,10 +260,18 @@ Example enabling debug mode for the CLI command `sqlmesh plan`:
 === "Bash"
 
     ```bash
+    $ sqlmesh --debug plan
+    ```
+
+    ```bash
     $ SQLMESH_DEBUG=1 sqlmesh plan
     ```
 
 === "MS Powershell"
+
+    ```powershell
+    PS> sqlmesh --debug plan
+    ```
 
     ```powershell
     PS> $env:SQLMESH_DEBUG=1
@@ -270,9 +281,32 @@ Example enabling debug mode for the CLI command `sqlmesh plan`:
 === "MS CMD"
 
     ```cmd
+    C:\> sqlmesh --debug plan
+    ```
+
+    ```cmd
     C:\> set SQLMESH_DEBUG=1
     C:\> sqlmesh plan
     ```
+
+## Runtime Environment
+
+SQLMesh can run in different runtime environments. For example, you might run it in a regular command-line terminal, in a Jupyter notebook, or in Github's CI/CD platform.
+
+When it starts up, SQLMesh automatically detects the runtime environment and adjusts its behavior accordingly. For example, it registers `%magic` commands if in a Jupyter notebook and adjusts logging behavior if in a CI/CD environment.
+
+If necessary, you may force SQLMesh to use a specific runtime environment by setting the `SQLMESH_RUNTIME_ENVIRONMENT` environment variable.
+
+It accepts the following values, which will cause SQLMesh to behave as if it were in the runtime environment in parentheses:
+
+- `terminal` (CLI console)
+- `databricks` (Databricks notebook)
+- `google_colab` (Google Colab notebook)
+- `jupyter` (Jupyter notebook)
+- `debugger` (Debugging output)
+- `non_interactive` (environment without real-time interactivity, such as CI/CD)
+- `ci` (CI/CD environment, equivalent to `non_interactive`)
+
 
 ## Anonymized usage information
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -304,9 +304,7 @@ It accepts the following values, which will cause SQLMesh to behave as if it wer
 - `google_colab` (Google Colab notebook)
 - `jupyter` (Jupyter notebook)
 - `debugger` (Debugging output)
-- `non_interactive` (environment without real-time interactivity, such as CI/CD)
-- `ci` (CI/CD environment, equivalent to `non_interactive`)
-
+- `ci` (CI/CD or other non-interactive environment)
 
 ## Anonymized usage information
 

--- a/sqlmesh/__init__.py
+++ b/sqlmesh/__init__.py
@@ -55,7 +55,7 @@ class RuntimeEnv(str, Enum):
     GOOGLE_COLAB = "google_colab"  # Not currently officially supported
     JUPYTER = "jupyter"
     DEBUGGER = "debugger"
-    NON_INTERACTIVE = "non_interactive"  # CI or other envs that shouldn't use emojis
+    CI = "ci"  # CI or other envs that shouldn't use emojis
 
     @classmethod
     def get(cls) -> RuntimeEnv:
@@ -66,13 +66,10 @@ class RuntimeEnv(str, Enum):
         """
         runtime_env_var = os.getenv("SQLMESH_RUNTIME_ENVIRONMENT")
         if runtime_env_var:
-            runtime_env_var = runtime_env_var.lower().strip().replace(" ", "").replace("-", "_")
-            runtime_env_var = "non_interactive" if runtime_env_var == "ci" else runtime_env_var
-            runtime_env_var = "debugger" if "debug" in runtime_env_var else runtime_env_var
             try:
                 return RuntimeEnv(runtime_env_var)
             except ValueError:
-                valid_values = [f'"{member.value}"' for member in RuntimeEnv] + ['"ci"']
+                valid_values = [f'"{member.value}"' for member in RuntimeEnv]
                 raise ValueError(
                     f"Invalid SQLMESH_RUNTIME_ENVIRONMENT value: {runtime_env_var}. Must be one of {', '.join(valid_values)}."
                 )
@@ -92,7 +89,7 @@ class RuntimeEnv(str, Enum):
             return RuntimeEnv.DEBUGGER
 
         if is_cicd_environment() or not is_interactive_environment():
-            return RuntimeEnv.NON_INTERACTIVE
+            return RuntimeEnv.CI
 
         return RuntimeEnv.TERMINAL
 
@@ -113,12 +110,12 @@ class RuntimeEnv(str, Enum):
         return self == RuntimeEnv.GOOGLE_COLAB
 
     @property
-    def is_non_interactive(self) -> bool:
-        return self == RuntimeEnv.NON_INTERACTIVE
+    def is_ci(self) -> bool:
+        return self == RuntimeEnv.CI
 
     @property
     def is_notebook(self) -> bool:
-        return not self.is_terminal and not self.is_non_interactive
+        return not self.is_terminal and not self.is_ci
 
 
 def is_cicd_environment() -> bool:

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -767,11 +767,11 @@ class TerminalConsole(Console):
 
     TABLE_DIFF_SOURCE_BLUE = "#0248ff"
     TABLE_DIFF_TARGET_GREEN = "green"
-    CHECK_MARK = "\u2714"
-    AUDIT_PASS_MARK = CHECK_MARK
+    AUDIT_PASS_MARK = "\u2714"
     GREEN_AUDIT_PASS_MARK = f"[green]{AUDIT_PASS_MARK}[/green]"
     AUDIT_FAIL_MARK = "\u274c"
     AUDIT_PADDING = 0
+    CHECK_MARK = f"{AUDIT_PASS_MARK} "
 
     def __init__(
         self,
@@ -996,7 +996,7 @@ class TerminalConsole(Console):
         if self.evaluation_progress_live:
             self.evaluation_progress_live.stop()
             if success:
-                self.log_success(f"{self.CHECK_MARK} Model batches executed")
+                self.log_success(f"{self.CHECK_MARK}Model batches executed")
 
         self.evaluation_progress_live = None
         self.evaluation_total_progress = None
@@ -1060,7 +1060,7 @@ class TerminalConsole(Console):
             self.creation_progress.stop()
             self.creation_progress = None
             if success:
-                self.log_success(f"\n{self.CHECK_MARK} Physical layer updated")
+                self.log_success(f"\n{self.CHECK_MARK}Physical layer updated")
 
         self.environment_naming_info = EnvironmentNamingInfo()
         self.default_catalog = None
@@ -1161,7 +1161,7 @@ class TerminalConsole(Console):
             self.promotion_progress.stop()
             self.promotion_progress = None
             if success:
-                self.log_success(f"\n{self.CHECK_MARK} Virtual layer updated")
+                self.log_success(f"\n{self.CHECK_MARK}Virtual layer updated")
 
         self.environment_naming_info = EnvironmentNamingInfo()
         self.default_catalog = None

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -2850,13 +2850,13 @@ class MarkdownConsole(CaptureTerminalConsole):
             )
             return
 
-        self._print(f"**Summary of differences from `{context_diff.environment}`:**\n")
+        self._print(f"\n**Summary of differences from `{context_diff.environment}`:**")
 
         if context_diff.has_requirement_changes:
-            self._print(f"Requirements:\n{context_diff.requirements_diff()}")
+            self._print(f"\nRequirements:\n{context_diff.requirements_diff()}")
 
         if context_diff.has_environment_statements_changes and not no_diff:
-            self._print("[bold]Environment statements:\n")
+            self._print("\nEnvironment statements:\n")
             for _, diff in context_diff.environment_statements_diff(
                 include_python_env=not context_diff.is_new_environment
             ):

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -2845,8 +2845,12 @@ class MarkdownConsole(CaptureTerminalConsole):
                 return
 
         if not context_diff.has_changes:
-            self._print(f"**No differences when compared to `{context_diff.environment}`**\n")
+            self._print(
+                f"\n**No changes to plan: project files match the `{context_diff.environment}` environment**\n"
+            )
             return
+
+        self._print(f"**Summary of differences from `{context_diff.environment}`:**\n")
 
         if context_diff.has_requirement_changes:
             self._print(f"Requirements:\n{context_diff.requirements_diff()}")

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -78,9 +78,6 @@ SNAPSHOT_CHANGE_CATEGORY_STR = {
 
 PROGRESS_BAR_WIDTH = 40
 LINE_WRAP_WIDTH = 100
-CHECK_MARK = "\u2714"
-GREEN_CHECK_MARK = f"[green]{CHECK_MARK}[/green]"
-RED_X_MARK = "\u274c"
 
 
 class LinterConsole(abc.ABC):
@@ -770,6 +767,11 @@ class TerminalConsole(Console):
 
     TABLE_DIFF_SOURCE_BLUE = "#0248ff"
     TABLE_DIFF_TARGET_GREEN = "green"
+    CHECK_MARK = "\u2714"
+    AUDIT_PASS_MARK = CHECK_MARK
+    GREEN_AUDIT_PASS_MARK = f"[green]{AUDIT_PASS_MARK}[/green]"
+    AUDIT_FAIL_MARK = "\u274c"
+    AUDIT_PADDING = 0
 
     def __init__(
         self,
@@ -879,7 +881,9 @@ class TerminalConsole(Console):
             progress_table.add_row(self.evaluation_total_progress)
             progress_table.add_row(self.evaluation_model_progress)
 
-            self.evaluation_progress_live = Live(progress_table, refresh_per_second=10)
+            self.evaluation_progress_live = Live(
+                progress_table, console=self.console, refresh_per_second=10
+            )
             self.evaluation_progress_live.start()
 
             batch_sizes = {
@@ -891,7 +895,7 @@ class TerminalConsole(Console):
 
             # determine column widths
             self.evaluation_column_widths["annotation"] = (
-                _calculate_annotation_str_len(batched_intervals)
+                _calculate_annotation_str_len(batched_intervals, self.AUDIT_PADDING)
                 + 3  # brackets and opening escape backslash
             )
             self.evaluation_column_widths["name"] = max(
@@ -956,13 +960,16 @@ class TerminalConsole(Console):
                 )
                 audits_str = ""
                 if num_audits_passed:
-                    audits_str += f" {CHECK_MARK}{num_audits_passed}"
+                    audits_str += f" {self.AUDIT_PASS_MARK}{num_audits_passed}"
                 if num_audits_failed:
-                    audits_str += f" {RED_X_MARK}{num_audits_failed}"
+                    audits_str += f" {self.AUDIT_FAIL_MARK}{num_audits_failed}"
                 audits_str = f", audits{audits_str}" if audits_str else ""
                 annotation_len = self.evaluation_column_widths["annotation"]
+                # don't adjust the annotation_len if we're using AUDIT_PADDING
                 annotation = f"\\[{annotation + audits_str}]".ljust(
-                    annotation_len - 1 if num_audits_failed else annotation_len
+                    annotation_len - 1
+                    if num_audits_failed and self.AUDIT_PADDING == 0
+                    else annotation_len
                 )
 
                 duration = f"{(duration_ms / 1000.0):.2f}s".ljust(
@@ -970,7 +977,7 @@ class TerminalConsole(Console):
                 )
 
                 msg = f"{batch} {display_name}   {annotation}   {duration}".replace(
-                    CHECK_MARK, GREEN_CHECK_MARK
+                    self.AUDIT_PASS_MARK, self.GREEN_AUDIT_PASS_MARK
                 )
 
                 self.evaluation_progress_live.console.print(msg)
@@ -989,7 +996,7 @@ class TerminalConsole(Console):
         if self.evaluation_progress_live:
             self.evaluation_progress_live.stop()
             if success:
-                self.log_success(f"{GREEN_CHECK_MARK} Model batches executed")
+                self.log_success(f"{self.CHECK_MARK} Model batches executed")
 
         self.evaluation_progress_live = None
         self.evaluation_total_progress = None
@@ -1053,7 +1060,7 @@ class TerminalConsole(Console):
             self.creation_progress.stop()
             self.creation_progress = None
             if success:
-                self.log_success(f"\n{GREEN_CHECK_MARK} Physical layer updated")
+                self.log_success(f"\n{self.CHECK_MARK} Physical layer updated")
 
         self.environment_naming_info = EnvironmentNamingInfo()
         self.default_catalog = None
@@ -1154,7 +1161,7 @@ class TerminalConsole(Console):
             self.promotion_progress.stop()
             self.promotion_progress = None
             if success:
-                self.log_success(f"\n{GREEN_CHECK_MARK} Virtual layer updated")
+                self.log_success(f"\n{self.CHECK_MARK} Virtual layer updated")
 
         self.environment_naming_info = EnvironmentNamingInfo()
         self.default_catalog = None
@@ -2807,6 +2814,12 @@ class MarkdownConsole(CaptureTerminalConsole):
     where you want to display a plan or test results in markdown.
     """
 
+    CHECK_MARK = ""
+    AUDIT_PASS_MARK = "passed "
+    GREEN_AUDIT_PASS_MARK = AUDIT_PASS_MARK
+    AUDIT_FAIL_MARK = "failed "
+    AUDIT_PADDING = 7
+
     def __init__(self, **kwargs: t.Any) -> None:
         super().__init__(**{**kwargs, "console": RichConsole(no_color=True)})
 
@@ -2822,17 +2835,18 @@ class MarkdownConsole(CaptureTerminalConsole):
             no_diff: Hide the actual environment statements differences.
         """
         if context_diff.is_new_environment:
-            self._print(
-                f"**New environment `{context_diff.environment}` will be created from `{context_diff.create_from}`**\n"
+            msg = (
+                f"\n**`{context_diff.environment}` environment will be initialized**"
+                if not context_diff.create_from_env_exists
+                else f"\n**New environment `{context_diff.environment}` will be created from `{context_diff.create_from}`**"
             )
+            self._print(msg)
             if not context_diff.has_snapshot_changes:
                 return
 
         if not context_diff.has_changes:
             self._print(f"**No differences when compared to `{context_diff.environment}`**\n")
             return
-
-        self._print(f"**Summary of differences against `{context_diff.environment}`:**\n")
 
         if context_diff.has_requirement_changes:
             self._print(f"Requirements:\n{context_diff.requirements_diff()}")
@@ -2984,7 +2998,7 @@ class MarkdownConsole(CaptureTerminalConsole):
                 dialect=self.dialect,
             )
             snapshots.append(
-                f"* `{display_name}`: [{_format_missing_intervals(snapshot, missing)}]{preview_modifier}"
+                f"* `{display_name}`: \\[{_format_missing_intervals(snapshot, missing)}]{preview_modifier}"
             )
 
         length = len(snapshots)
@@ -3032,6 +3046,21 @@ class MarkdownConsole(CaptureTerminalConsole):
             self._print("```\n")
             self._print(tree)
             self._print("\n```")
+
+    def stop_evaluation_progress(self, success: bool = True) -> None:
+        super().stop_evaluation_progress(success)
+        self._print("\n")
+
+    def stop_creation_progress(self, success: bool = True) -> None:
+        super().stop_creation_progress(success)
+        self._print("\n")
+
+    def stop_promotion_progress(self, success: bool = True) -> None:
+        super().stop_promotion_progress(success)
+        self._print("\n")
+
+    def log_success(self, message: str) -> None:
+        self._print(message)
 
     def log_test_results(
         self, result: unittest.result.TestResult, output: t.Optional[str], target_dialect: str
@@ -3081,6 +3110,12 @@ class MarkdownConsole(CaptureTerminalConsole):
     def log_warning(self, short_message: str, long_message: t.Optional[str] = None) -> None:
         logger.warning(long_message or short_message)
         self._print(f"```\n\\[WARNING] {short_message}```\n\n")
+
+    def _print(self, value: t.Any, **kwargs: t.Any) -> None:
+        self.console.print(value, **kwargs)
+        with self.console.capture() as capture:
+            self.console.print(value, **kwargs)
+        self._captured_outputs.append(capture.get())
 
 
 class DatabricksMagicConsole(CaptureTerminalConsole):
@@ -3473,6 +3508,7 @@ def create_console(
         RuntimeEnv.TERMINAL: TerminalConsole,
         RuntimeEnv.GOOGLE_COLAB: NotebookMagicConsole,
         RuntimeEnv.DEBUGGER: DebuggerTerminalConsole,
+        RuntimeEnv.NON_INTERACTIVE: MarkdownConsole,
     }
     rich_console_kwargs: t.Dict[str, t.Any] = {"theme": srich.theme}
     if runtime_env.is_jupyter or runtime_env.is_google_colab:
@@ -3598,7 +3634,7 @@ def _calculate_interval_str_len(snapshot: Snapshot, intervals: t.List[Interval])
     return interval_str_len
 
 
-def _calculate_audit_str_len(snapshot: Snapshot) -> int:
+def _calculate_audit_str_len(snapshot: Snapshot, audit_padding: int = 0) -> int:
     # The annotation includes audit results. We cannot build the audits result string
     # until after evaluation occurs, but we must determine the annotation column width here.
     # Therefore, we add enough padding for the longest possible audits result string.
@@ -3619,21 +3655,38 @@ def _calculate_audit_str_len(snapshot: Snapshot) -> int:
         )
         if num_audits == 1:
             # +1 for "1" audit count, +1 for red X
-            audit_len = audit_base_str_len + (2 if num_nonblocking_audits else 1)
+            # if audit_padding is > 0 we're using "failed" instead of red X
+            audit_len = (
+                audit_base_str_len
+                + (2 if num_nonblocking_audits else 1)
+                + (
+                    audit_padding - 1
+                    if num_nonblocking_audits and audit_padding > 0
+                    else audit_padding
+                )
+            )
         else:
-            audit_len = audit_base_str_len + len(str(num_audits))
+            audit_len = audit_base_str_len + len(str(num_audits)) + audit_padding
             if num_nonblocking_audits:
                 # +1 for space, +1 for red X
-                audit_len += len(str(num_nonblocking_audits)) + 2
+                # if audit_padding is > 0 we're using "failed" instead of red X
+                audit_len += (
+                    len(str(num_nonblocking_audits))
+                    + 2
+                    + (audit_padding - 1 if audit_padding > 0 else audit_padding)
+                )
         audit_str_len = max(audit_str_len, audit_len)
     return audit_str_len
 
 
-def _calculate_annotation_str_len(batched_intervals: t.Dict[Snapshot, t.List[Interval]]) -> int:
+def _calculate_annotation_str_len(
+    batched_intervals: t.Dict[Snapshot, t.List[Interval]], audit_padding: int = 0
+) -> int:
     annotation_str_len = 0
     for snapshot, intervals in batched_intervals.items():
         annotation_str_len = max(
             annotation_str_len,
-            _calculate_interval_str_len(snapshot, intervals) + _calculate_audit_str_len(snapshot),
+            _calculate_interval_str_len(snapshot, intervals)
+            + _calculate_audit_str_len(snapshot, audit_padding),
         )
     return annotation_str_len

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -3512,7 +3512,7 @@ def create_console(
         RuntimeEnv.TERMINAL: TerminalConsole,
         RuntimeEnv.GOOGLE_COLAB: NotebookMagicConsole,
         RuntimeEnv.DEBUGGER: DebuggerTerminalConsole,
-        RuntimeEnv.NON_INTERACTIVE: MarkdownConsole,
+        RuntimeEnv.CI: MarkdownConsole,
     }
     rich_console_kwargs: t.Dict[str, t.Any] = {"theme": srich.theme}
     if runtime_env.is_jupyter or runtime_env.is_google_colab:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -8,7 +8,8 @@ import pytest
 from click.testing import CliRunner
 import time_machine
 import json
-
+from unittest.mock import MagicMock
+from sqlmesh import RuntimeEnv
 from sqlmesh.cli.example_project import ProjectTemplate, init_example_project
 from sqlmesh.cli.main import cli
 from sqlmesh.core.context import Context
@@ -18,6 +19,11 @@ from sqlmesh.utils.date import now_ds, time_like_to_str, timedelta, to_datetime,
 FREEZE_TIME = "2023-01-01 00:00:00 UTC"
 
 pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(autouse=True)
+def mock_runtime_env(monkeypatch):
+    monkeypatch.setattr("sqlmesh.RuntimeEnv.get", MagicMock(return_value=RuntimeEnv.TERMINAL))
 
 
 @pytest.fixture(scope="session")

--- a/tests/integrations/github/cicd/test_github_commands.py
+++ b/tests/integrations/github/cicd/test_github_commands.py
@@ -144,7 +144,8 @@ def test_run_all_success_with_approvers_approved(
 <details>
   <summary>:ship: Prod Plan Being Applied</summary>
 
-**New environment `prod` will be created from `prod`**"""
+
+**`prod` environment will be initialized**"""
     )
     with open(github_output_file, "r", encoding="utf-8") as f:
         output = f.read()
@@ -271,7 +272,8 @@ def test_run_all_success_with_approvers_approved_merge_delete(
 <details>
   <summary>:ship: Prod Plan Being Applied</summary>
 
-**New environment `prod` will be created from `prod`**"""
+
+**`prod` environment will be initialized**"""
     )
     with open(github_output_file, "r", encoding="utf-8") as f:
         output = f.read()
@@ -918,7 +920,8 @@ def make_test_prod_update_failure_case(
 <details>
   <summary>:ship: Prod Plan Being Applied</summary>
 
-**New environment `prod` will be created from `prod`**"""
+
+**`prod` environment will be initialized**"""
     )
 
     with open(github_output_file, "r", encoding="utf-8") as f:
@@ -1210,7 +1213,8 @@ def test_comment_command_deploy_prod(
 <details>
   <summary>:ship: Prod Plan Being Applied</summary>
 
-**New environment `prod` will be created from `prod`**"""
+
+**`prod` environment will be initialized**"""
     )
 
     with open(github_output_file, "r", encoding="utf-8") as f:

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -287,15 +287,15 @@ def test_merge_pr_has_non_breaking_change(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
-    expected_prod_plan_summary = """**Summary of differences against `prod`:**
+    expected_prod_plan_summary = """**Summary of differences from `prod`:**
 
 
 **Directly Modified:**
 - `sushi.waiter_revenue_by_day`
 ```diff
---- 
+---
 
-+++ 
++++
 
 @@ -16,7 +16,8 @@
 
@@ -484,15 +484,15 @@ def test_merge_pr_has_non_breaking_change_diff_start(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
     assert prod_plan_preview_checks_runs[2]["output"]["title"] == "Prod Plan Preview"
-    expected_prod_plan = """**Summary of differences against `prod`:**
+    expected_prod_plan = """**Summary of differences from `prod`:**
 
 
 **Directly Modified:**
 - `sushi.waiter_revenue_by_day`
 ```diff
---- 
+---
 
-+++ 
++++
 
 @@ -16,7 +16,8 @@
 
@@ -827,7 +827,9 @@ def test_merge_pr_has_no_changes(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
-    expected_prod_plan_summary = "**No differences when compared to `prod`**\n\n\n"
+    expected_prod_plan_summary = (
+        "\n**No changes to plan: project files match the `prod` environment**\n\n\n"
+    )
     assert prod_plan_preview_checks_runs[2]["output"]["title"] == "Prod Plan Preview"
     assert prod_plan_preview_checks_runs[2]["output"]["summary"] == expected_prod_plan_summary
 
@@ -990,15 +992,15 @@ def test_no_merge_since_no_deploy_signal(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
-    expected_prod_plan = """**Summary of differences against `prod`:**
+    expected_prod_plan = """**Summary of differences from `prod`:**
 
 
 **Directly Modified:**
 - `sushi.waiter_revenue_by_day`
 ```diff
---- 
+---
 
-+++ 
++++
 
 @@ -16,7 +16,8 @@
 
@@ -1171,15 +1173,15 @@ def test_no_merge_since_no_deploy_signal_no_approvers_defined(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
-    expected_prod_plan = """**Summary of differences against `prod`:**
+    expected_prod_plan = """**Summary of differences from `prod`:**
 
 
 **Directly Modified:**
 - `sushi.waiter_revenue_by_day`
 ```diff
---- 
+---
 
-+++ 
++++
 
 @@ -16,7 +16,8 @@
 
@@ -1341,15 +1343,15 @@ def test_deploy_comment_pre_categorized(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
-    expected_prod_plan = """**Summary of differences against `prod`:**
+    expected_prod_plan = """**Summary of differences from `prod`:**
 
 
 **Directly Modified:**
 - `sushi.waiter_revenue_by_day`
 ```diff
---- 
+---
 
-+++ 
++++
 
 @@ -16,7 +16,8 @@
 
@@ -1680,15 +1682,15 @@ def test_overlapping_changes_models(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
-    expected_prod_plan_summary = """**Summary of differences against `prod`:**
+    expected_prod_plan_summary = """**Summary of differences from `prod`:**
 
 
 **Directly Modified:**
 - `sushi.customers`
 ```diff
---- 
+---
 
-+++ 
++++
 
 @@ -25,7 +25,8 @@
 
@@ -1875,7 +1877,7 @@ def test_pr_delete_model(
         == """<table><thead><tr><th colspan="3">PR Environment Summary</th></tr><tr><th>Model</th><th>Change Type</th><th>Dates Loaded</th></tr></thead><tbody><tr><td>"memory"."sushi"."top_waiters"</td><td>Breaking</td><td>REMOVED</td></tr></tbody></table>"""
     )
 
-    expected_prod_plan_summary = """**Summary of differences against `prod`:**
+    expected_prod_plan_summary = """**Summary of differences from `prod`:**
 
 
 **Removed Models:**

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -287,15 +287,14 @@ def test_merge_pr_has_non_breaking_change(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
-    expected_prod_plan_summary = """**Summary of differences from `prod`:**
-
+    expected_prod_plan_summary = """\n**Summary of differences from `prod`:**
 
 **Directly Modified:**
 - `sushi.waiter_revenue_by_day`
 ```diff
----
+--- 
 
-+++
++++ 
 
 @@ -16,7 +16,8 @@
 
@@ -484,15 +483,14 @@ def test_merge_pr_has_non_breaking_change_diff_start(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
     assert prod_plan_preview_checks_runs[2]["output"]["title"] == "Prod Plan Preview"
-    expected_prod_plan = """**Summary of differences from `prod`:**
-
+    expected_prod_plan = """\n**Summary of differences from `prod`:**
 
 **Directly Modified:**
 - `sushi.waiter_revenue_by_day`
 ```diff
----
+--- 
 
-+++
++++ 
 
 @@ -16,7 +16,8 @@
 
@@ -992,15 +990,14 @@ def test_no_merge_since_no_deploy_signal(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
-    expected_prod_plan = """**Summary of differences from `prod`:**
-
+    expected_prod_plan = """\n**Summary of differences from `prod`:**
 
 **Directly Modified:**
 - `sushi.waiter_revenue_by_day`
 ```diff
----
+--- 
 
-+++
++++ 
 
 @@ -16,7 +16,8 @@
 
@@ -1173,15 +1170,14 @@ def test_no_merge_since_no_deploy_signal_no_approvers_defined(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
-    expected_prod_plan = """**Summary of differences from `prod`:**
-
+    expected_prod_plan = """\n**Summary of differences from `prod`:**
 
 **Directly Modified:**
 - `sushi.waiter_revenue_by_day`
 ```diff
----
+--- 
 
-+++
++++ 
 
 @@ -16,7 +16,8 @@
 
@@ -1343,15 +1339,14 @@ def test_deploy_comment_pre_categorized(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
-    expected_prod_plan = """**Summary of differences from `prod`:**
-
+    expected_prod_plan = """\n**Summary of differences from `prod`:**
 
 **Directly Modified:**
 - `sushi.waiter_revenue_by_day`
 ```diff
----
+--- 
 
-+++
++++ 
 
 @@ -16,7 +16,8 @@
 
@@ -1682,15 +1677,14 @@ def test_overlapping_changes_models(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
-    expected_prod_plan_summary = """**Summary of differences from `prod`:**
-
+    expected_prod_plan_summary = """\n**Summary of differences from `prod`:**
 
 **Directly Modified:**
 - `sushi.customers`
 ```diff
----
+--- 
 
-+++
++++ 
 
 @@ -25,7 +25,8 @@
 
@@ -1877,8 +1871,7 @@ def test_pr_delete_model(
         == """<table><thead><tr><th colspan="3">PR Environment Summary</th></tr><tr><th>Model</th><th>Change Type</th><th>Dates Loaded</th></tr></thead><tbody><tr><td>"memory"."sushi"."top_waiters"</td><td>Breaking</td><td>REMOVED</td></tr></tbody></table>"""
     )
 
-    expected_prod_plan_summary = """**Summary of differences from `prod`:**
-
+    expected_prod_plan_summary = """\n**Summary of differences from `prod`:**
 
 **Removed Models:**
 - `sushi.top_waiters`

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -324,7 +324,7 @@ def test_run_dag(
         "'Evaluating models ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.0% • 18/18"
     )
     assert not output.stderr
-    assert len(output.outputs) == 2
+    assert len(output.outputs) == 6
     assert convert_all_html_output_to_text(output) == [
         "✔ Model batches executed",
         "Run finished for environment 'prod'",


### PR DESCRIPTION
Some terminals do not support unicode emoji like those used in the standard CLI output (e.g., running SQLMesh with Powershell.exe in Github Actions). Using the `MarkdownConsole` instead of standard `TerminalConsole` addresses this problem.

There is not a universal way to determine whether a given terminal supports Unicode, so we instead assume that unicode is not needed in any non-interactive context (typically a CI platform).

This PR:
- Automatically detects if we're in a non-interactive context and uses `MarkdownConsole` if so
  - Non-interactive contexts include CI (detected via env vars commonly set by CI systems) or anywhere stdout and stdin are not both tty
- Brings the MarkdownConsole output into alignment with recent CLI updates
- Allows the user to force terminal output of any runtime environment with the `SQLMESH_RUNTIME_ENVIRONMENT` env var
  - Accepted values: `terminal`, `databricks`, `google_colab`, `jupyter`, `debugger`, `non_interactive`, `ci`

![Screenshot 2025-05-02 at 5 27 38 PM](https://github.com/user-attachments/assets/3eca7c92-0c43-4274-b2f4-b9d5178bbc44)
