### PR TITLE
Add ducklake `DATA_INLINING_ROW_LIMIT` attach option

### DIFF
--- a/docs/integrations/engines/duckdb.md
+++ b/docs/integrations/engines/duckdb.md
@@ -79,6 +79,7 @@ SQLMesh will place models with the explicit catalog "ephemeral", such as `epheme
               path: 'catalog.ducklake'
               data_path: data/ducklake
               encrypted: True
+              data_inlining_row_limit: 10
     ```
     
 === "Python"
@@ -102,7 +103,8 @@ SQLMesh will place models with the explicit catalog "ephemeral", such as `epheme
                             type="ducklake",
                             path="catalog.ducklake",
                             data_path="data/ducklake",
-                            encrypted=True
+                            encrypted=True,
+                            data_inlining_row_limit=10,
                         ),
                     }
                 )

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -224,6 +224,7 @@ class DuckDBAttachOptions(BaseConfig):
     # DuckLake specific options
     data_path: t.Optional[str] = None
     encrypted: bool = False
+    data_inlining_row_limit: t.Optional[int] = None
 
     def to_sql(self, alias: str) -> str:
         options = []
@@ -240,6 +241,8 @@ class DuckDBAttachOptions(BaseConfig):
                 options.append(f"DATA_PATH '{self.data_path}'")
             if self.encrypted:
                 options.append("ENCRYPTED")
+            if self.data_inlining_row_limit:
+                options.append(f"DATA_INLINING_ROW_LIMIT {self.data_inlining_row_limit}")
 
         options_sql = f" ({', '.join(options)})" if options else ""
         alias_sql = ""

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -611,6 +611,7 @@ def test_duckdb_attach_ducklake_catalog(make_config):
                 path="catalog.ducklake",
                 data_path="/tmp/ducklake_data",
                 encrypted=True,
+                data_inlining_row_limit=10,
             ),
         },
     )
@@ -621,9 +622,11 @@ def test_duckdb_attach_ducklake_catalog(make_config):
     assert ducklake_catalog.path == "catalog.ducklake"
     assert ducklake_catalog.data_path == "/tmp/ducklake_data"
     assert ducklake_catalog.encrypted is True
+    assert ducklake_catalog.data_inlining_row_limit == 10
     # Check that the generated SQL includes DATA_PATH
     assert "DATA_PATH '/tmp/ducklake_data'" in ducklake_catalog.to_sql("ducklake")
     assert "ENCRYPTED" in ducklake_catalog.to_sql("ducklake")
+    assert "DATA_INLINING_ROW_LIMIT 10" in ducklake_catalog.to_sql("ducklake")
 
 
 def test_duckdb_attach_options():


### PR DESCRIPTION
This PR adds support for configuring the `DATA_INLINING_ROW_LIMIT` (https://ducklake.select/docs/stable/duckdb/advanced_features/data_inlining
) parameter in DuckLake catalogs. This allows users to control the number of rows that can be inlined in a DuckLake catalog.

Changes:
- Added `data_inlining_row_limit` configuration option to `DuckDBAttachOptions`
- Updated documentation with example configuration
- Added tests

#4600 already did ground work for this change.

