### PR TITLE
Chore: improve error message when no MODEL block

### DIFF
--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -452,10 +452,12 @@ class Loader(abc.ABC):
         self._path_mtimes[path] = path.stat().st_mtime
 
     def _failed_to_load_model_error(self, path: Path, error: t.Union[str, Exception]) -> str:
-        base_message = f"Failed to load model definition at '{path}':"
+        base_message = f"Failed to load model from file '{path}':"
         if isinstance(error, ValidationError):
             return validation_error_message(error, base_message)
-        return f"{base_message}\n  {error}"
+        # indent all lines of error message
+        error_message = str(error).replace("\n", "\n  ")
+        return f"{base_message}\n\n  {error_message}"
 
 
 class SqlMeshLoader(Loader):

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2036,18 +2036,25 @@ def load_sql_based_model(
         variables: The variables to pass to the model.
         kwargs: Additional kwargs to pass to the loader.
     """
+    missing_model_msg = f"""Please add a required MODEL block at top of the file. Example:
+
+MODEL (
+  name sqlmesh_example.full_model, --model name
+  kind VIEW, --materialization
+  cron '@daily', --schedule
+);
+
+Learn more at https://sqlmesh.readthedocs.io/en/stable/concepts/models/overview
+"""
+
     if not expressions:
-        raise_config_error("Incomplete model definition, missing MODEL statement", path)
+        raise_config_error(missing_model_msg)
 
     dialect = dialect or ""
     meta = expressions[0]
     if not isinstance(meta, d.Model):
         if not infer_names:
-            raise_config_error(
-                "The MODEL statement is required as the first statement in the definition, "
-                "unless model name inference is enabled.",
-                path,
-            )
+            raise_config_error(missing_model_msg)
         meta = d.Model(expressions=[])  # Dummy meta node
         expressions.insert(0, meta)
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2036,7 +2036,7 @@ def load_sql_based_model(
         variables: The variables to pass to the model.
         kwargs: Additional kwargs to pass to the loader.
     """
-    missing_model_msg = f"""Please add a required MODEL block at top of the file. Example:
+    missing_model_msg = f"""Please add a MODEL block at the top of the file. Example:
 
 MODEL (
   name sqlmesh_example.full_model, --model name

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2040,7 +2040,7 @@ def load_sql_based_model(
 
 MODEL (
   name sqlmesh_example.full_model, --model name
-  kind VIEW, --materialization
+  kind FULL, --materialization
   cron '@daily', --schedule
 );
 

--- a/tests/core/test_loader.py
+++ b/tests/core/test_loader.py
@@ -159,7 +159,7 @@ def execute(
 
     with pytest.raises(
         ConfigError,
-        match=r"Failed to load model definition at '.*'.\n  Duplicate name: 'test_schema.test_model'.",
+        match=r"Failed to load model from file '.*'.\n\n  Duplicate name: 'test_schema.test_model'.",
     ):
         Context(paths=tmp_path, config=config)
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -576,7 +576,7 @@ def test_no_model_statement(tmp_path: Path):
     expressions = d.parse("SELECT 1 AS x")
     with pytest.raises(
         ConfigError,
-        match="Please add a required MODEL block at top of the file. Example:",
+        match="Please add a MODEL block at the top of the file. Example:",
     ):
         load_sql_based_model(expressions)
 
@@ -613,7 +613,7 @@ def test_unordered_model_statements():
 
     with pytest.raises(ConfigError) as ex:
         load_sql_based_model(expressions)
-    assert "Please add a required MODEL block at top of the file. Example:" in str(ex.value)
+    assert "Please add a MODEL block at the top of the file. Example:" in str(ex.value)
 
 
 def test_no_query():

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -613,7 +613,7 @@ def test_unordered_model_statements():
 
     with pytest.raises(ConfigError) as ex:
         load_sql_based_model(expressions)
-    assert "MODEL statement is required" in str(ex.value)
+    assert "Please add a required MODEL block at top of the file. Example:" in str(ex.value)
 
 
 def test_no_query():

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -576,7 +576,7 @@ def test_no_model_statement(tmp_path: Path):
     expressions = d.parse("SELECT 1 AS x")
     with pytest.raises(
         ConfigError,
-        match="The MODEL statement is required as the first statement in the definition, unless model name inference is enabled. at '.'",
+        match="Please add a required MODEL block at top of the file. Example:",
     ):
         load_sql_based_model(expressions)
 


### PR DESCRIPTION
Old
```
The MODEL statement is required as the first statement in the definition, unless model name inference is enabled.
```

New
```
Please add a MODEL block at the top of the file. Example:

MODEL (
  name sqlmesh_example.full_model, --model name
  kind VIEW, --materialization
  cron '@daily', --schedule
);

Learn more at https://sqlmesh.readthedocs.io/en/stable/concepts/models/overview
```