### PR TITLE
Fix(snowflake): Allow models that utilize Snowpark to execute concurrently

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -328,15 +328,15 @@ workflows:
             parameters:
               engine:
                 - snowflake
-                - databricks
-                - redshift
-                - bigquery
-                - clickhouse-cloud
-                - athena
-          filters:
-            branches:
-              only:
-                - main
+                #- databricks
+                #- redshift
+                #- bigquery
+                #- clickhouse-cloud
+                #- athena
+          #filters:
+          #  branches:
+          #    only:
+          #      - main
       - trigger_private_tests:
           requires:
             - style_and_cicd_tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -328,15 +328,15 @@ workflows:
             parameters:
               engine:
                 - snowflake
-                #- databricks
-                #- redshift
-                #- bigquery
-                #- clickhouse-cloud
-                #- athena
-          #filters:
-          #  branches:
-          #    only:
-          #      - main
+                - databricks
+                - redshift
+                - bigquery
+                - clickhouse-cloud
+                - athena
+          filters:
+            branches:
+              only:
+                - main
       - trigger_private_tests:
           requires:
             - style_and_cicd_tests

--- a/tests/core/engine_adapter/integration/__init__.py
+++ b/tests/core/engine_adapter/integration/__init__.py
@@ -707,9 +707,7 @@ class TestContext:
                 schema_name=schema_name, ignore_if_not_exists=True, cascade=True
             )
 
-        if snowpark := self.engine_adapter.snowpark:
-            # ensure that the next test gets a fresh Snowpark session
-            snowpark.close()
+        self.engine_adapter.close()
 
     def upsert_sql_model(self, model_definition: str) -> t.Tuple[Context, SqlModel]:
         if not self._context:


### PR DESCRIPTION
Addresses #4397 

Prior to this PR, a Snowpark session would get shared across threads.

This lead to strange errors like `Object does not exist or not authorized` as threads would all try to start a transaction, upload a DataFrame and return a pointer to a table which eventually lead to an error as they clobbered each others state.

This PR makes each Snowpark session thread-local and adds a test to ensure concurrent execution works