### PR TITLE
Fix: Improve error messages around concurrent plan application

### DIFF
--- a/sqlmesh/core/state_sync/db/environment.py
+++ b/sqlmesh/core/state_sync/db/environment.py
@@ -152,8 +152,8 @@ class EnvironmentState:
         stored_plan_id = stored_plan_id_row[0]
         if stored_plan_id != environment.plan_id:
             raise SQLMeshError(
-                f"Another plan ({stored_plan_id}) was applied to the target environment '{environment.name}' while the current plan "
-                f"({environment.plan_id}) was still in progress. Please re-apply your plan to resolve this error."
+                f"Another plan ({stored_plan_id}) was applied to the target environment '{environment.name}' while your current plan "
+                f"({environment.plan_id}) was still in progress, interrupting it. Please re-apply your plan to resolve this error."
             )
 
         environment.finalized_ts = now_timestamp()

--- a/sqlmesh/core/state_sync/db/environment.py
+++ b/sqlmesh/core/state_sync/db/environment.py
@@ -152,8 +152,8 @@ class EnvironmentState:
         stored_plan_id = stored_plan_id_row[0]
         if stored_plan_id != environment.plan_id:
             raise SQLMeshError(
-                f"Plan '{environment.plan_id}' is no longer valid for the target environment '{environment.name}'. "
-                f"Stored plan ID: '{stored_plan_id}'. Please recreate the plan and try again"
+                f"Another plan ({stored_plan_id}) was applied to the target environment '{environment.name}' while the current plan "
+                f"({environment.plan_id}) was still in progress. Please re-apply your plan to resolve this error."
             )
 
         environment.finalized_ts = now_timestamp()

--- a/sqlmesh/core/state_sync/db/facade.py
+++ b/sqlmesh/core/state_sync/db/facade.py
@@ -205,9 +205,8 @@ class EngineAdapterStateSync(StateSync):
             if not existing_environment.expired:
                 if environment.previous_plan_id != existing_environment.plan_id:
                     raise ConflictingPlanError(
-                        f"Plan '{environment.plan_id}' is no longer valid for the target environment '{environment.name}'. "
-                        f"Expected previous plan ID: '{environment.previous_plan_id}', actual previous plan ID: '{existing_environment.plan_id}'. "
-                        "Please recreate the plan and try again"
+                        f"Another plan ({existing_environment.plan_id}) was applied to the target environment '{environment.name}' while the current plan "
+                        f"({environment.plan_id}) was still in progress. Please re-apply your plan to resolve this error."
                     )
                 if no_gaps_snapshot_names != set():
                     snapshots = self.get_snapshots(environment.snapshots).values()

--- a/sqlmesh/core/state_sync/db/facade.py
+++ b/sqlmesh/core/state_sync/db/facade.py
@@ -205,8 +205,8 @@ class EngineAdapterStateSync(StateSync):
             if not existing_environment.expired:
                 if environment.previous_plan_id != existing_environment.plan_id:
                     raise ConflictingPlanError(
-                        f"Another plan ({existing_environment.plan_id}) was applied to the target environment '{environment.name}' while the current plan "
-                        f"({environment.plan_id}) was still in progress. Please re-apply your plan to resolve this error."
+                        f"Another plan ({existing_environment.plan_id}) was applied to the target environment '{environment.name}' while your current plan "
+                        f"({environment.plan_id}) was still in progress, interrupting it. Please re-apply your plan to resolve this error."
                     )
                 if no_gaps_snapshot_names != set():
                     snapshots = self.get_snapshots(environment.snapshots).values()
@@ -613,7 +613,8 @@ class EngineAdapterStateSync(StateSync):
 
                     if missing_intervals:
                         raise SQLMeshError(
-                            f"Detected gaps in snapshot {target_snapshot.snapshot_id}: {missing_intervals}"
+                            f"Detected missing intervals for model {target_snapshot.name}, interrupting your current plan. "
+                            "Please re-apply your plan to resolve this error."
                         )
 
     @contextlib.contextmanager

