### PR TITLE
Fix!: Allow python models to emit DataFrame's with a different column order 

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -285,10 +285,10 @@ workflows:
                 - bigquery
                 - clickhouse-cloud
                 - athena
-          filters:
-            branches:
-              only:
-                - main
+          #filters:
+          #  branches:
+          #    only:
+          #      - main
       - trigger_private_tests:
           requires:
             - style_and_cicd_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -285,10 +285,10 @@ workflows:
                 - bigquery
                 - clickhouse-cloud
                 - athena
-          #filters:
-          #  branches:
-          #    only:
-          #      - main
+          filters:
+            branches:
+              only:
+                - main
       - trigger_private_tests:
           requires:
             - style_and_cicd_tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ athena = ["PyAthena[Pandas]"]
 azuresql = ["pymssql"]
 bigquery = [
     "google-cloud-bigquery[pandas]",
-    "google-cloud-bigquery-storage"
+    "google-cloud-bigquery-storage",
+    "bigframes>=1.32.0"
 ]
-bigframes = ["bigframes>=1.32.0"]
 clickhouse = ["clickhouse-connect"]
 databricks = ["databricks-sql-connector[pyarrow]"]
 dev = [
@@ -107,8 +107,7 @@ slack = ["slack_sdk"]
 snowflake = [
     "cryptography",
     "snowflake-connector-python[pandas,secure-local-storage]",
-    # as at 2024-08-05, snowflake-snowpark-python is only available up to Python 3.11
-    "snowflake-snowpark-python; python_version<'3.12'",
+    "snowflake-snowpark-python",
 ]
 trino = ["trino"]
 web = [

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -246,7 +246,12 @@ class EngineAdapter:
         assert isinstance(df, pd.DataFrame)
         num_rows = len(df.index)
         batch_size = sys.maxsize if batch_size == 0 else batch_size
+
+        # we need to ensure that the order of the columns in columns_to_types columns matches the order of the values
+        # they can differ if a user specifies columns() on a python model in a different order than what's in the DataFrame's emitted by that model
+        df = df[list(columns_to_types.keys())]
         values = list(df.itertuples(index=False, name=None))
+
         return [
             SourceQuery(
                 query_factory=partial(

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -249,7 +249,7 @@ class EngineAdapter:
 
         # we need to ensure that the order of the columns in columns_to_types columns matches the order of the values
         # they can differ if a user specifies columns() on a python model in a different order than what's in the DataFrame's emitted by that model
-        df = df[list(columns_to_types.keys())]
+        df = df[list(columns_to_types)]
         values = list(df.itertuples(index=False, name=None))
 
         return [

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -218,10 +218,13 @@ class MSSQLEngineAdapter(
             # as later calls.
             if not self.table_exists(temp_table):
                 columns_to_types_create = columns_to_types.copy()
-                self._convert_df_datetime(df, columns_to_types_create)
+                ordered_df = df[
+                    list(columns_to_types_create.keys())
+                ]  # reorder DataFrame so it matches columns_to_types
+                self._convert_df_datetime(ordered_df, columns_to_types_create)
                 self.create_table(temp_table, columns_to_types_create)
                 rows: t.List[t.Tuple[t.Any, ...]] = list(
-                    df.replace({np.nan: None}).itertuples(index=False, name=None)  # type: ignore
+                    ordered_df.replace({np.nan: None}).itertuples(index=False, name=None)  # type: ignore
                 )
                 conn = self._connection_pool.get()
                 conn.bulk_copy(temp_table.sql(dialect=self.dialect), rows)

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -219,7 +219,7 @@ class MSSQLEngineAdapter(
             if not self.table_exists(temp_table):
                 columns_to_types_create = columns_to_types.copy()
                 ordered_df = df[
-                    list(columns_to_types_create.keys())
+                    list(columns_to_types_create)
                 ]  # reorder DataFrame so it matches columns_to_types
                 self._convert_df_datetime(ordered_df, columns_to_types_create)
                 self.create_table(temp_table, columns_to_types_create)

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -300,7 +300,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
                 temp_table.set("catalog", database)
                 df_renamed = df.rename(
                     {
-                        col: exp.to_identifier(col, quoted=True).sql(dialect=self.dialect)
+                        col: exp.to_identifier(col).sql(dialect=self.dialect, identify=True)
                         for col in columns_to_types
                     }
                 )  # type: ignore

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -288,8 +288,25 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
         is_snowpark_dataframe = snowpark and isinstance(df, snowpark.dataframe.DataFrame)
 
         def query_factory() -> Query:
+            # The catalog needs to be normalized before being passed to Snowflake's library functions because they
+            # just wrap whatever they are given in quotes without checking if its already quoted
+            database = (
+                normalize_identifiers(temp_table.catalog, dialect=self.dialect)
+                if temp_table.catalog
+                else None
+            )
+
             if is_snowpark_dataframe:
-                df.createOrReplaceTempView(temp_table.sql(dialect=self.dialect, identify=True))  # type: ignore
+                temp_table.set("catalog", database)
+                df_renamed = df.rename(
+                    {
+                        col: exp.to_identifier(col, quoted=True).sql(dialect=self.dialect)
+                        for col in columns_to_types
+                    }
+                )  # type: ignore
+                df_renamed.createOrReplaceTempView(
+                    temp_table.sql(dialect=self.dialect, identify=True)
+                )  # type: ignore
             elif isinstance(df, pd.DataFrame):
                 from snowflake.connector.pandas_tools import write_pandas
 
@@ -325,11 +342,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
                     df,
                     temp_table.name,
                     schema=temp_table.db or None,
-                    database=normalize_identifiers(temp_table.catalog, dialect=self.dialect).sql(
-                        dialect=self.dialect
-                    )
-                    if temp_table.catalog
-                    else None,
+                    database=database.sql(dialect=self.dialect) if database else None,
                     chunk_size=self.DEFAULT_BATCH_SIZE,
                     overwrite=True,
                     table_type="temp",

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -281,14 +281,14 @@ class SparkEngineAdapter(
         if pyspark_df:
             if columns_to_types:
                 # ensure Spark dataframe column order matches columns_to_types
-                pyspark_df = pyspark_df.select(*list(columns_to_types.keys()))
+                pyspark_df = pyspark_df.select(*list(columns_to_types))
             return pyspark_df
         df = self.try_get_pandas_df(generic_df)
         if df is None:
             raise SQLMeshError("Ensure PySpark DF can only be run on a PySpark or Pandas DataFrame")
         if columns_to_types:
             # ensure Pandas dataframe column order matches columns_to_types
-            df = df[list(columns_to_types.keys())]
+            df = df[list(columns_to_types)]
         kwargs = (
             dict(schema=self.sqlglot_to_spark_types(columns_to_types)) if columns_to_types else {}
         )

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -279,10 +279,16 @@ class SparkEngineAdapter(
     ) -> PySparkDataFrame:
         pyspark_df = self.try_get_pyspark_df(generic_df)
         if pyspark_df:
+            if columns_to_types:
+                # ensure Spark dataframe column order matches columns_to_types
+                pyspark_df = pyspark_df.select(*list(columns_to_types.keys()))
             return pyspark_df
         df = self.try_get_pandas_df(generic_df)
         if df is None:
             raise SQLMeshError("Ensure PySpark DF can only be run on a PySpark or Pandas DataFrame")
+        if columns_to_types:
+            # ensure Pandas dataframe column order matches columns_to_types
+            df = df[list(columns_to_types.keys())]
         kwargs = (
             dict(schema=self.sqlglot_to_spark_types(columns_to_types)) if columns_to_types else {}
         )

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -281,7 +281,7 @@ class SparkEngineAdapter(
         if pyspark_df:
             if columns_to_types:
                 # ensure Spark dataframe column order matches columns_to_types
-                pyspark_df = pyspark_df.select(*list(columns_to_types))
+                pyspark_df = pyspark_df.select(*columns_to_types)
             return pyspark_df
         df = self.try_get_pandas_df(generic_df)
         if df is None:

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -2734,9 +2734,11 @@ def test_state_migrate_from_scratch(ctx: TestContext):
     sqlmesh_context.migrate()
 
 
-def test_python_model_column_order(ctx: TestContext, tmp_path: pathlib.Path):
+def test_python_model_column_order(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
     if ctx.test_type != "df":
         pytest.skip("python model column order test only needs to be run once per db")
+
+    tmp_path = tmp_path_factory.mktemp(f"column_order_{ctx.test_id}")
 
     test_schema = ctx.add_test_suffix("column_order")
 

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -2736,14 +2736,13 @@ def test_state_migrate_from_scratch(ctx: TestContext):
     sqlmesh_context.migrate()
 
 
-def test_python_model_column_order(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
+def test_python_model_column_order(ctx: TestContext, tmp_path: pathlib.Path):
     if ctx.test_type == "pyspark" and ctx.dialect in ("spark", "databricks"):
         # dont skip
         pass
     elif ctx.test_type != "df":
         pytest.skip("python model column order test only needs to be run once per db")
 
-    tmp_path = tmp_path_factory.mktemp(f"column_order_{ctx.test_id}")
     schema = ctx.add_test_suffix(TEST_SCHEMA)
 
     (tmp_path / "models").mkdir()


### PR DESCRIPTION
... than what is declared in `@model`. Addresses #3915 and #4232 

Prior to this PR, on many adapters the column order in the `DataFrame` emitted by a Python model had to match what was defined for `columns`.

This is because when we convert the `DataFrame` into a `VALUES(...)` list to insert it into the table, the values were in `DataFrame` order but the columns list was in `columns_to_types` order. If these didnt match, then we tried to insert the wrong value into the wrong column.

This PR adjusts the DataFrame to match `columns_to_types` before converting it to a `VALUES(...)` list.

**This PR fixes broken behaviour and thus may have unintended consequences**

Previously, if you had something like:
```
@model (
   "foo",
   "columns": { "a": "int", "b": "int" }
)
def execute(context: ExecutionContext, **kwargs: t.Any) -> pd.DataFrame:
   pd.DataFrame({"b": [1], "a": [2]})
```

Then this wouldnt fail because the column types match. So we would write this as `a=1` and `b=2` instead of what the user emitted in the DataFrame, `a=2` and `b=1`. I really hope nobody was relying on this

