### PR TITLE
Fix: Improve the field location reporting in config errors

### DIFF
--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -221,7 +221,8 @@ def _formatted_validation_errors(error: pydantic.ValidationError) -> t.List[str]
     for e in error.errors():
         msg = e["msg"]
         loc: t.Optional[t.Tuple] = e.get("loc")
-        result.append(f"Invalid field '{loc[0]}':\n    {msg}" if loc else msg)
+        loc_str = ".".join(loc) if loc else None
+        result.append(f"Invalid field '{loc_str}':\n    {msg}" if loc_str else msg)
     return result
 
 


### PR DESCRIPTION
Before:
```
Error: Invalid project config:
  Invalid field 'plan':
    Extra inputs are not permitted

Verify your config.yaml and environment variables.
```
After:
```
Error: Invalid project config:
  Invalid field 'plan.no_diffs':
    Extra inputs are not permitted

Verify your config.yaml and environment variables.
```