### PR TITLE
Refactor: Move engine adapter instantiation after loading on-demand

### DIFF
--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -55,6 +55,14 @@ class SchedulerConfig(abc.ABC):
         """
 
     @abc.abstractmethod
+    def get_default_catalog_per_gateway(self, context: GenericContext) -> t.Dict[str, str]:
+        """Returns the default catalog for each gateway.
+
+        Args:
+            context: The SQLMesh Context.
+        """
+
+    @abc.abstractmethod
     def state_sync_fingerprint(self, context: GenericContext) -> str:
         """Returns the fingerprint of the State Sync configuration.
 
@@ -138,6 +146,13 @@ class BuiltInSchedulerConfig(_EngineAdapterStateSyncSchedulerConfig, BaseConfig)
 
     def get_default_catalog(self, context: GenericContext) -> t.Optional[str]:
         return context.engine_adapter.default_catalog
+
+    def get_default_catalog_per_gateway(self, context: GenericContext) -> t.Dict[str, str]:
+        return {
+            name: adapter.default_catalog
+            for name, adapter in context.engine_adapters.items()
+            if adapter.default_catalog
+        }
 
 
 SCHEDULER_CONFIG_TO_TYPE = {

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -332,18 +332,18 @@ def test_evaluate_limit():
 def test_gateway_specific_adapters(copy_to_temp_path, mocker):
     path = copy_to_temp_path("examples/sushi")
     ctx = Context(paths=path, config="isolated_systems_config", gateway="prod")
-    assert len(ctx._engine_adapters) == 3
-    assert ctx.engine_adapter == ctx._engine_adapters["prod"]
-    assert ctx._get_engine_adapter("dev") == ctx._engine_adapters["dev"]
+    assert len(ctx.engine_adapters) == 3
+    assert ctx.engine_adapter == ctx.engine_adapters["prod"]
+    assert ctx._get_engine_adapter("dev") == ctx.engine_adapters["dev"]
 
     ctx = Context(paths=path, config="isolated_systems_config")
-    assert len(ctx._engine_adapters) == 3
-    assert ctx.engine_adapter == ctx._engine_adapters["dev"]
+    assert len(ctx.engine_adapters) == 3
+    assert ctx.engine_adapter == ctx.engine_adapters["dev"]
 
     ctx = Context(paths=path, config="isolated_systems_config")
     assert len(ctx.engine_adapters) == 3
     assert ctx.engine_adapter == ctx._get_engine_adapter()
-    assert ctx._get_engine_adapter("test") == ctx._engine_adapters["test"]
+    assert ctx._get_engine_adapter("test") == ctx.engine_adapters["test"]
 
 
 def test_multiple_gateways(tmp_path: Path):
@@ -800,7 +800,8 @@ def test_janitor(sushi_context, mocker: MockerFixture) -> None:
         ),
     ]
 
-    sushi_context._engine_adapters = {sushi_context.config.default_gateway: adapter_mock}
+    sushi_context._engine_adapter = adapter_mock
+    sushi_context.engine_adapters = {sushi_context.config.default_gateway: adapter_mock}
     sushi_context._state_sync = state_sync_mock
     state_sync_mock.get_expired_snapshots.return_value = []
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -4518,7 +4518,7 @@ def test_model_session_properties(sushi_context):
                 name test_schema.test_model,
                 session_properties (
                     'query_label' = (
-                        'some value', 
+                        'some value',
                         'another value',
                         'yet another value',
                     )
@@ -8350,7 +8350,7 @@ def test_gateway_specific_render(assert_exp_eq) -> None:
         default_gateway="main",
     )
     context = Context(config=config)
-    assert context.engine_adapter == context._engine_adapters["main"]
+    assert context.engine_adapter == context.engine_adapters["main"]
 
     @model(
         name="dummy_model",
@@ -8376,7 +8376,7 @@ def test_gateway_specific_render(assert_exp_eq) -> None:
         """,
     )
     assert isinstance(context._get_engine_adapter("duckdb"), DuckDBEngineAdapter)
-    assert len(context._engine_adapters) == 2
+    assert len(context.engine_adapters) == 2
 
 
 def test_model_on_virtual_update(make_snapshot: t.Callable):

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -2128,7 +2128,7 @@ def test_test_with_gateway_specific_model(tmp_path: Path, mocker: MockerFixture)
         return_value=pd.DataFrame({"c": [5]}),
     )
 
-    assert context.engine_adapter == context._engine_adapters["main"]
+    assert context.engine_adapter == context.engine_adapters["main"]
     with pytest.raises(
         SQLMeshError, match=r"Gateway 'wrong' not found in the available engine adapters."
     ):
@@ -2136,8 +2136,8 @@ def test_test_with_gateway_specific_model(tmp_path: Path, mocker: MockerFixture)
 
     # Create test should use the gateway specific engine adapter
     context.create_test("sqlmesh_example.gw_model", input_queries=input_queries, overwrite=True)
-    assert context._get_engine_adapter("second") == context._engine_adapters["second"]
-    assert len(context._engine_adapters) == 2
+    assert context._get_engine_adapter("second") == context.engine_adapters["second"]
+    assert len(context.engine_adapters) == 2
 
     test = load_yaml(context.path / c.TESTS / "test_gw_model.yaml")
 


### PR DESCRIPTION
This update refactors context to defer engine adapter creation until after the context is loaded creating it in the snapshot evaluation instantiation when needed. It also adapts the default_catalog_per_gateway mapping to be sourced from the scheduler config instead.