### PR TITLE
Fix columns example in tests doc

### DIFF
--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -605,7 +605,7 @@ An optional dictionary that maps columns to their types:
 ```yaml linenums="1"
     <upstream_model>:
       columns:
-        - <column_name>: <column_type>
+        <column_name>: <column_type>
         ...
 ```
 


### PR DESCRIPTION
For unit tests YAML, `<test_name>.inputs.<upstream_model>.columns` actually expects a dictionary. I tested that the current example syntax with `- ` fails, and the fixed version works.