### PR TITLE
Fix: Don't show stacktraces when tests fail

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -349,18 +349,21 @@ class ModelTest(unittest.TestCase):
         else:
             _raise_error(f"Model '{name}' is an unsupported model type for testing", path)
 
-        return test_type(
-            body,
-            test_name,
-            t.cast(Model, model),
-            models,
-            engine_adapter,
-            dialect,
-            path,
-            preserve_fixtures,
-            default_catalog,
-            concurrency,
-        )
+        try:
+            return test_type(
+                body,
+                test_name,
+                t.cast(Model, model),
+                models,
+                engine_adapter,
+                dialect,
+                path,
+                preserve_fixtures,
+                default_catalog,
+                concurrency,
+            )
+        except Exception as e:
+            raise TestError(f"Failed to create test {test_name} ({path})\n{str(e)}")
 
     def __str__(self) -> str:
         return f"{self.test_name} ({self.path})"
@@ -905,8 +908,8 @@ def _row_difference(left: pd.DataFrame, right: pd.DataFrame) -> pd.DataFrame:
 
 def _raise_error(msg: str, path: Path | None = None) -> None:
     if path:
-        raise TestError(f"{msg} at {path}")
-    raise TestError(msg)
+        raise TestError(f"Failed to run test at {path}:\n{msg}")
+    raise TestError(f"Failed to run test:\n{msg}")
 
 
 def _normalize_df_value(value: t.Any) -> t.Any:

--- a/sqlmesh/core/test/runner.py
+++ b/sqlmesh/core/test/runner.py
@@ -150,9 +150,11 @@ def run_tests(
             if result.successes:
                 combined_results.addSuccess(result.successes[0])
             elif result.errors:
-                combined_results.addError(result.original_err[0], result.original_err[1])
+                for error_test, error in result.original_errors:
+                    combined_results.addError(error_test, error)
             elif result.failures:
-                combined_results.addFailure(result.original_err[0], result.original_err[1])
+                for failure_test, failure in result.original_failures:
+                    combined_results.addFailure(failure_test, failure)
             elif result.skipped:
                 skipped_args = result.skipped[0]
                 combined_results.addSkip(skipped_args[0], skipped_args[1])


### PR DESCRIPTION
Before:
```
$ sqlmesh test     
E
======================================================================
ERROR: Traceback (most recent call last):
  File "/Users/izeigerman/github/sqlmesh/sqlmesh/core/test/definition.py", line 193, in setUp
    self.engine_adapter.create_view(
  File "/Users/izeigerman/github/sqlmesh/sqlmesh/core/engine_adapter/shared.py", line 302, in internal_wrapper
    return func(*list_args, **kwargs)
  File "/Users/izeigerman/github/sqlmesh/sqlmesh/core/engine_adapter/base.py", line 1103, in create_view
    self.execute(
  File "/Users/izeigerman/github/sqlmesh/sqlmesh/core/engine_adapter/base.py", line 2154, in execute
    self._execute(sql, **kwargs)
  File "/Users/izeigerman/github/sqlmesh/sqlmesh/core/engine_adapter/base.py", line 2175, in _execute
    self.cursor.execute(sql, **kwargs)
duckdb.duckdb.CatalogException: Catalog Error: Table with name missing does not exist!
Did you mean "pg_settings"?

LINE 1: ...") AS SELECT "id", "item_id", NULL AS "event_date" FROM "missing"
                                                                   ^

----------------------------------------------------------------------
Ran 1 test in 0.046s 

FAILED (errors=1)
```
After:
```
$ sqlmesh test
E
======================================================================
ERROR: test_example_full_model (/Users/izeigerman/github/sqlmesh/examples/tmp/tests/test_full_model.yaml)
duckdb.duckdb.CatalogException: Catalog Error: Table with name missing does not exist!
Did you mean "pg_settings"?

LINE 1: ...") AS SELECT "id", "item_id", NULL AS "event_date" FROM "missing"
                                                                   ^

----------------------------------------------------------------------
Ran 1 test in 0.060s 

FAILED (errors=1)
```