### PR TITLE
feat(vscode): add ability to specify project path

### DIFF
--- a/vscode/extension/package.json
+++ b/vscode/extension/package.json
@@ -34,7 +34,7 @@
         "sqlmesh.projectPath": {
           "type": "string",
           "default": "",
-          "markdownDescription": "The path to the SQLMesh project. If not set, the extension will try to find the project root automatically. If set, the extension will use the project root as the workspace path, e.g. it will run `sqlmesh` and `sqlmesh_lsp` in the project root. The path can be absolute or relative to the workspace root."
+          "markdownDescription": "The path to the SQLMesh project. If not set, the extension will try to find the project root automatically. If set, the extension will use the project root as the workspace path, e.g. it will run `sqlmesh` and `sqlmesh_lsp` in the project root. The path can be absolute `/Users/sqlmesh_user/sqlmesh_project/sushi` or relative `./project_folder/sushi` to the workspace root."
         }
       }
     },

--- a/vscode/extension/package.json
+++ b/vscode/extension/package.json
@@ -27,6 +27,17 @@
     "ms-python.python"
   ],
   "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "SQLMesh",
+      "properties": {
+        "sqlmesh.projectPath": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "The path to the SQLMesh project. If not set, the extension will try to find the project root automatically. If set, the extension will use the project root as the workspace path, e.g. it will run `sqlmesh` and `sqlmesh_lsp` in the project root. The path can be absolute or relative to the workspace root."
+        }
+      }
+    },
     "viewsContainers": {
       "panel": [
         {

--- a/vscode/extension/src/lsp/lsp.ts
+++ b/vscode/extension/src/lsp/lsp.ts
@@ -45,7 +45,8 @@ export class LSPClient implements Disposable {
     }
 
     const folder = workspaceFolders[0]
-    const workspacePath = workspaceFolders[0].uri.fsPath
+    // Use the workspace path from sqlmesh config, which respects the projectPath setting
+    const workspacePath = sqlmesh.value.workspacePath
     const serverOptions: ServerOptions = {
       run: {
         command: sqlmesh.value.bin,

--- a/vscode/extension/src/lsp/lsp.ts
+++ b/vscode/extension/src/lsp/lsp.ts
@@ -8,7 +8,7 @@ import {
 import { sqlmeshLspExec } from '../utilities/sqlmesh/sqlmesh'
 import { err, isErr, ok, Result } from '@bus/result'
 import { getWorkspaceFolders } from '../utilities/common/vscodeapi'
-import { traceError } from '../utilities/common/log'
+import { traceError, traceInfo } from '../utilities/common/log'
 import { ErrorType } from '../utilities/errors'
 import { CustomLSPMethods } from './custom'
 
@@ -43,9 +43,6 @@ export class LSPClient implements Disposable {
         message: 'Invalid number of workspace folders',
       })
     }
-
-    const folder = workspaceFolders[0]
-    // Use the workspace path from sqlmesh config, which respects the projectPath setting
     const workspacePath = sqlmesh.value.workspacePath
     const serverOptions: ServerOptions = {
       run: {
@@ -67,11 +64,13 @@ export class LSPClient implements Disposable {
     }
     const clientOptions: LanguageClientOptions = {
       documentSelector: [{ scheme: 'file', pattern: `**/*.sql` }],
-      workspaceFolder: folder,
       diagnosticCollectionName: 'sqlmesh',
       outputChannel: outputChannel,
     }
 
+    traceInfo(
+      `Starting SQLMesh Language Server with workspace path: ${workspacePath} with server options ${JSON.stringify(serverOptions)} and client options ${JSON.stringify(clientOptions)}`,
+    )
     this.client = new LanguageClient(
       'sqlmesh-lsp',
       'SQLMesh Language Server',

--- a/vscode/extension/src/utilities/config.ts
+++ b/vscode/extension/src/utilities/config.ts
@@ -1,0 +1,78 @@
+import { workspace, WorkspaceFolder } from 'vscode'
+import path from 'path'
+import fs from 'fs'
+import { Result, err, ok } from '@bus/result'
+import { traceVerbose, traceInfo } from './common/log'
+
+export interface SqlmeshConfiguration {
+  projectPath: string
+}
+
+/**
+ * Get the SQLMesh configuration from VS Code settings.
+ *
+ * @returns The SQLMesh configuration
+ */
+export function getSqlmeshConfiguration(): SqlmeshConfiguration {
+  const config = workspace.getConfiguration('sqlmesh')
+  const projectPath = config.get<string>('projectPath', '')
+
+  return {
+    projectPath,
+  }
+}
+
+/**
+ * Validate and resolve the project path from configuration.
+ * If no project path is configured, use the workspace folder.
+ * If the project path is configured, it must be a directory that contains a SQLMesh project.
+ *
+ * @param workspaceFolder The current workspace folder
+ * @returns A Result containing the resolved project path or an error
+ */
+export function resolveProjectPath(
+  workspaceFolder: WorkspaceFolder,
+): Result<string, string> {
+  const config = getSqlmeshConfiguration()
+
+  if (!config.projectPath) {
+    // If no project path is configured, use the workspace folder
+    traceVerbose('No project path configured, using workspace folder')
+    return ok(workspaceFolder.uri.fsPath)
+  }
+  let resolvedPath: string
+
+  // Check if the path is absolute
+  if (path.isAbsolute(config.projectPath)) {
+    resolvedPath = config.projectPath
+  } else {
+    // Resolve relative path from workspace root
+    resolvedPath = path.join(workspaceFolder.uri.fsPath, config.projectPath)
+  }
+
+  // Normalize the path
+  resolvedPath = path.normalize(resolvedPath)
+
+  // Validate that the path exists
+  if (!fs.existsSync(resolvedPath)) {
+    return err(`Configured project path does not exist: ${resolvedPath}`)
+  }
+
+  // Validate that it's a directory
+  const stats = fs.statSync(resolvedPath)
+  if (!stats.isDirectory()) {
+    return err(`Configured project path is not a directory: ${resolvedPath}`)
+  }
+
+  // Check if it contains SQLMesh project files (config.yaml, config.yml, or config.py)
+  const configFiles = ['config.yaml', 'config.yml', 'config.py']
+  const hasConfigFile = configFiles.some(file =>
+    fs.existsSync(path.join(resolvedPath, file)),
+  )
+  if (!hasConfigFile) {
+    traceInfo(`Warning: No SQLMesh configuration file found in ${resolvedPath}`)
+  }
+
+  traceVerbose(`Using project path: ${resolvedPath}`)
+  return ok(resolvedPath)
+}

--- a/vscode/extension/src/utilities/config.ts
+++ b/vscode/extension/src/utilities/config.ts
@@ -16,7 +16,6 @@ export interface SqlmeshConfiguration {
 export function getSqlmeshConfiguration(): SqlmeshConfiguration {
   const config = workspace.getConfiguration('sqlmesh')
   const projectPath = config.get<string>('projectPath', '')
-
   return {
     projectPath,
   }

--- a/vscode/extension/tests/lineage.spec.ts
+++ b/vscode/extension/tests/lineage.spec.ts
@@ -14,52 +14,8 @@ const SUSHI_SOURCE_PATH = path.join(__dirname, '..', '..', '..', 'examples', 'su
  * Helper function to launch VS Code and test lineage with given project path config
  */
 async function testLineageWithProjectPath(
-  workspaceDir: string,
-  projectDir: string,
-  projectPathConfig?: string
+  window: Page,
 ): Promise<void> {
-  const ciArgs = process.env.CI ? [
-    '--disable-gpu',
-    '--headless',
-    '--no-sandbox',
-    '--disable-dev-shm-usage',
-    '--window-position=-10000,0',
-  ] : [];
-  
-  const userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-user-data-'));
-  
-  try {
-    // If projectPathConfig is provided, create .vscode/settings.json in the workspace
-    if (projectPathConfig !== undefined) {
-      const vscodeDir = path.join(workspaceDir, '.vscode');
-      await fs.ensureDir(vscodeDir);
-      const settings = {
-        "sqlmesh.projectPath": projectPathConfig
-      };
-      await fs.writeJson(path.join(vscodeDir, 'settings.json'), settings, { spaces: 2 });
-    }
-    
-    const args = [
-      ...ciArgs,
-      `--extensionDevelopmentPath=${EXT_PATH}`,
-      '--disable-workspace-trust',
-      '--disable-telemetry',
-      `--user-data-dir=${userDataDir}`,
-      workspaceDir,
-    ];
-    
-    const electronApp = await electron.launch({
-      executablePath: VS_CODE_EXE,
-      args,
-    });
-
-    const window = await electronApp.firstWindow();
-    await window.waitForLoadState('domcontentloaded');
-    await window.waitForLoadState('networkidle');
-    
-    // Wait a bit for the extension to fully initialize with the settings
-    await window.waitForTimeout(2000);
-
     // Trigger lineage command
     await window.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+P' : 'Control+Shift+P');
     await window.keyboard.type('Lineage: Focus On View');
@@ -67,57 +23,143 @@ async function testLineageWithProjectPath(
 
     // Wait for "Loaded SQLmesh Context" text to appear
     const loadedContextText = window.locator('text=Loaded SQLMesh Context');
-    await expect(loadedContextText.first()).toBeVisible({ timeout: 15000 });
-
-    await electronApp.close();
-  } finally {
-    await fs.remove(userDataDir);
-  }
+    await expect(loadedContextText.first()).toBeVisible({ timeout: 10_000 });
 }
 
-export const startVSCode = async (workspaceDir: string) => {
-  
+/**
+ * Launch VS Code and return the window and a function to close the app.
+ * @param workspaceDir The workspace directory to open.
+ * @returns The window and a function to close the app.
+ */
+export const startVSCode = async (workspaceDir: string): Promise<{
+  window: Page,
+  close: () => Promise<void>,
+}> => {
+  const userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-user-data-'));
+  const ciArgs = process.env.CI ? [
+    '--disable-gpu',
+    '--headless',
+    '--no-sandbox',
+    '--disable-dev-shm-usage',
+    '--window-position=-10000,0',
+  ] : [];
+  const args = [
+    ...ciArgs,
+    `--extensionDevelopmentPath=${EXT_PATH}`,
+    '--disable-workspace-trust',
+    '--disable-telemetry',
+    `--user-data-dir=${userDataDir}`,
+    workspaceDir,
+  ];
+  const electronApp = await electron.launch({
+    executablePath: VS_CODE_EXE,
+    args,
+  });
+  const window = await electronApp.firstWindow();
+  await window.waitForLoadState('domcontentloaded');
+  await window.waitForLoadState('networkidle');
+  await window.waitForTimeout(2_000);
+  return { window, close: async () => {
+    await electronApp.close();
+    await fs.remove(userDataDir);
+  } };
 }
 
 test('Lineage panel renders correctly - no project path config (default)', async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-test-sushi-'));
   await fs.copy(SUSHI_SOURCE_PATH, tempDir);
-
   try {
-    await testLineageWithProjectPath(tempDir, tempDir);
-  } finally {
+  const { window, close } = await startVSCode(tempDir);
+  await testLineageWithProjectPath(window);
+    await close();
+  } finally { 
     await fs.remove(tempDir);
   }
 });
 
 test('Lineage panel renders correctly - relative project path', async () => {
-  // Create workspace directory with subdirectory containing the project
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-test-workspace-'));
-  const projectSubdir = path.join(workspaceDir, 'projects', 'sushi');
-  await fs.ensureDir(path.dirname(projectSubdir));
-  await fs.copy(SUSHI_SOURCE_PATH, projectSubdir);
+  const projectDir = path.join(workspaceDir, 'projects', 'sushi');
+  await fs.copy(SUSHI_SOURCE_PATH, projectDir);
+
+  const settings = {
+    "sqlmesh.projectPath": "./projects/sushi",
+  };
+  await fs.ensureDir(path.join(workspaceDir, '.vscode'));
+  await fs.writeJson(path.join(workspaceDir, '.vscode', 'settings.json'), settings, { spaces: 2 });
 
   try {
-    // Test with relative path
-    await testLineageWithProjectPath(workspaceDir, projectSubdir, 'projects/sushi');
+    const { window, close } = await startVSCode(workspaceDir);
+    await testLineageWithProjectPath(window);
+    await close();
   } finally {
     await fs.remove(workspaceDir);
   }
 });
 
 test('Lineage panel renders correctly - absolute project path', async () => {
-  // Create workspace directory
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-test-workspace-'));
-  
-  // Create project directory outside workspace
-  const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-test-sushi-project-'));
+  const projectDir = path.join(workspaceDir, 'projects', 'sushi');
+  await fs.ensureDir(path.join(workspaceDir, '.vscode'));
   await fs.copy(SUSHI_SOURCE_PATH, projectDir);
+  await fs.ensureDir(path.join(workspaceDir, '.vscode'));
+  const settings = {
+    "sqlmesh.projectPath": projectDir,
+  };
+  await fs.writeJson(path.join(workspaceDir, '.vscode', 'settings.json'), settings, { spaces: 2 });
 
   try {
-    // Test with absolute path
-    await testLineageWithProjectPath(workspaceDir, projectDir, projectDir);
+    const { window, close } = await startVSCode(workspaceDir);
+    await testLineageWithProjectPath(window);
+    await close();
   } finally {
     await fs.remove(workspaceDir);
-    await fs.remove(projectDir);
+  }
+});
+
+
+test("Lineage panel renders correctly - relative project outside of workspace", async () => {
+  const tempFolder = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-test-workspace-'));
+  const projectDir = path.join(tempFolder, 'projects', 'sushi');
+  await fs.copy(SUSHI_SOURCE_PATH, projectDir);
+
+  const workspaceDir = path.join(tempFolder, 'workspace');
+  await fs.ensureDir(workspaceDir);
+
+  const settings = {
+    "sqlmesh.projectPath": "./../projects/sushi",
+  };
+  await fs.ensureDir(path.join(workspaceDir, '.vscode'));
+  await fs.writeJson(path.join(workspaceDir, '.vscode', 'settings.json'), settings, { spaces: 2 });
+
+  try {
+    const { window, close } = await startVSCode(workspaceDir);
+    await testLineageWithProjectPath(window);
+    await close();
+  } finally {
+    await fs.remove(tempFolder);
+  }
+});
+
+test("Lineage panel renders correctly - absolute path project outside of workspace", async () => {
+  const tempFolder = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-test-workspace-'));
+  const projectDir = path.join(tempFolder, 'projects', 'sushi');
+  await fs.copy(SUSHI_SOURCE_PATH, projectDir);
+
+  const workspaceDir = path.join(tempFolder, 'workspace');
+  await fs.ensureDir(workspaceDir);
+
+  const settings = {
+    "sqlmesh.projectPath": projectDir,
+  };
+  await fs.ensureDir(path.join(workspaceDir, '.vscode'));
+  await fs.writeJson(path.join(workspaceDir, '.vscode', 'settings.json'), settings, { spaces: 2 });
+
+  try {
+    const { window, close } = await startVSCode(workspaceDir);
+    await testLineageWithProjectPath(window);
+    await close();
+  } finally {
+    await fs.remove(tempFolder);
   }
 });


### PR DESCRIPTION
- allows context loading in the API if not yet done if it's needed
- tests with e2e tests 
- adds configuration to the vscode extension that allows the absolute/relative path to be configured 

![image](https://github.com/user-attachments/assets/d2207c39-38e5-4bf1-a735-f7ef15cf451c)
