### PR TITLE
Fix(table_diff): Allow diffing of empty tables

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -2181,6 +2181,12 @@ class TerminalConsole(Console):
     def show_row_diff(
         self, row_diff: RowDiff, show_sample: bool = True, skip_grain_check: bool = False
     ) -> None:
+        if row_diff.empty:
+            self.console.print(
+                "\n[b][red]Neither the source nor the target table contained any records[/red][/b]"
+            )
+            return
+
         source_name = row_diff.source
         if row_diff.source_alias:
             source_name = row_diff.source_alias.upper()

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -84,6 +84,15 @@ class RowDiff(PydanticModel, frozen=True):
         return int(self.stats["t_count"])
 
     @property
+    def empty(self) -> bool:
+        return (
+            self.source_count == 0
+            and self.target_count == 0
+            and self.s_only_count == 0
+            and self.t_only_count == 0
+        )
+
+    @property
     def count_pct_change(self) -> float:
         """The percentage change of the counts."""
         if self.source_count == 0:
@@ -446,7 +455,7 @@ class TableDiff:
 
                 summary_query = exp.select(*summary_sums).from_(table)
 
-                stats_df = self.adapter.fetchdf(summary_query, quote_identifiers=True)
+                stats_df = self.adapter.fetchdf(summary_query, quote_identifiers=True).fillna(0)
                 stats_df["s_only_count"] = stats_df["s_count"] - stats_df["join_count"]
                 stats_df["t_only_count"] = stats_df["t_count"] - stats_df["join_count"]
                 stats = stats_df.iloc[0].to_dict()


### PR DESCRIPTION
Fixes #4320 

Prior to this PR, diffing a pair of empty tables that had schema changes resulted in a Pydantic error at the row diff step:
![Screenshot From 2025-05-09 13-08-51](https://github.com/user-attachments/assets/a1b800e8-bf94-4ce3-9901-96e80c7c0815)

This PR accounts for this:
![Screenshot From 2025-05-09 13-09-06](https://github.com/user-attachments/assets/29a3a561-042e-4b13-92c3-f996d56dbb37)

