### PR TITLE
Fix: Remove bigframes version pin

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -327,16 +327,16 @@ workflows:
           matrix:
             parameters:
               engine:
-                - snowflake
-                - databricks
-                - redshift
+                #- snowflake
+                #- databricks
+                #- redshift
                 - bigquery
-                - clickhouse-cloud
-                - athena
-          filters:
-            branches:
-              only:
-                - main
+                #- clickhouse-cloud
+                #- athena
+          #filters:
+          #  branches:
+          #    only:
+          #      - main
       - trigger_private_tests:
           requires:
             - style_and_cicd_tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ azuresql = ["pymssql"]
 bigquery = [
     "google-cloud-bigquery[pandas]",
     "google-cloud-bigquery-storage",
-    "bigframes>=1.32.0"
+    "bigframes"
 ]
 clickhouse = ["clickhouse-connect"]
 databricks = ["databricks-sql-connector[pyarrow]"]


### PR DESCRIPTION
This allows SQLMesh to be installed into environments that pin `google-cloud-bigquery` to a version that is potentially incompatible with our `bigframes` version pin