### PR TITLE
Chore!: bump sqlglot to v26.17.1

### DIFF
--- a/examples/sushi/models/marketing.sql
+++ b/examples/sushi/models/marketing.sql
@@ -20,7 +20,5 @@ FROM
         customer_id: 'int',
         status: 'text',
         updated_at: 'timestamp',
-        valid_from: 'timestamp',
-        valid_to: 'timestamp',
     }
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "requests",
     "rich[jupyter]",
     "ruamel.yaml",
-    "sqlglot[rs]~=26.16.3",
+    "sqlglot[rs]~=26.17.1",
     "tenacity",
     "time-machine",
     "json-stream"

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -250,7 +250,7 @@ def test_model_union_query(sushi_context, assert_exp_eq):
         """SELECT
   CAST("marketing"."customer_id" AS INT) AS "customer_id",
   CAST("marketing"."status" AS TEXT) AS "status",
-  CAST("marketing"."updated_at" AS TIMESTAMP) AS "updated_at",
+  CAST("marketing"."updated_at" AS TIMESTAMPNTZ) AS "updated_at",
   CAST("marketing"."valid_from" AS TIMESTAMP) AS "valid_from",
   CAST("marketing"."valid_to" AS TIMESTAMP) AS "valid_to"
 FROM "memory"."sushi"."marketing" AS "marketing"
@@ -258,7 +258,7 @@ UNION ALL
 SELECT
   CAST("marketing"."customer_id" AS INT) AS "customer_id",
   CAST("marketing"."status" AS TEXT) AS "status",
-  CAST("marketing"."updated_at" AS TIMESTAMP) AS "updated_at",
+  CAST("marketing"."updated_at" AS TIMESTAMPNTZ) AS "updated_at",
   CAST("marketing"."valid_from" AS TIMESTAMP) AS "valid_from",
   CAST("marketing"."valid_to" AS TIMESTAMP) AS "valid_to"
 FROM "memory"."sushi"."marketing" AS "marketing"


### PR DESCRIPTION
Changes in the tests were triggered by this [commit](https://github.com/tobymao/sqlglot/commit/807fbbc5a89925fd3c98e823003a9dc929fcaff6) and are expected.

For future reference:
- https://github.com/tobymao/sqlglot/issues/4859
- https://github.com/eakmanrq/sqlframe/issues/326
- https://github.com/tobymao/sqlglot/pull/4878