### PR TITLE
Feat(lsp): Add find all and go to references support for Macros

### DIFF
--- a/examples/sushi/models/customers.sql
+++ b/examples/sushi/models/customers.sql
@@ -33,7 +33,8 @@ LEFT JOIN (
   WITH current_marketing AS (
     SELECT
       customer_id,
-      status
+      status,
+      @ADD_ONE(1) AS another_column,
     FROM current_marketing_outer
   )
   SELECT * FROM current_marketing

--- a/sqlmesh/lsp/reference.py
+++ b/sqlmesh/lsp/reference.py
@@ -450,75 +450,76 @@ def get_model_find_all_references(
     Returns:
         A list of references to the model across all files
     """
-    # First, get the references in the current file to determine what model we're looking for
-    current_file_references = [
-        ref
-        for ref in get_model_definitions_for_a_path(lint_context, document_uri)
-        if isinstance(ref, LSPModelReference)
-    ]
-
     # Find the model reference at the cursor position
-    target_model_uri: t.Optional[str] = None
-    for ref in current_file_references:
-        if _position_within_range(position, ref.range):
-            # This is a model reference, get the target model URI
-            target_model_uri = ref.uri
-            break
+    model_at_position = next(
+        filter(
+            lambda ref: isinstance(ref, LSPModelReference)
+            and _position_within_range(position, ref.range),
+            get_model_definitions_for_a_path(lint_context, document_uri),
+        ),
+        None,
+    )
 
-    if target_model_uri is None:
+    if not model_at_position:
         return []
+
+    assert isinstance(model_at_position, LSPModelReference)  # for mypy
+
+    target_model_uri = model_at_position.uri
 
     # Start with the model definition
     all_references: t.List[LSPModelReference] = [
         LSPModelReference(
-            uri=ref.uri,
+            uri=model_at_position.uri,
             range=Range(
                 start=Position(line=0, character=0),
                 end=Position(line=0, character=0),
             ),
-            markdown_description=ref.markdown_description,
+            markdown_description=model_at_position.markdown_description,
         )
     ]
 
-    # Then add the original reference
-    for ref in current_file_references:
-        if ref.uri == target_model_uri and isinstance(ref, LSPModelReference):
-            all_references.append(
-                LSPModelReference(
-                    uri=document_uri.value,
-                    range=ref.range,
-                    markdown_description=ref.markdown_description,
-                )
+    # Then add references from the current file
+    current_file_refs = filter(
+        lambda ref: isinstance(ref, LSPModelReference) and ref.uri == target_model_uri,
+        get_model_definitions_for_a_path(lint_context, document_uri),
+    )
+
+    for ref in current_file_refs:
+        assert isinstance(ref, LSPModelReference)  # for mypy
+
+        all_references.append(
+            LSPModelReference(
+                uri=document_uri.value,
+                range=ref.range,
+                markdown_description=ref.markdown_description,
             )
+        )
 
     # Search through the models in the project
-    for path, target in lint_context.map.items():
-        if not isinstance(target, (ModelTarget, AuditTarget)):
-            continue
-
+    for path, _ in lint_context.map.items():
         file_uri = URI.from_path(path)
 
         # Skip current file, already processed
         if file_uri.value == document_uri.value:
             continue
 
-        # Get model references for this file
-        file_references = [
-            ref
-            for ref in get_model_definitions_for_a_path(lint_context, file_uri)
-            if isinstance(ref, LSPModelReference)
-        ]
+        # Get model references that point to the target model
+        matching_refs = filter(
+            lambda ref: isinstance(ref, LSPModelReference) and ref.uri == target_model_uri,
+            get_model_definitions_for_a_path(lint_context, file_uri),
+        )
 
-        # Add references that point to the target model file
-        for ref in file_references:
-            if ref.uri == target_model_uri and isinstance(ref, LSPModelReference):
-                all_references.append(
-                    LSPModelReference(
-                        uri=file_uri.value,
-                        range=ref.range,
-                        markdown_description=ref.markdown_description,
-                    )
+        for ref in matching_refs:
+            assert isinstance(ref, LSPModelReference)  # for mypy
+
+            all_references.append(
+                LSPModelReference(
+                    uri=file_uri.value,
+                    range=ref.range,
+                    markdown_description=ref.markdown_description,
                 )
+            )
 
     return all_references
 
@@ -588,7 +589,7 @@ def get_cte_references(
 
 
 def get_macro_find_all_references(
-    lint_context: LSPContext, document_uri: URI, position: Position
+    lsp_context: LSPContext, document_uri: URI, position: Position
 ) -> t.List[LSPMacroReference]:
     """
     Get all references to a macro at a specific position in a document.
@@ -596,32 +597,30 @@ def get_macro_find_all_references(
     This function finds all usages of a macro across the entire project.
 
     Args:
-        lint_context: The LSP context
+        lsp_context: The LSP context
         document_uri: The URI of the document
         position: The position to check for macro references
 
     Returns:
         A list of references to the macro across all files
     """
-    # First, get the macro references in the current file to identify the target macro
-    current_file_references = [
-        ref
-        for ref in get_macro_definitions_for_a_path(lint_context, document_uri)
-        if isinstance(ref, LSPMacroReference)
-    ]
-
     # Find the macro reference at the cursor position
-    target_macro_uri: t.Optional[str] = None
-    target_macro_target_range: t.Optional[Range] = None
+    macro_at_position = next(
+        filter(
+            lambda ref: isinstance(ref, LSPMacroReference)
+            and _position_within_range(position, ref.range),
+            get_macro_definitions_for_a_path(lsp_context, document_uri),
+        ),
+        None,
+    )
 
-    for ref in current_file_references:
-        if _position_within_range(position, ref.range):
-            target_macro_uri = ref.uri
-            target_macro_target_range = ref.target_range
-            break
-
-    if target_macro_uri is None:
+    if not macro_at_position:
         return []
+
+    assert isinstance(macro_at_position, LSPMacroReference)  # for mypy
+
+    target_macro_uri = macro_at_position.uri
+    target_macro_target_range = macro_at_position.target_range
 
     # Start with the macro definition
     all_references: t.List[LSPMacroReference] = [
@@ -634,30 +633,27 @@ def get_macro_find_all_references(
     ]
 
     # Search through all SQL and audit files in the project
-    for path, target in lint_context.map.items():
-        if not isinstance(target, (ModelTarget, AuditTarget)):
-            continue
-
+    for path, _ in lsp_context.map.items():
         file_uri = URI.from_path(path)
 
-        # Get macro references for this file
-        file_macro_references = [
-            ref
-            for ref in get_macro_definitions_for_a_path(lint_context, file_uri)
-            if isinstance(ref, LSPMacroReference)
-        ]
+        # Get macro references that point to the same macro definition
+        matching_refs = filter(
+            lambda ref: isinstance(ref, LSPMacroReference)
+            and ref.uri == target_macro_uri
+            and ref.target_range == target_macro_target_range,
+            get_macro_definitions_for_a_path(lsp_context, file_uri),
+        )
 
-        # Add references that point to the same macro definition
-        for ref in file_macro_references:
-            if ref.uri == target_macro_uri and ref.target_range == target_macro_target_range:
-                all_references.append(
-                    LSPMacroReference(
-                        uri=file_uri.value,
-                        range=ref.range,
-                        target_range=ref.target_range,
-                        markdown_description=ref.markdown_description,
-                    )
+        for ref in matching_refs:
+            assert isinstance(ref, LSPMacroReference)  # for mypy
+            all_references.append(
+                LSPMacroReference(
+                    uri=file_uri.value,
+                    range=ref.range,
+                    target_range=ref.target_range,
+                    markdown_description=ref.markdown_description,
                 )
+            )
 
     return all_references
 

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -1684,7 +1684,7 @@ def test_overlapping_changes_models(
 
 +++ 
 
-@@ -25,7 +25,8 @@
+@@ -29,7 +29,8 @@
 
  SELECT DISTINCT
    CAST(o.customer_id AS INT) AS customer_id,

--- a/tests/lsp/test_reference_macro_find_all.py
+++ b/tests/lsp/test_reference_macro_find_all.py
@@ -47,30 +47,32 @@ def test_find_all_references_for_macro_add_one():
     expected_ranges = [
         # Macro definition in utils.py
         {
-            "uri": "file:///Users/themistoklisvaltinos/Developer/sqlmesh/examples/sushi/macros/utils.py",
+            "uri_file": "utils.py",
             "range": ((6, 0), (9, 22)),
         },
         # Usage in customers.sql
         {
-            "uri": "file:///Users/themistoklisvaltinos/Developer/sqlmesh/examples/sushi/models/customers.sql",
+            "uri_file": "customers.sql",
             "range": ((36, 7), (36, 14)),
         },
         # Usage in top_waiters.sql
         {
-            "uri": "file:///Users/themistoklisvaltinos/Developer/sqlmesh/examples/sushi/models/top_waiters.sql",
+            "uri_file": "top_waiters.sql",
             "range": ((12, 5), (12, 12)),
         },
     ]
 
     for expected in expected_ranges:
         assert any(
-            ref.uri == expected["uri"] and
-            ref.range.start.line == expected["range"][0][0] and
-            ref.range.start.character == expected["range"][0][1] and
-            ref.range.end.line == expected["range"][1][0] and
-            ref.range.end.character == expected["range"][1][1]
+            expected["uri_file"] in ref.uri
+            and ref.range.start.line == expected["range"][0][0]
+            and ref.range.start.character == expected["range"][0][1]
+            and ref.range.end.line == expected["range"][1][0]
+            and ref.range.end.character == expected["range"][1][1]
             for ref in all_references
-        ), f"Expected reference with uri {expected['uri']} and range {expected['range']} not found"
+        ), (
+            f"Expected reference with uri {expected['uri_file']} and range {expected['range']} not found"
+        )
 
 
 def test_find_all_references_for_macro_multiply():
@@ -171,8 +173,7 @@ def test_multi_repo_macro_references():
         # Click on the second macro reference which appears under the same name in repo_1 ('dup')
         first_ref = macro_references[1]
         position = Position(
-            line=first_ref.range.start.line,
-            character=first_ref.range.start.character + 1
+            line=first_ref.range.start.line, character=first_ref.range.start.character + 1
         )
         all_references = get_macro_find_all_references(lsp_context, d_uri, position)
 
@@ -183,4 +184,6 @@ def test_multi_repo_macro_references():
         assert any("repo_2" in ref.uri for ref in all_references), "Should find macro in repo_2"
 
         # But not references in repo_1 since despite identical name they're different macros
-        assert not any("repo_1" in ref.uri for ref in all_references), "Shouldn't find macro in repo_1"
+        assert not any("repo_1" in ref.uri for ref in all_references), (
+            "Shouldn't find macro in repo_1"
+        )

--- a/tests/lsp/test_reference_macro_find_all.py
+++ b/tests/lsp/test_reference_macro_find_all.py
@@ -1,0 +1,186 @@
+from lsprotocol.types import Position
+from sqlmesh.core.context import Context
+from sqlmesh.lsp.context import LSPContext, ModelTarget
+from sqlmesh.lsp.reference import (
+    get_macro_find_all_references,
+    get_macro_definitions_for_a_path,
+)
+from sqlmesh.lsp.uri import URI
+
+
+def test_find_all_references_for_macro_add_one():
+    """Test finding all references to the @ADD_ONE macro."""
+    context = Context(paths=["examples/sushi"])
+    lsp_context = LSPContext(context)
+
+    # Find the top_waiters model that uses @ADD_ONE macro
+    top_waiters_path = next(
+        path
+        for path, info in lsp_context.map.items()
+        if isinstance(info, ModelTarget) and "sushi.top_waiters" in info.names
+    )
+
+    top_waiters_uri = URI.from_path(top_waiters_path)
+    macro_references = get_macro_definitions_for_a_path(lsp_context, top_waiters_uri)
+
+    # Find the @ADD_ONE reference
+    add_one_ref = next((ref for ref in macro_references if ref.range.start.line == 12), None)
+    assert add_one_ref is not None, "Should find @ADD_ONE reference in top_waiters"
+
+    # Click on the @ADD_ONE macro at line 13, character 5 (the @ symbol)
+    position = Position(line=12, character=5)
+
+    all_references = get_macro_find_all_references(lsp_context, top_waiters_uri, position)
+
+    # Should find at least 2 references: the definition and the usage in top_waiters
+    assert len(all_references) >= 2, f"Expected at least 2 references, found {len(all_references)}"
+
+    # Verify the macro definition is included
+    definition_refs = [ref for ref in all_references if "utils.py" in ref.uri]
+    assert len(definition_refs) >= 1, "Should include the macro definition in utils.py"
+
+    # Verify the usage in top_waiters is included
+    usage_refs = [ref for ref in all_references if "top_waiters" in ref.uri]
+    assert len(usage_refs) >= 1, "Should include the usage in top_waiters.sql"
+
+    # breakpoint()
+    expected_ranges = [
+        # Macro definition in utils.py
+        {
+            "uri": "file:///Users/themistoklisvaltinos/Developer/sqlmesh/examples/sushi/macros/utils.py",
+            "range": ((6, 0), (9, 22)),
+        },
+        # Usage in customers.sql
+        {
+            "uri": "file:///Users/themistoklisvaltinos/Developer/sqlmesh/examples/sushi/models/customers.sql",
+            "range": ((36, 7), (36, 14)),
+        },
+        # Usage in top_waiters.sql
+        {
+            "uri": "file:///Users/themistoklisvaltinos/Developer/sqlmesh/examples/sushi/models/top_waiters.sql",
+            "range": ((12, 5), (12, 12)),
+        },
+    ]
+
+    for expected in expected_ranges:
+        assert any(
+            ref.uri == expected["uri"] and
+            ref.range.start.line == expected["range"][0][0] and
+            ref.range.start.character == expected["range"][0][1] and
+            ref.range.end.line == expected["range"][1][0] and
+            ref.range.end.character == expected["range"][1][1]
+            for ref in all_references
+        ), f"Expected reference with uri {expected['uri']} and range {expected['range']} not found"
+
+
+def test_find_all_references_for_macro_multiply():
+    """Test finding all references to the @MULTIPLY macro."""
+    context = Context(paths=["examples/sushi"])
+    lsp_context = LSPContext(context)
+
+    # Find the top_waiters model that uses @MULTIPLY macro
+    top_waiters_path = next(
+        path
+        for path, info in lsp_context.map.items()
+        if isinstance(info, ModelTarget) and "sushi.top_waiters" in info.names
+    )
+
+    top_waiters_uri = URI.from_path(top_waiters_path)
+    macro_references = get_macro_definitions_for_a_path(lsp_context, top_waiters_uri)
+
+    # Find the @MULTIPLY reference
+    multiply_ref = next((ref for ref in macro_references if ref.range.start.line == 13), None)
+    assert multiply_ref is not None, "Should find @MULTIPLY reference in top_waiters"
+
+    # Click on the @MULTIPLY macro at line 14, character 5 (the @ symbol)
+    position = Position(line=13, character=5)
+    all_references = get_macro_find_all_references(lsp_context, top_waiters_uri, position)
+
+    # Should find at least 2 references: the definition and the usage
+    assert len(all_references) >= 2, f"Expected at least 2 references, found {len(all_references)}"
+
+    # Verify both definition and usage are included
+    assert any("utils.py" in ref.uri for ref in all_references), "Should include macro definition"
+    assert any("top_waiters" in ref.uri for ref in all_references), "Should include usage"
+
+
+def test_find_all_references_for_sql_literal_macro():
+    """Test finding references to @SQL_LITERAL macro ."""
+    context = Context(paths=["examples/sushi"])
+    lsp_context = LSPContext(context)
+
+    # Find the top_waiters model that uses @SQL_LITERAL macro
+    top_waiters_path = next(
+        path
+        for path, info in lsp_context.map.items()
+        if isinstance(info, ModelTarget) and "sushi.top_waiters" in info.names
+    )
+
+    top_waiters_uri = URI.from_path(top_waiters_path)
+    macro_references = get_macro_definitions_for_a_path(lsp_context, top_waiters_uri)
+
+    # Find the @SQL_LITERAL reference
+    sql_literal_ref = next((ref for ref in macro_references if ref.range.start.line == 14), None)
+    assert sql_literal_ref is not None, "Should find @SQL_LITERAL reference in top_waiters"
+
+    # Click on the @SQL_LITERAL macro
+    position = Position(line=14, character=5)
+    all_references = get_macro_find_all_references(lsp_context, top_waiters_uri, position)
+
+    # For user-defined macros in utils.py, should find references
+    assert len(all_references) >= 2, f"Expected at least 2 references, found {len(all_references)}"
+
+
+def test_find_references_from_outside_macro_position():
+    """Test that clicking outside a macro doesn't return macro references."""
+    context = Context(paths=["examples/sushi"])
+    lsp_context = LSPContext(context)
+
+    top_waiters_path = next(
+        path
+        for path, info in lsp_context.map.items()
+        if isinstance(info, ModelTarget) and "sushi.top_waiters" in info.names
+    )
+
+    top_waiters_uri = URI.from_path(top_waiters_path)
+
+    # Click on a position that is not on a macro
+    position = Position(line=0, character=0)  # First line, which is a comment
+    all_references = get_macro_find_all_references(lsp_context, top_waiters_uri, position)
+
+    # Should return empty list when not on a macro
+    assert len(all_references) == 0, "Should not find macro references when not on a macro"
+
+
+def test_multi_repo_macro_references():
+    """Test finding macro references across multiple repositories."""
+    context = Context(paths=["examples/multi/repo_1", "examples/multi/repo_2"], gateway="memory")
+    lsp_context = LSPContext(context)
+
+    # Find model 'd' which uses macros from repo_2
+    d_path = next(
+        path
+        for path, info in lsp_context.map.items()
+        if isinstance(info, ModelTarget) and "silver.d" in info.names
+    )
+
+    d_uri = URI.from_path(d_path)
+    macro_references = get_macro_definitions_for_a_path(lsp_context, d_uri)
+
+    if macro_references:
+        # Click on the second macro reference which appears under the same name in repo_1 ('dup')
+        first_ref = macro_references[1]
+        position = Position(
+            line=first_ref.range.start.line,
+            character=first_ref.range.start.character + 1
+        )
+        all_references = get_macro_find_all_references(lsp_context, d_uri, position)
+
+        # Should find the definition and usage
+        assert len(all_references) == 2, f"Expected 2 references, found {len(all_references)}"
+
+        # Verify references from repo_2
+        assert any("repo_2" in ref.uri for ref in all_references), "Should find macro in repo_2"
+
+        # But not references in repo_1 since despite identical name they're different macros
+        assert not any("repo_1" in ref.uri for ref in all_references), "Shouldn't find macro in repo_1"

--- a/tests/test_forking.py
+++ b/tests/test_forking.py
@@ -46,12 +46,14 @@ LEFT JOIN (
   WITH "current_marketing" AS (
     SELECT
       "current_marketing_outer"."customer_id" AS "customer_id",
-      "current_marketing_outer"."status" AS "status"
+      "current_marketing_outer"."status" AS "status",
+      2 AS "another_column"
     FROM "current_marketing_outer" AS "current_marketing_outer"
   )
   SELECT
     "current_marketing"."customer_id" AS "customer_id",
-    "current_marketing"."status" AS "status"
+    "current_marketing"."status" AS "status",
+    "current_marketing"."another_column" AS "another_column"
   FROM "current_marketing" AS "current_marketing"
 ) AS "m"
   ON "m"."customer_id" = "o"."customer_id"

--- a/tests/web/test_lineage.py
+++ b/tests/web/test_lineage.py
@@ -62,12 +62,14 @@ LEFT JOIN (
   WITH "current_marketing" AS (
     SELECT
       "current_marketing_outer"."customer_id" AS "customer_id",
-      "current_marketing_outer"."status" AS "status"
+      "current_marketing_outer"."status" AS "status",
+      2 AS "another_column"
     FROM "current_marketing_outer" AS "current_marketing_outer"
   )
   SELECT
     "current_marketing"."customer_id" AS "customer_id",
-    "current_marketing"."status" AS "status"
+    "current_marketing"."status" AS "status",
+    "current_marketing"."another_column" AS "another_column"
   FROM "current_marketing" AS "current_marketing"
 ) AS "m"
   ON "m"."customer_id" = "o"."customer_id"


### PR DESCRIPTION
Building on #4652  and #4680, this update adds "Find All References" and "Go to References" support for macros in the SQLMesh VSCode extension.

<img width="1254" alt="macrorefs" src="https://github.com/user-attachments/assets/fa2584c5-4871-4c59-8aa1-a404197c9bfb" />
