### PR TITLE
fix(vscode): filter go to definitions by position

### DIFF
--- a/sqlmesh/lsp/completions.py
+++ b/sqlmesh/lsp/completions.py
@@ -2,11 +2,7 @@ from functools import lru_cache
 from sqlglot import Dialect, Tokenizer
 from sqlmesh.lsp.custom import AllModelsResponse
 import typing as t
-<<<<<<< HEAD
 from sqlmesh.lsp.context import AuditTarget, LSPContext, ModelTarget
-=======
-from sqlmesh.lsp.context import LSPContext, ModelTarget
->>>>>>> f70b3d9b (feat(vscode): go to definition for standalone audits)
 
 
 def get_sql_completions(context: t.Optional[LSPContext], file_uri: str) -> AllModelsResponse:

--- a/sqlmesh/lsp/completions.py
+++ b/sqlmesh/lsp/completions.py
@@ -2,7 +2,11 @@ from functools import lru_cache
 from sqlglot import Dialect, Tokenizer
 from sqlmesh.lsp.custom import AllModelsResponse
 import typing as t
+<<<<<<< HEAD
 from sqlmesh.lsp.context import AuditTarget, LSPContext, ModelTarget
+=======
+from sqlmesh.lsp.context import LSPContext, ModelTarget
+>>>>>>> f70b3d9b (feat(vscode): go to definition for standalone audits)
 
 
 def get_sql_completions(context: t.Optional[LSPContext], file_uri: str) -> AllModelsResponse:

--- a/sqlmesh/lsp/main.py
+++ b/sqlmesh/lsp/main.py
@@ -14,7 +14,10 @@ from sqlmesh.core.linter.definition import AnnotatedRuleViolation
 from sqlmesh.lsp.completions import get_sql_completions
 from sqlmesh.lsp.context import LSPContext, ModelTarget
 from sqlmesh.lsp.custom import ALL_MODELS_FEATURE, AllModelsRequest, AllModelsResponse
-from sqlmesh.lsp.reference import get_model_definitions_for_a_path, filter_references_by_position
+from sqlmesh.lsp.reference import (
+    get_model_definitions_for_a_path,
+    filter_references_by_position,
+)
 
 
 class SQLMeshLanguageServer:
@@ -186,18 +189,10 @@ class SQLMeshLanguageServer:
                 if self.lsp_context is None:
                     raise RuntimeError(f"No context found for document: {document.path}")
 
-                # Get all possible references
                 references = get_model_definitions_for_a_path(
                     self.lsp_context, params.text_document.uri
                 )
-                if not references:
-                    return []
-
-                # Filter references by cursor position
                 filtered_references = filter_references_by_position(references, params.position)
-                if not filtered_references:
-                    return []
-
                 return [
                     types.LocationLink(
                         target_uri=reference.uri,

--- a/sqlmesh/lsp/main.py
+++ b/sqlmesh/lsp/main.py
@@ -14,7 +14,7 @@ from sqlmesh.core.linter.definition import AnnotatedRuleViolation
 from sqlmesh.lsp.completions import get_sql_completions
 from sqlmesh.lsp.context import LSPContext, ModelTarget
 from sqlmesh.lsp.custom import ALL_MODELS_FEATURE, AllModelsRequest, AllModelsResponse
-from sqlmesh.lsp.reference import get_model_definitions_for_a_path
+from sqlmesh.lsp.reference import get_model_definitions_for_a_path, filter_references_by_position
 
 
 class SQLMeshLanguageServer:
@@ -186,10 +186,16 @@ class SQLMeshLanguageServer:
                 if self.lsp_context is None:
                     raise RuntimeError(f"No context found for document: {document.path}")
 
+                # Get all possible references
                 references = get_model_definitions_for_a_path(
                     self.lsp_context, params.text_document.uri
                 )
                 if not references:
+                    return []
+
+                # Filter references by cursor position
+                filtered_references = filter_references_by_position(references, params.position)
+                if not filtered_references:
                     return []
 
                 return [
@@ -205,7 +211,7 @@ class SQLMeshLanguageServer:
                         ),
                         origin_selection_range=reference.range,
                     )
-                    for reference in references
+                    for reference in filtered_references
                 ]
 
             except Exception as e:

--- a/sqlmesh/lsp/reference.py
+++ b/sqlmesh/lsp/reference.py
@@ -14,6 +14,39 @@ class Reference(PydanticModel):
     uri: str
 
 
