### PR TITLE
ci: testing in windows

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -11,6 +11,9 @@ parameters:
     type: boolean
     default: false
 
+orbs:
+  windows: circleci/windows@5.0
+
 commands:
   halt_unless_core:
     steps:
@@ -93,6 +96,38 @@ jobs:
       - run:
           name: Run cicd tests
           command: make cicd-test
+      - store_test_results:
+          path: test-results
+
+  style_and_cicd_tests_windows:
+    executor:
+      name: windows/default
+      size: large
+    environment:
+      PYTEST_XDIST_AUTO_NUM_WORKERS: 4
+    steps:
+      - halt_unless_core
+      - checkout
+      - run:
+          name: Install Python 3.9
+          command: |
+            choco install python --version=3.9 -y
+            refreshenv
+      - run: 
+          name: Install make
+          command: choco install make -y
+      - run:
+          name: Install SQLMesh dev dependencies
+          command: make install-dev
+      - run:
+          name: Fix Git URL override
+          command: git config --global --unset url."ssh://git@github.com".insteadOf
+      # - run:
+      #     name: Run linters and code style checks
+      #     command: make py-style
+      - run:
+          name: Run cicd tests
+          command: pytest -n auto -m "fast" --junitxml=test-results/junit-cicd.xml tests/lsp
       - store_test_results:
           path: test-results
 
@@ -269,6 +304,7 @@ workflows:
                 - "3.10"
                 - "3.11"
                 - "3.12"
+      - style_and_cicd_tests_windows
       - engine_tests_docker:
           name: engine_<< matrix.engine >>
           matrix:


### PR DESCRIPTION
This introduces basic testing over `tests/lsp`, it is a start of working tests on Windows. It's not yet checking mypy and all the other tests but it's a start and proves:

1. That sushi loads successfully on Windows
2. That the LSP features especially those around path issues work correctly.

Future improvements should include:

- running mypy
- running full test suite

