### PR TITLE
Chore: detect invalid audit refs and raise early

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2478,6 +2478,14 @@ def _create_model(
 
     model.audit_definitions.update(audit_definitions)
 
+    from sqlmesh.core.audit.builtin import BUILT_IN_AUDITS
+
+    # Ensure that all audits referenced in the model are defined
+    available_audits = BUILT_IN_AUDITS.keys() | model.audit_definitions.keys()
+    for referenced_audit, *_ in model.audits:
+        if referenced_audit not in available_audits:
+            raise_config_error(f"Audit '{referenced_audit}' is undefined", location=path)
+
     # Any macro referenced in audits or signals needs to be treated as metadata-only
     statements.extend((audit.query, True) for audit in audit_definitions.values())
     for _, audit_args in model.audits:


### PR DESCRIPTION
This is a UX improvement. If a model references an undefined model today, we crash with a `KeyError` after loading, in the metadata hash computation logic:

```
  File "sqlmesh/core/model/definition.py", line 1112, in metadata_hash
    audit = self.audit_definitions[audit_name]
            ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'not_nulll'
```

This PR gracefully handles invalid references and raises early to avoid this:

```
Error: Failed to load model definition at '.../playground/models/test.sql'.
Audit 'not_nulll' is undefined at '.../playground/models/test.sql'
```