### PR TITLE
Fix: propagate correct snapshot dict to renderer for virtual statements

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -978,7 +978,6 @@ class SnapshotEvaluator:
                 end=end,
                 execution_time=execution_time,
                 engine_adapter=adapter,
-                snapshots=snapshots,
                 deployability_index=deployability_index,
                 table_mapping=table_mapping,
                 runtime_stage=RuntimeStage.PROMOTING,
@@ -988,8 +987,12 @@ class SnapshotEvaluator:
                 view_name=view_name,
                 model=snapshot.model,
                 environment=environment_naming_info.name,
+                snapshots=snapshots,
                 **render_kwargs,
             )
+
+            snapshot_by_name = {s.name: s for s in (snapshots or {}).values()}
+            render_kwargs["snapshots"] = snapshot_by_name
             adapter.execute(snapshot.model.render_on_virtual_update(**render_kwargs))
 
         if on_complete is not None:


### PR DESCRIPTION
The issue is that `snapshots` in the `SnapshotEvaluator._promote_snapshot` method was a `SnapshotId -> Snapshot` dict instead of a `str -> Snapshot`, which is expected by the rendering methods. Since this dict flows into the macro evaluator, `columns_to_types` lookup using string keys would always fail and we'd fail.

I also updated the `_statement_renderer` and `_create_renderer` to pass the `mapping_schema` for consistency, since we do this for the query renderer as well. This is unrelated to the above issue, so happy to revert if we're unsure if it's safe.