### PR TITLE
Chore: Enable tests for native DataFrame implementations

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -297,10 +297,10 @@ workflows:
                 - bigquery
                 - clickhouse-cloud
                 - athena
-          #filters:
-          #  branches:
-          #    only:
-          #      - main
+          filters:
+            branches:
+              only:
+                - main
       - trigger_private_tests:
           requires:
             - style_and_cicd_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -281,7 +281,6 @@ workflows:
                 - trino
                 - spark
                 - clickhouse
-                - clickhouse-cluster
                 - risingwave
       - engine_tests_cloud:
           name: cloud_engine_<< matrix.engine >>

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -297,10 +297,10 @@ workflows:
                 - bigquery
                 - clickhouse-cloud
                 - athena
-          filters:
-            branches:
-              only:
-                - main
+          #filters:
+          #  branches:
+          #    only:
+          #      - main
       - trigger_private_tests:
           requires:
             - style_and_cicd_tests

--- a/Makefile
+++ b/Makefile
@@ -126,54 +126,51 @@ engine-%-down:
 ##################
 
 clickhouse-test: engine-clickhouse-up
-	pytest -n auto -x -m "clickhouse" --retries 3 --junitxml=test-results/junit-clickhouse.xml
-
-clickhouse-cluster-test: engine-clickhouse-up
-	pytest -n auto -x -m "clickhouse_cluster" --retries 3 --junitxml=test-results/junit-clickhouse-cluster.xml
+	pytest -n auto -m "clickhouse" --retries 3 --junitxml=test-results/junit-clickhouse.xml
 
 duckdb-test: engine-duckdb-install
-	pytest -n auto -x -m "duckdb" --retries 3 --junitxml=test-results/junit-duckdb.xml
+	pytest -n auto -m "duckdb" --retries 3 --junitxml=test-results/junit-duckdb.xml
 
 mssql-test: engine-mssql-up
-	pytest -n auto -x -m "mssql" --retries 3 --junitxml=test-results/junit-mssql.xml
+	pytest -n auto -m "mssql" --retries 3 --junitxml=test-results/junit-mssql.xml
 
 mysql-test: engine-mysql-up
-	pytest -n auto -x -m "mysql" --retries 3 --junitxml=test-results/junit-mysql.xml
+	pytest -n auto -m "mysql" --retries 3 --junitxml=test-results/junit-mysql.xml
 
 postgres-test: engine-postgres-up
-	pytest -n auto -x -m "postgres" --retries 3 --junitxml=test-results/junit-postgres.xml
+	pytest -n auto -m "postgres" --retries 3 --junitxml=test-results/junit-postgres.xml
 
 spark-test: engine-spark-up
-	pytest -n auto -x -m "spark or pyspark" --retries 3 --junitxml=test-results/junit-spark.xml
+	pytest -n auto -m "spark" --retries 3 --junitxml=test-results/junit-spark.xml
 
 trino-test: engine-trino-up
-	pytest -n auto -x -m "trino or trino_iceberg or trino_delta or trino_nessie" --retries 3 --junitxml=test-results/junit-trino.xml
+	pytest -n auto -m "trino" --retries 3 --junitxml=test-results/junit-trino.xml
 
 risingwave-test: engine-risingwave-up
-	pytest -n auto -x -m "risingwave" --retries 3 --junitxml=test-results/junit-risingwave.xml
+	pytest -n auto -m "risingwave" --retries 3 --junitxml=test-results/junit-risingwave.xml
 
 #################
 # Cloud Engines #
 #################
 
 snowflake-test: guard-SNOWFLAKE_ACCOUNT guard-SNOWFLAKE_WAREHOUSE guard-SNOWFLAKE_DATABASE guard-SNOWFLAKE_USER guard-SNOWFLAKE_PASSWORD engine-snowflake-install
-	pytest -n auto -x -m "snowflake" --retries 3 --junitxml=test-results/junit-snowflake.xml
+	pytest -n auto -m "snowflake" --retries 3 --junitxml=test-results/junit-snowflake.xml
 
 bigquery-test: guard-BIGQUERY_KEYFILE engine-bigquery-install
-	pytest -n auto -x -m "bigquery" --retries 3 --junitxml=test-results/junit-bigquery.xml
+	pytest -n auto -m "bigquery" --retries 3 --junitxml=test-results/junit-bigquery.xml
 
 databricks-test: guard-DATABRICKS_CATALOG guard-DATABRICKS_SERVER_HOSTNAME guard-DATABRICKS_HTTP_PATH guard-DATABRICKS_ACCESS_TOKEN guard-DATABRICKS_CONNECT_VERSION engine-databricks-install
 	pip install 'databricks-connect==${DATABRICKS_CONNECT_VERSION}'
-	pytest -n auto -x -m "databricks" --retries 3 --junitxml=test-results/junit-databricks.xml
+	pytest -n auto -m "databricks" --retries 3 --junitxml=test-results/junit-databricks.xml
 
 redshift-test: guard-REDSHIFT_HOST guard-REDSHIFT_USER guard-REDSHIFT_PASSWORD guard-REDSHIFT_DATABASE engine-redshift-install
-	pytest -n auto -x -m "redshift" --retries 3 --junitxml=test-results/junit-redshift.xml
+	pytest -n auto -m "redshift" --retries 3 --junitxml=test-results/junit-redshift.xml
 
 clickhouse-cloud-test: guard-CLICKHOUSE_CLOUD_HOST guard-CLICKHOUSE_CLOUD_USERNAME guard-CLICKHOUSE_CLOUD_PASSWORD engine-clickhouse-install
 	pytest -n 1 -m "clickhouse_cloud" --retries 3 --junitxml=test-results/junit-clickhouse-cloud.xml
 
 athena-test: guard-AWS_ACCESS_KEY_ID guard-AWS_SECRET_ACCESS_KEY guard-ATHENA_S3_WAREHOUSE_LOCATION engine-athena-install
-	pytest -n auto -x -m "athena" --retries 3 --retry-delay 10 --junitxml=test-results/junit-athena.xml
+	pytest -n auto -m "athena" --retries 3 --retry-delay 10 --junitxml=test-results/junit-athena.xml
 
 vscode_settings:
 	mkdir -p .vscode

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,13 +16,11 @@ markers =
     github: test for Github CI/CD bot
     jupyter: tests for Jupyter integration
     web: tests for web UI
-    spark_pyspark: test for Spark with PySpark dependency
     # Engine Adapters
     engine: test all engine adapters
     athena: test for Athena
     bigquery: test for BigQuery
-    clickhouse: test for Clickhouse (standalone mode)
-    clickhouse_cluster: test for Clickhouse (cluster mode)
+    clickhouse: test for Clickhouse (standalone mode / cluster mode)
     clickhouse_cloud: test for Clickhouse (cloud mode)
     databricks: test for Databricks
     duckdb: test for DuckDB
@@ -33,9 +31,8 @@ markers =
     redshift: test for Redshift
     snowflake: test for Snowflake
     spark: test for Spark
-    trino: test for Trino (Hive connector)
-    trino_iceberg: test for Trino (Iceberg connector)
-    trino_delta: test for Trino (Delta connector)
+    trino: test for Trino (all connectors)
+    risingwave: test for Risingwave
 addopts = -n 0 --dist=loadgroup
 
 asyncio_default_fixture_loop_scope = session

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -2011,7 +2011,7 @@ class EngineAdapter:
         """
         Take a "native" DataFrame (eg Pyspark, Bigframe, Snowpark etc) and convert it to Pandas
         """
-        if isinstance(query_or_df, (exp.Expression, pd.DataFrame)):
+        if isinstance(query_or_df, (exp.Query, exp.DerivedTable, pd.DataFrame)):
             return query_or_df
 
         # EngineAdapter subclasses that have native DataFrame types should override this

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -1008,6 +1008,8 @@ class EngineAdapter:
         if materialized_properties and not materialized:
             raise SQLMeshError("Materialized properties are only supported for materialized views")
 
