### PR TITLE
chore: allow debugging vscode tests

### DIFF
--- a/tooling/vscode/settings.json
+++ b/tooling/vscode/settings.json
@@ -13,5 +13,15 @@
     "vscode/react/dist": true
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off"
+  "typescript.tsc.autoDetect": "off",
+  // Playwright configuration
+  // Python configuration to ensure consistent environment
+  "python.defaultInterpreterPath": "${env:VIRTUAL_ENV}/bin/python",
+  "python.terminal.activateEnvironment": true,
+  "terminal.integrated.env.osx": {
+    "PATH": "${env:VIRTUAL_ENV}/bin:${env:PATH}"
+  },
+  "terminal.integrated.env.linux": {
+    "PATH": "${env:VIRTUAL_ENV}/bin:${env:PATH}"
+  }
 }

--- a/vscode/extension/tests/utils.ts
+++ b/vscode/extension/tests/utils.ts
@@ -5,7 +5,7 @@ import { _electron as electron, Page } from '@playwright/test'
 
 // Absolute path to the VS Code executable you downloaded in step 1.
 export const VS_CODE_EXE = fs.readJsonSync(
-  '.vscode-test/paths.json',
+  path.join(__dirname, '..', '.vscode-test', 'paths.json'),
 ).executablePath
 // Where your extension lives on disk
 export const EXT_PATH = path.resolve(__dirname, '..')


### PR DESCRIPTION
sets up the playwright extension correctly in vscode so that playwright tests called from the vscode extension work correctly

To set up 
```sh
make vscode_settings
```