### PR TITLE
Fix: table_diff - correctly handle nulls in boolean columns when displaying the row diff

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -2205,6 +2205,10 @@ def _cells_match(x: t.Any, y: t.Any) -> bool:
 
     # Convert array-like objects to list for consistent comparison
     def _normalize(val: t.Any) -> t.Any:
+        # Convert Pandas null to Python null for the purposes of comparison to prevent errors like the following on boolean fields:
+        # - TypeError: boolean value of NA is ambiguous
+        if pd.isnull(val):
+            val = None
         return list(val) if isinstance(val, (pd.Series, np.ndarray)) else val
 
     return _normalize(x) == _normalize(y)


### PR DESCRIPTION
Prior to this, running table_diff on tables with a boolean column that contained nulls would produce the following error:
```
TypeError: boolean value of NA is ambiguous
```

This error is thrown when `pd.NA` is attempted to be converted to a Python boolean, eg `bool(pd.NA)`.

This PR converts the `pd.NA` to a Python `None` before determining if cells match to avoid this error
