### PR TITLE
feat: lazy import duckdb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "astor",
     "click",
     "croniter",
-    "duckdb!=0.10.3",
+    "duckdb>=0.10.0,!=0.10.3",
     "dateparser",
     "hyperscript>=0.1.0",
     "importlib-metadata; python_version<'3.12'",
@@ -275,6 +275,7 @@ extend-select = ["TID"]
 
 [tool.ruff.lint.flake8-tidy-imports]
 banned-module-level-imports = [
-    "pandas",
+    "duckdb",
     "numpy",
+    "pandas",
 ]

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import typing as t
-from duckdb import __version__ as duckdb_version
 from sqlglot import exp
 
 from sqlmesh.core.engine_adapter.mixins import (
@@ -18,7 +17,6 @@ from sqlmesh.core.engine_adapter.shared import (
     SourceQuery,
     set_catalog,
 )
-from sqlmesh.utils import major_minor
 from sqlmesh.core.schema_diff import SchemaDiffer
 
 if t.TYPE_CHECKING:
@@ -35,13 +33,8 @@ class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin,
             exp.DataType.build("DECIMAL", dialect=DIALECT).this: [(18, 3), (0,)],
         },
     )
-
-    # TODO: remove once we stop supporting DuckDB 0.9
-    COMMENT_CREATION_TABLE, COMMENT_CREATION_VIEW = (
-        (CommentCreationTable.UNSUPPORTED, CommentCreationView.UNSUPPORTED)
-        if major_minor(duckdb_version) < (0, 10)
-        else (CommentCreationTable.COMMENT_COMMAND_ONLY, CommentCreationView.COMMENT_COMMAND_ONLY)
-    )
+    COMMENT_CREATION_TABLE = CommentCreationTable.COMMENT_COMMAND_ONLY
+    COMMENT_CREATION_VIEW = CommentCreationView.COMMENT_COMMAND_ONLY
 
     @property
     def catalog_support(self) -> CatalogSupport:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from unittest.mock import PropertyMock
 import os
 import shutil
 
-import duckdb
+import duckdb  # noqa: TID253
 import pandas as pd  # noqa: TID253
 import pytest
 from pytest_mock.plugin import MockerFixture

--- a/tests/core/state_sync/test_state_sync.py
+++ b/tests/core/state_sync/test_state_sync.py
@@ -4,7 +4,7 @@ import re
 import typing as t
 from unittest.mock import call, patch
 
-import duckdb
+import duckdb  # noqa: TID253
 import pandas as pd  # noqa: TID253
 import pytest
 import time_machine


### PR DESCRIPTION
Similar PRs: 
https://github.com/TobikoData/sqlmesh/pull/4653
https://github.com/TobikoData/sqlmesh/pull/4631

Removed support for <0.10.0 release of DuckDB since 0.10.0 was released Feb 2024 therefore I think we are safe to deprecate. 