+def filter_references_by_position(
+    references: t.List[Reference], position: Position
+) -> t.List[Reference]:
+    """
+    Filter references to only include those that contain the given position.
+
+    Args:
+        references: List of Reference objects
+        position: The cursor position to check
+
+    Returns:
+        List of Reference objects that contain the position
+    """
+    filtered_references = []
+
+    for reference in references:
+        # Check if position is within the reference range
+        range_start = reference.range.start
+        range_end = reference.range.end
+
+        # Position is within range if it's after or at start and before or at end
+        if (
+            range_start.line < position.line
+            or (range_start.line == position.line and range_start.character <= position.character)
+        ) and (
+            range_end.line > position.line
+            or (range_end.line == position.line and range_end.character >= position.character)
+        ):
+            filtered_references.append(reference)
+
+    return filtered_references
+
+
 def get_model_definitions_for_a_path(
     lint_context: LSPContext, document_uri: str
 ) -> t.List[Reference]:

--- a/tests/lsp/test_reference.py
+++ b/tests/lsp/test_reference.py
@@ -130,7 +130,8 @@ def test_filter_references_by_position() -> None:
 
     # Get file contents to locate positions for testing
     path = waiter_revenue_by_day_uri.removeprefix("file://")
-    read_file = open(path, "r").readlines()
+    with open(path, "r") as file:
+        read_file = file.readlines()
 
     # Test positions for each reference
     for i, reference in enumerate(all_references):

--- a/tests/lsp/test_reference.py
+++ b/tests/lsp/test_reference.py
@@ -1,7 +1,8 @@
 import pytest
+from lsprotocol.types import Position
 from sqlmesh.core.context import Context
 from sqlmesh.lsp.context import LSPContext, ModelTarget, AuditTarget
-from sqlmesh.lsp.reference import get_model_definitions_for_a_path
+from sqlmesh.lsp.reference import get_model_definitions_for_a_path, filter_references_by_position
 
 
 @pytest.mark.fast
@@ -108,3 +109,69 @@ def get_string_from_range(file_lines, range_obj) -> str:
         result += file_lines[line_num]
     result += file_lines[end_line][:end_character]  # Last line up to end_character
     return result
+
+
+@pytest.mark.fast
+def test_filter_references_by_position() -> None:
+    """Test that we can filter references correctly based on cursor position."""
+    context = Context(paths=["examples/sushi"])
+    lsp_context = LSPContext(context)
+
+    # Use a file with multiple references (waiter_revenue_by_day)
+    waiter_revenue_by_day_uri = next(
+        uri
+        for uri, info in lsp_context.map.items()
+        if isinstance(info, ModelTarget) and "sushi.waiter_revenue_by_day" in info.names
+    )
+
+    # Get all references in the file
+    all_references = get_model_definitions_for_a_path(lsp_context, waiter_revenue_by_day_uri)
+    assert len(all_references) == 3
+
+    # Get file contents to locate positions for testing
+    path = waiter_revenue_by_day_uri.removeprefix("file://")
+    read_file = open(path, "r").readlines()
+
+    # Test positions for each reference
+    for i, reference in enumerate(all_references):
+        # Position inside the reference - should return exactly one reference
+        middle_line = (reference.range.start.line + reference.range.end.line) // 2
+        middle_char = (reference.range.start.character + reference.range.end.character) // 2
+        position_inside = Position(line=middle_line, character=middle_char)
+        filtered = filter_references_by_position(all_references, position_inside)
+        assert len(filtered) == 1
+        assert filtered[0].uri == reference.uri
+        assert filtered[0].range == reference.range
+
+        # For testing outside position, use a position before the current reference
+        # or after the last reference for the last one
+        if i == 0:
+            outside_line = reference.range.start.line
+            outside_char = max(0, reference.range.start.character - 5)
+        else:
+            prev_ref = all_references[i - 1]
+            outside_line = prev_ref.range.end.line
+            outside_char = prev_ref.range.end.character + 5
+
+        position_outside = Position(line=outside_line, character=outside_char)
+        filtered_outside = filter_references_by_position(all_references, position_outside)
+        assert reference not in filtered_outside, (
+            f"Reference {i} should not match position outside its range"
+        )
+
+    # Test case: cursor at beginning of file - no references should match
+    position_start = Position(line=0, character=0)
+    filtered_start = filter_references_by_position(all_references, position_start)
+    assert len(filtered_start) == 0 or all(
+        ref.range.start.line == 0 and ref.range.start.character <= 0 for ref in filtered_start
+    )
+
+    # Test case: cursor at end of file - no references should match (unless there's a reference at the end)
+    last_line = len(read_file) - 1
+    last_char = len(read_file[last_line]) - 1
+    position_end = Position(line=last_line, character=last_char)
+    filtered_end = filter_references_by_position(all_references, position_end)
+    assert len(filtered_end) == 0 or all(
+        ref.range.end.line >= last_line and ref.range.end.character >= last_char
+        for ref in filtered_end
+    )


### PR DESCRIPTION
- before we were returning the references for a whole file
- now we filter by the position of the request