### PR TITLE
Fix: Pop select model in tablediff to ensure backwards compatibility

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -908,13 +908,19 @@ def table_diff(
     """Show the diff between two tables or a selection of models when they are specified."""
     source, target = source_to_target.split(":")
     select_model = kwargs.pop("select_model", None)
-    select_models = {model} if model else select_model
-    obj.table_diff(
-        source=source,
-        target=target,
-        select_models=select_models,
-        **kwargs,
-    )
+
+    if model and select_model:
+        obj.console.log_error(
+            "The --select-model option cannot be used together with a model argument. Please choose one of them."
+        )
+    else:
+        select_models = {model} if model else select_model
+        obj.table_diff(
+            source=source,
+            target=target,
+            select_models=select_models,
+            **kwargs,
+        )
 
 
 @cli.command("rewrite")

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -17,7 +17,7 @@ from sqlmesh.utils import Verbosity
 from sqlmesh.core.config import load_configs
 from sqlmesh.core.context import Context
 from sqlmesh.utils.date import TimeLike
-from sqlmesh.utils.errors import MissingDependencyError
+from sqlmesh.utils.errors import MissingDependencyError, SQLMeshError
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -910,17 +910,17 @@ def table_diff(
     select_model = kwargs.pop("select_model", None)
 
     if model and select_model:
-        obj.console.log_error(
+        raise SQLMeshError(
             "The --select-model option cannot be used together with a model argument. Please choose one of them."
         )
-    else:
-        select_models = {model} if model else select_model
-        obj.table_diff(
-            source=source,
-            target=target,
-            select_models=select_models,
-            **kwargs,
-        )
+
+    select_models = {model} if model else select_model
+    obj.table_diff(
+        source=source,
+        target=target,
+        select_models=select_models,
+        **kwargs,
+    )
 
 
 @cli.command("rewrite")

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -907,7 +907,8 @@ def table_diff(
 ) -> None:
     """Show the diff between two tables or a selection of models when they are specified."""
     source, target = source_to_target.split(":")
-    select_models = {model} if model else kwargs.pop("select_model", None)
+    select_model = kwargs.pop("select_model", None)
+    select_models = {model} if model else select_model
     obj.table_diff(
         source=source,
         target=target,


### PR DESCRIPTION
This fixes a bug in the `table_diff` command when used without the `select-model` to ensure backwards compatibility:
```bash
> sqlmesh table_diff dev:prod model
```
which would raise a keyword argument error as the select model would be passed in the kwargs. This fixes it by popping the select model from the kwargs beforehand regardless similarly to the handling in other commands.