### PR TITLE
chore(vscode): make auth status output match

### DIFF
--- a/vscode/extension/src/auth/auth.ts
+++ b/vscode/extension/src/auth/auth.ts
@@ -28,10 +28,16 @@ const tokenSchema = z.object({
   email: z.string(),
 })
 
-const statusResponseSchema = z.object({
-  is_logged_in: z.boolean(),
-  id_token: tokenSchema.optional().nullable(),
-})
+const statusResponseSchema = z.discriminatedUnion('is_logged_in', [
+  z.object({
+    is_logged_in: z.literal(true),
+    id_token: tokenSchema,
+  }),
+  z.object({
+    is_logged_in: z.literal(false),
+    id_token: z.object({}),
+  }),
+])
 
 type StatusResponse = z.infer<typeof statusResponseSchema>
 


### PR DESCRIPTION
The output from tcloud is 

{ "is_logged_in": true, "id_token": { ... } }
 { "is_logged_in": false, "id_token": {} }

and so this makes the zod definition match that. 
