### PR TITLE
Fix: prompt if there are any uncategorized snapshots in a plan

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1269,8 +1269,11 @@ class GenericContext(BaseContext, t.Generic[C]):
             skip_linter=skip_linter,
         )
 
-        if no_auto_categorization:
+        plan = plan_builder.build()
+
+        if no_auto_categorization or plan.uncategorized:
             # Prompts are required if the auto categorization is disabled
+            # or if there are any uncategorized snapshots in the plan
             no_prompts = False
 
         self.console.plan(
@@ -1281,7 +1284,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             no_prompts=no_prompts if no_prompts is not None else self.config.plan.no_prompts,
         )
 
-        return plan_builder.build()
+        return plan
 
     @python_api_analytics
     def plan_builder(


### PR DESCRIPTION
See the added test for reference. The issue that we saw in the wild looked something like this:

```
-  event_date
+  event_date,
+  1 AS z
 FROM sqlmesh_example.seed_model
 WHERE
   event_date BETWEEN @start_date AND @end_date
Directly Modified: sqlmesh_example.incremental_model
└── Indirectly Modified Children:
    └── sqlmesh_example.full_model
Models needing backfill:
└── sqlmesh_example.incremental_model: [2020-01-01 - 2025-05-20]
Apply - Backfill Tables [y/n]: y
Error: Can't apply a plan with uncategorized changes.
```

This happened after running `sqlmesh plan` with a config that switches off auto-categorization:

```python
PlanConfig(
    auto_categorize_changes=CategorizerConfig(
        external=AutoCategorizationMode.OFF,
        python=AutoCategorizationMode.OFF,
        sql=AutoCategorizationMode.OFF,
        seed=AutoCategorizationMode.OFF,
    ),
)
```

One workaround for this^ issue today is to set `no_prompts=False` in the plan config, but knowing this or having to reach out for it is not as good of an experience, which is what motivated this PR.