### PR TITLE
Feat: Add condition in the union macro for conditional union of tables

### DIFF
--- a/docs/concepts/macros/sqlmesh_macros.md
+++ b/docs/concepts/macros/sqlmesh_macros.md
@@ -855,7 +855,9 @@ FROM foo
 
 `@UNION` returns a `UNION` query that selects all columns with matching names and data types from the tables.
 
-Its first argument is the `UNION` "type", `'DISTINCT'` (removing duplicated rows) or `'ALL'` (returning all rows). Subsequent arguments are the tables to be combined.
+Its first argument can be either a condition or the `UNION` "type". If the first argument evaluates to a boolean (`TRUE` or `FALSE`), it's treated as a condition. If the condition is `FALSE`, only the first table is returned. If it's `TRUE`, the union operation is performed.
+
+If the first argument is not a boolean condition, it's treated as the `UNION` "type": either `'DISTINCT'` (removing duplicated rows) or `'ALL'` (returning all rows). Subsequent arguments are the tables to be combined.
 
 Let's assume that:
 
@@ -880,6 +882,47 @@ SELECT
   CAST(a AS INT) AS a,
   CAST(c AS TEXT) AS c
 FROM bar
+```
+
+If the union type is omitted, `'ALL'` is used as the default. So the following expression:
+
+```sql linenums="1"
+@UNION(foo, bar)
+```
+
+would be rendered as:
+
+```sql linenums="1"
+SELECT
+  CAST(a AS INT) AS a,
+  CAST(c AS TEXT) AS c
+FROM foo
+UNION ALL
+SELECT
+  CAST(a AS INT) AS a,
+  CAST(c AS TEXT) AS c
+FROM bar
+```
+
+You can also use a condition to control whether the union happens:
+
+```sql linenums="1"
+@UNION(1 > 0, 'all', foo, bar)
+```
+
+This would render the same as above. However, if the condition is `FALSE`:
+
+```sql linenums="1"
+@UNION(1 > 2, 'all', foo, bar)
+```
+
+Only the first table would be selected:
+
+```sql linenums="1"
+SELECT
+  CAST(a AS INT) AS a,
+  CAST(c AS TEXT) AS c
+FROM foo
 ```
 
 ### @HAVERSINE_DISTANCE

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -994,7 +994,7 @@ def union(
     """
 
     if not args:
-        raise SQLMeshError("At least one table is required for UNION.")
+        raise SQLMeshError("At least one table is required for the @UNION macro.")
 
     arg_idx = 0
     # Check for condition
@@ -1002,11 +1002,11 @@ def union(
     if isinstance(condition, bool):
         arg_idx += 1
         if arg_idx >= len(args):
-            raise SQLMeshError("Expected more arguments after condition.")
+            raise SQLMeshError("Expected more arguments after the condition of the `@UNION` macro.")
 
     # Check for union type
     type_ = exp.Literal.string("ALL")
-    if arg_idx < len(args) and isinstance(args[arg_idx], exp.Literal):
+    if isinstance(args[arg_idx], exp.Literal):
         type_ = args[arg_idx]  # type: ignore
         arg_idx += 1
     kind = type_.name.upper()
@@ -1014,13 +1014,9 @@ def union(
         raise SQLMeshError(f"Invalid type '{type_}'. Expected 'ALL' or 'DISTINCT'.")
 
     # Remaining args should be tables
-    tables = []
-    for table in args[arg_idx:]:
-        if isinstance(table, exp.Column):
-            table = exp.table_(table.this, db=table.args.get("table"), catalog=table.args.get("db"))
-        else:
-            table = exp.to_table(table, dialect=evaluator.dialect)  # type: ignore
-        tables.append(table)
+    tables = [
+        exp.to_table(e.sql(evaluator.dialect), dialect=evaluator.dialect) for e in args[arg_idx:]
+    ]
 
     columns = {
         column

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -970,10 +970,16 @@ def safe_div(_: MacroEvaluator, numerator: exp.Expression, denominator: exp.Expr
 @macro()
 def union(
     evaluator: MacroEvaluator,
-    type_: exp.Literal = exp.Literal.string("ALL"),
-    *tables: exp.Table,
+    *args: exp.Expression,
 ) -> exp.Query:
     """Returns a UNION of the given tables. Only choosing columns that have the same name and type.
+
+    Args:
+        evaluator: MacroEvaluator that invoked the macro
+        args: Variable arguments that can be:
+            - First argument can be a condition (exp.Condition)
+            - A union type ('ALL' or 'DISTINCT') as exp.Literal
+            - Tables (exp.Table)
 
     Example:
         >>> from sqlglot import parse_one
@@ -982,81 +988,50 @@ def union(
         >>> sql = "@UNION('distinct', foo, bar)"
         >>> MacroEvaluator(schema=MappingSchema({"foo": {"a": "int", "b": "string", "c": "string"}, "bar": {"c": "string", "a": "int", "b": "int"}})).transform(parse_one(sql)).sql()
         'SELECT CAST(a AS INT) AS a, CAST(c AS TEXT) AS c FROM foo UNION SELECT CAST(a AS INT) AS a, CAST(c AS TEXT) AS c FROM bar'
-    """
-    kind = type_.name.upper()
-    if kind not in ("ALL", "DISTINCT"):
-        raise SQLMeshError(f"Invalid type '{type_}'. Expected 'ALL' or 'DISTINCT'.")
-
-    columns = {
-        column
-        for column, _ in reduce(
-            lambda a, b: a & b,  # type: ignore
-            (evaluator.columns_to_types(table).items() for table in tables),
-        )
-    }
-
-    projections = [
-        exp.cast(column, type_, dialect=evaluator.dialect).as_(column)
-        for column, type_ in evaluator.columns_to_types(tables[0]).items()
-        if column in columns
-    ]
-
-    return reduce(
-        lambda a, b: a.union(b, distinct=kind == "DISTINCT"),  # type: ignore
-        [exp.select(*projections).from_(t) for t in tables],
-    )
-
-
-@macro()
-def union_if(
-    evaluator: MacroEvaluator,
-    condition: exp.Expression,
-    type_: exp.Literal = exp.Literal.string("ALL"),
-    *tables: exp.Table | exp.Query,
-) -> exp.Query:
-    """Returns a UNION of the given tables or queries if the condition is true, otherwise returns just the first.
-
-    Example:
-        >>> from sqlglot import parse_one
-        >>> from sqlglot.schema import MappingSchema
-        >>> from sqlmesh.core.macros import MacroEvaluator
-        >>> sql = "@UNION_IF(True, 'distinct', foo, bar)"
+        >>> sql = "@UNION(True, 'distinct', foo, bar)"
         >>> MacroEvaluator(schema=MappingSchema({"foo": {"a": "int", "b": "string", "c": "string"}, "bar": {"c": "string", "a": "int", "b": "int"}})).transform(parse_one(sql)).sql()
         'SELECT CAST(a AS INT) AS a, CAST(c AS TEXT) AS c FROM foo UNION SELECT CAST(a AS INT) AS a, CAST(c AS TEXT) AS c FROM bar'
     """
+
+    if not args:
+        raise SQLMeshError("At least one table is required for UNION.")
+
+    arg_idx = 0
+    # Check for condition
+    condition = evaluator.eval_expression(args[arg_idx])
+    if isinstance(condition, bool):
+        arg_idx += 1
+        if arg_idx >= len(args):
+            raise SQLMeshError("Expected more arguments after condition.")
+
+    # Check for union type
+    type_ = exp.Literal.string("ALL")
+    if arg_idx < len(args) and isinstance(args[arg_idx], exp.Literal):
+        type_ = args[arg_idx]  # type: ignore
+        arg_idx += 1
     kind = type_.name.upper()
     if kind not in ("ALL", "DISTINCT"):
         raise SQLMeshError(f"Invalid type '{type_}'. Expected 'ALL' or 'DISTINCT'.")
 
-    result = evaluator.eval_expression(condition)
-
-    if isinstance(tables[0], exp.Query):
-        if not result:
-            # If condition is false, return just the first query
-            return tables[0]
-        return tables[0].union(*tables[1:], distinct=kind == "DISTINCT")
+    # Remaining args should be tables
+    tables = args[arg_idx:]
 
     columns = {
         column
         for column, _ in reduce(
             lambda a, b: a & b,  # type: ignore
-            (
-                evaluator.columns_to_types(table).items()
-                for table in tables
-                if isinstance(table, exp.Table)  # for mypy
-            ),
+            (evaluator.columns_to_types(table).items() for table in tables),  # type: ignore
         )
     }
 
     projections = [
         exp.cast(column, type_, dialect=evaluator.dialect).as_(column)
-        for column, type_ in evaluator.columns_to_types(tables[0]).items()
+        for column, type_ in evaluator.columns_to_types(tables[0]).items()  # type: ignore
         if column in columns
     ]
 
-    result = evaluator.eval_expression(condition)
-    if not result:
-        # If condition is false, return just the first table with proper column casting
+    # Skip the union if condition is False
+    if condition == False:
         return exp.select(*projections).from_(tables[0])
 
     return reduce(

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -1021,7 +1021,7 @@ def union_if(
         >>> from sqlglot import parse_one
         >>> from sqlglot.schema import MappingSchema
         >>> from sqlmesh.core.macros import MacroEvaluator
-        >>> sql = "@UNION_IF(@start_ts = '2025-01-01 00:00:00', 'distinct', foo, bar)"
+        >>> sql = "@UNION_IF(True, 'distinct', foo, bar)"
         >>> MacroEvaluator(schema=MappingSchema({"foo": {"a": "int", "b": "string", "c": "string"}, "bar": {"c": "string", "a": "int", "b": "int"}})).transform(parse_one(sql)).sql()
         'SELECT CAST(a AS INT) AS a, CAST(c AS TEXT) AS c FROM foo UNION SELECT CAST(a AS INT) AS a, CAST(c AS TEXT) AS c FROM bar'
     """

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -318,6 +318,46 @@ FROM "memory"."sushi"."marketing" AS "marketing"
             2,
             lambda expected_select: f"{expected_select}\nUNION ALL\n{expected_select}\n",
         ),
+        # Test case 7: Missing union type AND condition
+        (
+            "test_7",
+            "",
+            "",
+            2,
+            lambda expected_select: f"{expected_select}\nUNION ALL\n{expected_select}\n",
+        ),
+        # Test case 8: Missing union type AND condition multiple tables
+        (
+            "test_8",
+            "",
+            "",
+            3,
+            lambda expected_select: f"{expected_select}\nUNION ALL\n{expected_select}\n\nUNION ALL\n{expected_select}\n",
+        ),
+        # Test case 9: Missing union type AND condition one table
+        (
+            "test_9",
+            "",
+            "",
+            1,
+            lambda expected_select: f"{expected_select}",
+        ),
+        # Test case 10: Union type with one table
+        (
+            "test_10",
+            "",
+            "'distinct'",
+            1,
+            lambda expected_select: f"{expected_select}",
+        ),
+        # Test case 11: Condition with one table
+        (
+            "test_9",
+            "True",
+            "",
+            1,
+            lambda expected_select: f"{expected_select}",
+        ),
     ],
 )
 def test_model_union_conditional(

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -267,103 +267,98 @@ FROM "memory"."sushi"."marketing" AS "marketing"
 
 
 @time_machine.travel("1996-02-10 00:00:00 UTC")
-def test_model_union_if_table(sushi_context, assert_exp_eq):
+@pytest.mark.parametrize(
+    "test_id, condition, union_type, table_count, expected_result",
+    [
+        # Test case 1: Basic conditional union - True condition
+        (
+            "test_1",
+            "@get_date() == '1996-02-10'",
+            "'all'",
+            2,
+            lambda expected_select: f"{expected_select}\nUNION ALL\n{expected_select}\n",
+        ),
+        # Test case 2: False condition - should return just first table
+        (
+            "test_2",
+            "@get_date() > '1996-02-10'",
+            "'all'",
+            2,
+            lambda expected_select: f"{expected_select}\n",
+        ),
+        # Test case 3: Multiple tables in union
+        (
+            "test_3",
+            "@get_date() == '1996-02-10'",
+            "'all'",
+            3,
+            lambda expected_select: f"{expected_select}\nUNION ALL\n{expected_select}\nUNION ALL\n{expected_select}\n",
+        ),
+        # Test case 4: DISTINCT type
+        (
+            "test_4",
+            "@get_date() == '1996-02-10'",
+            "'distinct'",
+            2,
+            lambda expected_select: f"{expected_select}\nUNION\n{expected_select}\n",
+        ),
+        # Test case 5: Complex condition
+        (
+            "test_5",
+            "@get_date() = '1996-02-10' and 1=1 or @get_date() > '1996-02-10'",
+            "'distinct'",
+            2,
+            lambda expected_select: f"{expected_select}\nUNION\n{expected_select}\n",
+        ),
+        # Test case 6: Missing union type (defaults to ALL)
+        (
+            "test_6",
+            "@get_date() == '1996-02-10'",
+            "",
+            2,
+            lambda expected_select: f"{expected_select}\nUNION ALL\n{expected_select}\n",
+        ),
+    ],
+)
+def test_model_union_conditional(
+    sushi_context, assert_exp_eq, test_id, condition, union_type, table_count, expected_result
+):
     @macro()
     def get_date(evaluator):
         from sqlmesh.utils.date import now
 
         return f"'{now().date()}'"
 
-    expressions = d.parse(
-        """
-        MODEL (
-            name sushi.test_1,
-            kind FULL,
-        );
-
-        @union_if(@get_date() == '1996-02-10', 'all', sushi.marketing, sushi.marketing)
-        """
-    )
-    sushi_context.upsert_model(load_sql_based_model(expressions, default_catalog="memory"))
-    assert_exp_eq(
-        sushi_context.get_model("sushi.test_1").render_query(),
-        """SELECT
+    expected_select = """SELECT
   CAST("marketing"."customer_id" AS INT) AS "customer_id",
   CAST("marketing"."status" AS TEXT) AS "status",
-  CAST("marketing"."updated_at" AS TIMESTAMP) AS "updated_at",
+  CAST("marketing"."updated_at" AS TIMESTAMPNTZ) AS "updated_at",
   CAST("marketing"."valid_from" AS TIMESTAMP) AS "valid_from",
   CAST("marketing"."valid_to" AS TIMESTAMP) AS "valid_to"
 FROM "memory"."sushi"."marketing" AS "marketing"
-UNION ALL
-SELECT
-  CAST("marketing"."customer_id" AS INT) AS "customer_id",
-  CAST("marketing"."status" AS TEXT) AS "status",
-  CAST("marketing"."updated_at" AS TIMESTAMP) AS "updated_at",
-  CAST("marketing"."valid_from" AS TIMESTAMP) AS "valid_from",
-  CAST("marketing"."valid_to" AS TIMESTAMP) AS "valid_to"
-FROM "memory"."sushi"."marketing" AS "marketing"
-        """,
-    )
+"""
+
+    # Create tables argument list based on table_count
+    tables = ", ".join(["sushi.marketing"] * table_count)
+
+    # Handle the missing union_type case
+    union_type_arg = f", {union_type}" if union_type else ""
 
     expressions = d.parse(
-        """
+        f"""
         MODEL (
-            name sushi.test_2,
+            name sushi.{test_id},
             kind FULL,
         );
 
-        @union_if(@get_date() > '1996-02-10', 'all', sushi.marketing, sushi.marketing)
-        """
-    )
-    sushi_context.upsert_model(load_sql_based_model(expressions, default_catalog="memory"))
-    assert_exp_eq(
-        sushi_context.get_model("sushi.test_2").render_query(),
-        """
-SELECT
-  CAST("marketing"."customer_id" AS INT) AS "customer_id",
-  CAST("marketing"."status" AS TEXT) AS "status",
-  CAST("marketing"."updated_at" AS TIMESTAMP) AS "updated_at",
-  CAST("marketing"."valid_from" AS TIMESTAMP) AS "valid_from",
-  CAST("marketing"."valid_to" AS TIMESTAMP) AS "valid_to"
-FROM "memory"."sushi"."marketing" AS "marketing"
-        """,
-    )
-
-
-def test_model_union_if_query(sushi_context, assert_exp_eq):
-    expressions = d.parse(
-        """
-        MODEL (
-            name sushi.test_query,
-            kind FULL,
-        );
-
-        @union_if(True, 'all', 'select 1 as c', 'select 2 as c', 'select 3 as c')
+        @union({condition}{union_type_arg}, {tables})
         """
     )
     sushi_context.upsert_model(load_sql_based_model(expressions, default_catalog="memory"))
 
     assert_exp_eq(
-        sushi_context.get_model("sushi.test_query").render_query(),
-        """SELECT 1 AS "c" UNION ALL SELECT 2 AS "c" UNION ALL SELECT 3 AS "c"
-        """,
-    )
-
-    expressions = d.parse(
-        """
-        MODEL (
-            name sushi.test_query,
-            kind FULL,
-        );
-
-        @union_if(False, 'all', 'select 1 as c', 'select 2 as c', 'select 3 as c')
-        """
-    )
-    sushi_context.upsert_model(load_sql_based_model(expressions, default_catalog="memory"))
-
-    assert_exp_eq(
-        sushi_context.get_model("sushi.test_query").render_query(),
-        'SELECT 1 AS "c"',
+        sushi_context.get_model(f"sushi.{test_id}").render_query(),
+        expected_result(expected_select),
     )
 
 


### PR DESCRIPTION
This update extends the `@UNION` macro  with a condition that is statically evaluatable and if it is false it short-circuits and it only keeps the first table, otherwise unions all tables, fixes: #4202 

Example:
```sql
MODEL (
  name sushi.table_4
);
  
@UNION(@get_date() > '1996-02-10', 'distinct', sushi.table_1, sushi.table_2, sushi.table_3)
```

the previous behaviour when the first argument can't be interpreted as a conditional True or False remains with the first argument being the union type and then the table names.