### PR TITLE
fix: cicd bot correctly surface plan errors

### DIFF
--- a/sqlmesh/integrations/github/cicd/command.py
+++ b/sqlmesh/integrations/github/cicd/command.py
@@ -185,9 +185,11 @@ def _deploy_production(controller: GithubController) -> bool:
             skip_reason=str(e),
         )
         return False
-    except PlanError:
+    except PlanError as e:
         controller.update_prod_environment_check(
-            status=GithubCheckStatus.COMPLETED, conclusion=GithubCheckConclusion.ACTION_REQUIRED
+            status=GithubCheckStatus.COMPLETED,
+            conclusion=GithubCheckConclusion.ACTION_REQUIRED,
+            plan_error=e,
         )
         return False
     except Exception:

--- a/tests/integrations/github/cicd/test_github_commands.py
+++ b/tests/integrations/github/cicd/test_github_commands.py
@@ -884,6 +884,15 @@ def make_test_prod_update_failure_case(
     assert GithubCheckStatus(prod_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(prod_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_checks_runs[2]["conclusion"]) == expect_prod_sync_conclusion
+    if expect_prod_sync_conclusion.is_action_required:
+        assert prod_checks_runs[2]["output"]["title"] == "Failed due to error applying plan"
+        assert (
+            prod_checks_runs[2]["output"]["summary"]
+            == f"""**Plan error:**
+```
+{to_raise_on_prod_plan}
+```"""
+        )
 
     assert "SQLMesh - Run Unit Tests" in controller._check_run_mapping
     test_checks_runs = controller._check_run_mapping["SQLMesh - Run Unit Tests"].all_kwargs


### PR DESCRIPTION
Prior to this PR, plan errors would not be surfaced back to the user and would give a confusing `action_required` check title. Now the title communicates a plan error and then the plan error is shown in the summary. 