### PR TITLE
Fix(table_diff): Make `--limit` per-sample and not across all samples

### DIFF
--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -2358,8 +2358,8 @@ def test_table_diff_grain_check_multiple_keys(ctx: TestContext):
     assert row_diff.stats["distinct_count_s"] == 7
     assert row_diff.stats["t_count"] != row_diff.stats["distinct_count_t"]
     assert row_diff.stats["distinct_count_t"] == 10
-    assert row_diff.s_sample.shape == (0, 3)
-    assert row_diff.t_sample.shape == (3, 3)
+    assert row_diff.s_sample.shape == (row_diff.s_only_count, 3)
+    assert row_diff.t_sample.shape == (row_diff.t_only_count, 3)
 
 
 def test_table_diff_arbitrary_condition(ctx: TestContext):


### PR DESCRIPTION
Prior to this PR, when fetching samples, the sample data was fetched in a single query and then client-side separated out into "source_only", "target_only" and "common".

The `--limit` was being applied to the overall query which meant that common rows with mismatches could be pushed out by target only rows.

This lead to output like (note that screenshot uses `--limit 2` to illustrate the problem):
![Screenshot From 2025-06-12 11-05-11](https://github.com/user-attachments/assets/127ef39f-bbbb-49c2-93c3-277c7b7276dc)

Notice the partial match but then the sample claims that all joined rows match and no source only rows are shown

This PR changes how the sample data is fetched by applying the `--limit` on a per-sample basis ("source_only", "target_only", "common") and not on an overall basis.

This updates the above output with `--limit 2` to look like:
![Screenshot From 2025-06-12 11-03-52](https://github.com/user-attachments/assets/34b38b43-608a-4fb5-b30b-eacd201ee248)


