### PR TITLE
Chore: Fix flaky dbt test by grouping it with xdist

### DIFF
--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -1556,9 +1556,9 @@ def test_grain():
     assert model.to_sqlmesh(context).grains == [exp.to_column("id_a")]
 
 
-def test_on_run_start_end(copy_to_temp_path):
-    project_root = "tests/fixtures/dbt/sushi_test"
-    sushi_context = Context(paths=copy_to_temp_path(project_root))
+@pytest.mark.xdist_group("dbt_manifest")
+def test_on_run_start_end():
+    sushi_context = Context(paths=["tests/fixtures/dbt/sushi_test"])
     assert len(sushi_context._environment_statements) == 2
 
     # Root project's on run start / on run end should be first by checking the macros


### PR DESCRIPTION
This test has been failing in some commits so marked the test with `@pytest.mark.xdist_group("dbt_manifest")`, and since we simply load reuse the path than create a copy, to prevent flaky behaviour similar to the rest dbt manifest-related tests.