### PR TITLE
feat(vscode): initialize on python as well

### DIFF
--- a/vscode/extension/package.json
+++ b/vscode/extension/package.json
@@ -17,7 +17,8 @@
     "Other"
   ],
   "activationEvents": [
-    "onLanguage:sql"
+    "onLanguage:sql",
+    "onLanguage:python"
   ],
   "extensionKind": [
     "workspace"


### PR DESCRIPTION
- starts the vscode extension when a python file gets opened as well
- starts the lsp and now if the workspace that is opnened is a valid
  sqlmesh project, loads it directly
- stops the 'bug' of the project not getting activated when you are looking at 
  python models
