### PR TITLE
fix: pseudo-column type is BQ `TIMESTAMP` which maps to `TIMESTAMPTZ`

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -289,7 +289,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
                 and bq_table.time_partitioning
                 and not bq_table.time_partitioning.field
             ):
-                columns["_PARTITIONTIME"] = exp.DataType.build("TIMESTAMPTZ")
+                columns["_PARTITIONTIME"] = exp.DataType.build("TIMESTAMP", dialect="bigquery")
                 if bq_table.time_partitioning.type_ == "DAY":
                     columns["_PARTITIONDATE"] = exp.DataType.build("DATE")
 

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -289,7 +289,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
                 and bq_table.time_partitioning
                 and not bq_table.time_partitioning.field
             ):
-                columns["_PARTITIONTIME"] = exp.DataType.build("TIMESTAMP")
+                columns["_PARTITIONTIME"] = exp.DataType.build("TIMESTAMPTZ")
                 if bq_table.time_partitioning.type_ == "DAY":
                     columns["_PARTITIONDATE"] = exp.DataType.build("DATE")
 


### PR DESCRIPTION
[Documentation](https://cloud.google.com/bigquery/docs/querying-partitioned-tables#query_an_ingestion-time_partitioned_table) states that the `_PARTITIONTIME`'s pseudo-column type is `TIMESTAMP` (which is `TIMESTAMPTZ`)