### PR TITLE
Feat: add support for Trino's authorization session property

### DIFF
--- a/sqlmesh/core/engine_adapter/trino.py
+++ b/sqlmesh/core/engine_adapter/trino.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import pandas as pd
 import re
 import typing as t
 from functools import lru_cache
@@ -27,7 +26,6 @@ from sqlmesh.core.engine_adapter.shared import (
     SourceQuery,
     set_catalog,
 )
-from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.core.schema_diff import SchemaDiffer
 from sqlmesh.utils.date import TimeLike
 
@@ -98,10 +96,8 @@ class TrinoEngineAdapter(
             yield
             return
 
-        if isinstance(authorization, str):
+        if not isinstance(authorization, exp.Expression):
             authorization = exp.Literal.string(authorization)
-        if not (isinstance(authorization, exp.Expression) and authorization.is_string):
-            raise SQLMeshError(f"Invalid authorization: '{authorization}'")
 
         authorization_sql = authorization.sql(dialect=self.dialect)
 

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -319,7 +319,9 @@ class ModelMeta(_Node):
             return parsed_session_properties
 
         for eq in parsed_session_properties:
-            if eq.name == "query_label":
+            prop_name = eq.left.name
+
+            if prop_name == "query_label":
                 query_label = eq.right
                 if not (
                     isinstance(query_label, exp.Array)
@@ -345,6 +347,12 @@ class ModelMeta(_Node):
                         raise ConfigError(
                             "Invalid entry in `session_properties.query_label`. Must be tuples of string literals with length 2."
                         )
+            elif prop_name == "authorization":
+                authorization = eq.right
+                if not (isinstance(authorization, exp.Literal) and authorization.is_string):
+                    raise ConfigError(
+                        "Invalid value for `session_properties.authorization`. Must be a string literal."
+                    )
 
         return parsed_session_properties
 

--- a/tests/core/engine_adapter/test_trino.py
+++ b/tests/core/engine_adapter/test_trino.py
@@ -11,7 +11,6 @@ from sqlmesh.core.engine_adapter import TrinoEngineAdapter
 from sqlmesh.core.model import load_sql_based_model
 from sqlmesh.core.model.definition import SqlModel
 from sqlmesh.core.dialect import schema_
-from sqlmesh.utils.errors import SQLMeshError
 from tests.core.engine_adapter import to_sql_calls
 
 pytestmark = [pytest.mark.engine, pytest.mark.trino]
@@ -624,13 +623,7 @@ def test_session_authorization(trino_mocked_engine_adapter: TrinoEngineAdapter):
         "RESET SESSION AUTHORIZATION",
     ]
 
-    # Test 4: Invalid authorization (non-string expression)
-    adapter.cursor.execute.reset_mock()
-    with pytest.raises(SQLMeshError, match="Invalid authorization"):
-        with adapter.session({"authorization": exp.Literal.number(123)}):
-            pass
-
-    # Test 5: RESET is called even if exception occurs during session
+    # Test 4: RESET is called even if exception occurs during session
     adapter.cursor.execute.reset_mock()
     try:
         with adapter.session({"authorization": "test_user"}):

--- a/tests/core/engine_adapter/test_trino.py
+++ b/tests/core/engine_adapter/test_trino.py
@@ -11,6 +11,7 @@ from sqlmesh.core.engine_adapter import TrinoEngineAdapter
 from sqlmesh.core.model import load_sql_based_model
 from sqlmesh.core.model.definition import SqlModel
 from sqlmesh.core.dialect import schema_
+from sqlmesh.utils.errors import SQLMeshError
 from tests.core.engine_adapter import to_sql_calls
 
 pytestmark = [pytest.mark.engine, pytest.mark.trino]
@@ -591,3 +592,55 @@ def test_create_schema_sets_location(make_mocked_engine_adapter: t.Callable, moc
             'CREATE SCHEMA IF NOT EXISTS "landing"."transactions" WITH (LOCATION=\'s3://raw-data/landing/transactions\')',  # match '^landing\..*$'
         ]
     )
+
+
+def test_session_authorization(trino_mocked_engine_adapter: TrinoEngineAdapter):
+    adapter = trino_mocked_engine_adapter
+
+    # Test 1: No authorization property - should not execute any authorization commands
+    with adapter.session({}):
+        pass
+
+    assert to_sql_calls(adapter) == []
+
+    # Test 2: String authorization
+    with adapter.session({"authorization": "test_user"}):
+        adapter.execute("SELECT 1")
+
+    assert to_sql_calls(adapter) == [
+        "SET SESSION AUTHORIZATION 'test_user'",
+        "SELECT 1",
+        "RESET SESSION AUTHORIZATION",
+    ]
+
+    # Test 3: Expression authorization
+    adapter.cursor.execute.reset_mock()
+    with adapter.session({"authorization": exp.Literal.string("another_user")}):
+        adapter.execute("SELECT 2")
+
+    assert to_sql_calls(adapter) == [
+        "SET SESSION AUTHORIZATION 'another_user'",
+        "SELECT 2",
+        "RESET SESSION AUTHORIZATION",
+    ]
+
+    # Test 4: Invalid authorization (non-string expression)
+    adapter.cursor.execute.reset_mock()
+    with pytest.raises(SQLMeshError, match="Invalid authorization"):
+        with adapter.session({"authorization": exp.Literal.number(123)}):
+            pass
+
+    # Test 5: RESET is called even if exception occurs during session
+    adapter.cursor.execute.reset_mock()
+    try:
+        with adapter.session({"authorization": "test_user"}):
+            adapter.execute("SELECT 1")
+            raise RuntimeError("Test exception")
+    except RuntimeError:
+        pass
+
+    assert to_sql_calls(adapter) == [
+        "SET SESSION AUTHORIZATION 'test_user'",
+        "SELECT 1",
+        "RESET SESSION AUTHORIZATION",
+    ]


### PR DESCRIPTION
This adds first-class support for Trino's `SET SESSION AUTHORIZATION` ([docs](https://trino.io/docs/current/sql/set-session-authorization.html)), using the existing `session_properties` mapping. One can now do the following:

```sql
MODEL (
    name <model_name>,
    ...,
    session_properties (
        authorization = 'foo'
    )
);
```

which will result in the following statement:

```sql
SET SESSION AUTHORIZATION 'foo';
```

to be run **before** anything relevant to this model is executed, and then the following statement:

```sql
RESET SESSION AUTHORIZATION;
```

will run **after** all statements relevant to this model have been executed.
