### PR TITLE
Chore!: bump sqlglot to v26.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "requests",
     "rich[jupyter]",
     "ruamel.yaml",
-    "sqlglot[rs]~=26.17.1",
+    "sqlglot[rs]~=26.19.0",
     "tenacity",
     "time-machine",
     "json-stream"

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -5067,7 +5067,8 @@ def test_when_matched():
     unique_key ("purchase_order_id"),
     when_matched (
       WHEN MATCHED AND __MERGE_SOURCE__._operation = 1 THEN DELETE
-      WHEN MATCHED AND __MERGE_SOURCE__._operation <> 1 THEN UPDATE SET __MERGE_TARGET__.purchase_order_id = 1
+      WHEN MATCHED AND __MERGE_SOURCE__._operation <> 1 THEN UPDATE SET
+        __MERGE_TARGET__.purchase_order_id = 1
     ),
     batch_concurrency 1,
     forward_only FALSE,
@@ -5118,7 +5119,8 @@ FROM @{macro_val}.upstream"""
   kind INCREMENTAL_BY_UNIQUE_KEY (
     unique_key ("purchase_order_id"),
     when_matched (
-      WHEN MATCHED AND __MERGE_SOURCE__.salary <> __MERGE_TARGET__.salary THEN UPDATE SET ARRAY('target.update_datetime = source.update_datetime', 'target.salary = source.salary')
+      WHEN MATCHED AND __MERGE_SOURCE__.salary <> __MERGE_TARGET__.salary THEN UPDATE SET
+        ARRAY('target.update_datetime = source.update_datetime', 'target.salary = source.salary')
     ),
     batch_concurrency 1,
     forward_only FALSE,
@@ -7495,7 +7497,8 @@ def test_merge_filter():
     unique_key ("purchase_order_id"),
     when_matched (
       WHEN MATCHED AND {MERGE_SOURCE_ALIAS}._operation = 1 THEN DELETE
-      WHEN MATCHED AND {MERGE_SOURCE_ALIAS}._operation <> 1 THEN UPDATE SET {MERGE_TARGET_ALIAS}.purchase_order_id = 1
+      WHEN MATCHED AND {MERGE_SOURCE_ALIAS}._operation <> 1 THEN UPDATE SET
+        {MERGE_TARGET_ALIAS}.purchase_order_id = 1
     ),
     merge_filter (
       {MERGE_SOURCE_ALIAS}.ds > (

--- a/tests/lsp/test_completions.py
+++ b/tests/lsp/test_completions.py
@@ -11,13 +11,13 @@ TOKENIZER_KEYWORDS = set(Tokenizer.KEYWORDS.keys())
 
 @pytest.mark.fast
 def test_get_keywords_from_tokenizer():
-    assert len(get_keywords_from_tokenizer()) > len(TOKENIZER_KEYWORDS)
+    assert len(get_keywords_from_tokenizer()) >= len(TOKENIZER_KEYWORDS)
 
 
 @pytest.mark.fast
 def test_get_sql_completions_no_context():
     completions = get_sql_completions(None, None)
-    assert len(completions.keywords) > len(TOKENIZER_KEYWORDS)
+    assert len(completions.keywords) >= len(TOKENIZER_KEYWORDS)
     assert len(completions.models) == 0
 
 


### PR DESCRIPTION
Regarding the changes in the test suite:

- The pretty-printing logic for `Merge` [recently changed](https://github.com/tobymao/sqlglot/commit/2b928e238cba63e5e043207dae1bfe2f140a1c2b).
- In `test_completions.py` there were a couple of assertions that were tighter than needed.