### PR TITLE
Fix: Recreate views even if the change was categorized as indirect non-breaking to update table references

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -902,7 +902,7 @@ class SnapshotEvaluator:
         if (
             not snapshot.is_paused
             or not snapshot.is_model
-            or deployability_index.is_representative(snapshot)
+            or (deployability_index.is_representative(snapshot) and not snapshot.is_view)
         ):
             return
 


### PR DESCRIPTION
If I have model A and a downstream view model B, and I make a `Non-Breaking` change to A, then B is categorized as `Indirect Non-Breaking`. In this case, A gets a new physical table assigned to it, while B continues using the previous physical table by design.

This is generally an acceptable strategy when the physical tables represent materialized tables, but it presents a problem if B's physical table represents a view - in that case, the model query itself is part of the physical table definition and needs to be updated.

If not updated, the view will continue referencing the old physical table of A. This means that when querying B, the user will either get outdated data or encounter a query failure if the old snapshot is deleted by the janitor.

This update ensures that views are always recreated for `Indirect Non-Breaking` snapshots when they are deployed to production.