### PR TITLE
Fix: Adjust condition in table diff to filter in forward only models

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1677,9 +1677,9 @@ class GenericContext(BaseContext, t.Generic[C]):
                 target_snapshot = target_snapshots_to_name.get(model.fqn)
 
                 if target_snapshot and source_snapshot:
-                    if (
-                        source_snapshot.fingerprint.data_hash
-                        != target_snapshot.fingerprint.data_hash
+                    if (source_snapshot.fingerprint != target_snapshot.fingerprint) and (
+                        (source_snapshot.version != target_snapshot.version)
+                        or (source_snapshot.is_forward_only or target_snapshot.is_forward_only)
                     ):
                         # Compare the virtual layer instead of the physical layer because the virtual layer is guaranteed to point
                         # to the correct/active snapshot for the model in the specified environment, taking into account things like dev previews

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -695,3 +695,96 @@ def test_data_diff_multiple_models(sushi_context_fixed_date, capsys, caplog):
         skip_grain_check=False,
     )
     assert len(diffs) == 0
+
+
+@pytest.mark.slow
+def test_data_diff_forward_only(sushi_context_fixed_date, capsys, caplog):
+    expressions = d.parse(
+        """
+        MODEL (name memory.sushi.full_1, kind full, grain(key),);
+        SELECT
+            key,
+            value,
+        FROM
+            (VALUES
+                (1, 3),
+                (2, 4),
+            ) AS t (key, value)
+    """
+    )
+    model_s = load_sql_based_model(expressions, dialect="snowflake")
+    sushi_context_fixed_date.upsert_model(model_s)
+
+    # Create second analytics model sourcing from first
+    expressions_2 = d.parse(
+        """
+        MODEL (name memory.sushi.full_2, kind full, grain(key),);
+        SELECT
+            key,
+            value as amount,
+        FROM
+            memory.sushi.full_1
+    """
+    )
+    model_s2 = load_sql_based_model(expressions_2, dialect="snowflake")
+    sushi_context_fixed_date.upsert_model(model_s2)
+
+    sushi_context_fixed_date.plan(
+        "target_dev",
+        no_prompts=True,
+        auto_apply=True,
+        skip_tests=True,
+        start="2023-01-31",
+        end="2023-01-31",
+    )
+
+    model = sushi_context_fixed_date.models['"MEMORY"."SUSHI"."FULL_1"']
+    modified_model = model.dict()
+    modified_model["query"] = exp.select("*").from_("(VALUES (12, 6),(5,3),) AS t (key, value)")
+    modified_sqlmodel = SqlModel(**modified_model)
+    sushi_context_fixed_date.upsert_model(modified_sqlmodel)
+
+    sushi_context_fixed_date.auto_categorize_changes = CategorizerConfig(
+        sql=AutoCategorizationMode.FULL
+    )
+
+    plan_builder = sushi_context_fixed_date.plan_builder(
+        "source_dev", skip_tests=True, forward_only=True
+    )
+    plan = plan_builder.build()
+
+    sushi_context_fixed_date.apply(plan)
+
+    # Get diffs for both models
+    selector = {"*full*"}
+    diffs = sushi_context_fixed_date.table_diff(
+        source="source_dev",
+        target="target_dev",
+        on=["key"],
+        select_models=selector,
+        skip_grain_check=False,
+    )
+
+    # Both models should be diffed
+    assert len(diffs) == 2
+
+    # Check full_1 diff
+    diff1 = next(d for d in diffs if "FULL_1" in d.source)
+    row_diff1 = diff1.row_diff()
+    diff2 = next(d for d in diffs if "FULL_2" in d.source)
+    row_diff2 = diff2.row_diff()
+
+    # Both diffs should show the same matches
+    for row_diff in [row_diff1, row_diff2]:
+        assert row_diff.full_match_count == 0
+        assert row_diff.full_match_pct == 0.0
+        assert row_diff.s_only_count == 2
+        assert row_diff.t_only_count == 2
+        assert row_diff.stats["join_count"] == 0
+        assert row_diff.stats["null_grain_count"] == 0
+        assert row_diff.stats["s_count"] == 2
+        assert row_diff.stats["distinct_count_s"] == 2
+        assert row_diff.stats["t_count"] == 2
+        assert row_diff.stats["distinct_count_t"] == 2
+        assert row_diff.s_sample.shape == (2, 2)
+        assert row_diff.t_sample.shape == (2, 2)


### PR DESCRIPTION
This fix adjusts the condition for `table_diff` when used with a selector option to pick up from the selected models the forward only as well in the tables to compare.