### PR TITLE
Fix: Escape backslash to prevent syntax error in string

### DIFF
--- a/sqlmesh/core/plan/explainer.py
+++ b/sqlmesh/core/plan/explainer.py
@@ -195,7 +195,7 @@ class RichExplainerConsole(ExplainerConsole):
 
                 tree.add(model_tree)
             else:
-                tree.add(f"{display_name} \[standalone audit]")
+                tree.add(f"{display_name} \\[standalone audit]")
         return tree
 
     def visit_migrate_schemas_stage(self, stage: stages.MigrateSchemasStage) -> Tree:


### PR DESCRIPTION
Add extra backslash to prevent raising syntax error in python versions [3.12 or earlier](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes)