### PR TITLE
Feat: Introduce runtime check for identifier limits per engine

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -2140,7 +2140,7 @@ class EngineAdapter:
         with self.transaction():
             for e in ensure_list(expressions):
                 if isinstance(e, exp.Expression):
-                    self._check_identifier_length(e, check_only_ddl=True)
+                    self._check_identifier_length(e)
                     sql = self._to_sql(e, quote=quote_identifiers, **to_sql_kwargs)
                 else:
                     sql = t.cast(str, e)
@@ -2515,12 +2515,8 @@ class EngineAdapter:
     def _select_columns(cls, columns: t.Iterable[str]) -> exp.Select:
         return exp.select(*(exp.column(c, quoted=True) for c in columns))
 
-    def _check_identifier_length(
-        self, expression: exp.Expression, check_only_ddl: bool = True
-    ) -> None:
-        if self.MAX_IDENTIFIER_LENGTH is None or (
-            check_only_ddl and not isinstance(expression, exp.DDL)
-        ):
+    def _check_identifier_length(self, expression: exp.Expression) -> None:
+        if self.MAX_IDENTIFIER_LENGTH is None or not isinstance(expression, exp.DDL):
             return
 
         for identifier in expression.find_all(exp.Identifier):
@@ -2528,7 +2524,7 @@ class EngineAdapter:
             name_length = len(name)
             if name_length > self.MAX_IDENTIFIER_LENGTH:
                 raise SQLMeshError(
-                    f"Identifier name {name} (length {name_length}) exceeds {self.dialect.capitalize()}'s max identifier limit of {self.MAX_IDENTIFIER_LENGTH} characters"
+                    f"Identifier name '{name}' (length {name_length}) exceeds {self.dialect.capitalize()}'s max identifier limit of {self.MAX_IDENTIFIER_LENGTH} characters"
                 )
 
 

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -106,6 +106,7 @@ class EngineAdapter:
     SUPPORTS_REPLACE_TABLE = True
     DEFAULT_CATALOG_TYPE = DIALECT
     QUOTE_IDENTIFIERS_IN_VIEWS = True
+    MAX_IDENTIFIER_LENGTH: t.Optional[int] = None
 
     def __init__(
         self,
@@ -2138,14 +2139,12 @@ class EngineAdapter:
         )
         with self.transaction():
             for e in ensure_list(expressions):
