### PR TITLE
Chore!: Make `default_connection` optional

### DIFF
--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -122,7 +122,7 @@ class Config(BaseConfig):
     """
 
     gateways: GatewayDict = {"": GatewayConfig()}
-    default_connection: SerializableConnectionConfig = DuckDBConnectionConfig()
+    default_connection: t.Optional[SerializableConnectionConfig] = None
     default_test_connection_: t.Optional[SerializableConnectionConfig] = Field(
         default=None, alias="default_test_connection"
     )
@@ -280,7 +280,11 @@ class Config(BaseConfig):
         return self.gateways
 
     def get_connection(self, gateway_name: t.Optional[str] = None) -> ConnectionConfig:
-        return self.get_gateway(gateway_name).connection or self.default_connection
+        connection = self.get_gateway(gateway_name).connection or self.default_connection
+        if connection is None:
+            msg = f" for gateway '{gateway_name}'" if gateway_name else ""
+            raise ConfigError(f"No connection configured{msg}.")
+        return connection
 
     def get_state_connection(
         self, gateway_name: t.Optional[str] = None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,26 @@
+import typing as t
+
 from sqlmesh.core import constants as c
 from sqlmesh.core.analytics import disable_analytics
+from sqlmesh.core.config import Config, DuckDBConnectionConfig
+from sqlmesh.core.config.connection import ConnectionConfig
 
 c.MAX_FORK_WORKERS = 1
 disable_analytics()
+
+
+# Replace the implementation of Config._get_connection with a new one that always
+# returns a ConnectionConfig to simplify testing
+original_get_connection = Config.get_connection
+
+
+def _lax_get_connection(self, gateway_name: t.Optional[str] = None) -> ConnectionConfig:
+    try:
+        connection = original_get_connection(self, gateway_name)
+    except:
+        connection = DuckDBConnectionConfig()
+    return connection
+
+
+setattr(Config, "original_get_connection", original_get_connection)
+setattr(Config, "get_connection", _lax_get_connection)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,26 +1,5 @@
-import typing as t
-
 from sqlmesh.core import constants as c
 from sqlmesh.core.analytics import disable_analytics
-from sqlmesh.core.config import Config, DuckDBConnectionConfig
-from sqlmesh.core.config.connection import ConnectionConfig
 
 c.MAX_FORK_WORKERS = 1
 disable_analytics()
-
-
-# Replace the implementation of Config._get_connection with a new one that always
-# returns a ConnectionConfig to simplify testing
-original_get_connection = Config.get_connection
-
-
-def _lax_get_connection(self, gateway_name: t.Optional[str] = None) -> ConnectionConfig:
-    try:
-        connection = original_get_connection(self, gateway_name)
-    except:
-        connection = DuckDBConnectionConfig()
-    return connection
-
-
-setattr(Config, "original_get_connection", original_get_connection)
-setattr(Config, "get_connection", _lax_get_connection)


### PR DESCRIPTION
Up until now the config's `default_connection` was default initialized to DuckDB for less setup friction.

However, if the gateway connection was not configured properly, this could lead to us silently replacing it with DuckDB.

Our tests largely depended on that fact so as to reduce boilerplate code, and by making it optional there were many failures introduced. For that matter, I went ahead and solved it by monkey-patching `Config.get_connection()`.

