### PR TITLE
Add plan diff lsp endpoint and vscode command

### DIFF
--- a/sqlmesh/lsp/custom.py
+++ b/sqlmesh/lsp/custom.py
@@ -143,3 +143,30 @@ class FormatProjectResponse(CustomMethodResponseBaseClass):
     """
 
     pass
+
+
+LIST_ENVIRONMENTS_FEATURE = "sqlmesh/list_environments"
+
+
+class ListEnvironmentsRequest(CustomMethodRequestBaseClass):
+    pass
+
+
+class ListEnvironmentsResponse(CustomMethodResponseBaseClass):
+    environments: t.List[str]
+
+
+PLAN_DIFF_FEATURE = "sqlmesh/plan_diff"
+
+
+class PlanDiffRequest(CustomMethodRequestBaseClass):
+    environment: str
+
+
+class PlanDiffEntry(PydanticModel):
+    name: str
+    diff: str
+
+
+class PlanDiffResponse(CustomMethodResponseBaseClass):
+    diffs: t.List[PlanDiffEntry]

--- a/vscode/extension/package.json
+++ b/vscode/extension/package.json
@@ -93,6 +93,11 @@
         "title": "Render Model",
         "description": "Render the model in the current editor",
         "icon": "$(open-preview)"
+      },
+      {
+        "command": "sqlmesh.plan",
+        "title": "Show Plan Diff",
+        "description": "Create a plan and show the diff"
       }
     ],
     "menus": {

--- a/vscode/extension/src/commands/planDiff.ts
+++ b/vscode/extension/src/commands/planDiff.ts
@@ -1,0 +1,66 @@
+import * as vscode from 'vscode'
+import { LSPClient } from '../lsp/lsp'
+import { isErr } from '@bus/result'
+
+export function planDiff(lspClient?: LSPClient) {
+  return async () => {
+    if (!lspClient) {
+      vscode.window.showErrorMessage('LSP client not available')
+      return
+    }
+
+    const envResult = await lspClient.call_custom_method(
+      'sqlmesh/list_environments',
+      {},
+    )
+
+    if (isErr(envResult)) {
+      vscode.window.showErrorMessage(
+        `Failed to list environments: ${envResult.error.message}`,
+      )
+      return
+    }
+
+    const env = await vscode.window.showQuickPick(envResult.value.environments, {
+      placeHolder: 'Select environment to plan',
+    })
+
+    if (!env) {
+      return
+    }
+
+    const diffResult = await lspClient.call_custom_method('sqlmesh/plan_diff', {
+      environment: env,
+    })
+
+    if (isErr(diffResult)) {
+      vscode.window.showErrorMessage(
+        `Failed to get plan diff: ${diffResult.error.message}`,
+      )
+      return
+    }
+
+    if (!diffResult.value.diffs.length) {
+      vscode.window.showInformationMessage('No changes detected')
+      return
+    }
+
+    let selected = diffResult.value.diffs[0]
+    if (diffResult.value.diffs.length > 1) {
+      const pick = await vscode.window.showQuickPick(
+        diffResult.value.diffs.map(d => ({ label: d.name })),
+        { placeHolder: 'Select a model diff to view' },
+      )
+      if (!pick) {
+        return
+      }
+      selected = diffResult.value.diffs.find(d => d.name === pick.label)!
+    }
+
+    const doc = await vscode.workspace.openTextDocument({
+      content: selected.diff,
+      language: 'diff',
+    })
+    await vscode.window.showTextDocument(doc, { preview: true })
+  }
+}

--- a/vscode/extension/src/extension.ts
+++ b/vscode/extension/src/extension.ts
@@ -13,6 +13,7 @@ import { signOut } from './commands/signout'
 import { signIn } from './commands/signin'
 import { signInSpecifyFlow } from './commands/signinSpecifyFlow'
 import { renderModel, reRenderModelForSourceFile } from './commands/renderModel'
+import { planDiff } from './commands/planDiff'
 import { isErr } from '@bus/result'
 import { handleError } from './utilities/errors'
 import { selector, completionProvider } from './completion/completion'
@@ -80,6 +81,13 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       'sqlmesh.format',
       format(authProvider, lspClient),
+    ),
+  )
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'sqlmesh.plan',
+      planDiff(lspClient),
     ),
   )
 

--- a/vscode/extension/src/lsp/custom.ts
+++ b/vscode/extension/src/lsp/custom.ts
@@ -33,6 +33,8 @@ export type CustomLSPMethods =
   | AllModelsForRenderMethod
   | SupportedMethodsMethod
   | FormatProjectMethod
+  | ListEnvironmentsMethod
+  | PlanDiffMethod
 
 interface AllModelsRequest {
   textDocument: {
@@ -106,3 +108,35 @@ interface FormatProjectRequest {}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface FormatProjectResponse {}
+
+export interface ListEnvironmentsMethod {
+  method: 'sqlmesh/list_environments'
+  request: ListEnvironmentsRequest
+  response: ListEnvironmentsResponse
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface ListEnvironmentsRequest {}
+
+interface ListEnvironmentsResponse {
+  environments: string[]
+}
+
+export interface PlanDiffMethod {
+  method: 'sqlmesh/plan_diff'
+  request: PlanDiffRequest
+  response: PlanDiffResponse
+}
+
+interface PlanDiffRequest {
+  environment: string
+}
+
+interface PlanDiffEntry {
+  name: string
+  diff: string
+}
+
+interface PlanDiffResponse {
+  diffs: PlanDiffEntry[]
+}


### PR DESCRIPTION
## Summary
- expose plan diff and environment listing over LSP
- add VS Code command to run plan diff

## Testing
- `pre-commit run --files sqlmesh/lsp/custom.py sqlmesh/lsp/main.py`
- `pnpm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849dfe865f483309482ec6bd2f0ba4f