### PR TITLE
Fix: Make plan dates relative to `--execution-time`

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -120,7 +120,14 @@ from sqlmesh.core.user import User
 from sqlmesh.utils import UniqueKeyDict, Verbosity
 from sqlmesh.utils.concurrency import concurrent_apply_to_values
 from sqlmesh.utils.dag import DAG
-from sqlmesh.utils.date import TimeLike, now_ds, to_timestamp, format_tz_datetime, now_timestamp
+from sqlmesh.utils.date import (
+    TimeLike,
+    now_ds,
+    to_timestamp,
+    format_tz_datetime,
+    now_timestamp,
+    now,
+)
 from sqlmesh.utils.errors import (
     CircuitBreakerError,
     ConfigError,
@@ -1517,7 +1524,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                 max_interval_end_per_model,
                 backfill_models,
                 modified_model_names,
-                execution_time,
+                execution_time or now(),
             )
 
             # Refresh snapshot intervals to ensure that they are up to date with values reflected in the max_interval_end_per_model.

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1513,7 +1513,11 @@ class GenericContext(BaseContext, t.Generic[C]):
             # If no end date is specified, use the max interval end from prod
             # to prevent unintended evaluation of the entire DAG.
             default_start, default_end = self._get_plan_default_start_end(
-                snapshots, max_interval_end_per_model, backfill_models, modified_model_names
+                snapshots,
+                max_interval_end_per_model,
+                backfill_models,
+                modified_model_names,
+                execution_time,
             )
 
             # Refresh snapshot intervals to ensure that they are up to date with values reflected in the max_interval_end_per_model.
@@ -2818,6 +2822,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         max_interval_end_per_model: t.Dict[str, int],
         backfill_models: t.Optional[t.Set[str]],
         modified_model_names: t.Set[str],
+        execution_time: t.Optional[TimeLike] = None,
     ) -> t.Tuple[t.Optional[int], t.Optional[int]]:
         if not max_interval_end_per_model:
             return None, None
@@ -2843,6 +2848,12 @@ class GenericContext(BaseContext, t.Generic[C]):
                     )
                 ),
             )
