### PR TITLE
Feat(table_diff): Add flag to warn when models lack grain and diff the remaining

### DIFF
--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -169,7 +169,10 @@ sqlmesh table_diff prod:dev -m "tag:finance" -m "metrics.*_daily"
 
 When multiple selectors are provided, they are combined with OR logic, meaning a model matching any of the selectors will be included.
 
-> Note: All models being compared must have their `grain` defined that is unique and not null, as this is used to perform the join between the tables in the two environments.
+!!! note
+    All models being compared must have their `grain` defined that is unique and not null, as this is used to perform the join between the tables in the two environments.
+
+    If the `--warn-grain-check` option is used, this requirement is not enforced. Instead of raising an error, a warning is displayed for the models without a defined grain and diffs are computed for the remaining models.
 
 ## Diffing tables or views
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -557,6 +557,8 @@ Options:
                            floating point columns. Default: 3
   --skip-grain-check       Disable the check for a primary key (grain) that is
                            missing or is not unique.
+  --warn-grain-check       Warn if any selected model is missing a grain,
+                           and compute diffs for the remaining models.
   --temp-schema TEXT       Schema used for temporary tables. It can be
                            `CATALOG.SCHEMA` or `SCHEMA`. Default:
                            `sqlmesh_temp`

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -300,8 +300,8 @@ Create a schema file containing external model schemas.
 %table_diff [--on [ON ...]] [--skip-columns [SKIP_COLUMNS ...]]
                 [--model MODEL] [--where WHERE] [--limit LIMIT]
                 [--show-sample] [--decimals DECIMALS] [--skip-grain-check]
-                [--temp-schema SCHEMA] [--select-model [SELECT_MODEL ...]]
-                SOURCE:TARGET
+                [--warn-grain-check] [--temp-schema SCHEMA]
+                [--select-model [SELECT_MODEL ...]] SOURCE:TARGET
 
 Show the diff between two tables.
 
@@ -326,6 +326,8 @@ options:
                         floating point columns. Default: 3
   --skip-grain-check    Disable the check for a primary key (grain) that is
                         missing or is not unique.
+  --warn-grain-check    Warn if any selected model is missing a grain,
+                        and compute diffs for the remaining models.
   --temp-schema SCHEMA  The schema to use for temporary tables.
   --select-model <[SELECT_MODEL ...]>
                         Select specific models to diff using a pattern.

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -907,6 +907,11 @@ def create_external_models(obj: Context, **kwargs: t.Any) -> None:
     help="Disable the check for a primary key (grain) that is missing or is not unique.",
 )
 @click.option(
+    "--warn-grain-check",
+    is_flag=True,
+    help="Warn if any selected model is missing a grain, and compute diffs for the remaining models.",
+)
+@click.option(
     "--temp-schema",
     type=str,
     help="Schema used for temporary tables. It can be `CATALOG.SCHEMA` or `SCHEMA`. Default: `sqlmesh_temp`",

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -702,6 +702,11 @@ class SQLMeshMagics(Magics):
         action="store_true",
         help="Disable the check for a primary key (grain) that is missing or is not unique.",
     )
+    @argument(
+        "--warn-grain-check",
+        action="store_true",
+        help="Warn if any selected model is missing a grain, and compute diffs for the remaining models.",
+    )
     @line_magic
     @pass_sqlmesh_context
     def table_diff(self, context: Context, line: str) -> None:
@@ -723,6 +728,7 @@ class SQLMeshMagics(Magics):
             show_sample=args.show_sample,
             decimals=args.decimals,
             skip_grain_check=args.skip_grain_check,
+            warn_grain_check=args.warn_grain_check,
         )
 
     @magic_arguments()


### PR DESCRIPTION
This update introduces a new `--warn-grain-check` flag to the `table diff` command, providing a more lenient alternative to the current grain enforcement behavioru, closes: #4422

```bash
❯ sqlmesh table_diff dev:prod "*" --warn-grain-check
```

By default, missing grain for a couple of models when selecting multiple models to diff will cause the diff operation to fail. With the `--warn-grain-check` flag, this strict requirement is relaxed:

* Models without a valid grain will trigger a warning and be listed instead of an error.
* Diffs will be computed for the remaining models that do have valid grains.

This allows users to proceed with partial diffs if they desire while still being informed of models that require attention.