### PR TITLE
Fix: ensure paths exist before treating them as relative (metaprogramming)

### DIFF
--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -37,7 +37,7 @@ def _is_relative_to(path: t.Optional[Path | str], other: t.Optional[Path | str])
     if isinstance(other, str):
         other = Path(other)
 
-    if "site-packages" in str(path):
+    if "site-packages" in str(path) or not path.exists() or not other.exists():
         return False
 
     try:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -10122,3 +10122,24 @@ def check_self_schema(evaluator):
 
     context = Context(paths=tmp_path, config=config)
     context.plan(no_prompts=True, auto_apply=True)
+
+
+def test_model_relies_on_os_getenv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    init_example_project(tmp_path, dialect="duckdb", template=ProjectTemplate.EMPTY)
+
+    (tmp_path / "macros" / "getenv_macro.py").write_text(
+        """
+from os import getenv
+from sqlmesh import macro
+
+@macro()
+def getenv_macro(evaluator):
+    getenv("foo", None)
+    return 1"""
+    )
+    (tmp_path / "models" / "model.sql").write_text(
+        "MODEL (name test); SELECT @getenv_macro() AS foo"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    ctx = Context(paths=tmp_path)


### PR DESCRIPTION
Added test failed with the following error prior to this fix:

```
E       sqlmesh.utils.errors.ConfigError: Failed to load model definition at '/private/var/folders/d9/8x4drv4j38j2y2qxm_3bvp_80000gn/T/pytest-of-georgesittas/pytest-147/test_model_relies_on_os_getenv0/models/model.sql':
E         lineno is out of bounds
```

The issue is that `inspect.getfile` returns `'<frozen os>'` for `getenv`, which is incorrectly treated as relative to the project:

```
(Pdb) path.absolute()
PosixPath('/private/var/folders/d9/8x4drv4j38j2y2qxm_3bvp_80000gn/T/pytest-of-georgesittas/pytest-147/test_model_relies_on_os_getenv0/macros/getenv_macro.py')
(Pdb) other.absolute()
PosixPath('/private/var/folders/d9/8x4drv4j38j2y2qxm_3bvp_80000gn/T/pytest-of-georgesittas/pytest-147/test_model_relies_on_os_getenv0')
(Pdb) path.absolute().relative_to(other.absolute())
PosixPath('macros/getenv_macro.py')
```

^ This makes sqlmesh think that `getenv` is defined locally in the project, so while trying to serialize its source code it crashes with the above "out of bounds" error, since when we try to fetch its source code it's an empty string.