### PR TITLE
Fix: improve error handling when SQL model query is invalid

### DIFF
--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -10150,3 +10150,22 @@ def getenv_macro(evaluator):
 
     monkeypatch.chdir(tmp_path)
     ctx = Context(paths=tmp_path)
+
+
+def test_invalid_sql_model_query() -> None:
+    for kind in ("", ", KIND FULL"):
+        expressions = d.parse(
+            f"""
+            MODEL (name db.table{kind});
+
+            JINJA_STATEMENT_BEGIN;
+            SELECT 1 AS c;
+            JINJA_END;
+            """
+        )
+
+        with pytest.raises(
+            ConfigError,
+            match=r"^A query is required and must be a SELECT statement, a UNION statement, or a JINJA_QUERY block.*",
+        ):
+            load_sql_based_model(expressions)


### PR DESCRIPTION
Behavior in main today (note that we need `JINJA_QUERY_BEGIN`):

```sql
MODEL (name test);

JINJA_STATEMENT_BEGIN;
SELECT 1 AS c
JINJA_END;
```

Fails with a `KeyError: kind` due to this [line](https://github.com/TobikoData/sqlmesh/blob/68def3041e7ae2dad72e2bb3732736157635e4f1/sqlmesh/core/model/definition.py#L2192), which is reported... poorly :)

```
$ sqlmesh --debug info
Error: Failed to load model definition at '.../playground/models/test.sql':
  'kind'
```

If I set the model kind explicitly:

```sql
MODEL (name test, kind FULL);

JINJA_STATEMENT_BEGIN;
SELECT 1 AS c
JINJA_END;
```

I see an error that the `path` attribute is missing, even though that's only relevant to `SEED` models:

```
$ sqlmesh --debug info
Error: Failed to load model definition at '.../playground/models/test.sql':
  Invalid field 'path':
    Field required
```