### PR TITLE
Chore: Remove `t.Optional` from get_snapshots() API

### DIFF
--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -86,14 +86,12 @@ class StateReader(abc.ABC):
 
     @abc.abstractmethod
     def get_snapshots(
-        self,
-        snapshot_ids: t.Optional[t.Iterable[SnapshotIdLike]],
+        self, snapshot_ids: t.Iterable[SnapshotIdLike]
     ) -> t.Dict[SnapshotId, Snapshot]:
         """Bulk fetch snapshots given the corresponding snapshot ids.
 
         Args:
-            snapshot_ids: Iterable of snapshot ids to get. If not provided all
-                available snapshots will be returned.
+            snapshot_ids: Iterable of snapshot ids to get.
 
         Returns:
             A dictionary of snapshot ids to snapshots for ones that could be found.

--- a/sqlmesh/core/state_sync/cache.py
+++ b/sqlmesh/core/state_sync/cache.py
@@ -46,11 +46,8 @@ class CachingStateSync(DelegatingStateSync):
         return snapshot
 
     def get_snapshots(
-        self, snapshot_ids: t.Optional[t.Iterable[SnapshotIdLike]]
+        self, snapshot_ids: t.Iterable[SnapshotIdLike]
     ) -> t.Dict[SnapshotId, Snapshot]:
-        if snapshot_ids is None:
-            return self.state_sync.get_snapshots(snapshot_ids)
-
         existing = {}
         missing = set()
         now = now_timestamp()

--- a/sqlmesh/core/state_sync/db/facade.py
+++ b/sqlmesh/core/state_sync/db/facade.py
@@ -365,7 +365,7 @@ class EngineAdapterStateSync(StateSync):
 
     def get_snapshots(
         self,
-        snapshot_ids: t.Optional[t.Iterable[SnapshotIdLike]],
+        snapshot_ids: t.Iterable[SnapshotIdLike],
     ) -> t.Dict[SnapshotId, Snapshot]:
         """Fetches snapshots from the state.
 

--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -35,7 +35,6 @@ from sqlmesh.core.snapshot import (
 )
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 from sqlmesh.utils.date import now_timestamp, TimeLike, now, to_timestamp
-from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.pydantic import PydanticModel
 from sqlmesh.utils import unique
 
@@ -309,7 +308,7 @@ class SnapshotState:
 
     def get_snapshots(
         self,
-        snapshot_ids: t.Optional[t.Iterable[SnapshotIdLike]],
+        snapshot_ids: t.Iterable[SnapshotIdLike],
     ) -> t.Dict[SnapshotId, Snapshot]:
         """Fetches snapshots.
 
@@ -319,8 +318,6 @@ class SnapshotState:
         Returns:
             A dictionary of snapshot IDs to snapshots.
         """
-        if snapshot_ids is None:
-            raise SQLMeshError("Must provide snapshot IDs to fetch snapshots.")
         return self._get_snapshots(snapshot_ids)
 
     def snapshots_exist(self, snapshot_ids: t.Iterable[SnapshotIdLike]) -> t.Set[SnapshotId]:


### PR DESCRIPTION
[Internal discussion](https://tobikodata.slack.com/archives/C04DTU8RF4J/p1746464244824879)

The `StateSync` API allows `snapshot_ids` to be optional (this used to return all snapshots) but `SnapshotState` will raise an error if `None` is passed in which is counter intuitive.

Note 1: I had initially transformed the check to `if not snapshot_ids` to check for empty iterables but this breaks a few tests. An example of that is if we do `get_snapshots(snapshot.previous_versions)` which might be an empty list (instead of `None`). That is fine, right?

Note 2: The `lock_for_update` arg of `SnapshotState::_get_snapshots()` and `SnapshotState::_get_snapshots_expressions()` seems unused, it's always initialized to `False` and `SnapshotState::get_snapshot()` does not bubble it up. Do we want to remove it too?