### PR TITLE
fix: Set `OBJC_DISABLE_INITIALIZE_FORK_SAFETY` for macOS in CLI integration tests

### DIFF
--- a/tests/cli/test_integration_cli.py
+++ b/tests/cli/test_integration_cli.py
@@ -7,6 +7,8 @@ from sqlmesh.utils import yaml
 import shutil
 import site
 import uuid
+import os
+import platform
 
 pytestmark = pytest.mark.slow
 
@@ -30,6 +32,11 @@ def invoke_cli(tmp_path: Path) -> InvokeCliType:
     ).stdout.strip()
 
     def _invoke(sqlmesh_args: t.List[str], **kwargs: t.Any) -> subprocess.CompletedProcess:
+        # Set up environment to handle macOS fork safety, see https://stackoverflow.com/a/52230415
+        env = os.environ.copy()
+        if platform.system() == "Darwin":
+            env["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
+
         return subprocess.run(
             args=[sqlmesh_bin] + sqlmesh_args,
             # set the working directory to the isolated temp dir for this test
@@ -39,6 +46,7 @@ def invoke_cli(tmp_path: Path) -> InvokeCliType:
             # combine stdout/stderr into a single stream
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            env=env,
             **kwargs,
         )
 


### PR DESCRIPTION
This PR fixes failing CLI integration tests on macOS that were caused by fork safety issues with Objective-C runtime.

## Problem

The test `test_load_snapshots_that_reference_nonexistent_python_libraries` was failing on macOS with the following error:

```
  objc[12949]: +[NSMutableString initialize] may have been in progress in another thread when fork() was called.
  objc[12949]: +[NSMutableString initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process.
  Crashing instead.
```

This is a known issue on macOS when using multiprocessing with `fork()` context, which SQLMesh uses for parallel model loading. The issue is related to this [commit](https://github.com/TobikoData/sqlmeshcommit/67428f0efedce7875e6bbd04099cc5a2b13b1e14).

When `load_sql_models` is called in a forked process via `ProcessPoolExecutor`, and a seed model is loaded, it triggers the first pandas import inside the forked process.

On macOS, importing certain libraries (especially those that use Objective-C like pandas/numpy) after `fork()` can cause the "NSMutableString initialize" error.

## Solution

Set the `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` environment variable for subprocess calls in the CLI integration tests when running on macOS. This disables the fork safety check that was causing the tests to crash.