+
+        if execution_time and to_timestamp(default_end) > to_timestamp(execution_time):
+            # the end date can't be in the future, which can happen if a specific `execution_time` is set and prod intervals
+            # are newer than it
+            default_end = to_timestamp(execution_time)
+
         return default_start, default_end
 
     def _get_max_interval_end_per_model(

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -83,8 +83,9 @@ class Plan(PydanticModel, frozen=True):
     def end(self) -> TimeLike:
         return self.provided_end or self.execution_time
 
-    @property
+    @cached_property
     def execution_time(self) -> TimeLike:
+        # note: property is cached so that it returns a consistent timestamp for now()
         return self.execution_time_ or now()
 
     @property

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from functools import cached_property
+from pydantic import Field
 
 from sqlmesh.core.context_diff import ContextDiff
 from sqlmesh.core.environment import Environment, EnvironmentNamingInfo, EnvironmentStatements
@@ -63,7 +64,7 @@ class Plan(PydanticModel, frozen=True):
     models_to_backfill: t.Optional[t.Set[str]] = None
     """All models that should be backfilled as part of this plan."""
     effective_from: t.Optional[TimeLike] = None
-    execution_time: t.Optional[TimeLike] = None
+    execution_time_: t.Optional[TimeLike] = Field(default=None, alias="execution_time")
 
     user_provided_flags: t.Optional[t.Dict[str, UserProvidedFlags]] = None
 
@@ -80,7 +81,11 @@ class Plan(PydanticModel, frozen=True):
 
     @cached_property
     def end(self) -> TimeLike:
-        return self.provided_end or now()
+        return self.provided_end or self.execution_time
+
+    @property
+    def execution_time(self) -> TimeLike:
+        return self.execution_time_ or now()
 
     @property
     def previous_plan_id(self) -> t.Optional[str]:
@@ -271,7 +276,7 @@ class Plan(PydanticModel, frozen=True):
 
     @cached_property
     def _earliest_interval_start(self) -> datetime:
-        return earliest_interval_start(self.snapshots.values())
+        return earliest_interval_start(self.snapshots.values(), self.execution_time)
 
 
 class EvaluatablePlan(PydanticModel):
@@ -345,8 +350,10 @@ class SnapshotIntervals:
         return format_intervals(self.merged_intervals, unit)
 
 
-def earliest_interval_start(snapshots: t.Collection[Snapshot]) -> datetime:
-    earliest_start = earliest_start_date(snapshots)
+def earliest_interval_start(
+    snapshots: t.Collection[Snapshot], execution_time: t.Optional[TimeLike] = None
+) -> datetime:
+    earliest_start = earliest_start_date(snapshots, relative_to=execution_time)
     earliest_interval_starts = [s.intervals[0][0] for s in snapshots if s.intervals]
     return (
         min(earliest_start, to_datetime(min(earliest_interval_starts)))

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1995,7 +1995,12 @@ def earliest_start_date(
             start_date(snapshot, snapshots, cache=cache, relative_to=relative_to)
             for snapshot in snapshots.values()
         )
-    return yesterday()
+
+    relative_base = None
+    if relative_to is not None:
+        relative_base = to_datetime(relative_to)
+
+    return yesterday(relative_base=relative_base)
 
 
 def start_date(

--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -87,34 +87,34 @@ def now_ds() -> str:
     return to_ds(now())
 
 
-def yesterday() -> datetime:
+def yesterday(relative_base: t.Optional[datetime] = None) -> datetime:
     """
     Yesterday utc datetime.
 
     Returns:
         A datetime object with tz utc representing yesterday's date
     """
-    return to_datetime("yesterday")
+    return to_datetime("yesterday", relative_base=relative_base)
 
 
-def yesterday_ds() -> str:
+def yesterday_ds(relative_base: t.Optional[datetime] = None) -> str:
     """
     Yesterday utc ds.
 
     Returns:
         Yesterday's ds string.
     """
-    return to_ds("yesterday")
+    return to_ds("yesterday", relative_base=relative_base)
 
 
-def yesterday_timestamp() -> int:
+def yesterday_timestamp(relative_base: t.Optional[datetime] = None) -> int:
     """
     Yesterday utc timestamp.
 
     Returns:
         UTC epoch millis timestamp of yesterday
     """
-    return to_timestamp(yesterday())
+    return to_timestamp(yesterday(relative_base=relative_base))
 
 
 def to_timestamp(
@@ -265,19 +265,19 @@ def date_dict(
     return kwargs
 
 
-def to_ds(obj: TimeLike) -> str:
+def to_ds(obj: TimeLike, relative_base: t.Optional[datetime] = None) -> str:
     """Converts a TimeLike object into YYYY-MM-DD formatted string."""
-    return to_ts(obj)[0:10]
+    return to_ts(obj, relative_base=relative_base)[0:10]
 
 
-def to_ts(obj: TimeLike) -> str:
+def to_ts(obj: TimeLike, relative_base: t.Optional[datetime] = None) -> str:
     """Converts a TimeLike object into YYYY-MM-DD HH:MM:SS formatted string."""
-    return to_datetime(obj).replace(tzinfo=None).isoformat(sep=" ")
+    return to_datetime(obj, relative_base=relative_base).replace(tzinfo=None).isoformat(sep=" ")
 
 
-def to_tstz(obj: TimeLike) -> str:
+def to_tstz(obj: TimeLike, relative_base: t.Optional[datetime] = None) -> str:
     """Converts a TimeLike object into YYYY-MM-DD HH:MM:SS+00:00 formatted string."""
-    return to_datetime(obj).isoformat(sep=" ")
+    return to_datetime(obj, relative_base=relative_base).isoformat(sep=" ")
 
 
 def is_date(obj: TimeLike) -> bool:

--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -373,6 +373,16 @@ def is_categorical_relative_expression(expression: str) -> bool:
     return not any(k in TIME_UNITS for k in grain_kwargs)
 
 
+def is_relative(value: TimeLike) -> bool:
+    """
+    Tests a TimeLike object to see if it is a relative expression, eg '1 week ago' as opposed to an absolute timestamp
+    """
+    if isinstance(value, str):
+        return is_categorical_relative_expression(value)
+
+    return False
+
+
 def to_time_column(
     time_column: t.Union[TimeLike, exp.Null],
     time_column_type: exp.DataType,

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -19,6 +19,7 @@ from sqlmesh.integrations.github.cicd.controller import (
     GithubCheckStatus,
     MergeStateStatus,
 )
+from sqlmesh.utils.date import to_datetime, now
 from tests.integrations.github.cicd.conftest import MockIssueComment
 
 pytestmark = pytest.mark.github
@@ -236,6 +237,7 @@ def test_pr_plan(github_client, make_controller):
 def test_pr_plan_auto_categorization(github_client, make_controller):
     custom_categorizer_config = CategorizerConfig.all_semi()
     default_start = "1 week ago"
+    default_start_absolute = to_datetime(default_start, relative_base=now())
     controller = make_controller(
         "tests/fixtures/github/pull_request_synchronized.json",
         github_client,
@@ -249,7 +251,7 @@ def test_pr_plan_auto_categorization(github_client, make_controller):
     assert not controller._context.apply.called
     assert controller._context._run_plan_tests.call_args == call(skip_tests=True)
     assert controller._pr_plan_builder._categorizer_config == custom_categorizer_config
-    assert controller.pr_plan.start == default_start
+    assert controller.pr_plan.start == default_start_absolute
 
 
 def test_prod_plan(github_client, make_controller):

--- a/tests/utils/test_date.py
+++ b/tests/utils/test_date.py
@@ -12,6 +12,7 @@ from sqlmesh.utils.date import (
     date_dict,
     format_tz_datetime,
     is_categorical_relative_expression,
+    is_relative,
     make_inclusive,
     to_datetime,
     to_time_column,
@@ -324,3 +325,17 @@ def test_format_tz_datetime():
     test_datetime = to_datetime("2020-01-01 00:00:00")
     assert format_tz_datetime(test_datetime) == "2020-01-01 12:00AM UTC"
     assert format_tz_datetime(test_datetime, format_string=None) == "2020-01-01 00:00:00+00:00"
+
+
+def test_is_relative():
+    assert is_relative("1 week ago")
+    assert is_relative("1 week")
+    assert is_relative("1 day ago")
+    assert is_relative("yesterday")
+
+    assert not is_relative("2024-01-01")
+    assert not is_relative("2024-01-01 01:02:03")
+    assert not is_relative(to_datetime("2024-01-01 01:02:03"))
+    assert not is_relative(to_timestamp("2024-01-01 01:02:03"))
+    assert not is_relative(to_datetime("1 week ago"))
+    assert not is_relative(to_timestamp("1 day ago"))


### PR DESCRIPTION
This addresses some issues with setting `--execution-time` on a plan, which is intended to run a plan "as at" a certain time.

Currently, if you specify a relative start date like `--start '2 days ago'` and then you specify a fixed `--execution-time`, eg `--execution-time '2020-01-05'`, SQLMesh will make the start date relative to the current time and not the execution time.

This gets confusing because it makes the plan start / end and any relative dates show no relation to the execution time.

This is also causes problems when `--execution-time` is set to a value older than the latest prod interval for a model, eg:
```
$ sqlmesh plan dev --execution-time 2020-01-05 --start '2 days ago'
...SNIP
Error: Start date / time (2 days ago) can't be greater than end date / time (1749168000000)
```

This PR tightens up the behavior, adds new checks at the plan building stage and adds tests to verify the relative date behaviour.

After this PR, the above command works as intended by making the plan end time not able to exceed the execution time