### PR TITLE
Chore: Improve error messages returned by pydantic

### DIFF
--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -20,7 +20,7 @@ from sqlmesh.utils.metaprogramming import (
     prepare_env,
     serialize_env,
 )
-from sqlmesh.utils.pydantic import ValidationInfo, field_validator
+from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator
 
 if t.TYPE_CHECKING:
     from sqlglot.dialects.dialect import DialectType
@@ -258,6 +258,22 @@ def parse_dependencies(
                 )
 
     return depends_on, used_variables
+
+
+def validate_extra_and_required_fields(
+    klass: t.Type[PydanticModel],
+    provided_fields: t.Set[str],
+    entity_name: str,
+) -> None:
+    missing_required_fields = klass.missing_required_fields(provided_fields)
+    if missing_required_fields:
+        raise_config_error(
+            f"Missing required fields {missing_required_fields} in the {entity_name}"
+        )
+
+    extra_fields = klass.extra_fields(provided_fields)
+    if extra_fields:
+        raise_config_error(f"Invalid extra fields {extra_fields} in the {entity_name}")
 
 
 def single_value_or_tuple(values: t.Sequence) -> exp.Identifier | exp.Tuple:

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -12,7 +12,11 @@ from sqlglot.optimizer.simplify import gen
 from sqlglot.time import format_time
 
 from sqlmesh.core import dialect as d
-from sqlmesh.core.model.common import parse_properties, properties_validator
+from sqlmesh.core.model.common import (
+    parse_properties,
+    properties_validator,
+    validate_extra_and_required_fields,
+)
 from sqlmesh.core.model.seed import CsvSettings
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.pydantic import (
@@ -1011,6 +1015,7 @@ def create_model_kind(v: t.Any, dialect: str, defaults: t.Dict[str, t.Any]) -> M
                 actual_kind_type, _ = custom_materialization
                 return actual_kind_type(**props)
 
+        validate_extra_and_required_fields(kind_type, set(props), f"model kind '{name}'")
         return kind_type(**props)
 
     name = (v.name if isinstance(v, exp.Expression) else str(v)).upper()

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -355,7 +355,7 @@ class ModelMeta(_Node):
                 and not (kind.is_view and kind.materialized)
             ):
                 name = field[:-1] if field.endswith("_") else field
-                raise ValueError(f"{name} field cannot be set for {kind} models")
+                raise ValueError(f"{name} field cannot be set for {kind.name} models")
         if kind.is_incremental_by_partition and not getattr(self, "partitioned_by_", None):
             raise ValueError(f"partitioned_by field is required for {kind.name} models")
 

--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -211,6 +211,20 @@ def positive_int_validator(v: t.Any) -> int:
     return v
 
 