+        query_or_df = self._native_df_to_pandas_df(query_or_df)
+
         if isinstance(query_or_df, pd.DataFrame):
             values: t.List[t.Tuple[t.Any, ...]] = list(
                 query_or_df.itertuples(index=False, name=None)
@@ -2001,6 +2003,19 @@ class EngineAdapter:
         with self.transaction():
             self.execute(query, quote_identifiers=quote_identifiers)
             return self.cursor.fetchdf()
+
+    def _native_df_to_pandas_df(
+        self,
+        query_or_df: QueryOrDF,
+    ) -> t.Union[Query, pd.DataFrame]:
+        """
+        Take a "native" DataFrame (eg Pyspark, Bigframe, Snowpark etc) and convert it to Pandas
+        """
+        if isinstance(query_or_df, (exp.Expression, pd.DataFrame)):
+            return query_or_df
+
+        # EngineAdapter subclasses that have native DataFrame types should override this
+        raise NotImplementedError(f"Unable to convert {type(query_or_df)} to Pandas")
 
     def fetchdf(
         self, query: t.Union[exp.Expression, str], quote_identifiers: bool = False

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -26,6 +26,7 @@ from sqlmesh.core.schema_diff import SchemaDiffer
 from sqlmesh.utils import optional_import
 from sqlmesh.utils.date import to_datetime
 from sqlmesh.utils.errors import SQLMeshError
+from sqlmesh.utils.pandas import columns_to_types_from_dtypes
 
 if t.TYPE_CHECKING:
     from google.api_core.retry import Retry
@@ -1106,6 +1107,39 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
 
     def _normalize_nested_value(self, col: exp.Expression) -> exp.Expression:
         return exp.func("TO_JSON_STRING", col, dialect=self.dialect)
+
+    @t.overload
+    def _columns_to_types(
+        self, query_or_df: DF, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
+    ) -> t.Dict[str, exp.DataType]: ...
+
+    @t.overload
+    def _columns_to_types(
+        self, query_or_df: Query, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
+    ) -> t.Optional[t.Dict[str, exp.DataType]]: ...
+
+    def _columns_to_types(
+        self, query_or_df: QueryOrDF, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
+    ) -> t.Optional[t.Dict[str, exp.DataType]]:
+        if (
+            not columns_to_types
+            and bigframes
+            and isinstance(query_or_df, bigframes.dataframe.DataFrame)
+        ):
+            # using dry_run=True attempts to prevent the DataFrame from being materialized just to read the column types from it
+            dtypes = query_or_df.to_pandas(dry_run=True).columnDtypes
+            return columns_to_types_from_dtypes(dtypes.items())
+
+        return super()._columns_to_types(query_or_df, columns_to_types)
+
+    def _native_df_to_pandas_df(
+        self,
+        query_or_df: QueryOrDF,
+    ) -> t.Union[Query, pd.DataFrame]:
+        if bigframes and isinstance(query_or_df, bigframes.dataframe.DataFrame):
+            return query_or_df.to_pandas()
+
+        return super()._native_df_to_pandas_df(query_or_df)
 
     @property
     def _query_data(self) -> t.Any:

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -451,6 +451,10 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
         if object_names:
             query = query.where(exp.column("TABLE_NAME").isin(*object_names))
 
+        # exclude SNOWPARK_TEMP_TABLE tables that are managed by the Snowpark library and are an implementation
+        # detail of dealing with DataFrame's
+        query = query.where(exp.column("TABLE_NAME").like("SNOWPARK_TEMP_TABLE%").not_())
+
         df = self.fetchdf(query, quote_identifiers=True)
         if df.empty:
             return []

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -27,6 +27,7 @@ from sqlmesh.core.engine_adapter.shared import (
 from sqlmesh.core.schema_diff import SchemaDiffer
 from sqlmesh.utils import optional_import
 from sqlmesh.utils.errors import SQLMeshError
+from sqlmesh.utils.pandas import columns_to_types_from_dtypes
 
 logger = logging.getLogger(__name__)
 snowpark = optional_import("snowflake.snowpark")
@@ -298,13 +299,23 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
 
             if is_snowpark_dataframe:
                 temp_table.set("catalog", database)
-                df_renamed = df.rename(
-                    {
-                        col: exp.to_identifier(col).sql(dialect=self.dialect, identify=True)
-                        for col in columns_to_types
-                    }
-                )  # type: ignore
-                df_renamed.createOrReplaceTempView(
+
+                # only quote columns if they arent already quoted
+                # if the Snowpark dataframe was created from a Pandas dataframe via snowpark.create_dataframe(pandas_df),
+                # then they will be quoted already. But if the Snowpark dataframe was created manually by the user, then the
+                # columns may not be quoted
+                columns_already_quoted = all(
+                    col.startswith('"') and col.endswith('"') for col in df.columns
+                )
+                local_df = df
+                if not columns_already_quoted:
+                    local_df = df.rename(
+                        {
+                            col: exp.to_identifier(col).sql(dialect=self.dialect, identify=True)
+                            for col in columns_to_types
+                        }
+                    )  # type: ignore
+                local_df.createOrReplaceTempView(
                     temp_table.sql(dialect=self.dialect, identify=True)
                 )  # type: ignore
             elif isinstance(df, pd.DataFrame):
@@ -356,6 +367,11 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
 
         def cleanup() -> None:
             if is_snowpark_dataframe:
+                if hasattr(df, "table_name"):
+                    if isinstance(df.table_name, str):
+                        # created by the Snowpark library if the Snowpark DataFrame was created from a Pandas DataFrame
+                        # (if the Snowpark DataFrame was created via native means then there is no 'table_name' property and no temp table)
+                        self.drop_table(df.table_name)
                 self.drop_view(temp_table)
             else:
                 self.drop_table(temp_table)
@@ -380,6 +396,15 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
             rows = self.cursor.fetchall()
             columns = self.cursor._result_set.batches[0].column_names
             return pd.DataFrame([dict(zip(columns, row)) for row in rows])
+
+    def _native_df_to_pandas_df(
+        self,
+        query_or_df: QueryOrDF,
+    ) -> t.Union[Query, pd.DataFrame]:
+        if snowpark and isinstance(query_or_df, snowpark.DataFrame):
+            return query_or_df.to_pandas()
+
+        return super()._native_df_to_pandas_df(query_or_df)
 
     def _get_data_objects(
         self, schema_name: SchemaName, object_names: t.Optional[t.Set[str]] = None
@@ -537,3 +562,21 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
             clone_kwargs=clone_kwargs,
             **kwargs,
         )
+
+    @t.overload
+    def _columns_to_types(
+        self, query_or_df: DF, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
+    ) -> t.Dict[str, exp.DataType]: ...
+
+    @t.overload
+    def _columns_to_types(
+        self, query_or_df: Query, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
+    ) -> t.Optional[t.Dict[str, exp.DataType]]: ...
+
+    def _columns_to_types(
+        self, query_or_df: QueryOrDF, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
+    ) -> t.Optional[t.Dict[str, exp.DataType]]:
+        if not columns_to_types and snowpark and isinstance(query_or_df, snowpark.DataFrame):
+            return columns_to_types_from_dtypes(query_or_df.sample(n=1).to_pandas().dtypes.items())
+
+        return super()._columns_to_types(query_or_df, columns_to_types)

--- a/sqlmesh/utils/pandas.py
+++ b/sqlmesh/utils/pandas.py
@@ -27,13 +27,20 @@ PANDAS_TYPE_MAPPINGS = {
     pd.Float32Dtype(): exp.DataType.build("float"),
     pd.Float64Dtype(): exp.DataType.build("double"),
     pd.StringDtype(): exp.DataType.build("text"),  # type: ignore
+    pd.StringDtype("pyarrow"): exp.DataType.build("text"),
     pd.BooleanDtype(): exp.DataType.build("boolean"),
 }
 
 
 def columns_to_types_from_df(df: pd.DataFrame) -> t.Dict[str, exp.DataType]:
+    return columns_to_types_from_dtypes(df.dtypes.items())
+
+
+def columns_to_types_from_dtypes(
+    dtypes: t.Iterable[t.Tuple[t.Hashable, t.Any]],
+) -> t.Dict[str, exp.DataType]:
     result = {}
-    for column_name, column_type in df.dtypes.items():
+    for column_name, column_type in dtypes:
         exp_type: t.Optional[exp.DataType] = None
         if hasattr(pd, "DatetimeTZDtype") and isinstance(column_type, pd.DatetimeTZDtype):
             exp_type = exp.DataType.build("timestamptz")

--- a/tests/core/engine_adapter/integration/__init__.py
+++ b/tests/core/engine_adapter/integration/__init__.py
@@ -304,13 +304,7 @@ class TestContext:
 
     def get_metadata_results(self, schema: t.Optional[str] = None) -> MetadataResults:
         schema = schema if schema else self.schema(TEST_SCHEMA)
-        results = MetadataResults.from_data_objects(self.engine_adapter.get_data_objects(schema))
-        if self.dialect == "snowflake" and self.test_type == "df":
-            # The Snowpark library manages the lifecycle of the SNOWPARK_TEMP_TABLE_* tables and drops them at the end of the session
-            # Our paramterized tests are just checking for tables *we* manage so including the Snowpark tables gives off-by-one errors
-            # when asserting table counts
-            results.tables = [t for t in results.tables if not t.startswith("SNOWPARK_TEMP_TABLE")]
-        return results
+        return MetadataResults.from_data_objects(self.engine_adapter.get_data_objects(schema))
 
     def _init_engine_adapter(self) -> None:
         schema = self.schema(TEST_SCHEMA)

--- a/tests/core/engine_adapter/integration/__init__.py
+++ b/tests/core/engine_adapter/integration/__init__.py
@@ -713,6 +713,10 @@ class TestContext:
                 schema_name=schema_name, ignore_if_not_exists=True, cascade=True
             )
 
+        if snowpark := self.engine_adapter.snowpark:
+            # ensure that the next test gets a fresh Snowpark session
+            snowpark.close()
+
     def upsert_sql_model(self, model_definition: str) -> t.Tuple[Context, SqlModel]:
         if not self._context:
             self._context = self.create_context()

--- a/tests/core/engine_adapter/integration/config.yaml
+++ b/tests/core/engine_adapter/integration/config.yaml
@@ -8,7 +8,7 @@ gateways:
         testing: 'testing.duckdb'
 
   # Databases with docker images available
-  inttest_trino:
+  inttest_trino_hive:
     connection:
       type: trino
       host: {{ env_var('DOCKER_HOSTNAME', 'localhost') }}
@@ -81,7 +81,7 @@ gateways:
       password: mysql
       port: 3306
       charset: utf8
-  inttest_clickhouse:
+  inttest_clickhouse_standalone:
     connection:
       type: clickhouse
       host: {{ env_var('DOCKER_HOSTNAME', 'localhost') }}

--- a/tests/core/engine_adapter/integration/conftest.py
+++ b/tests/core/engine_adapter/integration/conftest.py
@@ -7,12 +7,23 @@ import os
 import logging
 from pytest import FixtureRequest
 
+
 from sqlmesh import Config, EngineAdapter
-from sqlmesh.core.config.connection import AthenaConnectionConfig
+from sqlmesh.core.config.connection import (
+    ConnectionConfig,
+    AthenaConnectionConfig,
+    DuckDBConnectionConfig,
+)
 from sqlmesh.core.engine_adapter import AthenaEngineAdapter
 from sqlmesh.core.config import load_config_from_paths
 
-from tests.core.engine_adapter.integration import TestContext, TEST_SCHEMA
+from tests.core.engine_adapter.integration import (
+    TestContext,
+    TEST_SCHEMA,
+    generate_pytest_params,
+    ENGINES,
+    IntegrationTestEngine,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -30,77 +41,114 @@ def config() -> Config:
 
 
 @pytest.fixture
-def engine_adapter(
-    mark_gateway: t.Tuple[str, str],
-    config,
-    testrun_uid: str,
+def create_engine_adapter(
     request: pytest.FixtureRequest,
-) -> EngineAdapter:
-    mark, gateway = mark_gateway
+    testrun_uid: str,
+    config: Config,
+) -> t.Callable[[str, str], EngineAdapter]:
+    def _create(engine_name: str, gateway: str) -> EngineAdapter:
+        assert gateway in config.gateways
+        connection_config = config.gateways[gateway].connection
+        assert isinstance(connection_config, ConnectionConfig)
 
-    if gateway not in config.gateways:
-        # TODO: Once everything is fully setup we want to error if a gateway is not configured that we expect
-        pytest.skip(f"Gateway {gateway} not configured")
+        engine_adapter = connection_config.create_engine_adapter()
 
-    connection_config = config.gateways[gateway].connection
+        if engine_name == "athena":
+            assert isinstance(connection_config, AthenaConnectionConfig)
+            assert isinstance(engine_adapter, AthenaEngineAdapter)
 
-    engine_adapter = connection_config.create_engine_adapter()
+            # S3 files need to go into a unique location for each test run
+            # This is because DROP TABLE on a Hive table just drops the table from the metastore
+            # The files still exist in S3, so if you CREATE TABLE to the same location, the old data shows back up
+            # Note that the `testrun_uid` fixture comes from the xdist plugin
+            if connection_config.s3_warehouse_location:
+                engine_adapter.s3_warehouse_location = os.path.join(
+                    connection_config.s3_warehouse_location,
+                    f"testrun_{testrun_uid}",
+                    request.node.originalname,
+                )
 
-    if "athena" in mark:
-        assert isinstance(connection_config, AthenaConnectionConfig)
-        assert isinstance(engine_adapter, AthenaEngineAdapter)
+        # Trino: If we batch up the requests then when running locally we get a table not found error after creating the
+        # table and then immediately after trying to insert rows into it. There seems to be a delay between when the
+        # metastore is made aware of the table and when it responds that it exists. I'm hoping this is not an issue
+        # in practice on production machines.
+        if engine_name == "trino":
+            engine_adapter.DEFAULT_BATCH_SIZE = 1
 
-        # S3 files need to go into a unique location for each test run
-        # This is because DROP TABLE on a Hive table just drops the table from the metastore
-        # The files still exist in S3, so if you CREATE TABLE to the same location, the old data shows back up
-        # Note that the `testrun_uid` fixture comes from the xdist plugin
-        if connection_config.s3_warehouse_location:
-            engine_adapter.s3_warehouse_location = os.path.join(
-                connection_config.s3_warehouse_location,
-                f"testrun_{testrun_uid}",
-                request.node.originalname,
-            )
+        # Clear our any local db files that may have been left over from previous runs
+        if engine_name == "duckdb":
+            assert isinstance(connection_config, DuckDBConnectionConfig)
+            for raw_path in [
+                v for v in (connection_config.catalogs or {}).values() if isinstance(v, str)
+            ]:
+                pathlib.Path(raw_path).unlink(missing_ok=True)
 
-    # Trino: If we batch up the requests then when running locally we get a table not found error after creating the
-    # table and then immediately after trying to insert rows into it. There seems to be a delay between when the
-    # metastore is made aware of the table and when it responds that it exists. I'm hoping this is not an issue
-    # in practice on production machines.
-    if not mark.startswith("trino"):
-        engine_adapter.DEFAULT_BATCH_SIZE = 1
+        return engine_adapter
 
-    # Clear our any local db files that may have been left over from previous runs
-    if mark == "duckdb":
-        for raw_path in (connection_config.catalogs or {}).values():
-            pathlib.Path(raw_path).unlink(missing_ok=True)
-
-    return engine_adapter
+    return _create
 
 
 @pytest.fixture
+def create_test_context(
+    request: FixtureRequest, create_engine_adapter: t.Callable[[str, str], EngineAdapter]
+) -> t.Callable[[IntegrationTestEngine, str, str, str], t.Iterable[TestContext]]:
+    def _create(
+        engine: IntegrationTestEngine, gateway: str, test_type: str, table_format: str
+    ) -> t.Iterable[TestContext]:
+        is_remote = request.node.get_closest_marker("remote") is not None
+
+        engine_adapter = create_engine_adapter(engine.engine, gateway)
+
+        ctx = TestContext(
+            test_type,
+            engine_adapter,
+            f"{engine.engine}_{table_format}",
+            gateway,
+            is_remote=is_remote,
+        )
+        ctx.init()
+
+        with ctx.engine_adapter.session({}):
+            yield ctx
+
+        try:
+            ctx.cleanup()
+        except Exception:
+            # We need to catch this exception because if there is an error during teardown, pytest-retry aborts immediately
+            # instead of retrying
+            logger.exception("Context cleanup failed")
+
+    return _create
+
+
+@pytest.fixture(
+    params=list(generate_pytest_params(ENGINES, query=True, show_variant_in_test_id=False))
+)
 def ctx(
     request: FixtureRequest,
-    engine_adapter: EngineAdapter,
-    test_type: str,
-    mark_gateway: t.Tuple[str, str],
+    create_test_context: t.Callable[[IntegrationTestEngine, str], t.Iterable[TestContext]],
 ) -> t.Iterable[TestContext]:
-    mark, gateway = mark_gateway
-    is_remote = request.node.get_closest_marker("remote") is not None
-
-    ctx = TestContext(test_type, engine_adapter, mark, gateway, is_remote=is_remote)
-    ctx.init()
-
-    with ctx.engine_adapter.session({}):
-        yield ctx
-
-    try:
-        ctx.cleanup()
-    except Exception:
-        # We need to catch this exception because if there is an error during teardown, pytest-retry aborts immediately
-        # instead of retrying
-        logger.exception("Context cleanup failed")
+    yield from create_test_context(*request.param)
 
 
-@pytest.fixture
+@pytest.fixture(params=list(generate_pytest_params(ENGINES, query=False, df=True)))
+def ctx_df(
+    request: FixtureRequest,
+    create_test_context: t.Callable[[IntegrationTestEngine, str], t.Iterable[TestContext]],
+) -> t.Iterable[TestContext]:
+    yield from create_test_context(*request.param)
+
+
+@pytest.fixture(params=list(generate_pytest_params(ENGINES, query=True, df=True)))
+def ctx_query_and_df(
+    request: FixtureRequest,
+    create_test_context: t.Callable[[IntegrationTestEngine, str], t.Iterable[TestContext]],
+) -> t.Iterable[TestContext]:
+    yield from create_test_context(*request.param)
+
+
+# @pytest.fixture
+# todo: is anything using this fixture?
 def schema(ctx: TestContext) -> str:
     schema_name = ctx.schema(TEST_SCHEMA)
     ctx.engine_adapter.create_schema(

--- a/tests/core/engine_adapter/integration/conftest.py
+++ b/tests/core/engine_adapter/integration/conftest.py
@@ -19,7 +19,6 @@ from sqlmesh.core.config import load_config_from_paths
 
 from tests.core.engine_adapter.integration import (
     TestContext,
-    TEST_SCHEMA,
     generate_pytest_params,
     ENGINES,
     IntegrationTestEngine,
@@ -72,7 +71,7 @@ def create_engine_adapter(
         # table and then immediately after trying to insert rows into it. There seems to be a delay between when the
         # metastore is made aware of the table and when it responds that it exists. I'm hoping this is not an issue
         # in practice on production machines.
-        if engine_name == "trino":
+        if not engine_name == "trino":
             engine_adapter.DEFAULT_BATCH_SIZE = 1
 
         # Clear our any local db files that may have been left over from previous runs
@@ -145,13 +144,3 @@ def ctx_query_and_df(
     create_test_context: t.Callable[[IntegrationTestEngine, str], t.Iterable[TestContext]],
 ) -> t.Iterable[TestContext]:
     yield from create_test_context(*request.param)
-
-
-# @pytest.fixture
-# todo: is anything using this fixture?
-def schema(ctx: TestContext) -> str:
-    schema_name = ctx.schema(TEST_SCHEMA)
-    ctx.engine_adapter.create_schema(
-        schema_name
-    )  # note: gets cleaned up when the TestContext fixture gets cleaned up
-    return schema_name

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -82,185 +82,7 @@ class PlanResults(PydanticModel):
         return self.table_name_for(snapshot, is_deployable=False)
 
 
-@pytest.fixture(params=["df", "query", "pyspark"])
-def test_type(request):
-    return request.param
-
-
-@pytest.fixture(
-    params=[
-        pytest.param(
-            "duckdb",
-            marks=[
-                pytest.mark.duckdb,
-                pytest.mark.engine,
-                pytest.mark.slow,
-                # the duckdb tests cannot run concurrently because many of them point at the same files
-                # and duckdb does not support multi process read/write on the same files
-                # ref: https://duckdb.org/docs/connect/concurrency.html#writing-to-duckdb-from-multiple-processes
-                pytest.mark.xdist_group("engine_integration_duckdb"),
-            ],
-        ),
-        pytest.param(
-            "postgres",
-            marks=[
-                pytest.mark.docker,
-                pytest.mark.engine,
-                pytest.mark.postgres,
-            ],
-        ),
-        pytest.param(
-            "mysql",
-            marks=[
-                pytest.mark.docker,
-                pytest.mark.engine,
-                pytest.mark.mysql,
-            ],
-        ),
-        pytest.param(
-            "mssql",
-            marks=[
-                pytest.mark.docker,
-                pytest.mark.engine,
-                pytest.mark.mssql,
-            ],
-        ),
-        pytest.param(
-            "trino",
-            marks=[
-                pytest.mark.docker,
-                pytest.mark.engine,
-                pytest.mark.trino,
-            ],
-        ),
-        pytest.param(
-            "trino_iceberg",
-            marks=[
-                pytest.mark.docker,
-                pytest.mark.engine,
-                pytest.mark.trino_iceberg,
-            ],
-        ),
-        pytest.param(
-            "trino_delta",
-            marks=[
-                pytest.mark.docker,
-                pytest.mark.engine,
-                pytest.mark.trino_delta,
-            ],
-        ),
-        pytest.param(
-            "trino_nessie",
-            marks=[
-                pytest.mark.docker,
-                pytest.mark.engine,
-                pytest.mark.trino_nessie,
-            ],
-        ),
-        pytest.param(
-            "spark",
-            marks=[
-                pytest.mark.docker,
-                pytest.mark.engine,
-                pytest.mark.spark,
-            ],
-        ),
-        pytest.param(
-            "clickhouse",
-            marks=[
-                pytest.mark.docker,
-                pytest.mark.engine,
-                pytest.mark.clickhouse,
-            ],
-        ),
-        pytest.param(
-            "clickhouse_cluster",
-            marks=[
-                pytest.mark.docker,
-                pytest.mark.engine,
-                pytest.mark.clickhouse_cluster,
-            ],
-        ),
-        pytest.param(
-            "bigquery",
-            marks=[
-                pytest.mark.bigquery,
-                pytest.mark.engine,
-                pytest.mark.remote,
-            ],
-        ),
-        pytest.param(
-            "databricks",
-            marks=[
-                pytest.mark.databricks,
-                pytest.mark.engine,
-                pytest.mark.remote,
-            ],
-        ),
-        # TODO: add motherduck tests once they support DuckDB>=0.10.0
-        pytest.param(
-            "redshift",
-            marks=[
-                pytest.mark.engine,
-                pytest.mark.remote,
-                pytest.mark.redshift,
-            ],
-        ),
-        pytest.param(
-            "snowflake",
-            marks=[
-                pytest.mark.engine,
-                pytest.mark.remote,
-                pytest.mark.snowflake,
-            ],
-        ),
-        pytest.param(
-            "clickhouse_cloud",
-            marks=[
-                pytest.mark.engine,
-                pytest.mark.remote,
-                pytest.mark.clickhouse_cloud,
-            ],
-        ),
-        pytest.param(
-            "athena_hive",
-            marks=[
-                pytest.mark.engine,
-                pytest.mark.remote,
-                pytest.mark.athena,
-            ],
-        ),
-        pytest.param(
-            "athena_iceberg",
-            marks=[
-                pytest.mark.engine,
-                pytest.mark.remote,
-                pytest.mark.athena,
-            ],
-        ),
-        pytest.param(
-            "risingwave",
-            marks=[
-                pytest.mark.docker,
-                pytest.mark.engine,
-                pytest.mark.risingwave,
-            ],
-        ),
-    ]
-)
-def mark_gateway(request) -> t.Tuple[str, str]:
-    gateway = "athena" if "athena" in request.param else request.param
-    return request.param, f"inttest_{gateway}"
-
-
-@pytest.fixture
-def default_columns_to_types():
-    return {"id": exp.DataType.build("int"), "ds": exp.DataType.build("string")}
-
-
 def test_connection(ctx: TestContext):
-    if ctx.test_type != "query":
-        pytest.skip("Connection tests only need to run once so we skip anything not query")
     cursor_from_connection = ctx.engine_adapter.connection.cursor()
     cursor_from_connection.execute("SELECT 1")
     assert cursor_from_connection.fetchone()[0] == 1
@@ -274,8 +96,6 @@ def test_catalog_operations(ctx: TestContext):
         pytest.skip(
             f"Engine adapter {ctx.engine_adapter.dialect} doesn't support catalog operations"
         )
-    if ctx.test_type != "query":
-        pytest.skip("Catalog operation tests only need to run once so we skip anything not query")
 
     # use a unique name so that integration tests on cloud databases can run in parallel
     catalog_name = "testing" if not ctx.is_remote else ctx.add_test_suffix("testing")
@@ -333,8 +153,6 @@ def test_drop_schema_catalog(ctx: TestContext, caplog):
         pytest.skip(
             "Currently local spark is configured to have iceberg be the testing catalog and drop cascade doesn't work on iceberg. Skipping until we have time to fix."
         )
-    if ctx.test_type != "query":
-        pytest.skip("Drop Schema Catalog tests only need to run once so we skip anything not query")
 
     catalog_name = "testing" if not ctx.is_remote else ctx.add_test_suffix("testing")
     if ctx.dialect == "bigquery":
@@ -359,7 +177,8 @@ def test_drop_schema_catalog(ctx: TestContext, caplog):
         ctx.drop_catalog(catalog_name)
 
 
-def test_temp_table(ctx: TestContext):
+def test_temp_table(ctx_query_and_df: TestContext):
+    ctx = ctx_query_and_df
     input_data = pd.DataFrame(
         [
             {"id": 1, "ds": "2022-01-01"},
@@ -405,7 +224,8 @@ def test_create_table(ctx: TestContext):
         assert column_comments == {"id": "test id column description"}
 
 
-def test_ctas(ctx: TestContext):
+def test_ctas(ctx_query_and_df: TestContext):
+    ctx = ctx_query_and_df
     table = ctx.table("test_table")
 
     input_data = pd.DataFrame(
@@ -442,7 +262,8 @@ def test_ctas(ctx: TestContext):
         ctx.engine_adapter.ctas(table, exp.select("1").limit(0))
 
 
-def test_create_view(ctx: TestContext):
+def test_create_view(ctx_query_and_df: TestContext):
+    ctx = ctx_query_and_df
     input_data = pd.DataFrame(
         [
             {"id": 1, "ds": "2022-01-01"},
@@ -484,7 +305,8 @@ def test_create_view(ctx: TestContext):
         )
 
 
-def test_materialized_view(ctx: TestContext):
+def test_materialized_view(ctx_query_and_df: TestContext):
+    ctx = ctx_query_and_df
     if not ctx.engine_adapter.SUPPORTS_MATERIALIZED_VIEWS:
         pytest.skip(f"Engine adapter {ctx.engine_adapter} doesn't support materialized views")
     if ctx.engine_adapter.dialect == "databricks":
@@ -523,8 +345,6 @@ def test_materialized_view(ctx: TestContext):
 
 
 def test_drop_schema(ctx: TestContext):
-    if ctx.test_type != "query":
-        pytest.skip("Drop Schema tests only need to run once so we skip anything not query")
     ctx.columns_to_types = {"one": "int"}
     schema = ctx.schema(TEST_SCHEMA)
     ctx.engine_adapter.drop_schema(schema, cascade=True)
@@ -546,9 +366,8 @@ def test_drop_schema(ctx: TestContext):
     assert len(results.views) == 0
 
 
-def test_nan_roundtrip(ctx: TestContext):
-    if ctx.test_type != "df":
-        pytest.skip("NaN roundtrip test only relevant for dataframes.")
+def test_nan_roundtrip(ctx_df: TestContext):
+    ctx = ctx_df
     ctx.engine_adapter.DEFAULT_BATCH_SIZE = sys.maxsize
     table = ctx.table("test_table")
     # Initial Load
@@ -573,7 +392,8 @@ def test_nan_roundtrip(ctx: TestContext):
     ctx.compare_with_current(table, input_data)
 
 
-def test_replace_query(ctx: TestContext):
+def test_replace_query(ctx_query_and_df: TestContext):
+    ctx = ctx_query_and_df
     ctx.engine_adapter.DEFAULT_BATCH_SIZE = sys.maxsize
     table = ctx.table("test_table")
     # Initial Load
@@ -629,7 +449,8 @@ def test_replace_query(ctx: TestContext):
         ctx.compare_with_current(table, replace_data)
 
 
-def test_replace_query_batched(ctx: TestContext):
+def test_replace_query_batched(ctx_query_and_df: TestContext):
+    ctx = ctx_query_and_df
     ctx.engine_adapter.DEFAULT_BATCH_SIZE = 1
     table = ctx.table("test_table")
     # Initial Load
@@ -661,7 +482,7 @@ def test_replace_query_batched(ctx: TestContext):
     ctx.compare_with_current(table, input_data)
 
     # Replace that we only need to run once
-    if type == "df":
+    if ctx.test_type == "df":
         replace_data = pd.DataFrame(
             [
                 {"id": 4, "ds": "2022-01-04"},
@@ -685,7 +506,8 @@ def test_replace_query_batched(ctx: TestContext):
         ctx.compare_with_current(table, replace_data)
 
 
-def test_insert_append(ctx: TestContext):
+def test_insert_append(ctx_query_and_df: TestContext):
+    ctx = ctx_query_and_df
     table = ctx.table("test_table")
     ctx.engine_adapter.create_table(
         table, ctx.columns_to_types, table_format=ctx.default_table_format
@@ -707,7 +529,7 @@ def test_insert_append(ctx: TestContext):
     ctx.compare_with_current(table, input_data)
 
     # Replace that we only need to run once
-    if type == "df":
+    if ctx.test_type == "df":
         append_data = pd.DataFrame(
             [
                 {"id": 4, "ds": "2022-01-04"},
@@ -725,7 +547,8 @@ def test_insert_append(ctx: TestContext):
         ctx.compare_with_current(table, pd.concat([input_data, append_data]))
 
 
-def test_insert_overwrite_by_time_partition(ctx: TestContext):
+def test_insert_overwrite_by_time_partition(ctx_query_and_df: TestContext):
+    ctx = ctx_query_and_df
     ds_type = "string"
     if ctx.dialect == "bigquery":
         ds_type = "datetime"
@@ -812,7 +635,8 @@ def test_insert_overwrite_by_time_partition(ctx: TestContext):
         )
 
 
-def test_merge(ctx: TestContext):
+def test_merge(ctx_query_and_df: TestContext):
+    ctx = ctx_query_and_df
     if not ctx.supports_merge:
         pytest.skip(f"{ctx.dialect} doesn't support merge")
 
@@ -877,7 +701,8 @@ def test_merge(ctx: TestContext):
         )
 
 
-def test_scd_type_2_by_time(ctx: TestContext):
+def test_scd_type_2_by_time(ctx_query_and_df: TestContext):
+    ctx = ctx_query_and_df
     # Athena only supports the operations required for SCD models on Iceberg tables
     if ctx.mark == "athena_hive":
         pytest.skip("SCD Type 2 is only supported on Athena / Iceberg")
@@ -956,6 +781,7 @@ def test_scd_type_2_by_time(ctx: TestContext):
 
     if ctx.test_type == "query":
         return
+
     current_data = pd.DataFrame(
         [
             # Change `a` to `x`
@@ -1030,7 +856,8 @@ def test_scd_type_2_by_time(ctx: TestContext):
     )
 
 
-def test_scd_type_2_by_column(ctx: TestContext):
+def test_scd_type_2_by_column(ctx_query_and_df: TestContext):
+    ctx = ctx_query_and_df
     # Athena only supports the operations required for SCD models on Iceberg tables
     if ctx.mark == "athena_hive":
         pytest.skip("SCD Type 2 is only supported on Athena / Iceberg")
@@ -1116,6 +943,7 @@ def test_scd_type_2_by_column(ctx: TestContext):
 
     if ctx.test_type == "query":
         return
+
     current_data = pd.DataFrame(
         [
             # Change `a` to `x`
@@ -1205,7 +1033,8 @@ def test_scd_type_2_by_column(ctx: TestContext):
     )
 
 
-def test_get_data_objects(ctx: TestContext):
+def test_get_data_objects(ctx_query_and_df: TestContext):
+    ctx = ctx_query_and_df
     table = ctx.table("test_table")
     view = ctx.table("test_view")
     ctx.engine_adapter.create_table(
@@ -1280,9 +1109,6 @@ def test_get_data_objects(ctx: TestContext):
 
 
 def test_truncate_table(ctx: TestContext):
-    if ctx.test_type != "query":
-        pytest.skip("Truncate table test does not change based on input data type")
-
     table = ctx.table("test_table")
 
     ctx.engine_adapter.create_table(
@@ -1304,8 +1130,6 @@ def test_truncate_table(ctx: TestContext):
 def test_transaction(ctx: TestContext):
     if ctx.engine_adapter.SUPPORTS_TRANSACTIONS is False:
         pytest.skip(f"Engine adapter {ctx.engine_adapter.dialect} doesn't support transactions")
-    if ctx.test_type != "query":
-        pytest.skip("Transaction test can just run for query")
 
     table = ctx.table("test_table")
     input_data = pd.DataFrame(
@@ -1328,9 +1152,6 @@ def test_transaction(ctx: TestContext):
 
 
 def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
-    if ctx.test_type != "query":
-        pytest.skip("Sushi end-to-end tests only need to run for query")
-
     if ctx.mark == "athena_hive":
         pytest.skip(
             "Sushi end-to-end tests only need to run once for Athena because sushi needs a hybrid of both Hive and Iceberg"
@@ -1736,9 +1557,6 @@ def test_sushi(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
 
 
 def test_init_project(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory):
-    if ctx.test_type != "query":
-        pytest.skip("Init example project end-to-end tests only need to run for query")
-
     tmp_path = tmp_path_factory.mktemp(f"init_project_{ctx.test_id}")
 
     schema_name = ctx.add_test_suffix(TEST_SCHEMA)
@@ -1850,9 +1668,6 @@ def test_init_project(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory
 
 
 def test_dialects(ctx: TestContext):
-    if ctx.test_type != "query":
-        pytest.skip("Dialect tests only need to run once so we skip anything not query")
-
     from sqlglot import Dialect, parse_one
 
     dialect = Dialect[ctx.dialect]
@@ -1969,9 +1784,6 @@ def test_dialects(ctx: TestContext):
 def test_to_time_column(
     ctx: TestContext, time_column, time_column_type, time_column_format, result
 ):
-    if ctx.test_type != "query":
-        pytest.skip("Time column tests only need to run for query")
-
     # TODO: can this be cleaned up after recent sqlglot updates?
     if ctx.dialect == "clickhouse" and time_column_type.is_type(exp.DataType.Type.TIMESTAMPTZ):
         # Clickhouse does not have natively timezone-aware types and does not accept timestrings
@@ -1992,15 +1804,9 @@ def test_to_time_column(
         assert df[col_name][0] == expected
 
 
-def test_batch_size_on_incremental_by_unique_key_model(
-    ctx: TestContext, mark_gateway: t.Tuple[str, str]
-):
-    if ctx.test_type != "query":
-        pytest.skip("This only needs to run once so we skip anything not query")
-
+def test_batch_size_on_incremental_by_unique_key_model(ctx: TestContext):
     if not ctx.supports_merge:
-        _, gateway = mark_gateway
-        pytest.skip(f"{ctx.dialect} on {gateway} doesnt support merge")
+        pytest.skip(f"{ctx.dialect} on {ctx.gateway} doesnt support merge")
 
     def _mutate_config(current_gateway_name: str, config: Config):
         # make stepping through in the debugger easier
@@ -2102,9 +1908,6 @@ def test_managed_model_upstream_forward_only(ctx: TestContext):
             - We need to ensure we ignore the normal table for Model B (it was just a dev preview) and create a new managed table for prod
             - Upon apply to prod, Model B should be completely recreated as a managed table
     """
-
-    if ctx.test_type != "query":
-        pytest.skip("This only needs to run once so we skip anything not query")
 
     if not ctx.engine_adapter.SUPPORTS_MANAGED_MODELS:
         pytest.skip("This test only runs for engines that support managed models")
@@ -2351,9 +2154,6 @@ def test_value_normalization(
     input_data: t.Tuple[t.Any, ...],
     expected_results: t.Tuple[str, ...],
 ) -> None:
-    if ctx.test_type != "query":
-        pytest.skip("Value normalization tests only need to run for query")
-
     if (
         ctx.dialect == "trino"
         and ctx.engine_adapter.current_catalog_type == "hive"
@@ -2445,9 +2245,6 @@ def test_value_normalization(
 
 
 def test_table_diff_grain_check_single_key(ctx: TestContext):
-    if ctx.test_type != "query":
-        pytest.skip("table_diff tests are only relevant for query")
-
     if not isinstance(ctx.engine_adapter, RowDiffMixin):
         pytest.skip("table_diff tests are only relevant for engines with row diffing implemented")
 
@@ -2509,9 +2306,6 @@ def test_table_diff_grain_check_single_key(ctx: TestContext):
 
 
 def test_table_diff_grain_check_multiple_keys(ctx: TestContext):
-    if ctx.test_type != "query":
-        pytest.skip("table_diff tests are only relevant for query")
-
     if not isinstance(ctx.engine_adapter, RowDiffMixin):
         pytest.skip("table_diff tests are only relevant for engines with row diffing implemented")
 
@@ -2570,9 +2364,6 @@ def test_table_diff_grain_check_multiple_keys(ctx: TestContext):
 
 
 def test_table_diff_arbitrary_condition(ctx: TestContext):
-    if ctx.test_type != "query":
-        pytest.skip("table_diff tests are only relevant for query")
-
     if not isinstance(ctx.engine_adapter, RowDiffMixin):
         pytest.skip("table_diff tests are only relevant for engines with row diffing implemented")
 
@@ -2640,9 +2431,6 @@ def test_table_diff_arbitrary_condition(ctx: TestContext):
 
 
 def test_table_diff_identical_dataset(ctx: TestContext):
-    if ctx.test_type != "query":
-        pytest.skip("table_diff tests are only relevant for query")
-
     if not isinstance(ctx.engine_adapter, RowDiffMixin):
         pytest.skip("table_diff tests are only relevant for engines with row diffing implemented")
 
@@ -2701,9 +2489,6 @@ def test_table_diff_identical_dataset(ctx: TestContext):
 
 
 def test_state_migrate_from_scratch(ctx: TestContext):
-    if ctx.test_type != "query":
-        pytest.skip("state migration tests are only relevant for query")
-
     test_schema = ctx.add_test_suffix("state")
     ctx._schemas.append(test_schema)  # so it gets cleaned up when the test finishes
 
@@ -2736,34 +2521,55 @@ def test_state_migrate_from_scratch(ctx: TestContext):
     sqlmesh_context.migrate()
 
 
-def test_python_model_column_order(ctx: TestContext, tmp_path: pathlib.Path):
-    if ctx.test_type == "pyspark" and ctx.dialect in ("spark", "databricks"):
-        # dont skip
-        pass
-    elif ctx.test_type != "df":
-        pytest.skip("python model column order test only needs to be run once per db")
+def test_python_model_column_order(ctx_df: TestContext, tmp_path: pathlib.Path):
+    ctx = ctx_df
 
-    schema = ctx.add_test_suffix(TEST_SCHEMA)
+    model_name = ctx.table("TEST")
 
     (tmp_path / "models").mkdir()
 
     # note: this model deliberately defines the columns in the @model definition to be in a different order than what
     # is returned by the DataFrame within the model
     model_path = tmp_path / "models" / "python_model.py"
-    if ctx.test_type == "pyspark":
+
+    model_definitions = {
+        # python model that emits a Pandas dataframe
+        "pandas": """
+import pandas as pd
+import typing as t
+from sqlmesh import ExecutionContext, model
+
+@model(
+    'MODEL_NAME',
+    columns={
+        "id": "int",
+        "name": "text"
+    },
+    dialect='DIALECT',
+    TABLE_FORMAT
+)
+def execute(
+    context: ExecutionContext,
+    **kwargs: t.Any,
+) -> pd.DataFrame:
+    record = { "name": "foo", "id": 1 } if context.engine_adapter.dialect != 'snowflake' else { "NAME": "foo", "ID": 1 }
+    return pd.DataFrame([
+        record
+    ])
+        """,
         # python model that emits a PySpark dataframe
-        model_path.write_text(
-            """
+        "pyspark": """
 from pyspark.sql import DataFrame, Row
 import typing as t
 from sqlmesh import ExecutionContext, model
 
 @model(
-    "TEST_SCHEMA.model",
+    'MODEL_NAME',
     columns={
         "id": "int",
         "name": "varchar"
-    }
+    },
+    dialect='DIALECT'
 )
 def execute(
     context: ExecutionContext,
@@ -2772,32 +2578,60 @@ def execute(
     return context.spark.createDataFrame([
         Row(name="foo", id=1)
     ])
-    """.replace("TEST_SCHEMA", schema)
-        )
-    else:
-        # python model that emits a Pandas DataFrame
-        model_path.write_text(
-            """
-import pandas as pd
+        """,
+        # python model that emits a BigFrame dataframe
+        "bigframe": """
+from bigframes.pandas import DataFrame
 import typing as t
 from sqlmesh import ExecutionContext, model
 
 @model(
-    "TEST_SCHEMA.model",
+    'MODEL_NAME',
     columns={
         "id": "int",
         "name": "varchar"
-    }
+    },
+    dialect="DIALECT"
 )
 def execute(
     context: ExecutionContext,
     **kwargs: t.Any,
-) -> pd.DataFrame:
-    return pd.DataFrame([
-        {"name": "foo", "id": 1}
-    ])
-    """.replace("TEST_SCHEMA", schema)
+) -> DataFrame:
+    return DataFrame({'name': ['foo'], 'id': [1]}, session=context.bigframe)
+        """,
+        # python model that emits a Snowpark dataframe
+        "snowpark": """
+from snowflake.snowpark.dataframe import DataFrame
+import typing as t
+from sqlmesh import ExecutionContext, model
+
+@model(
+    'MODEL_NAME',
+    columns={
+        "id": "int",
+        "name": "varchar"
+    },
+    dialect="DIALECT"
+)
+def execute(
+    context: ExecutionContext,
+    **kwargs: t.Any,
+) -> DataFrame:
+    return context.snowpark.create_dataframe([["foo", 1]], schema=["NAME", "ID"])
+        """,
+    }
+
+    model_path.write_text(
+        (
+            model_definitions[ctx.df_type]
+            .replace("MODEL_NAME", model_name.sql(dialect=ctx.dialect))
+            .replace("DIALECT", ctx.dialect)
+            .replace(
+                "TABLE_FORMAT",
+                f"table_format='{ctx.default_table_format}'" if ctx.default_table_format else "",
+            )
         )
+    )
 
     sqlmesh_ctx = ctx.create_context(path=tmp_path)
 
@@ -2808,9 +2642,13 @@ def execute(
 
     engine_adapter = sqlmesh_ctx.engine_adapter
 
-    query = exp.select("*").from_(
-        exp.to_table(f"{schema}.model", dialect=ctx.dialect), dialect=ctx.dialect
-    )
+    query = exp.select("*").from_(plan.environment.snapshots[0].fully_qualified_table)
     df = engine_adapter.fetchdf(query, quote_identifiers=True)
     assert len(df) == 1
-    assert df.iloc[0].to_dict() == {"id": 1, "name": "foo"}
+
+    # This test uses the dialect=<engine under test> on the model.
+    # For dialect=snowflake, this means that the identifiers are all normalized to uppercase by default
+    expected_result = (
+        {"id": 1, "name": "foo"} if ctx.dialect != "snowflake" else {"ID": 1, "NAME": "foo"}
+    )
+    assert df.iloc[0].to_dict() == expected_result

--- a/tests/core/engine_adapter/integration/test_integration_athena.py
+++ b/tests/core/engine_adapter/integration/test_integration_athena.py
@@ -7,6 +7,7 @@ from sqlmesh.core.engine_adapter import AthenaEngineAdapter
 from sqlmesh.utils.aws import parse_s3_uri
 from sqlmesh.utils.pandas import columns_to_types_from_df
 from sqlmesh.utils.date import to_ds, to_ts, TimeLike
+import dataclasses
 from tests.core.engine_adapter.integration import (
     TestContext,
     generate_pytest_params,
@@ -15,8 +16,12 @@ from tests.core.engine_adapter.integration import (
 )
 from sqlglot import exp
 
+# The tests in this file dont need to be called twice, so we create a single instance of Athena
+ENGINE_ATHENA = dataclasses.replace(ENGINES_BY_NAME["athena"], catalog_types=None)
+assert isinstance(ENGINE_ATHENA, IntegrationTestEngine)
 
-@pytest.fixture(params=list(generate_pytest_params(ENGINES_BY_NAME["athena"])))
+
+@pytest.fixture(params=list(generate_pytest_params(ENGINE_ATHENA)))
 def ctx(
     request: FixtureRequest,
     create_test_context: t.Callable[[IntegrationTestEngine, str, str], t.Iterable[TestContext]],

--- a/tests/core/engine_adapter/integration/test_integration_bigquery.py
+++ b/tests/core/engine_adapter/integration/test_integration_bigquery.py
@@ -14,18 +14,27 @@ from sqlmesh.core.model import SqlModel, load_sql_based_model
 from sqlmesh.core.plan import Plan
 from sqlmesh.core.table_diff import TableDiff
 from tests.core.engine_adapter.integration import TestContext
+from pytest import FixtureRequest
+from tests.core.engine_adapter.integration import (
+    TestContext,
+    generate_pytest_params,
+    ENGINES_BY_NAME,
+    IntegrationTestEngine,
+)
 
-pytestmark = [pytest.mark.engine, pytest.mark.remote, pytest.mark.bigquery]
+
+@pytest.fixture(params=list(generate_pytest_params(ENGINES_BY_NAME["bigquery"])))
+def ctx(
+    request: FixtureRequest,
+    create_test_context: t.Callable[[IntegrationTestEngine, str, str], t.Iterable[TestContext]],
+) -> t.Iterable[TestContext]:
+    yield from create_test_context(*request.param)
 
 
 @pytest.fixture
-def mark_gateway() -> t.Tuple[str, str]:
-    return "bigquery", "inttest_bigquery"
-
-
-@pytest.fixture
-def test_type() -> str:
-    return "query"
+def engine_adapter(ctx: TestContext) -> BigQueryEngineAdapter:
+    assert isinstance(ctx.engine_adapter, BigQueryEngineAdapter)
+    return ctx.engine_adapter
 
 
 def test_get_alter_expressions_includes_clustering(
@@ -431,50 +440,3 @@ def test_table_diff_table_name_matches_column_name(ctx: TestContext):
 
     assert row_diff.stats["join_count"] == 1
     assert row_diff.full_match_count == 1
-
-
-def test_bigframe_python_model_column_order(ctx: TestContext, tmp_path: Path):
-    model_name = ctx.table("TEST")
-
-    (tmp_path / "models").mkdir()
-
-    # note: this model deliberately defines the columns in the @model definition to be in a different order than what
-    # is returned by the DataFrame within the model
-    model_path = tmp_path / "models" / "python_model.py"
-
-    # python model that emits a BigFrame dataframe
-    model_path.write_text(
-        """
-from bigframes.pandas import DataFrame
-import typing as t
-from sqlmesh import ExecutionContext, model
-
-@model(
-    'MODEL_NAME',
-    columns={
-        "id": "int",
-        "name": "varchar"
-    },
-    dialect="bigquery"
-)
-def execute(
-    context: ExecutionContext,
-    **kwargs: t.Any,
-) -> DataFrame:
-    return DataFrame({'name': ['foo'], 'id': [1]}, session=context.bigframe)
-""".replace("MODEL_NAME", model_name.sql(dialect="bigquery"))
-    )
-
-    sqlmesh_ctx = ctx.create_context(path=tmp_path)
-
-    assert len(sqlmesh_ctx.models) == 1
-
-    plan = sqlmesh_ctx.plan(auto_apply=True)
-    assert len(plan.new_snapshots) == 1
-
-    engine_adapter = sqlmesh_ctx.engine_adapter
-
-    query = exp.select("*").from_(model_name)
-    df = engine_adapter.fetchdf(query, quote_identifiers=True)
-    assert len(df) == 1
-    assert df.iloc[0].to_dict() == {"id": 1, "name": "foo"}

--- a/tests/core/engine_adapter/integration/test_integration_postgres.py
+++ b/tests/core/engine_adapter/integration/test_integration_postgres.py
@@ -1,19 +1,29 @@
 import typing as t
 import pytest
+from pytest import FixtureRequest
 from sqlmesh.core.engine_adapter import PostgresEngineAdapter
 from tests.core.engine_adapter.integration import TestContext
 
-pytestmark = [pytest.mark.docker, pytest.mark.engine, pytest.mark.postgres]
+from tests.core.engine_adapter.integration import (
+    TestContext,
+    generate_pytest_params,
+    ENGINES_BY_NAME,
+    IntegrationTestEngine,
+)
+
+
+@pytest.fixture(params=list(generate_pytest_params(ENGINES_BY_NAME["postgres"])))
+def ctx(
+    request: FixtureRequest,
+    create_test_context: t.Callable[[IntegrationTestEngine, str, str], t.Iterable[TestContext]],
+) -> t.Iterable[TestContext]:
+    yield from create_test_context(*request.param)
 
 
 @pytest.fixture
-def mark_gateway() -> t.Tuple[str, str]:
-    return "postgres", "inttest_postgres"
-
-
-@pytest.fixture
-def test_type() -> str:
-    return "query"
+def engine_adapter(ctx: TestContext) -> PostgresEngineAdapter:
+    assert isinstance(ctx.engine_adapter, PostgresEngineAdapter)
+    return ctx.engine_adapter
 
 
 def test_engine_adapter(ctx: TestContext):

--- a/tests/core/engine_adapter/integration/test_integration_snowflake.py
+++ b/tests/core/engine_adapter/integration/test_integration_snowflake.py
@@ -1,7 +1,7 @@
 import typing as t
 import pytest
+from pytest import FixtureRequest
 from sqlglot import exp
-from pathlib import Path
 from sqlglot.optimizer.qualify_columns import quote_identifiers
 from sqlglot.helper import seq_get
 from sqlmesh.core.engine_adapter import SnowflakeEngineAdapter
@@ -11,17 +11,26 @@ from sqlmesh.core.model import SqlModel, load_sql_based_model
 from sqlmesh.core.plan import Plan
 from tests.core.engine_adapter.integration import TestContext
 
-pytestmark = [pytest.mark.engine, pytest.mark.remote, pytest.mark.snowflake]
+from tests.core.engine_adapter.integration import (
+    TestContext,
+    generate_pytest_params,
+    ENGINES_BY_NAME,
+    IntegrationTestEngine,
+)
+
+
+@pytest.fixture(params=list(generate_pytest_params(ENGINES_BY_NAME["snowflake"])))
+def ctx(
+    request: FixtureRequest,
+    create_test_context: t.Callable[[IntegrationTestEngine, str, str], t.Iterable[TestContext]],
+) -> t.Iterable[TestContext]:
+    yield from create_test_context(*request.param)
 
 
 @pytest.fixture
-def mark_gateway() -> t.Tuple[str, str]:
-    return "snowflake", "inttest_snowflake"
-
-
-@pytest.fixture
-def test_type() -> str:
-    return "query"
+def engine_adapter(ctx: TestContext) -> SnowflakeEngineAdapter:
+    assert isinstance(ctx.engine_adapter, SnowflakeEngineAdapter)
+    return ctx.engine_adapter
 
 
 def test_get_alter_expressions_includes_clustering(
@@ -211,49 +220,3 @@ def test_create_iceberg_table(ctx: TestContext, engine_adapter: SnowflakeEngineA
     result = sqlmesh.plan(auto_apply=True)
 
     assert len(result.new_snapshots) == 2
-
-
-def test_snowpark_python_model_column_order(ctx: TestContext, tmp_path: Path):
-    model_name = ctx.table("TEST")
-
-    (tmp_path / "models").mkdir()
-
-    # note: this model deliberately defines the columns in the @model definition to be in a different order than what
-    # is returned by the DataFrame within the model
-    model_path = tmp_path / "models" / "python_model.py"
-
-    # python model that emits a Snowpark DataFrame
-    model_path.write_text(
-        """
-from snowflake.snowpark.dataframe import DataFrame
-import typing as t
-from sqlmesh import ExecutionContext, model
-
-@model(
-    'MODEL_NAME',
-    columns={
-        "id": "int",
-        "name": "varchar"
-    }
-)
-def execute(
-    context: ExecutionContext,
-    **kwargs: t.Any,
-) -> DataFrame:
-    return context.snowpark.create_dataframe([["foo", 1]], schema=["name", "id"])
-""".replace("MODEL_NAME", model_name.sql(dialect="snowflake"))
-    )
-
-    sqlmesh_ctx = ctx.create_context(path=tmp_path)
-
-    assert len(sqlmesh_ctx.models) == 1
-
-    plan = sqlmesh_ctx.plan(auto_apply=True)
-    assert len(plan.new_snapshots) == 1
-
-    engine_adapter = sqlmesh_ctx.engine_adapter
-
-    query = exp.select("*").from_(plan.environment.snapshots[0].fully_qualified_table)
-    df = engine_adapter.fetchdf(query, quote_identifiers=True)
-    assert len(df) == 1
-    assert df.iloc[0].to_dict() == {"id": 1, "name": "foo"}

--- a/tests/core/engine_adapter/test_trino.py
+++ b/tests/core/engine_adapter/test_trino.py
@@ -49,8 +49,6 @@ def test_set_current_catalog(trino_mocked_engine_adapter: TrinoEngineAdapter):
     ]
 
 
-@pytest.mark.trino_iceberg
-@pytest.mark.trino_delta
 @pytest.mark.parametrize("storage_type", ["iceberg", "delta"])
 def test_get_catalog_type(
     trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: MockerFixture, storage_type: str
@@ -104,7 +102,6 @@ def test_get_catalog_type_cached(
     assert fetchone_mock.call_count == 2
 
 
-@pytest.mark.trino_delta
 @pytest.mark.parametrize("storage_type", ["hive", "delta"])
 def test_partitioned_by_hive_delta(
     trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: MockerFixture, storage_type: str
@@ -132,7 +129,6 @@ def test_partitioned_by_hive_delta(
     ]
 
 
-@pytest.mark.trino_iceberg
 def test_partitioned_by_iceberg(
     trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: MockerFixture
 ):
@@ -159,7 +155,6 @@ def test_partitioned_by_iceberg(
     ]
 
 
-@pytest.mark.trino_iceberg
 def test_partitioned_by_iceberg_transforms(
     trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: MockerFixture
 ):
@@ -203,7 +198,6 @@ def test_partitioned_by_iceberg_transforms(
     ]
 
 
-@pytest.mark.trino_iceberg
 def test_partitioned_by_with_multiple_catalogs_same_server(
     trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: MockerFixture
 ):
@@ -319,8 +313,6 @@ def test_comments_hive(mocker: MockerFixture, make_mocked_engine_adapter: t.Call
     ]
 
 
-@pytest.mark.trino_iceberg
-@pytest.mark.trino_delta
 @pytest.mark.parametrize("storage_type", ["iceberg", "delta"])
 def test_comments_iceberg_delta(
     mocker: MockerFixture, make_mocked_engine_adapter: t.Callable, storage_type: str
@@ -387,7 +379,6 @@ def test_comments_iceberg_delta(
     ]
 
 
-@pytest.mark.trino_delta
 def test_delta_timestamps(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(TrinoEngineAdapter)
 

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -1975,6 +1975,8 @@ def test_custom_materialization(init_and_plan_context: t.Callable):
 # needs to be defined at the top level. If its defined within the test body,
 # adding to the snapshot cache fails with: AttributeError: Can't pickle local object
 class TestCustomKind(CustomKind):
+    __test__ = False  # prevent pytest warning since this isnt a class containing tests
+
     @property
     def custom_property(self) -> str:
         return validate_string(self.materialization_properties.get("custom_property"))

--- a/tests/core/test_rule.py
+++ b/tests/core/test_rule.py
@@ -12,6 +12,8 @@ from sqlmesh.core.linter.rule import Rule, RuleViolation
 class TestRule(Rule):
     """A test rule for testing the get_definition_location method."""
 
+    __test__ = False  # prevent pytest warning since this isnt a class containing tests
+
     def check_model(self, model: Model) -> t.Optional[RuleViolation]:
         """The evaluation function that'll check for a violation of this rule."""
         return None


### PR DESCRIPTION
In implementing #4348 I noticed a gap in our engine adapter integration tests.

Currently:
 - For each engine adapter integration test, we parameterize it by engine (so it gets called at least once per engine)
 - Many engine adapter methods take a `QueryOrDF`, that is - a SQL Query or some kind of DataFrame. So we also parameterize each test by `query` and `df`
 - However, `df` really only refers to a Pandas DataFrame. At the time the tests were originally written, there was only one other DataFrame implementation - `pyspark`.
 - So we also parameterize each test by `pyspark` as well even though this is only relevant for two engines - Spark and Databricks
 - The net result is, we have parameterized each test 3 times _per engine adapter_ - once for `query`, `df` and `pyspark`. In many cases this isnt needed, which leads to test logic that looks like:
    ```
    if ctx.test_type != "query":
         pytest.skip("Test only needs to run for query")
    ```
 - So we generate a lot of tests that just exist to get skipped, while also forgetting about the other native DataFrame types: `bigframe` (BigQuery) and `snowpark` (Snowflake) which currently have zero test coverage
 - But if we add these to the existing `test_type` fixture to make it parametrized over (`query`, `df`, `pyspark`, `bigframe`, `snowpark`) then we would get 5 versions of each test _per engine adapter_ - just to skip most of them because `bigframe` is only relevant for BigQuery and `snowpark` is only relevant for Snowflake

So I decided to do some refactoring.

This PR changes things to:
 - Refactor how the engines themselves are defined to prevent duplication
   - For example, rather than defining `trino` 4 times, once per supported catalog - we define it once and generate a definition per supported catalog
   - If an engine has a native DataFrame type, it gets recorded on the engine definition so we only generate a test parameter for that engine rather than for every engine
 - This allowed the creation of 3 `TestContext` fixtures for a test to use depending on what it needs.
   - If a test only cares about SQL queries, it can depend on the `ctx` fixture which will only invoke the test once per engine adapter
   - If a test only cares about DataFrame's, it can depend on the `ctx_df` fixture which will invoke the test once for each DataFrame implementation supported by that engine
   - If a test cares about both SQL Queries and DataFrame's, it can depend on the `ctx_query_and_df` fixture which will call the test the correct amount of times for each engine - once for `query` and once for each DataFrame implementation supported by that engine

This has allowed the removal of the logic that was skipping tests based on `test_type` while also calling our parametrized tests for the native DataFrame implementations which were previously being skipped.

This uncovered a bunch of bugs / inconsistencies in how we were handling native DataFrame's which I have also fixed in this PR