### PR TITLE
Fix: Gracefully handle execution errors in before after all

### DIFF
--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -262,24 +262,29 @@ def execute_environment_statements(
     end: t.Optional[TimeLike] = None,
     execution_time: t.Optional[TimeLike] = None,
 ) -> None:
-    rendered_expressions = [
-        expr
-        for statements in environment_statements
-        for expr in render_statements(
-            statements=getattr(statements, runtime_stage.value),
-            dialect=adapter.dialect,
-            default_catalog=default_catalog,
-            python_env=statements.python_env,
-            jinja_macros=statements.jinja_macros,
-            snapshots=snapshots,
-            start=start,
-            end=end,
-            execution_time=execution_time,
-            environment_naming_info=environment_naming_info,
-            runtime_stage=runtime_stage,
-            engine_adapter=adapter,
+    try:
+        rendered_expressions = [
+            expr
+            for statements in environment_statements
+            for expr in render_statements(
+                statements=getattr(statements, runtime_stage.value),
+                dialect=adapter.dialect,
+                default_catalog=default_catalog,
+                python_env=statements.python_env,
+                jinja_macros=statements.jinja_macros,
+                snapshots=snapshots,
+                start=start,
+                end=end,
+                execution_time=execution_time,
+                environment_naming_info=environment_naming_info,
+                runtime_stage=runtime_stage,
+                engine_adapter=adapter,
+            )
+        ]
+    except Exception as e:
+        raise SQLMeshError(
+            f"An error occurred during rendering of the '{runtime_stage.value}' statements:\n\n{e}"
         )
-    ]
     if rendered_expressions:
         with adapter.transaction():
             for expr in rendered_expressions:
@@ -287,5 +292,5 @@ def execute_environment_statements(
                     adapter.execute(expr)
                 except Exception as e:
                     raise SQLMeshError(
-                        f"An error occurred during execution of the following `{runtime_stage.value}` statement:\n\n{expr}\n\n{e}"
+                        f"An error occurred during execution of the following '{runtime_stage.value}' statement:\n\n{expr}\n\n{e}"
                     )

--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -286,4 +286,6 @@ def execute_environment_statements(
                 try:
                     adapter.execute(expr)
                 except Exception as e:
-                    raise SQLMeshError(f"An error occurred during execution of:\n\n{expr}\n\n{e}")
+                    raise SQLMeshError(
+                        f"An error occurred during execution of the following `{runtime_stage.value}` statement:\n\n{expr}\n\n{e}"
+                    )

--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -14,6 +14,7 @@ from sqlmesh.core.renderer import render_statements
 from sqlmesh.core.snapshot import SnapshotId, SnapshotTableInfo, Snapshot
 from sqlmesh.utils import word_characters_only
 from sqlmesh.utils.date import TimeLike, now_timestamp
+from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.jinja import JinjaMacroRegistry
 from sqlmesh.utils.metaprogramming import Executable
 from sqlmesh.utils.pydantic import PydanticModel, field_validator, ValidationInfo
@@ -282,4 +283,7 @@ def execute_environment_statements(
     if rendered_expressions:
         with adapter.transaction():
             for expr in rendered_expressions:
-                adapter.execute(expr)
+                try:
+                    adapter.execute(expr)
+                except Exception as e:
+                    raise SQLMeshError(f"An error occurred during execution of:\n\n{expr}\n\n{e}")

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -5531,7 +5531,7 @@ def test_environment_statements_error_handling(tmp_path: Path):
     ctx = Context(paths=[tmp_path], config=config)
 
     expected_error_message = re.escape(
-        """An error occurred during execution of:
+        """An error occurred during execution of the following `before_all` statement:
 
 CREATE TABLE identical_table (physical_schema_name TEXT)
 

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -325,8 +325,8 @@ def test_run_dag(
     )
     assert not output.stderr
 
-    # At least 6 outputs expected as the number of models in the particular batch might vary
-    assert len(output.outputs) >= 6
+    # At least 4 outputs expected as the number of models in the particular batch might vary
+    assert len(output.outputs) >= 4
 
     html_text_actual = convert_all_html_output_to_text(output)
 


### PR DESCRIPTION
Catch and raise only the relevant error messages for `before all` and `after all` statements  (or dbt's `on_run_start` , `on_run_end` respectively) when an exception during their execution occurs