### PR TITLE
Chore!: configure logging before loading config to log errors properly

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -7,7 +7,7 @@ import typing as t
 
 import click
 
-from sqlmesh import configure_logging
+from sqlmesh import configure_logging, remove_excess_logs
 from sqlmesh.cli import error_handler
 from sqlmesh.cli import options as opt
 from sqlmesh.cli.example_project import ProjectTemplate, init_example_project
@@ -100,16 +100,18 @@ def cli(
         if ctx.invoked_subcommand in SKIP_LOAD_COMMANDS:
             load = False
 
-    configs = load_configs(config, Context.CONFIG_TYPE, paths)
-    log_limit = list(configs.values())[0].log_limit
     configure_logging(
         debug,
         log_to_stdout,
-        log_limit=log_limit,
         log_file_dir=log_file_dir,
         ignore_warnings=ignore_warnings,
     )
     configure_console(ignore_warnings=ignore_warnings)
+
+    configs = load_configs(config, Context.CONFIG_TYPE, paths)
+    log_limit = list(configs.values())[0].log_limit
+
+    remove_excess_logs(log_file_dir, log_limit)
 
     try:
         context = Context(

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -26,7 +26,7 @@ from sqlmesh.core.config.common import (
 )
 from sqlmesh.core.engine_adapter.shared import CatalogSupport
 from sqlmesh.core.engine_adapter import EngineAdapter
-from sqlmesh.utils import str_to_bool
+from sqlmesh.utils import debug_mode_enabled, str_to_bool
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.pydantic import (
     ValidationInfo,
@@ -66,7 +66,11 @@ def _get_engine_import_validator(
             return data
         try:
             importlib.import_module(import_name)
-        except ImportError:
+        except ImportError as e:
+            if debug_mode_enabled():
+                raise
+
+            logger.error(str(e))
             raise ConfigError(
                 f"Failed to import the '{engine_type}' engine library. Please run `pip install \"sqlmesh[{extra_name}]\"`."
             )

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -66,13 +66,17 @@ def _get_engine_import_validator(
             return data
         try:
             importlib.import_module(import_name)
-        except ImportError as e:
+        except ImportError:
             if debug_mode_enabled():
                 raise
 
-            logger.error(str(e))
+            logger.exception("Failed to import the engine library")
+
             raise ConfigError(
-                f"Failed to import the '{engine_type}' engine library. Please run `pip install \"sqlmesh[{extra_name}]\"`."
+                f"Failed to import the '{engine_type}' engine library. This may be due to a missing "
+                "or incompatible installation. Please ensure the required dependency is installed by "
+                f'running: pip install "sqlmesh[{extra_name}]". For more details, check the logs '
+                "in the 'logs/' folder, or rerun the command with the '--debug' flag."
             )
 
         return data

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -75,7 +75,7 @@ def _get_engine_import_validator(
             raise ConfigError(
                 f"Failed to import the '{engine_type}' engine library. This may be due to a missing "
                 "or incompatible installation. Please ensure the required dependency is installed by "
-                f'running: pip install "sqlmesh[{extra_name}]". For more details, check the logs '
+                f'running: `pip install "sqlmesh[{extra_name}]"`. For more details, check the logs '
                 "in the 'logs/' folder, or rerun the command with the '--debug' flag."
             )
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import abc
 import collections
-from itertools import chain
 import logging
 import sys
 import time
@@ -44,6 +43,7 @@ import typing as t
 import unittest.result
 from functools import cached_property
 from io import StringIO
+from itertools import chain
 from pathlib import Path
 from shutil import rmtree
 from types import MappingProxyType

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -1018,7 +1018,7 @@ def test_engine_import_validator():
         match=re.escape(
             "Failed to import the 'bigquery' engine library. This may be due to a missing "
             "or incompatible installation. Please ensure the required dependency is installed by "
-            'running: pip install "sqlmesh[bigquery]". For more details, check the logs '
+            'running: `pip install "sqlmesh[bigquery]"`. For more details, check the logs '
             "in the 'logs/' folder, or rerun the command with the '--debug' flag."
         ),
     ):
@@ -1033,7 +1033,7 @@ def test_engine_import_validator():
         match=re.escape(
             "Failed to import the 'bigquery' engine library. This may be due to a missing "
             "or incompatible installation. Please ensure the required dependency is installed by "
-            'running: pip install "sqlmesh[bigquery_extra]". For more details, check the logs '
+            'running: `pip install "sqlmesh[bigquery_extra]"`. For more details, check the logs '
             "in the 'logs/' folder, or rerun the command with the '--debug' flag."
         ),
     ):

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -1016,7 +1016,10 @@ def test_engine_import_validator():
     with pytest.raises(
         ConfigError,
         match=re.escape(
-            """Failed to import the 'bigquery' engine library. Please run `pip install "sqlmesh[bigquery]"`."""
+            "Failed to import the 'bigquery' engine library. This may be due to a missing "
+            "or incompatible installation. Please ensure the required dependency is installed by "
+            'running: pip install "sqlmesh[bigquery]". For more details, check the logs '
+            "in the 'logs/' folder, or rerun the command with the '--debug' flag."
         ),
     ):
 
@@ -1028,7 +1031,10 @@ def test_engine_import_validator():
     with pytest.raises(
         ConfigError,
         match=re.escape(
-            """Failed to import the 'bigquery' engine library. Please run `pip install "sqlmesh[bigquery_extra]"`."""
+            "Failed to import the 'bigquery' engine library. This may be due to a missing "
+            "or incompatible installation. Please ensure the required dependency is installed by "
+            'running: pip install "sqlmesh[bigquery_extra]". For more details, check the logs '
+            "in the 'logs/' folder, or rerun the command with the '--debug' flag."
         ),
     ):
 


### PR DESCRIPTION
This [commit](https://github.com/TobikoData/sqlmesh/commit/cc3e4931ed4ef361f90e340b4bc18793009935c5) introduced new error handling logic for connection configs: if sqlmesh fails to import an engine driver, then it suggests running `pip install` as a possible solution to the issue.

However, problems can arise at import time even if a driver _is_ installed. For example, `pymssql` is known to have [compatibility issues](https://github.com/pymssql/pymssql/issues/769) with M-series Mac systems. This leads to confusing error messages as shown below:

```
((.venv) ) ➜  sqlmesh info
Error: Failed to import the 'mssql' engine library. Please run `pip install "sqlmesh[mssql]"`.
((.venv) ) ➜  playground pip show pymssql  # The above message is misleading, pymssql is already installed
Name: pymssql
Version: 2.3.4
...
((.venv) ) ➜  SQLMESH_DEBUG=1 sqlmesh info  # This includes the actual error in the stack trace
...
  File "src/pymssql/_pymssql.pyx", line 1, in init pymssql._pymssql
ImportError: dlopen(.../sqlmesh/.venv/lib/python3.12/site-packages/pymssql/_mssql.cpython-312-darwin.so, 0x0002): symbol not found in flat namespace '_bcp_batch'
```

This PR addresses the issue by ensuring that the actual import error is raised when in debug mode, or logged otherwise.

One obstacle I faced was that `configure_logging` currently [depends on](https://github.com/TobikoData/sqlmesh/blob/ac25787cf4cfffb8fb3654392c6c321ef07a7941/sqlmesh/cli/main.py#L103-L112) `load_configs`, because the latter reads the `log_limit`, which is needed for purging excess log files.

I worked around this issue by decoupling the excess log file purging logic from `configure_logging`, so that we can run the latter before loading the configs, allowing the errors to be properly logged in a file instead of being printed in stdout.