### PR TITLE
Fix: Improve error message for missing engine imports

### DIFF
--- a/tests/core/engine_adapter/integration/config.yaml
+++ b/tests/core/engine_adapter/integration/config.yaml
@@ -17,6 +17,7 @@ gateways:
       catalog: datalake
       http_scheme: http
       retries: 20
+      check_import: false
     state_connection:
       type: duckdb
   inttest_trino_iceberg:
@@ -28,6 +29,7 @@ gateways:
       catalog: datalake_iceberg
       http_scheme: http
       retries: 20
+      check_import: false
     state_connection:
       type: duckdb
   inttest_trino_delta:
@@ -39,6 +41,7 @@ gateways:
       catalog: datalake_delta
       http_scheme: http
       retries: 20
+      check_import: false
     state_connection:
       type: duckdb
   inttest_trino_nessie:
@@ -50,6 +53,7 @@ gateways:
       catalog: datalake_nessie
       http_scheme: http
       retries: 20
+      check_import: false
     state_connection:
       type: duckdb
   inttest_spark:
@@ -57,6 +61,7 @@ gateways:
       type: spark
       config:
         spark.remote: sc://{{ env_var('DOCKER_HOSTNAME', 'localhost') }}
+      check_import: false
     state_connection:
       type: duckdb
   inttest_mssql:
@@ -65,6 +70,7 @@ gateways:
       host: {{ env_var('DOCKER_HOSTNAME', 'localhost') }}
       user: sa
       password: 1StrongPwd@@
+      check_import: false
   inttest_postgres:
     connection:
       type: postgres
@@ -73,6 +79,7 @@ gateways:
       database: postgres
       host: {{ env_var('DOCKER_HOSTNAME', 'localhost') }}
       port: 5432
+      check_import: false
   inttest_mysql:
     connection:
       type: mysql
@@ -81,6 +88,7 @@ gateways:
       password: mysql
       port: 3306
       charset: utf8
+      check_import: false
   inttest_clickhouse_standalone:
     connection:
       type: clickhouse
@@ -88,6 +96,7 @@ gateways:
       port: 8123
       username: clickhouse
       password: clickhouse
+      check_import: false
     state_connection:
       type: duckdb
   inttest_clickhouse_cluster:
@@ -98,6 +107,7 @@ gateways:
       username: clickhouse
       password: clickhouse
       cluster: cluster1
+      check_import: false
     state_connection:
       type: duckdb
   inttest_risingwave:
@@ -107,6 +117,7 @@ gateways:
       database: dev
       host: {{ env_var('DOCKER_HOSTNAME', 'localhost') }}
       port: 4566
+      check_import: false
 
 
   # Cloud databases
@@ -118,6 +129,7 @@ gateways:
       database: {{ env_var('SNOWFLAKE_DATABASE') }}
       user: {{ env_var('SNOWFLAKE_USER') }}
       password: {{ env_var('SNOWFLAKE_PASSWORD') }}
+      check_import: false
     state_connection:
       type: duckdb
 
@@ -128,6 +140,7 @@ gateways:
       server_hostname: {{ env_var('DATABRICKS_SERVER_HOSTNAME') }}
       http_path: {{ env_var('DATABRICKS_HTTP_PATH') }}
       access_token: {{ env_var('DATABRICKS_ACCESS_TOKEN') }}
+      check_import: false
 
   inttest_redshift:
     connection:
@@ -136,12 +149,14 @@ gateways:
       user: {{ env_var('REDSHIFT_USER') }}
       password: {{ env_var('REDSHIFT_PASSWORD') }}
       database: {{ env_var('REDSHIFT_DATABASE') }}
+      check_import: false
 
   inttest_bigquery:
     connection:
       type: bigquery
       method: service-account
       keyfile: {{ env_var('BIGQUERY_KEYFILE') }}
+      check_import: false
     state_connection:
       type: duckdb
 
@@ -155,6 +170,7 @@ gateways:
       connect_timeout: 30
       connection_pool_options:
         retries: 5
+      check_import: false
     state_connection:
       type: duckdb
 
@@ -166,6 +182,7 @@ gateways:
       region_name: {{ env_var("AWS_REGION") }}
       work_group: {{ env_var("ATHENA_WORK_GROUP", "primary") }}
       s3_warehouse_location: {{ env_var("ATHENA_S3_WAREHOUSE_LOCATION", "") }}
+      check_import: false
     state_connection:
       type: duckdb
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -343,6 +343,7 @@ model_defaults:
         os.environ,
         {
             "SQLMESH__GATEWAYS__TESTING__STATE_CONNECTION__TYPE": "bigquery",
+            "SQLMESH__GATEWAYS__TESTING__STATE_CONNECTION__CHECK_IMPORT": "false",
             "SQLMESH__DEFAULT_GATEWAY": "testing",
         },
     ):
@@ -353,7 +354,7 @@ model_defaults:
             gateways={
                 "testing": GatewayConfig(
                     connection=MotherDuckConnectionConfig(database="blah"),
-                    state_connection=BigQueryConnectionConfig(),
+                    state_connection=BigQueryConnectionConfig(check_import=False),
                 ),
             },
             model_defaults=ModelDefaultsConfig(dialect="bigquery"),
@@ -373,6 +374,7 @@ config = Config(gateways={"duckdb_gateway": GatewayConfig(connection=DuckDBConne
         os.environ,
         {
             "SQLMESH__GATEWAYS__DUCKDB_GATEWAY__STATE_CONNECTION__TYPE": "bigquery",
+            "SQLMESH__GATEWAYS__DUCKDB_GATEWAY__STATE_CONNECTION__CHECK_IMPORT": "false",
             "SQLMESH__DEFAULT_GATEWAY": "duckdb_gateway",
         },
     ):
@@ -384,7 +386,7 @@ config = Config(gateways={"duckdb_gateway": GatewayConfig(connection=DuckDBConne
             gateways={  # type: ignore
                 "duckdb_gateway": GatewayConfig(
                     connection=DuckDBConnectionConfig(),
-                    state_connection=BigQueryConnectionConfig(),
+                    state_connection=BigQueryConnectionConfig(check_import=False),
                 ),
             },
             model_defaults=ModelDefaultsConfig(dialect=""),
@@ -823,6 +825,7 @@ def test_gcp_postgres_ip_and_scopes(tmp_path):
       gcp_postgres:
         connection:
           type: gcp_postgres
+          check_import: false
           instance_connection_string: something
           user: user
           password: password


### PR DESCRIPTION
Example of the new error message that will be printed if the required engine import is not found:
```
Failed to import the 'bigquery' engine library. Please run `pip install "sqlmesh[bigquery]"`.
```