### PR TITLE
Fix: dbt-core 1.9.5 freshness error

### DIFF
--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -154,16 +154,21 @@ class ManifestHelper:
     def _load_sources(self) -> None:
         for source in self._manifest.sources.values():
             # starting in dbt-core 1.9.5, freshness can be set in both source and source config
-            freshness = merge_freshness(source.freshness, source.config.freshness)
-
-            config_source_dict = _config(source)
-            config_source_dict.pop("freshness", None)
-
             source_dict = source.to_dict()
             source_dict.pop("freshness", None)
 
+            source_config_dict = _config(source)
+            source_config_dict.pop("freshness", None)
+
+            source_config_freshness = getattr(source.config, "freshness", None)
+            freshness = (
+                merge_freshness(source.freshness, source_config_freshness)
+                if source_config_freshness
+                else source.freshness
+            )
+
             source_config = SourceConfig(
-                **config_source_dict,
+                **source_config_dict,
                 **source_dict,
                 freshness=freshness.to_dict() if freshness else None,
             )

--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -153,18 +153,19 @@ class ManifestHelper:
 
     def _load_sources(self) -> None:
         for source in self._manifest.sources.values():
-            config_source = _config(source)
-            source_dict = source.to_dict()
-
             # starting in dbt-core 1.9.5, freshness can be set in both source and source config
-            config_source_freshness = config_source.pop("freshness", None)
-            source_dict_freshness = source_dict.pop("freshness", None)
-            freshness = merge_freshness(source_dict_freshness, config_source_freshness)
+            freshness = merge_freshness(source.freshness, source.config.freshness)
+
+            config_source_dict = _config(source)
+            config_source_dict.pop("freshness", None)
+
+            source_dict = source.to_dict()
+            source_dict.pop("freshness", None)
 
             source_config = SourceConfig(
-                **config_source,
+                **config_source_dict,
                 **source_dict,
-                freshness=freshness,
+                freshness=freshness.to_dict() if freshness else None,
             )
             self._sources_per_package[source.package_name][source_config.config_name] = (
                 source_config

--- a/tests/dbt/test_manifest.py
+++ b/tests/dbt/test_manifest.py
@@ -113,6 +113,11 @@ def test_manifest_helper(caplog):
     assert sources["streaming.orders"].schema_ == "raw"
     assert sources["streaming.order_items"].table_name == "order_items"
     assert sources["streaming.order_items"].schema_ == "raw"
+    assert sources["streaming.order_items"].freshness == {
+        "error_after": {"count": 13, "period": "hour"},
+        "filter": None,
+        "warn_after": {"count": 12, "period": "hour"},
+    }
 
 
 @pytest.mark.xdist_group("dbt_manifest")

--- a/tests/dbt/test_manifest.py
+++ b/tests/dbt/test_manifest.py
@@ -9,6 +9,7 @@ from sqlmesh.dbt.context import DbtContext
 from sqlmesh.dbt.manifest import ManifestHelper
 from sqlmesh.dbt.profile import Profile
 from sqlmesh.dbt.builtin import Api, _relation_info_to_relation
+from sqlmesh.dbt.util import DBT_VERSION
 from sqlmesh.utils.jinja import MacroReference
 
 pytestmark = pytest.mark.dbt
@@ -113,10 +114,11 @@ def test_manifest_helper(caplog):
     assert sources["streaming.orders"].schema_ == "raw"
     assert sources["streaming.order_items"].table_name == "order_items"
     assert sources["streaming.order_items"].schema_ == "raw"
+
     assert sources["streaming.order_items"].freshness == {
-        "error_after": {"count": 13, "period": "hour"},
+        "warn_after": {"count": 10 if DBT_VERSION < (1, 9, 5) else 12, "period": "hour"},
+        "error_after": {"count": 11 if DBT_VERSION < (1, 9, 5) else 13, "period": "hour"},
         "filter": None,
-        "warn_after": {"count": 12, "period": "hour"},
     }
 
 

--- a/tests/fixtures/dbt/sushi_test/models/schema.yml
+++ b/tests/fixtures/dbt/sushi_test/models/schema.yml
@@ -9,8 +9,14 @@ models:
         data_type: double
       - name: model_columns
         data_type: int
+    freshness:
+      warn_after: {count: 6, period: hour}
+      error_after: {count: 7, period: hour}
     config:
       dialect: postgres
+      freshness:
+        warn_after: {count: 8, period: hour}
+        error_after: {count: 9, period: hour}
   - name: waiters
   - name: waiter_as_customer_by_day
   - name: waiter_revenue_by_day
@@ -30,6 +36,13 @@ sources:
       - name: items
       - name: orders
       - name: order_items
+    freshness:
+      warn_after: {count: 10, period: hour}
+      error_after: {count: 11, period: hour}
+    config:
+      freshness:
+        warn_after: {count: 12, period: hour}
+        error_after: {count: 13, period: hour}
 
   - name: parquet_file
     meta:


### PR DESCRIPTION
With 1.9.5, dbt-core added a `freshness` parameter to model and source configs (in addition to the existing top-level properties).

We pass all contents of both a source's top-level keys and config into our `SourceConfig` constructor, so we get a duplicate `freshness` key error.

This PR uses the dbt.parser.sources `merge_freshness` function to merge the two freshnesses before passing to `SourceConfig`.

closes #4574 