### PR TITLE
Chore: Remove obsolete warning when converting a dbt project

### DIFF
--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -314,14 +314,6 @@ class ModelConfig(BaseModelConfig):
                     **incremental_by_kind_kwargs,
                 )
 
-            incremental_by_time_str = collection_to_str(INCREMENTAL_BY_TIME_STRATEGIES)
-            incremental_by_unique_key_str = collection_to_str(
-                INCREMENTAL_BY_UNIQUE_KEY_STRATEGIES.union(["none"])
-            )
-            get_console().log_warning(
-                f"Using unmanaged incremental materialization for model '{self.canonical_name(context)}'. "
-                f"Some features might not be available. Consider adding either a time_column ({incremental_by_time_str}) or a unique_key ({incremental_by_unique_key_str}) configuration to mitigate this.",
-            )
             strategy = self.incremental_strategy or target.default_incremental_strategy(
                 IncrementalUnmanagedKind
             )

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -1314,7 +1314,6 @@ def test_clickhouse_properties(mocker: MockerFixture):
         "SQLMesh does not support 'incremental_predicates' - they will not be applied.",
         "SQLMesh does not support the 'query_settings' model configuration parameter. Specify the query settings directly in the model query.",
         "SQLMesh does not support the 'sharding_key' model configuration parameter or distributed materializations.",
-        "Using unmanaged incremental materialization for model '`test`.`model`'. Some features might not be available. Consider adding either a time_column ('delete+insert', 'insert_overwrite') or a unique_key ('merge', 'none') configuration to mitigate this.",
     ]
 
     assert [e.sql("clickhouse") for e in model_to_sqlmesh.partitioned_by] == [


### PR DESCRIPTION
The warning didn't age well.