### PR TITLE
Chore: add pyproject.toml in examples/custom_materializations

### DIFF
--- a/examples/custom_materializations/pyproject.toml
+++ b/examples/custom_materializations/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 61.0", "setuptools_scm"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Quick fix to silence the warning shown below:

```bash
$ make install-dev
...
Building wheels for collected packages: custom_materializations, sqlmesh
  DEPRECATION: Building 'custom_materializations' using the legacy setup.py bdist_wheel mechanism, which will be removed in a future version. pip 25.3 will enforce this behaviour change. A possible replacement is to use the standardized build interface by setting the `--use-pep517` option, (possibly combined with `--no-build-isolation`), or adding a `pyproject.toml` file to the source tree of 'custom_materializations'. Discussion can be found at https://github.com/pypa/pip/issues/6334
```

References:
- https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#is-pyproject-toml-mandatory
- https://github.com/TobikoData/sqlmesh/blob/a1c48404b8ef476e72e95deab0d8d3b7bbaadbcc/pyproject.toml#L144-L146