### PR TITLE
Feat: resolve (blueprint) variables when parsing python deps

### DIFF
--- a/docs/concepts/models/python_models.md
+++ b/docs/concepts/models/python_models.md
@@ -241,18 +241,16 @@ def execute(
     context.resolve_table("docs_example.another_dependency")
 ```
 
-User-defined [global variables](global-variables) can also be used in `resolve_table` calls, as long as the `depends_on` keyword argument is present and contains the required dependencies. This is shown in the following example:
+User-defined [global variables](global-variables) or [blueprint variables](#python-model-blueprinting) can also be used in `resolve_table` calls, as shown in the following example (similarly for `blueprint_var()`):
 
 ```python linenums="1"
 @model(
     "@schema_name.test_model2",
     kind="FULL",
     columns={"id": "INT"},
-    depends_on=["@schema_name.test_model1"],
 )
 def execute(context, **kwargs):
-    schema_name = context.var("schema_name")
-    table = context.resolve_table(f"{schema_name}.test_model1")
+    table = context.resolve_table(f"{context.var('schema_name')}.test_model1")
     select_query = exp.select("*").from_(table)
     return context.fetchdf(select_query)
 ```

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2286,7 +2286,13 @@ def create_python_model(
     dependencies_unspecified = depends_on is None
 
     parsed_depends_on, referenced_variables = (
-        parse_dependencies(python_env, entrypoint, strict_resolution=dependencies_unspecified)
+        parse_dependencies(
+            python_env,
+            entrypoint,
+            strict_resolution=dependencies_unspecified,
+            variables=variables,
+            blueprint_variables=blueprint_variables,
+        )
         if python_env is not None
         else (set(), set())
     )


### PR DESCRIPTION
Until now, calls in Python macros and models like `resolve_table(f"...{context.blueprint_var('some_var')}...")` would fail (unless `depends_on` was specified), because the Python dependency extraction logic could only handle string literal arguments in these calls.

This PR extends it so that it can also resolve global / blueprint variables, e.g., when interpolated in an f-string.