### PR TITLE
Chore: Fix make style by adding correct pygithub version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dev = [
     "psycopg2-binary",
     "pydantic",
     "PyAthena[Pandas]",
-    "PyGithub>=2.6.1",
+    "PyGithub>=2.6.0",
     "pyperf",
     "pyspark~=3.5.0",
     "pytest",


### PR DESCRIPTION
This PR: https://github.com/TobikoData/sqlmesh/pull/4648 removed `completed` from  `PullRequestReview` which makes `make style` fail for earlier versions so this pins version for dev of `PyGithub` to bigger or equal than [2.6.0](https://github.com/PyGithub/PyGithub/releases/tag/v2.6.0) where this was removed: https://github.com/PyGithub/PyGithub/pull/2746