--- a/tests/core/state_sync/test_state_sync.py
+++ b/tests/core/state_sync/test_state_sync.py
@@ -861,7 +861,7 @@ def test_promote_snapshots_parent_plan_id_mismatch(
     with pytest.raises(
         SQLMeshError,
         match=re.escape(
-            "Another plan (new_plan_id) was applied to the target environment 'prod' while the current plan (stale_new_plan_id) was still in progress. Please re-apply your plan to resolve this error."
+            "Another plan (new_plan_id) was applied to the target environment 'prod' while your current plan (stale_new_plan_id) was still in progress, interrupting it. Please re-apply your plan to resolve this error."
         ),
     ):
         state_sync.promote(stale_new_environment)
@@ -949,7 +949,7 @@ def test_promote_snapshots_no_gaps(state_sync: EngineAdapterStateSync, make_snap
     state_sync.add_interval(new_snapshot_missing_interval, "2022-01-01", "2022-01-02")
     with pytest.raises(
         SQLMeshError,
-        match=r"Detected gaps in snapshot.*",
+        match=r'Detected missing intervals for model "a", interrupting your current plan. Please re-apply your plan to resolve this error.',
     ):
         promote_snapshots(state_sync, [new_snapshot_missing_interval], "prod", no_gaps=True)
 
@@ -1026,7 +1026,7 @@ def test_finalize(state_sync: EngineAdapterStateSync, make_snapshot: t.Callable)
     with pytest.raises(
         SQLMeshError,
         match=re.escape(
-            "Another plan (test_plan_id) was applied to the target environment 'prod' while the current plan (different_plan_id) was still in progress. Please re-apply your plan to resolve this error."
+            "Another plan (test_plan_id) was applied to the target environment 'prod' while your current plan (different_plan_id) was still in progress, interrupting it. Please re-apply your plan to resolve this error."
         ),
     ):
         state_sync.finalize(env)
@@ -1061,7 +1061,7 @@ def test_start_date_gap(state_sync: EngineAdapterStateSync, make_snapshot: t.Cal
     state_sync.add_interval(snapshot, "2022-01-03", "2022-01-04")
     with pytest.raises(
         SQLMeshError,
-        match=r"Detected gaps in snapshot.*",
+        match=r'Detected missing intervals for model "a", interrupting your current plan. Please re-apply your plan to resolve this error.',
     ):
         promote_snapshots(state_sync, [snapshot], "prod", no_gaps=True)
 

--- a/tests/core/state_sync/test_state_sync.py
+++ b/tests/core/state_sync/test_state_sync.py
@@ -860,7 +860,9 @@ def test_promote_snapshots_parent_plan_id_mismatch(
 
     with pytest.raises(
         SQLMeshError,
-        match=r".*is no longer valid.*",
+        match=re.escape(
+            "Another plan (new_plan_id) was applied to the target environment 'prod' while the current plan (stale_new_plan_id) was still in progress. Please re-apply your plan to resolve this error."
+        ),
     ):
         state_sync.promote(stale_new_environment)
 
@@ -1023,7 +1025,9 @@ def test_finalize(state_sync: EngineAdapterStateSync, make_snapshot: t.Callable)
     env.plan_id = "different_plan_id"
     with pytest.raises(
         SQLMeshError,
-        match=r"Plan 'different_plan_id' is no longer valid for the target environment 'prod'.*",
+        match=re.escape(
+            "Another plan (test_plan_id) was applied to the target environment 'prod' while the current plan (different_plan_id) was still in progress. Please re-apply your plan to resolve this error."
+        ),
     ):
         state_sync.finalize(env)
 


### PR DESCRIPTION
Before:
```
Plan 'stale_new_plan_id' is no longer valid for the target environment 'prod'. Expected previous plan ID: 'test_plan_id', actual previous plan ID: 'new_plan_id'. Please recreate the plan and try again
```
After:
```
Another plan (new_plan_id) was applied to the target environment 'prod' while the current plan (stale_new_plan_id) was still in progress. Please re-apply your plan to resolve this error.
```
