### PR TITLE
Fix: make logger respect --ignore-warnings

### DIFF
--- a/sqlmesh/__init__.py
+++ b/sqlmesh/__init__.py
@@ -172,6 +172,7 @@ def configure_logging(
     write_to_file: bool = True,
     log_limit: int = c.DEFAULT_LOG_LIMIT,
     log_file_dir: t.Optional[t.Union[str, Path]] = None,
+    ignore_warnings: bool = False,
 ) -> None:
     # Remove noisy grpc logs that are not useful for users
     os.environ["GRPC_VERBOSITY"] = os.environ.get("GRPC_VERBOSITY", "NONE")
@@ -186,7 +187,7 @@ def configure_logging(
     if write_to_stdout:
         stdout_handler = logging.StreamHandler(sys.stdout)
         stdout_handler.setFormatter(CustomFormatter())
-        stdout_handler.setLevel(level)
+        stdout_handler.setLevel(logging.ERROR if ignore_warnings else level)
         logger.addHandler(stdout_handler)
 
     log_file_dir = log_file_dir or c.DEFAULT_LOG_FILE_DIR

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -102,7 +102,13 @@ def cli(
 
     configs = load_configs(config, Context.CONFIG_TYPE, paths)
     log_limit = list(configs.values())[0].log_limit
-    configure_logging(debug, log_to_stdout, log_limit=log_limit, log_file_dir=log_file_dir)
+    configure_logging(
+        debug,
+        log_to_stdout,
+        log_limit=log_limit,
+        log_file_dir=log_file_dir,
+        ignore_warnings=ignore_warnings,
+    )
     configure_console(ignore_warnings=ignore_warnings)
 
     try:

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -134,7 +134,12 @@ class SQLMeshMagics(Magics):
         args = parse_argstring(self.context, line)
         configs = load_configs(args.config, Context.CONFIG_TYPE, args.paths)
         log_limit = list(configs.values())[0].log_limit
-        configure_logging(args.debug, log_limit=log_limit, log_file_dir=args.log_file_dir)
+        configure_logging(
+            args.debug,
+            log_limit=log_limit,
+            log_file_dir=args.log_file_dir,
+            ignore_warnings=args.ignore_warnings,
+        )
         configure_console(ignore_warnings=args.ignore_warnings)
         try:
             context = Context(paths=args.paths, config=configs, gateway=args.gateway)


### PR DESCRIPTION
Currently, some warnings are printed to console even if `--ignore-warnings` is passed.

This PR fixes that by passing ignore_warnings into `configure_logging()`.