### PR TITLE
Fix: import pandas before loading in parallel to avoid macOS fork-related errors

### DIFF
--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -164,6 +164,13 @@ class Loader(abc.ABC):
     """Abstract base class to load macros and models for a context"""
 
     def __init__(self, context: GenericContext, path: Path) -> None:
+        # This ensures pandas is imported before any model loading happens in the forked process
+        # to avoid macOS fork() safety issues, see https://stackoverflow.com/a/52230415. Without
+        # it, the following error was observerd in a macOS 15.5 system:
+        #
+        # "+[NSMutableString initialize] may have been in progress in another thread when fork() was called."
+        import pandas as pd  # noqa
+
         from sqlmesh.core.console import get_console
 
         self._path_mtimes: t.Dict[Path, float] = {}

--- a/tests/cli/test_integration_cli.py
+++ b/tests/cli/test_integration_cli.py
@@ -7,8 +7,6 @@ from sqlmesh.utils import yaml
 import shutil
 import site
 import uuid
-import os
-import platform
 
 pytestmark = pytest.mark.slow
 
@@ -32,11 +30,6 @@ def invoke_cli(tmp_path: Path) -> InvokeCliType:
     ).stdout.strip()
 
     def _invoke(sqlmesh_args: t.List[str], **kwargs: t.Any) -> subprocess.CompletedProcess:
-        # Set up environment to handle macOS fork safety, see https://stackoverflow.com/a/52230415
-        env = os.environ.copy()
-        if platform.system() == "Darwin":
-            env["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
-
         return subprocess.run(
             args=[sqlmesh_bin] + sqlmesh_args,
             # set the working directory to the isolated temp dir for this test
@@ -46,7 +39,6 @@ def invoke_cli(tmp_path: Path) -> InvokeCliType:
             # combine stdout/stderr into a single stream
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            env=env,
             **kwargs,
         )
 


### PR DESCRIPTION
Related PR: https://github.com/TobikoData/sqlmesh/pull/4644

I thought this was only related to `tests/cli/test_integration_cli.py`, but I came across the same issue in a non-testing scenario as well:

```
((.venv) ) ➜  sqlmesh format
objc[66287]: +[NSMutableString initialize] may have been in progress in another thread when fork() was called.
objc[66287]: +[NSMutableString initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
Error: Failed to load model from file '/Users/georgesittas/Code/tobiko/playground/models/test.sql':

  A process in the process pool was terminated abruptly while the future was running or pending.
```

The issue appears to be a combination of lazily importing pandas and forking in macOS specifically, but I haven't pinpointed the root cause yet. However, I did verify this fixes it.

FWIW, Claude's analysis was...

```
The bug occurs on macOS when using Python's multiprocessing with the fork start method. The issue happens when pandas (or other libraries that use Objective-C frameworks) is imported after a fork() call.

  The Problem:
  - macOS uses Objective-C runtime which has thread-safety mechanisms
  - When fork() is called, it only copies the current thread, not other threads
  - If pandas is first imported in a forked child process, it initializes Objective-C classes like NSMutableString
  - This can conflict with partially initialized state from the parent process, causing the error: "+[NSMutableString initialize] may have been in progress in another thread when fork() was called."

  The Solution:
  By importing pandas (import pandas as pd) at line 172 in the __init__ function, we ensure pandas is loaded in the parent process before any forking occurs. This means:

  1. All Objective-C initialization happens in the parent process
  2. Child processes inherit the fully initialized state
  3. No new Objective-C initialization occurs in forked processes
  4. The thread safety error is avoided

  This is a common pattern for macOS Python applications that use multiprocessing with libraries that depend on system frameworks.
```