+def validation_error_message(error: pydantic.ValidationError, base: str) -> str:
+    errors = "\n  ".join(_formatted_validation_errors(error))
+    return f"{base}\n  {errors}"
+
+
+def _formatted_validation_errors(error: pydantic.ValidationError) -> t.List[str]:
+    result = []
+    for e in error.errors():
+        msg = e["msg"]
+        loc: t.Optional[t.Tuple] = e.get("loc")
+        result.append(f"Invalid field '{loc[0]}':\n    {msg}" if loc else msg)
+    return result
+
+
 def _get_field(
     v: t.Any,
     values: t.Any,
@@ -280,6 +294,9 @@ def cron_validator(v: t.Any) -> str:
         v = v.name
 
     from croniter import CroniterBadCronError, croniter
+
+    if not isinstance(v, str):
+        raise ValueError(f"Invalid cron expression '{v}'. Value must be a string.")
 
     try:
         croniter(v)

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -973,13 +973,13 @@ def test_databricks(make_config):
     assert oauth_u2m_config.oauth_client_secret is None
 
     # auth_type must match the AuthType enum if specified
-    with pytest.raises(ValueError, match=r".*nonexist does not match a valid option.*"):
+    with pytest.raises(ConfigError, match=r".*nonexist does not match a valid option.*"):
         make_config(
             type="databricks", server_hostname="dbc-test.cloud.databricks.com", auth_type="nonexist"
         )
 
     # if client_secret is specified, client_id must also be specified
-    with pytest.raises(ValueError, match=r"`oauth_client_id` is required.*"):
+    with pytest.raises(ConfigError, match=r"`oauth_client_id` is required.*"):
         make_config(
             type="databricks",
             server_hostname="dbc-test.cloud.databricks.com",
@@ -988,7 +988,7 @@ def test_databricks(make_config):
         )
 
     # http_path is still required when auth_type is specified
-    with pytest.raises(ValueError, match=r"`http_path` is still required.*"):
+    with pytest.raises(ConfigError, match=r"`http_path` is still required.*"):
         make_config(
             type="databricks",
             server_hostname="dbc-test.cloud.databricks.com",

--- a/tests/core/test_loader.py
+++ b/tests/core/test_loader.py
@@ -159,7 +159,7 @@ def execute(
 
     with pytest.raises(
         ConfigError,
-        match=r"Failed to load model definition at '.*'.\nDuplicate name: 'test_schema.test_model'.",
+        match=r"Failed to load model definition at '.*'.\n  Duplicate name: 'test_schema.test_model'.",
     ):
         Context(paths=tmp_path, config=config)
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -17,7 +17,7 @@ from sqlmesh.core.environment import EnvironmentNamingInfo
 from sqlmesh.core.model.kind import TimeColumn, ModelKindName
 
 from sqlmesh import CustomMaterialization, CustomKind
-from pydantic import model_validator
+from pydantic import model_validator, ValidationError
 from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
 from sqlmesh.core.console import get_console
@@ -1065,7 +1065,7 @@ def test_seed_model_creation_error():
         );
     """
     )
-    with pytest.raises(ConfigError, match="No such file or directory"):
+    with pytest.raises(FileNotFoundError, match="No such file or directory"):
         load_sql_based_model(expressions)
 
 
@@ -4512,7 +4512,7 @@ def test_view_non_materialized_partition_by():
         SELECT 1;
         """
     )
-    with pytest.raises(ConfigError, match=r".*partitioned_by field cannot be set for ViewKind.*"):
+    with pytest.raises(ValidationError, match=r".*partitioned_by field cannot be set for VIEW.*"):
         load_sql_based_model(view_model_expressions)
 
 
@@ -4527,7 +4527,7 @@ def test_view_non_materialized_clustered_by():
         SELECT 1;
         """
     )
-    with pytest.raises(ConfigError, match=r".*clustered_by field cannot be set for ViewKind.*"):
+    with pytest.raises(ValidationError, match=r".*clustered_by field cannot be set for VIEW.*"):
         load_sql_based_model(view_model_expressions)
 
 
@@ -5578,7 +5578,7 @@ def test_end_date():
     assert model.end == "2023-06-01"
     assert model.interval_unit == IntervalUnit.DAY
 
-    with pytest.raises(ConfigError, match=".*Start date.+can't be greater than end date.*"):
+    with pytest.raises(ValidationError, match=".*Start date.+can't be greater than end date.*"):
         load_sql_based_model(
             d.parse(
                 """
@@ -6829,7 +6829,7 @@ def test_incremental_by_partition(sushi_context, assert_exp_eq):
     assert not model.kind.disable_restatement
 
     with pytest.raises(
-        ConfigError,
+        ValidationError,
         match=r".*partitioned_by field is required for INCREMENTAL_BY_PARTITION models.*",
     ):
         expressions = d.parse(

--- a/tests/integrations/github/cicd/test_config.py
+++ b/tests/integrations/github/cicd/test_config.py
@@ -8,6 +8,7 @@ from sqlmesh.core.config import (
     Config,
     load_config_from_paths,
 )
+from sqlmesh.utils.errors import ConfigError
 from sqlmesh.integrations.github.cicd.config import MergeMethod
 from tests.utils.test_filesystem import create_temp_file
 
@@ -181,7 +182,7 @@ model_defaults:
 """,
     )
     with pytest.raises(
-        ValueError, match="enable_deploy_command must be set if command_namespace is set"
+        ConfigError, match=r".*enable_deploy_command must be set if command_namespace is set.*"
     ):
         load_config_from_paths(Config, project_paths=[tmp_path / "config.yaml"])
 
@@ -197,7 +198,7 @@ model_defaults:
 """,
     )
     with pytest.raises(
-        ValueError, match="merge_method must be set if enable_deploy_command is True"
+        ConfigError, match=r".*merge_method must be set if enable_deploy_command is True.*"
     ):
         load_config_from_paths(Config, project_paths=[tmp_path / "config.yaml"])
 
@@ -226,8 +227,8 @@ model_defaults:
 """,
     )
     with pytest.raises(
-        ValueError,
-        match="TTL '1 week' is in the past. Please specify a relative time in the future. Ex: `in 1 week` instead of `1 week`.",
+        ConfigError,
+        match=r".*TTL '1 week' is in the past. Please specify a relative time in the future. Ex: `in 1 week` instead of `1 week`.*",
     ):
         load_config_from_paths(Config, project_paths=[tmp_path / "config.yaml"])
 


### PR DESCRIPTION
This update improves the project validation error messages and changes them from the default pydantic format that looks like:
```
Error: Failed to load model definition at '/Users/izeigerman/github/sqlmesh/examples/tmp/models/incremental_model.sql'.
1 validation error for SqlModel
cron
  Value error, Invalid cron expression '123' [type=value_error, input_value=Literal(this=123, is_string=False), input_type=Literal]
    For further information visit https://errors.pydantic.dev/2.11/v/value_error at '/Users/izeigerman/github/sqlmesh/examples/tmp/models/incremental_model.sql'
```

To something more digestible. Below is a few examples:
```
Error: Invalid 'duckdb' connection config:
  Invalid field 'database':
    Input should be a valid string

Verify your config.yaml and environment variables.
```

```
Error: Invalid project config:
  Invalid field 'invalid':
    Extra inputs are not permitted
    
Verify your config.yaml and environment variables.
```

```
Error: Failed to load model definition at '/Users/izeigerman/github/sqlmesh/examples/tmp/models/incremental_model.sql':
  Invalid extra fields {'invalid'} in the model kind 'INCREMENTAL_BY_TIME_RANGE'
```

```
Error: Failed to load model definition at '/Users/izeigerman/github/sqlmesh/examples/tmp/models/incremental_model.sql':
  Invalid field 'cron':
    Value error, Invalid cron expression '123'
```    