### PR TITLE
Fix: skip project loading for clean, destroy and janitor commands

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -23,12 +23,15 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 SKIP_LOAD_COMMANDS = (
+    "clean",
     "create_external_models",
+    "destroy",
+    "environments",
+    "invalidate",
+    "janitor",
     "migrate",
     "rollback",
     "run",
-    "environments",
-    "invalidate",
     "table_name",
 )
 SKIP_CONTEXT_COMMANDS = ("init", "ui")


### PR DESCRIPTION
`sqlmesh clean` failed, while debugging a dbt project in the wild, due to a model that wasn't able to be loaded. Verified that manually running `rm -r .cache` and re-loading the project fixed the issue.