### PR TITLE
feat: macro autocomplete has descriptions

### DIFF
--- a/examples/sushi/macros/utils.py
+++ b/examples/sushi/macros/utils.py
@@ -5,14 +5,14 @@ from sqlmesh import SQL, macro
 
 @macro()
 def add_one(evaluator, column: int):
-    # typed column will be cast to an int and return an integer back
+    """typed column will be cast to an int and return an integer back"""
     assert isinstance(column, int)
     return column + 1
 
 
 @macro()
 def multiply(evaluator, column, num):
-    # untyped column will be a sqlglot column and return a sqlglot exp "column > 0"
+    """untyped column will be a sqlglot column and return a sqlglot exp "column > 0"""
     assert isinstance(column, exp.Column)
     return column * num
 

--- a/sqlmesh/lsp/custom.py
+++ b/sqlmesh/lsp/custom.py
@@ -23,6 +23,13 @@ class AllModelsRequest(CustomMethodRequestBaseClass):
     textDocument: types.TextDocumentIdentifier
 
 
+class MacroCompletion(PydanticModel):
+    """Information about a macro for autocompletion."""
+
+    name: str
+    description: t.Optional[str] = None
+
+
 class AllModelsResponse(CustomMethodResponseBaseClass):
     """
     Response to get all the models that are in the current project.
@@ -30,7 +37,7 @@ class AllModelsResponse(CustomMethodResponseBaseClass):
 
     models: t.List[str]
     keywords: t.List[str]
-    macros: t.List[str]
+    macros: t.List[MacroCompletion]
 
 
 RENDER_MODEL_FEATURE = "sqlmesh/render_model"

--- a/sqlmesh/lsp/main.py
+++ b/sqlmesh/lsp/main.py
@@ -625,7 +625,8 @@ class SQLMeshLanguageServer:
                     and getattr(params.context, "trigger_character", None) == "@"
                 )
 
-                for macro_name in completion_response.macros:
+                for macro in completion_response.macros:
+                    macro_name = macro.name
                     insert_text = macro_name if triggered_by_at else f"@{macro_name}"
 
                     completion_items.append(
@@ -636,6 +637,7 @@ class SQLMeshLanguageServer:
                             filter_text=macro_name,
                             kind=types.CompletionItemKind.Function,
                             detail="SQLMesh Macro",
+                            documentation=macro.description,
                         )
                     )
 

--- a/tests/lsp/test_completions.py
+++ b/tests/lsp/test_completions.py
@@ -33,8 +33,12 @@ def test_get_macros():
     file_uri = URI.from_path(file_path)
     completions = LSPContext.get_completions(lsp_context, file_uri, file_content)
 
-    assert "each" in completions.macros
-    assert "add_one" in completions.macros
+    each_macro = next((m for m in completions.macros if m.name == "each"))
+    assert each_macro.name == "each"
+    assert each_macro.description
+    add_one_macro = next((m for m in completions.macros if m.name == "add_one"))
+    assert add_one_macro.name == "add_one"
+    assert add_one_macro.description
 
 
 def test_get_sql_completions_with_context_no_file_uri():


### PR DESCRIPTION
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/1b3d226d-af72-4fb8-a7b2-cf6f5e9924f0" />


## Summary
- expose `MacroCompletion` with optional docstring
- include macro descriptions when building LSP completions
- surface macro docs as completion item documentation
- adjust tests for new structure

## Testing
- `pre-commit run --files sqlmesh/lsp/completions.py sqlmesh/lsp/custom.py sqlmesh/lsp/main.py tests/lsp/test_completions.py`
- `pytest tests/lsp/test_completions.py::test_get_macros -q`

------
https://chatgpt.com/codex/tasks/task_e_68493f049d348330899ab339336e981a