### PR TITLE
Feat: Add destroy command to remove entire project resources

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -23,6 +23,7 @@ Commands:
   create_external_models  Create a schema file containing external model...
   create_test             Generate a unit test fixture for a given model.
   dag                     Render the DAG as an html file.
+  destroy                 The destroy command removes all project resources.
   diff                    Show the diff between the local state and the...
   dlt_refresh             Attaches to a DLT pipeline with the option to...
   environments            Prints the list of SQLMesh environments with...
@@ -140,6 +141,17 @@ Usage: sqlmesh dag [OPTIONS] FILE
 
 Options:
   --select-model TEXT  Select specific models to include in the dag.
+  --help               Show this message and exit.
+```
+
+## destroy
+
+```
+Usage: sqlmesh destroy
+
+  Removes all project resources, including warehouse objects, state tables, the SQLMesh cache and any build artifacts.
+
+Options:
   --help               Show this message and exit.
 ```
 

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -232,6 +232,13 @@ options:
   --file FILE, -f FILE  An optional file path to write the HTML output to.
 ```
 
+#### destroy
+```
+%destroy
+
+Removes all project resources, including warehouse objects, state tables, the SQLMesh cache and any build artifacts.
+```
+
 #### dlt_refresh
 ```
 %dlt_refresh PIPELINE [--table] TABLE [--force]

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -546,6 +546,19 @@ def janitor(ctx: click.Context, ignore_ttl: bool, **kwargs: t.Any) -> None:
     ctx.obj.run_janitor(ignore_ttl, **kwargs)
 
 
+@cli.command("destroy")
+@click.pass_context
+@error_handler
+@cli_analytics
+def destroy(ctx: click.Context, **kwargs: t.Any) -> None:
+    """
+    The destroy command removes all project resources.
+
+    This includes engine-managed objects, state tables, the SQLMesh cache and any build artifacts.
+    """
+    ctx.obj.destroy(**kwargs)
+
+
 @cli.command("dag")
 @click.argument("file", required=True)
 @click.option(

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1574,7 +1574,6 @@ class GenericContext(BaseContext, t.Generic[C]):
             name: The name of the environment to invalidate.
             sync: If True, the call blocks until the environment is deleted. Otherwise, the environment will
                 be deleted asynchronously by the janitor process.
-            protect_prod: If True, prevents invalidation of the production environment.
         """
         name = Environment.sanitize_name(name)
         self.state_sync.invalidate_environment(name)

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -347,7 +347,7 @@ class StateSync(StateReader, abc.ABC):
         """
 
     @abc.abstractmethod
-    def invalidate_environment(self, name: str, protect_prod: t.Optional[bool] = True) -> None:
+    def invalidate_environment(self, name: str, protect_prod: bool = True) -> None:
         """Invalidates the target environment by setting its expiration timestamp to now.
 
         Args:
@@ -356,7 +356,7 @@ class StateSync(StateReader, abc.ABC):
         """
 
     @abc.abstractmethod
-    def remove_state(self) -> None:
+    def remove_state(self, including_backup: bool = False) -> None:
         """Removes the state store objects."""
 
     @abc.abstractmethod

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -347,12 +347,17 @@ class StateSync(StateReader, abc.ABC):
         """
 
     @abc.abstractmethod
-    def invalidate_environment(self, name: str) -> None:
+    def invalidate_environment(self, name: str, protect_prod: t.Optional[bool] = True) -> None:
         """Invalidates the target environment by setting its expiration timestamp to now.
 
         Args:
             name: The name of the environment to invalidate.
+            protect_prod: If True, prevents invalidation of the production environment.
         """
+
+    @abc.abstractmethod
+    def remove_state(self) -> None:
+        """Removes the state store objects."""
 
     @abc.abstractmethod
     def remove_intervals(

--- a/sqlmesh/core/state_sync/db/environment.py
+++ b/sqlmesh/core/state_sync/db/environment.py
@@ -108,7 +108,7 @@ class EnvironmentState:
                 columns_to_types=self._environment_statements_columns_to_types,
             )
 
-    def invalidate_environment(self, name: str, protect_prod: t.Optional[bool] = True) -> None:
+    def invalidate_environment(self, name: str, protect_prod: bool = True) -> None:
         """Invalidates the environment.
 
         Args:

--- a/sqlmesh/core/state_sync/db/environment.py
+++ b/sqlmesh/core/state_sync/db/environment.py
@@ -108,14 +108,15 @@ class EnvironmentState:
                 columns_to_types=self._environment_statements_columns_to_types,
             )
 
-    def invalidate_environment(self, name: str) -> None:
+    def invalidate_environment(self, name: str, protect_prod: t.Optional[bool] = True) -> None:
         """Invalidates the environment.
 
         Args:
             name: The name of the environment
+            protect_prod: If True, prevents invalidation of the production environment.
         """
         name = name.lower()
-        if name == c.PROD:
+        if protect_prod and name == c.PROD:
             raise SQLMeshError("Cannot invalidate the production environment.")
 
         filter_expr = exp.column("name").eq(name)

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -1111,6 +1111,13 @@ class SQLMeshMagics(Magics):
         args = parse_argstring(self.lint, line)
         context.lint_models(args.models)
 
+    @magic_arguments()
+    @line_magic
+    @pass_sqlmesh_context
+    def destroy(self, context: Context, line: str) -> None:
+        """Removes all project resources, engine-managed objects, state tables and clears the SQLMesh cache."""
+        context.destroy()
+
 
 def register_magics() -> None:
     try:

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -437,7 +437,7 @@ def test_try_invalidate_pr_environment(github_client, make_controller, mocker: M
     invalidate_controller._context._state_sync = mocker.MagicMock()
     invalidate_controller.try_invalidate_pr_environment()
     invalidate_controller._context._state_sync.invalidate_environment.assert_called_once_with(
-        "hello_world_2"
+        "hello_world_2", True
     )
 
     no_invalidate_controller = make_controller(

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -437,7 +437,7 @@ def test_try_invalidate_pr_environment(github_client, make_controller, mocker: M
     invalidate_controller._context._state_sync = mocker.MagicMock()
     invalidate_controller.try_invalidate_pr_environment()
     invalidate_controller._context._state_sync.invalidate_environment.assert_called_once_with(
-        "hello_world_2", True
+        "hello_world_2"
     )
 
     no_invalidate_controller = make_controller(


### PR DESCRIPTION
This update introduces the `sqlmesh destroy` command, which permanently deletes all engine-managed objects, including warehouse data, the associated state tables and cached SQLMesh assets, effectively resetting the entire project, fixes: #3684 

**Usage:** `sqlmesh destroy`

This might be useful for cleaning up development projects, proof-of-concept work or pre-production phases with temporary setups.

> ⚠️ This is destructive and irreversible, and it removes both development and the production environment, so it should only be used when a full removal is necessary.