### PR TITLE
Fix: Support dialects with normalization strategies for dbt projects

### DIFF
--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -12,6 +12,7 @@ import jinja2
 from dbt import version
 from dbt.adapters.base import BaseRelation, Column
 from ruamel.yaml import YAMLError
+from sqlglot import Dialect
 
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.snapshot.definition import DeployabilityIndex
@@ -49,7 +50,9 @@ class Exceptions:
 class Api:
     def __init__(self, dialect: t.Optional[str]) -> None:
         if dialect:
-            config_class = TARGET_TYPE_TO_CONFIG_CLASS[dialect]
+            config_class = TARGET_TYPE_TO_CONFIG_CLASS[
+                Dialect.get_or_raise(dialect).__class__.__name__.lower()
+            ]
             self.Relation = config_class.relation_class
             self.Column = config_class.column_class
             self.quote_policy = config_class.quote_policy

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -4268,7 +4268,7 @@ def test_dbt_dialect_with_normalization_strategy(init_and_plan_context: t.Callab
     context, _ = init_and_plan_context(
         "tests/fixtures/dbt/sushi_test", config="test_config_with_normalization_strategy"
     )
-    assert context.default_dialect == "duckdb,normalization_strategy=UPPERCASE"
+    assert context.default_dialect == "duckdb,normalization_strategy=LOWERCASE"
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -4263,6 +4263,14 @@ def test_dbt_requirements(sushi_dbt_context: Context):
     assert sushi_dbt_context.requirements["dbt-duckdb"].startswith("1.")
 
 
+@time_machine.travel("2023-01-08 15:00:00 UTC")
+def test_dbt_dialect_with_normalization_strategy(init_and_plan_context: t.Callable):
+    context, _ = init_and_plan_context(
+        "tests/fixtures/dbt/sushi_test", config="test_config_with_normalization_strategy"
+    )
+    assert context.default_dialect == "duckdb,normalization_strategy=UPPERCASE"
+
+
 @pytest.mark.parametrize(
     "context_fixture",
     ["sushi_context", "sushi_dbt_context", "sushi_test_dbt_context", "sushi_no_default_catalog"],

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2221,7 +2221,7 @@ def test_python_model(assert_exp_eq) -> None:
     m = model.get_registry()["my_model"].model(
         module_path=Path("."),
         path=Path("."),
-        dialect="duckdb",
+        dialect="duckdb,normalization_strategy=LOWERCASE",
     )
 
     assert list(m.pre_statements) == [
@@ -2231,14 +2231,14 @@ def test_python_model(assert_exp_eq) -> None:
         d.parse_one("DROP TABLE x"),
     ]
     assert m.enabled
-    assert m.dialect == "duckdb"
+    assert m.dialect == "duckdb,normalization_strategy=lowercase"
     assert m.depends_on == {'"foo"', '"bar"."baz"'}
-    assert m.columns_to_types == {"col": exp.DataType.build("int")}
+    assert m.columns_to_types == {"COL": exp.DataType.build("int")}
     assert_exp_eq(
         m.ctas_query(),
         """
 SELECT
-  CAST(NULL AS INT) AS "col"
+  CAST(NULL AS INT) AS "COL"
 FROM (VALUES
   (1)) AS t(dummy)
 WHERE

--- a/tests/fixtures/dbt/sushi_test/config.py
+++ b/tests/fixtures/dbt/sushi_test/config.py
@@ -16,5 +16,5 @@ test_config = config
 test_config_with_normalization_strategy = sqlmesh_config(
     Path(__file__).parent,
     variables=variables,
-    model_defaults=ModelDefaultsConfig(dialect="duckdb,normalization_strategy=UPPERCASE"),
+    model_defaults=ModelDefaultsConfig(dialect="duckdb,normalization_strategy=LOWERCASE"),
 )

--- a/tests/fixtures/dbt/sushi_test/config.py
+++ b/tests/fixtures/dbt/sushi_test/config.py
@@ -12,3 +12,9 @@ config = sqlmesh_config(
 
 
 test_config = config
+
+test_config_with_normalization_strategy = sqlmesh_config(
+    Path(__file__).parent,
+    variables=variables,
+    model_defaults=ModelDefaultsConfig(dialect="duckdb,normalization_strategy=UPPERCASE"),
+)


### PR DESCRIPTION
Support dialects defined as `bigquery,normalization_strategy=UPPERCASE`