### PR TITLE
Chore: Ensure model search fails gracefully

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -885,8 +885,15 @@ class GenericContext(BaseContext, t.Generic[C]):
                 if normalized_name in self._models:
                     return self._models[normalized_name]
         except:
-            if raise_if_missing:
-                raise SQLMeshError(f"Cannot find model with name '{model_or_snapshot}'")
+            pass
+
+        if raise_if_missing:
+            if model_or_snapshot.endswith((".sql", ".py")):
+                msg = "Resolving models by path is not supported, please pass in the model name instead."
+            else:
+                msg = f"Cannot find model with name '{model_or_snapshot}'"
+
+            raise SQLMeshError(msg)
 
         return None
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -869,7 +869,12 @@ class GenericContext(BaseContext, t.Generic[C]):
         Returns:
             The expected model.
         """
-        if isinstance(model_or_snapshot, str):
+        if isinstance(model_or_snapshot, Snapshot):
+            return model_or_snapshot.model
+        if not isinstance(model_or_snapshot, str):
+            return model_or_snapshot
+
+        try:
             # We should try all dialects referenced in the project for cases when models use mixed dialects.
             for dialect in self._all_dialects:
                 normalized_name = normalize_model_name(
@@ -879,13 +884,9 @@ class GenericContext(BaseContext, t.Generic[C]):
                 )
                 if normalized_name in self._models:
                     return self._models[normalized_name]
-        elif isinstance(model_or_snapshot, Snapshot):
-            return model_or_snapshot.model
-        else:
-            return model_or_snapshot
-
-        if raise_if_missing:
-            raise SQLMeshError(f"Cannot find model for '{model_or_snapshot}'")
+        except:
+            if raise_if_missing:
+                raise SQLMeshError(f"Cannot find model with name '{model_or_snapshot}'")
 
         return None
 

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -6148,3 +6148,13 @@ def test_missing_connection_config():
     ctx = Context(
         config=Config(gateways={"default": GatewayConfig(connection=DuckDBConnectionConfig())})
     )
+
+@use_terminal_console
+def test_render_path_instead_of_model(tmp_path: Path):
+    create_temp_file(tmp_path, Path("models/test.sql"), "MODEL (name test_model); SELECT 1 AS col")
+    ctx = Context(paths=tmp_path, config=Config())
+
+    with pytest.raises(SQLMeshError, match="Cannot find model with name 'models/test.sql'"):
+        ctx.render("models/test.sql")
+
+    assert ctx.render("test_model").sql() == 'SELECT 1 AS "col"'

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -6149,12 +6149,23 @@ def test_missing_connection_config():
         config=Config(gateways={"default": GatewayConfig(connection=DuckDBConnectionConfig())})
     )
 
+
 @use_terminal_console
 def test_render_path_instead_of_model(tmp_path: Path):
     create_temp_file(tmp_path, Path("models/test.sql"), "MODEL (name test_model); SELECT 1 AS col")
     ctx = Context(paths=tmp_path, config=Config())
 
-    with pytest.raises(SQLMeshError, match="Cannot find model with name 'models/test.sql'"):
-        ctx.render("models/test.sql")
+    # Case 1: Fail gracefully when the user is passing in a path instead of a model name
+    for test_model in ["models/test.sql", "models/test.py"]:
+        with pytest.raises(
+            SQLMeshError,
+            match="Resolving models by path is not supported, please pass in the model name instead.",
+        ):
+            ctx.render(test_model)
 
+    # Case 2: Fail gracefully when the model name is not found
+    with pytest.raises(SQLMeshError, match="Cannot find model with name 'incorrect_model'"):
+        ctx.render("incorrect_model")
+
+    # Case 3: Render the model successfully
     assert ctx.render("test_model").sql() == 'SELECT 1 AS "col"'


### PR DESCRIPTION
It is often that users try to render a model as `sqlmesh render <path>` instead of `sqlmesh render <model_name>`, which is followed by the cryptic error:

```Python3
❯ sqlmesh render models/test_model.sql
Error: Failed to parse 'models/test_model.sql' into <class 'sqlglot.expressions.Table'>
```

This PR makes it so that `GenericContext::get_model()` fails gracefully, which will then lead to a clearer error:

```
❯ sqlmesh render models/test_model.sql
Resolving models by path is not supported, please pass in the model name instead.
```