### PR TITLE
Fix incorrect flags in audit command documentation

### DIFF
--- a/docs/concepts/audits.md
+++ b/docs/concepts/audits.md
@@ -639,7 +639,7 @@ MODEL (
 You can execute audits with the `sqlmesh audit` command as follows:
 
 ```bash
-$ sqlmesh -p project audit -start 2022-01-01 -end 2022-01-02
+$ sqlmesh -p project audit --start 2022-01-01 --end 2022-01-02
 Found 1 audit(s).
 assert_item_price_is_not_null FAIL.
 


### PR DESCRIPTION
This PR corrects the incorrect usage of flags in the audit command within the documentation. Previously, the flags for specifying dates were incorrectly written as single-dash (`-start`, `-end`) instead of the correct double-dash syntax (`--start`, `--end`).