### PR TITLE
Fix: Compare columns by using the schema differ based on snapshots dialect

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -93,7 +93,6 @@ from sqlmesh.core.plan import Plan, PlanBuilder, SnapshotIntervals
 from sqlmesh.core.plan.definition import UserProvidedFlags
 from sqlmesh.core.reference import ReferenceGraph
 from sqlmesh.core.scheduler import Scheduler, CompletionStatus
-from sqlmesh.core.schema_diff import SchemaDiffer
 from sqlmesh.core.schema_loader import create_external_models_file
 from sqlmesh.core.selector import Selector
 from sqlmesh.core.snapshot import (
@@ -1541,7 +1540,6 @@ class GenericContext(BaseContext, t.Generic[C]):
             ),
             end_bounded=not run,
             ensure_finalized_snapshots=self.config.plan.use_finalized_state,
-            engine_schema_differ=SchemaDiffer(),  # TODO: fix to properly handle it
             interval_end_per_model=max_interval_end_per_model,
             console=self.console,
             user_provided_flags=user_provided_flags,

--- a/sqlmesh/core/schema_diff.py
+++ b/sqlmesh/core/schema_diff.py
@@ -723,5 +723,27 @@ def get_dropped_column_names(alter_expressions: t.List[exp.Alter]) -> t.List[str
     return dropped_columns
 
 
+def get_schema_differ(dialect: str) -> SchemaDiffer:
+    """
+    Returns the appropriate SchemaDiffer for a given dialect without initializing the engine adapter.
+
+    Args:
+        dialect: The dialect for which to get the schema differ.
+
+    Returns:
+        The SchemaDiffer instance configured for the given dialect.
+    """
+    from sqlmesh.core.engine_adapter import (
+        DIALECT_TO_ENGINE_ADAPTER,
+        DIALECT_ALIASES,
+        EngineAdapter,
+    )
+
+    dialect = dialect.lower()
+    dialect = DIALECT_ALIASES.get(dialect, dialect)
+    engine_adapter_class = DIALECT_TO_ENGINE_ADAPTER.get(dialect, EngineAdapter)
+    return getattr(engine_adapter_class, "SCHEMA_DIFFER", SchemaDiffer())
+
+
 def _get_name_and_type(struct: exp.ColumnDef) -> t.Tuple[exp.Identifier, exp.DataType]:
     return struct.this, struct.args["kind"]

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -279,7 +279,6 @@ def test_diff(sushi_context: Context, mocker: MockerFixture):
 
     plan = PlanBuilder(
         context_diff=sushi_context._context_diff("prod"),
-        engine_schema_differ=sushi_context.engine_adapter.SCHEMA_DIFFER,
     ).build()
 
     # stringify used to trigger an unhashable exception due to

--- a/tests/core/test_plan_evaluator.py
+++ b/tests/core/test_plan_evaluator.py
@@ -22,7 +22,6 @@ def sushi_plan(sushi_context: Context, mocker: MockerFixture) -> Plan:
 
     return PlanBuilder(
         sushi_context._context_diff("dev"),
-        sushi_context.engine_adapter.SCHEMA_DIFFER,
         is_dev=True,
         include_unmodified=True,
     ).build()
@@ -57,9 +56,7 @@ def test_builtin_evaluator_push(sushi_context: Context, make_snapshot):
     new_model_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
     new_view_model_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
 
-    plan = PlanBuilder(
-        sushi_context._context_diff("prod"), sushi_context.engine_adapter.SCHEMA_DIFFER
-    ).build()
+    plan = PlanBuilder(sushi_context._context_diff("prod")).build()
 
     evaluator = BuiltInPlanEvaluator(
         sushi_context.state_sync,


### PR DESCRIPTION
This update retrieves the schema differ when comparing columns based on the snapshot's dialect, instead of using a generic differ when comparing columns. This approach suggested by @georgesittas avoids the need to initialise an engine adapter by fetching the schema differ directly from the class using the dialect