### PR TITLE
Add data path and encrypted to duckdb catalog

### DIFF
--- a/docs/integrations/engines/duckdb.md
+++ b/docs/integrations/engines/duckdb.md
@@ -64,6 +64,50 @@ SQLMesh will place models with the explicit catalog "ephemeral", such as `epheme
     )
     ```
 
+#### DuckLake Catalog Example
+=== "YAML"
+
+    ```yaml linenums="1"
+    gateways:
+      my_gateway:
+        connection:
+          type: duckdb
+          catalogs:
+            ducklake:
+              type: ducklake
+              path: 'catalog.ducklake'
+              data_path: data/ducklake
+    ```
+    
+=== "Python"
+
+    ```python linenums="1"
+    from sqlmesh.core.config import (
+        Config,
+        ModelDefaultsConfig,
+        GatewayConfig,
+        DuckDBConnectionConfig
+    )
+    from sqlmesh.core.config.connection import DuckDBAttachOptions
+
+    config = Config(
+        model_defaults=ModelDefaultsConfig(dialect=<dialect>),
+        gateways={
+            "my_gateway": GatewayConfig(
+                connection=DuckDBConnectionConfig(
+                    catalogs={
+                        "ducklake": DuckDBAttachOptions(
+                            type="ducklake",
+                            path="catalog.ducklake",
+                            data_path="data/ducklake"
+                        ),
+                    }
+                )
+            ),
+        }
+    )
+    ```
+
 #### Other Connection Catalogs Example
 
 Catalogs can also be defined to connect to anything that [DuckDB can be attached to](https://duckdb.org/docs/sql/statements/attach.html).

--- a/docs/integrations/engines/duckdb.md
+++ b/docs/integrations/engines/duckdb.md
@@ -77,6 +77,7 @@ SQLMesh will place models with the explicit catalog "ephemeral", such as `epheme
               type: ducklake
               path: 'catalog.ducklake'
               data_path: data/ducklake
+              encrypted: True
     ```
     
 === "Python"
@@ -99,7 +100,8 @@ SQLMesh will place models with the explicit catalog "ephemeral", such as `epheme
                         "ducklake": DuckDBAttachOptions(
                             type="ducklake",
                             path="catalog.ducklake",
-                            data_path="data/ducklake"
+                            data_path="data/ducklake",
+                            encrypted=True
                         ),
                     }
                 )

--- a/docs/integrations/engines/duckdb.md
+++ b/docs/integrations/engines/duckdb.md
@@ -65,6 +65,7 @@ SQLMesh will place models with the explicit catalog "ephemeral", such as `epheme
     ```
 
 #### DuckLake Catalog Example
+
 === "YAML"
 
     ```yaml linenums="1"

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -220,6 +220,7 @@ class DuckDBAttachOptions(BaseConfig):
     type: str
     path: str
     read_only: bool = False
+    data_path: t.Optional[str] = None  # Support for ducklake DATA_PATH
 
     def to_sql(self, alias: str) -> str:
         options = []
@@ -229,6 +230,9 @@ class DuckDBAttachOptions(BaseConfig):
             options.append(f"TYPE {self.type.upper()}")
         if self.read_only:
             options.append("READ_ONLY")
+        # Add DATA_PATH for ducklake
+        if self.type == "ducklake" and self.data_path:
+            options.append(f"DATA_PATH '{self.data_path}'")
         options_sql = f" ({', '.join(options)})" if options else ""
         alias_sql = ""
         # TODO: Add support for Postgres schema. Currently adding it blocks access to the information_schema

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -220,7 +220,10 @@ class DuckDBAttachOptions(BaseConfig):
     type: str
     path: str
     read_only: bool = False
-    data_path: t.Optional[str] = None  # Support for ducklake DATA_PATH
+
+    # DuckLake specific options
+    data_path: t.Optional[str] = None
+    encrypted: bool = False
 
     def to_sql(self, alias: str) -> str:
         options = []
@@ -230,9 +233,13 @@ class DuckDBAttachOptions(BaseConfig):
             options.append(f"TYPE {self.type.upper()}")
         if self.read_only:
             options.append("READ_ONLY")
-        # Add DATA_PATH for ducklake
+
+        # DuckLake specific options
         if self.type == "ducklake" and self.data_path:
             options.append(f"DATA_PATH '{self.data_path}'")
+        if self.type == "ducklake" and self.encrypted:
+            options.append("ENCRYPTED")
+
         options_sql = f" ({', '.join(options)})" if options else ""
         alias_sql = ""
         # TODO: Add support for Postgres schema. Currently adding it blocks access to the information_schema

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -235,10 +235,11 @@ class DuckDBAttachOptions(BaseConfig):
             options.append("READ_ONLY")
 
         # DuckLake specific options
-        if self.type == "ducklake" and self.data_path:
-            options.append(f"DATA_PATH '{self.data_path}'")
-        if self.type == "ducklake" and self.encrypted:
-            options.append("ENCRYPTED")
+        if self.type == "ducklake":
+            if self.data_path:
+                options.append(f"DATA_PATH '{self.data_path}'")
+            if self.encrypted:
+                options.append("ENCRYPTED")
 
         options_sql = f" ({', '.join(options)})" if options else ""
         alias_sql = ""

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -602,6 +602,27 @@ def test_duckdb_attach_catalog(make_config):
     assert not config.is_recommended_for_state_sync
 
 
+def test_duckdb_attach_ducklake_catalog_with_data_path(make_config):
+    config = make_config(
+        type="duckdb",
+        catalogs={
+            "ducklake": DuckDBAttachOptions(
+                type="ducklake",
+                path="catalog.ducklake",
+                data_path="/tmp/ducklake_data",
+            ),
+        },
+    )
+    assert isinstance(config, DuckDBConnectionConfig)
+    ducklake_catalog = config.catalogs.get("ducklake")
+    assert ducklake_catalog is not None
+    assert ducklake_catalog.type == "ducklake"
+    assert ducklake_catalog.path == "catalog.ducklake"
+    assert ducklake_catalog.data_path == "/tmp/ducklake_data"
+    # Check that the generated SQL includes DATA_PATH
+    assert "DATA_PATH '/tmp/ducklake_data'" in ducklake_catalog.to_sql("ducklake")
+
+
 def test_duckdb_attach_options():
     options = DuckDBAttachOptions(
         type="postgres", path="dbname=postgres user=postgres host=127.0.0.1", read_only=True

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -602,7 +602,7 @@ def test_duckdb_attach_catalog(make_config):
     assert not config.is_recommended_for_state_sync
 
 
-def test_duckdb_attach_ducklake_catalog_with_data_path(make_config):
+def test_duckdb_attach_ducklake_catalog(make_config):
     config = make_config(
         type="duckdb",
         catalogs={
@@ -610,6 +610,7 @@ def test_duckdb_attach_ducklake_catalog_with_data_path(make_config):
                 type="ducklake",
                 path="catalog.ducklake",
                 data_path="/tmp/ducklake_data",
+                encrypted=True,
             ),
         },
     )
@@ -619,8 +620,10 @@ def test_duckdb_attach_ducklake_catalog_with_data_path(make_config):
     assert ducklake_catalog.type == "ducklake"
     assert ducklake_catalog.path == "catalog.ducklake"
     assert ducklake_catalog.data_path == "/tmp/ducklake_data"
+    assert ducklake_catalog.encrypted is True
     # Check that the generated SQL includes DATA_PATH
     assert "DATA_PATH '/tmp/ducklake_data'" in ducklake_catalog.to_sql("ducklake")
+    assert "ENCRYPTED" in ducklake_catalog.to_sql("ducklake")
 
 
 def test_duckdb_attach_options():


### PR DESCRIPTION
This pull request introduces support for the `ducklake` catalog type in DuckDB, including the ability to specify a `DATA_PATH` and activate encryption of the parquet files. The changes span documentation updates, configuration enhancements, SQL generation modifications, and new test cases to ensure functionality.

### Documentation Updates:
* Added a new section in `docs/integrations/engines/duckdb.md` demonstrating how to configure the `ducklake` catalog type in both YAML and Python formats, including the use of `DATA_PATH` & `ENCRYPTED`.

### Configuration Enhancements:
* Updated the `DuckDBAttachOptions` class in `sqlmesh/core/config/connection.py` to include a new `data_path` attribute for specifying the `DATA_PATH` option in `ducklake` catalogs. In addition to that, this also adds the `ENCRYPTED` option to activate the parquet encryption.

### SQL Generation Modifications:
* Enhanced the `to_sql` method in `DuckDBAttachOptions` to include the `DATA_PATH` option when the catalog type is `ducklake` and a `data_path` is provided. And also the `ENCRYPTED` flag, if set to True.

### Testing Additions:
* Added a new test case in `tests/core/test_connection_config.py` to validate the configuration and SQL generation for `ducklake` catalogs with a `DATA_PATH` and `ENCRYPTED`.

Closes #4590 