### PR TITLE
Fix: Use memory gateway for LSP test to avoid creating actual db

### DIFF
--- a/tests/lsp/test_reference_macro_multi.py
+++ b/tests/lsp/test_reference_macro_multi.py
@@ -7,7 +7,7 @@ from sqlmesh.lsp.uri import URI
 
 @pytest.mark.fast
 def test_macro_references_multirepo() -> None:
-    context = Context(paths=["examples/multi/repo_1", "examples/multi/repo_2"])
+    context = Context(paths=["examples/multi/repo_1", "examples/multi/repo_2"], gateway="memory")
     lsp_context = LSPContext(context)
 
     d_path = next(


### PR DESCRIPTION
This is to avoid creating an actual local duckdb database by using the in-memory config for multi repo for the lsp test.