### PR TITLE
Fix: use maybe_parse for python model depends_on instead of parse_one

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2295,7 +2295,7 @@ def create_python_model(
     else:
         depends_on_rendered = render_expression(
             expression=exp.Array(
-                expressions=[d.parse_one(dep, dialect=dialect) for dep in depends_on or []]
+                expressions=[exp.maybe_parse(dep, dialect=dialect) for dep in depends_on or []]
             ),
             module_path=module_path,
             macros=macros,


### PR DESCRIPTION
This PR fixes a small Python model bug related to how we parse the `depends_on` values. Other than that, it also adds a test that demonstrates how one can manually specify blueprint models as dependencies in Python model definitions.