-                sql = t.cast(
-                    str,
-                    (
-                        self._to_sql(e, quote=quote_identifiers, **to_sql_kwargs)
-                        if isinstance(e, exp.Expression)
-                        else e
-                    ),
-                )
+                if isinstance(e, exp.Expression):
+                    self._check_identifier_length(e, check_only_ddl=True)
+                    sql = self._to_sql(e, quote=quote_identifiers, **to_sql_kwargs)
+                else:
+                    sql = t.cast(str, e)
+
                 self._log_sql(
                     sql,
                     expression=e if isinstance(e, exp.Expression) else None,
@@ -2515,6 +2514,22 @@ class EngineAdapter:
     @classmethod
     def _select_columns(cls, columns: t.Iterable[str]) -> exp.Select:
         return exp.select(*(exp.column(c, quoted=True) for c in columns))
+
+    def _check_identifier_length(
+        self, expression: exp.Expression, check_only_ddl: bool = True
+    ) -> None:
+        if self.MAX_IDENTIFIER_LENGTH is None or (
+            check_only_ddl and not isinstance(expression, exp.DDL)
+        ):
+            return
+
+        for identifier in expression.find_all(exp.Identifier):
+            name = identifier.name
+            name_length = len(name)
+            if name_length > self.MAX_IDENTIFIER_LENGTH:
+                raise SQLMeshError(
+                    f"Identifier name {name} (length {name_length}) exceeds {self.dialect.capitalize()}'s max identifier limit of {self.MAX_IDENTIFIER_LENGTH} characters"
+                )
 
 
 class EngineAdapterWithIndexSupport(EngineAdapter):

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -39,6 +39,7 @@ class MySQLEngineAdapter(
     MAX_TABLE_COMMENT_LENGTH = 2048
     MAX_COLUMN_COMMENT_LENGTH = 1024
     SUPPORTS_REPLACE_TABLE = False
+    MAX_IDENTIFIER_LENGTH = 64
     SCHEMA_DIFFER = SchemaDiffer(
         parameterized_type_defaults={
             exp.DataType.build("BIT", dialect=DIALECT).this: [(1,)],

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -34,6 +34,7 @@ class PostgresEngineAdapter(
     HAS_VIEW_BINDING = True
     CURRENT_CATALOG_EXPRESSION = exp.column("current_catalog")
     SUPPORTS_REPLACE_TABLE = False
+    MAX_IDENTIFIER_LENGTH = 63
     SCHEMA_DIFFER = SchemaDiffer(
         parameterized_type_defaults={
             # DECIMAL without precision is "up to 131072 digits before the decimal point; up to 16383 digits after the decimal point"

--- a/sqlmesh/core/engine_adapter/risingwave.py
+++ b/sqlmesh/core/engine_adapter/risingwave.py
@@ -30,6 +30,7 @@ class RisingwaveEngineAdapter(PostgresEngineAdapter):
     COMMENT_CREATION_VIEW = CommentCreationView.UNSUPPORTED
     SUPPORTS_MATERIALIZED_VIEWS = True
     SUPPORTS_TRANSACTIONS = False
+    MAX_IDENTIFIER_LENGTH = None
 
     def _truncate_table(self, table_name: TableName) -> None:
         return self.execute(exp.Delete(this=exp.to_table(table_name)))

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import re
 import sys
 import typing as t
 import shutil
@@ -1571,7 +1572,6 @@ def test_init_project(ctx: TestContext, tmp_path_factory: pytest.TempPathFactory
 
     # normalize object names for snowflake
     if ctx.dialect == "snowflake":
-        import re
 
         def _normalize_snowflake(name: str, prefix_regex: str = "(sqlmesh__)(.*)"):
             match = re.search(prefix_regex, name)
@@ -1789,7 +1789,6 @@ def test_to_time_column(
         # Clickhouse does not have natively timezone-aware types and does not accept timestrings
         #   with UTC offset "+XX:XX". Therefore, we remove the timezone offset and set a timezone-
         #   specific data type to validate what is returned.
-        import re
 
         time_column = re.match(r"^(.*?)\+", time_column).group(1)
         time_column_type = exp.DataType.build("TIMESTAMP('UTC')", dialect="clickhouse")
@@ -2661,8 +2660,9 @@ def test_identifier_length_limit(ctx: TestContext):
 
     long_table_name = "a" * (adapter.MAX_IDENTIFIER_LENGTH + 1)
 
+    match = f"Identifier name '{long_table_name}' (length {len(long_table_name)}) exceeds {adapter.dialect.capitalize()}'s max identifier limit of {adapter.MAX_IDENTIFIER_LENGTH} characters"
     with pytest.raises(
         SQLMeshError,
-        match=f"Identifier name {long_table_name} (length {len(long_table_name)}) exceeds {adapter.dialect.capitalize()}'s max identifier limit of {adapter.MAX_IDENTIFIER_LENGTH} characters",
+        match=re.escape(match),
     ):
         adapter.create_table(long_table_name, {"col": exp.DataType.build("int")})


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/4082

This PR introduces an identifier limit check right before SQL execution in the engine adapter and enables this check for Postgres & MySQL; These 2 dialects are the only ones with <100 char limits afaict, but we can always go ahead and fill in the rest of the engines too.

In my opinion, the main consideration of this PR is to not cause this issue on our end which should mostly happen during physical table creation; This is the reason that we'll walk the AST only if (1) the engine adapter has set its limit and (2) if the expression is a DDL. 

We can also enable this check for _any_ query expression but we'll introduce a perf hit; This might help unsuspecting users catch some nasty bugs in _their_ SQL, but I wasn't sure if it's worth the added regression on **every** expression-based `execute` call.

The reason `MAX_IDENTIFIER_LENGTH` is generally set to `None` is because other dialects either don't make it clear what their limits are (e.g DuckDB) or allow for much larger table names (e.g [BigQuery](https://cloud.google.com/bigquery/docs/tables#table_naming) with 1024 chars).


Docs
----------
[Postgres](https://www.postgresql.org/docs/current/limits.html) | [MySQL](https://dev.mysql.com/doc/refman/8.0/en/identifier-length.html)
