### PR TITLE
Fix: expand the 'tag:' selector based on local models and not remote ones

### DIFF
--- a/sqlmesh/core/selector.py
+++ b/sqlmesh/core/selector.py
@@ -93,7 +93,7 @@ class Selector:
             }
 
         all_selected_models = self.expand_model_selections(
-            model_selections, models={**self._models, **env_models}
+            model_selections, models={**env_models, **self._models}
         )
 
         dag: DAG[str] = DAG()

--- a/tests/core/test_selector.py
+++ b/tests/core/test_selector.py
@@ -664,16 +664,9 @@ def test_select_models_local_tags_take_precedence_over_remote(
         name="db.existing",
         query=d.parse_one("SELECT 1 AS a"),
     )
-    new_model = SqlModel(
-        name="db.new",
-        tags=["a"],
-        query=d.parse_one("SELECT 1 as a"),
-    )
 
     existing_snapshot = make_snapshot(existing_model)
     existing_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
-    new_snapshot = make_snapshot(new_model)
-    new_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
 
     env_name = "test_env"
 
@@ -690,9 +683,13 @@ def test_select_models_local_tags_take_precedence_over_remote(
     }
 
     local_models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")
+    local_new = SqlModel(
+        name="db.new",
+        tags=["a"],
+        query=d.parse_one("SELECT 1 as a"),
+    )
     local_existing = existing_model.copy(update={"tags": ["a"]})  # type: ignore
     local_models[local_existing.fqn] = local_existing
-    local_new = new_model.copy()
     local_models[local_new.fqn] = local_new
 
     selector = Selector(state_reader_mock, local_models)


### PR DESCRIPTION
This addresses an issue where if you add a tag to a local model that has previously been run / committed to state and run `sqlmesh plan --select-model 'tag:<new tag>'`, the model doesnt get included.