### PR TITLE
Chore: detect xdb diff syntax and raise early

### DIFF
--- a/docs/guides/tablediff.md
+++ b/docs/guides/tablediff.md
@@ -253,12 +253,12 @@ Then, specify each table's gateway in the `table_diff` command with this syntax:
 For example, we could diff the `landing.table` table across `bigquery` and `snowflake` gateways like this:
 
 ```sh
-$ sqlmesh table_diff 'bigquery|landing.table:snowflake|lake.table'
+$ tcloud sqlmesh table_diff 'bigquery|landing.table:snowflake|lake.table'
 ```
 
 This syntax tells SQLMesh to use the cross-database diffing algorithm instead of the normal within-database diffing algorithm.
 
-After adding gateways to the table names, use `table_diff` as described above - the same options apply for specifying the join keys, decimal precision, etc. See `sqlmesh table_diff --help` for a [full list of options](../reference/cli.md#table_diff).
+After adding gateways to the table names, use `table_diff` as described above - the same options apply for specifying the join keys, decimal precision, etc. See `tcloud sqlmesh table_diff --help` for a [full list of options](../reference/cli.md#table_diff).
 
 !!! warning
 
@@ -273,7 +273,7 @@ A cross-database diff is broken up into two stages.
 The first stage is a schema diff. This example shows that differences in column name case across the two tables are identified as schema differences:
 
 ```bash
-$ sqlmesh table_diff 'bigquery|sqlmesh_example.full_model:snowflake|sqlmesh_example.full_model' --on item_id --show-sample
+$ tcloud sqlmesh table_diff 'bigquery|sqlmesh_example.full_model:snowflake|sqlmesh_example.full_model' --on item_id --show-sample
 
 Schema Diff Between 'BIGQUERY|SQLMESH_EXAMPLE.FULL_MODEL' and 'SNOWFLAKE|SQLMESH_EXAMPLE.FULL_MODEL':
 ├── Added Columns:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1677,6 +1677,12 @@ class GenericContext(BaseContext, t.Generic[C]):
             The list of TableDiff objects containing schema and summary differences.
         """
 
+        if "|" in source or "|" in target:
+            raise ConfigError(
+                "Cross-database table diffing is available in Tobiko Cloud. Read more here: "
+                "https://sqlmesh.readthedocs.io/en/stable/guides/tablediff/#diffing-tables-or-views-across-gateways"
+            )
+
         table_diffs: t.List[TableDiff] = []
 
         # Diffs multiple or a single model across two environments


### PR DESCRIPTION
Behavior in main:

```
((.venv) ) ➜  sqlmesh table_diff 'mssql|sales.fact_sales:databricks|george.sales.fact_sales' --on fact_id --show-sample
Error: Failed to parse 'mssql|sales.fact_sales' into <class 'sqlglot.expressions.Table'>
```

Behavior in this PR:

```
((.venv) ) ➜  sqlmesh table_diff 'mssql|sales.fact_sales:databricks|george.sales.fact_sales' --on fact_id --show-sample
Error: Cross-database table diffing is available in Tobiko Cloud. Read more here: https://sqlmesh.readthedocs.io/en/stable/guides/tablediff/#diffing-tables-or-views-across-gateways
```

Additionally, I've updated the [docs](https://sqlmesh.readthedocs.io/en/stable/guides/tablediff/#configuration-and-syntax) so that `tcloud sqlmesh` is used instead of `sqlmesh`, as the latter does not route to the correct xdb diffing logic.

cc @erindru @afzaljasani