### PR TITLE
fix(vscode): render models without descriptions

### DIFF
--- a/sqlmesh/lsp/custom.py
+++ b/sqlmesh/lsp/custom.py
@@ -36,7 +36,7 @@ class RenderModelEntry(PydanticModel):
 
     name: str
     fqn: str
-    description: str
+    description: t.Optional[str] = None
     rendered_query: str
 
 

--- a/vscode/extension/src/commands/renderModel.ts
+++ b/vscode/extension/src/commands/renderModel.ts
@@ -42,10 +42,10 @@ export function renderModel(lspClient?: LSPClient) {
     // If multiple models, let user choose
     let selectedModel: RenderModelEntry
     if (result.value.models.length > 1) {
-      const items = result.value.models.map((model: RenderModelEntry) => ({
+      const items = result.value.models.map(model => ({
         label: model.name,
         description: model.fqn,
-        detail: model.description,
+        detail: model.description ? model.description : undefined,
         model: model,
       }))
 

--- a/vscode/extension/src/lsp/custom.ts
+++ b/vscode/extension/src/lsp/custom.ts
@@ -21,7 +21,7 @@ interface RenderModelResponse {
 export interface RenderModelEntry {
   name: string
   fqn: string
-  description: string
+  description: string | null | undefined
   rendered_query: string
 }
 

--- a/vscode/extension/tests/utils.ts
+++ b/vscode/extension/tests/utils.ts
@@ -40,6 +40,8 @@ export const startVSCode = async (workspaceDir: string): Promise<{
       args,
     });
     const window = await electronApp.firstWindow();
+    await window.waitForLoadState('domcontentloaded');
+    await window.waitForLoadState('networkidle');
     return { window, close: async () => {
       await electronApp.close();
       await fs.removeSync(userDataDir);


### PR DESCRIPTION
There was a weird reasoon why `mypy` didn't catch mapping t.Optional[str] into str which caused an unexpected runtime error when the pydantic model was validated and the description was None