### PR TITLE
Fix!: use sql() instead of gen() for time data type data hash computation

### DIFF
--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -711,7 +711,7 @@ class _SCDType2Kind(_Incremental):
             gen(self.valid_from_name),
             gen(self.valid_to_name),
             str(self.invalidate_hard_deletes),
-            gen(self.time_data_type),
+            self.time_data_type.sql(self.dialect),
             gen(self.batch_size) if self.batch_size is not None else None,
         ]
 

--- a/sqlmesh/migrations/v0083_use_sql_for_scd_time_data_type_data_hash.py
+++ b/sqlmesh/migrations/v0083_use_sql_for_scd_time_data_type_data_hash.py
@@ -1,0 +1,5 @@
+"""Use sql(...) instead of gen when computing the data hash of the time data type."""
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    pass


### PR DESCRIPTION
This aims to fix an issue where `sqlmesh plan` would show an unexpected diff for the `time_data_type` after a migration was applied for Databricks.

The diff was due to the fact that the local model had the default `time_data_type` which is `Type.TIMESTAMP`, but the deserialized model would parse the `"TIMESTAMP"` according to the databricks dialect, resulting in `Type.TIMESTAMPTZ`. The two types produce a different value when generated with `gen()`, leading to a difference in the data hash.

Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1745437282778639