### PR TITLE
Chore: Update the plan evaluator to use stages

### DIFF
--- a/sqlmesh/core/plan/__init__.py
+++ b/sqlmesh/core/plan/__init__.py
@@ -8,6 +8,5 @@ from sqlmesh.core.plan.definition import (
 from sqlmesh.core.plan.evaluator import (
     BuiltInPlanEvaluator as BuiltInPlanEvaluator,
     PlanEvaluator as PlanEvaluator,
-    update_intervals_for_new_snapshots as update_intervals_for_new_snapshots,
 )
 from sqlmesh.core.plan.explainer import PlanExplainer as PlanExplainer

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -23,6 +23,7 @@ from sqlmesh.core.console import Console, get_console
 from sqlmesh.core.environment import EnvironmentNamingInfo, execute_environment_statements
 from sqlmesh.core.macros import RuntimeStage
 from sqlmesh.core.snapshot.definition import Interval, to_view_mapping
+from sqlmesh.core.plan import stages
 from sqlmesh.core.plan.definition import EvaluatablePlan
 from sqlmesh.core.scheduler import Scheduler
 from sqlmesh.core.snapshot import (
@@ -35,11 +36,10 @@ from sqlmesh.core.snapshot import (
     SnapshotTableInfo,
     SnapshotCreationFailedError,
 )
-from sqlmesh.utils import CompletionStatus
-from sqlmesh.core.state_sync import StateSync, StateReader
-from sqlmesh.core.state_sync.base import PromotionResult
+from sqlmesh.utils import to_snake_case
+from sqlmesh.core.state_sync import StateSync
 from sqlmesh.utils.concurrency import NodeExecutionFailedError
-from sqlmesh.utils.errors import PlanError
+from sqlmesh.utils.errors import PlanError, SQLMeshError
 from sqlmesh.utils.dag import DAG
 from sqlmesh.utils.date import now
 
@@ -77,12 +77,14 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         self.create_scheduler = create_scheduler
         self.default_catalog = default_catalog
         self.console = console or get_console()
+        self._circuit_breaker: t.Optional[t.Callable[[], bool]] = None
 
     def evaluate(
         self,
         plan: EvaluatablePlan,
         circuit_breaker: t.Optional[t.Callable[[], bool]] = None,
     ) -> None:
+        self._circuit_breaker = circuit_breaker
         self.console.start_plan_evaluation(plan)
         analytics.collector.on_plan_apply_start(
             plan=plan,
@@ -92,110 +94,8 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         )
 
         try:
-            new_snapshots = {s.snapshot_id: s for s in plan.new_snapshots}
-            stored_snapshots = self.state_sync.get_snapshots(plan.environment.snapshots)
-            snapshots = {**new_snapshots, **stored_snapshots}
-            snapshots_by_name = {s.name: s for s in snapshots.values()}
-
-            all_names = {name for name in snapshots_by_name if plan.is_selected_for_backfill(name)}
-
-            deployability_index_for_evaluation = DeployabilityIndex.create(
-                snapshots, start=plan.start
-            )
-            deployability_index_for_creation = deployability_index_for_evaluation
-            if plan.is_dev:
-                before_promote_snapshots = all_names
-                after_promote_snapshots = set()
-            else:
-                before_promote_snapshots = {
-                    s.name
-                    for s in snapshots.values()
-                    if deployability_index_for_evaluation.is_representative(s)
-                    and plan.is_selected_for_backfill(s.name)
-                }
-                after_promote_snapshots = all_names - before_promote_snapshots
-                deployability_index_for_evaluation = DeployabilityIndex.all_deployable()
-
-            # Step 1: Run before_all environment statements before doing anything else
-            execute_environment_statements(
-                adapter=self.snapshot_evaluator.adapter,
-                environment_statements=plan.environment_statements or [],
-                runtime_stage=RuntimeStage.BEFORE_ALL,
-                environment_naming_info=plan.environment.naming_info,
-                default_catalog=self.default_catalog,
-                snapshots=snapshots_by_name,
-                start=plan.start,
-                end=plan.end,
-                execution_time=plan.execution_time,
-            )
-
-            # Step 2:Store new snapshot records in the state and create physical tables for them
-            push_completion_status = self._push(plan, snapshots, deployability_index_for_creation)
-            if push_completion_status.is_nothing_to_do:
-                self.console.log_success(
-                    "" if plan.restatements else "\nSKIP: No physical layer updates to perform"
-                )
-
-            # Step 3: Update the intervals for the new forward-only snapshots
-            update_intervals_for_new_snapshots(plan.new_snapshots, self.state_sync)
-
-            # Step 4: Run audits without evaluations for snapshots that capture audit metadata changes
-            self._run_audits_for_metadata_snapshots(plan, new_snapshots)
-
-            # Step 5: Remove intervals for snapshots that need to be restated
-            self._restate(plan, snapshots_by_name)
-
-            # Step 6: Backfill missing intervals for snapshots that can be backfilled before updating
-            # the schema of production tables
-            first_bf_completion_status = self._backfill(
-                plan,
-                snapshots_by_name,
-                before_promote_snapshots,
-                deployability_index_for_evaluation,
-                circuit_breaker=circuit_breaker,
-            )
-
-            # Step 7: Update the target environment record in the state and migrate table schemas for forward-only
-            # snapshots if deploying to production
-            promotion_result = self._promote(
-                plan, snapshots, before_promote_snapshots, deployability_index_for_creation
-            )
-
-            # Step 8: Backfill missing intervals for snapshots that can be backfilled only after updating
-            # the schema of production tables
-            second_bf_completion_status = self._backfill(
-                plan,
-                snapshots_by_name,
-                after_promote_snapshots,
-                deployability_index_for_evaluation,
-                circuit_breaker=circuit_breaker,
-            )
-
-            if (
-                first_bf_completion_status.is_nothing_to_do
-                and second_bf_completion_status.is_nothing_to_do
-            ):
-                self.console.log_success("SKIP: No model batches to execute")
-
-            # Step 9: Update environment views to point at new physical tables and finalize the environment
-            # record in the state
-            self._update_views(
-                plan, snapshots, promotion_result, deployability_index_for_evaluation
-            )
-
-            # Step 10: Run after_all environment statements
-            execute_environment_statements(
-                adapter=self.snapshot_evaluator.adapter,
-                environment_statements=plan.environment_statements or [],
-                runtime_stage=RuntimeStage.AFTER_ALL,
-                environment_naming_info=plan.environment.naming_info,
-                default_catalog=self.default_catalog,
-                snapshots=snapshots_by_name,
-                start=plan.start,
-                end=plan.end,
-                execution_time=plan.execution_time,
-            )
-
+            plan_stages = stages.build_plan_stages(plan, self.state_sync, self.default_catalog)
+            self._evaluate_stages(plan_stages, plan)
         except Exception as e:
             analytics.collector.on_plan_apply_end(plan_id=plan.plan_id, error=e)
             raise
@@ -204,101 +104,80 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         finally:
             self.console.stop_plan_evaluation()
 
-    def _backfill(
-        self,
-        plan: EvaluatablePlan,
-        snapshots_by_name: t.Dict[str, Snapshot],
-        selected_snapshots: t.Set[str],
-        deployability_index: DeployabilityIndex,
-        circuit_breaker: t.Optional[t.Callable[[], bool]] = None,
-    ) -> CompletionStatus:
-        """Backfill missing intervals for snapshots that are part of the given plan.
+    def _evaluate_stages(
+        self, plan_stages: t.List[stages.PlanStage], plan: EvaluatablePlan
+    ) -> None:
+        for stage in plan_stages:
+            stage_name = stage.__class__.__name__
+            handler_name = f"visit_{to_snake_case(stage_name)}"
+            if not hasattr(self, handler_name):
+                raise SQLMeshError(f"Unexpected plan stage: {stage_name}")
+            logger.info("Evaluating plan stage %s", stage_name)
+            handler = getattr(self, handler_name)
+            handler(stage, plan)
 
-        Args:
-            plan: The plan to source snapshots from.
-            selected_snapshots: The snapshots to backfill.
-        """
-        if plan.empty_backfill:
-            intervals_to_add = []
-            for snapshot in snapshots_by_name.values():
-                if not snapshot.evaluatable or not plan.is_selected_for_backfill(snapshot.name):
-                    # Skip snapshots that are not evaluatable or not selected for backfill.
-                    continue
-                intervals = [
-                    snapshot.inclusive_exclusive(plan.start, plan.end, strict=False, expand=False)
-                ]
-                is_deployable = deployability_index.is_deployable(snapshot)
-                intervals_to_add.append(
-                    SnapshotIntervals(
-                        name=snapshot.name,
-                        identifier=snapshot.identifier,
-                        version=snapshot.version,
-                        dev_version=snapshot.dev_version,
-                        intervals=intervals if is_deployable else [],
-                        dev_intervals=intervals if not is_deployable else [],
-                    )
-                )
-            self.state_sync.add_snapshots_intervals(intervals_to_add)
-            return CompletionStatus.NOTHING_TO_DO
-
-        if not plan.requires_backfill or not selected_snapshots:
-            return CompletionStatus.NOTHING_TO_DO
-
-        scheduler = self.create_scheduler(snapshots_by_name.values())
-        completion_status = scheduler.run(
-            plan.environment,
-            plan.start,
-            plan.end,
+    def visit_before_all_stage(self, stage: stages.BeforeAllStage, plan: EvaluatablePlan) -> None:
+        execute_environment_statements(
+            adapter=self.snapshot_evaluator.adapter,
+            environment_statements=stage.statements,
+            runtime_stage=RuntimeStage.BEFORE_ALL,
+            environment_naming_info=plan.environment.naming_info,
+            default_catalog=self.default_catalog,
+            snapshots=stage.all_snapshots,
+            start=plan.start,
+            end=plan.end,
             execution_time=plan.execution_time,
-            restatements={
-                snapshots_by_name[name].snapshot_id: interval
-                for name, interval in plan.restatements.items()
-            },
-            selected_snapshots=selected_snapshots,
-            deployability_index=deployability_index,
-            circuit_breaker=circuit_breaker,
-            end_bounded=plan.end_bounded,
-            interval_end_per_model=plan.interval_end_per_model,
         )
-        if completion_status.is_failure:
-            raise PlanError("Plan application failed.")
 
-        return completion_status
+    def visit_after_all_stage(self, stage: stages.AfterAllStage, plan: EvaluatablePlan) -> None:
+        execute_environment_statements(
+            adapter=self.snapshot_evaluator.adapter,
+            environment_statements=stage.statements,
+            runtime_stage=RuntimeStage.AFTER_ALL,
+            environment_naming_info=plan.environment.naming_info,
+            default_catalog=self.default_catalog,
+            snapshots=stage.all_snapshots,
+            start=plan.start,
+            end=plan.end,
+            execution_time=plan.execution_time,
+        )
 
-    def _push(
-        self,
-        plan: EvaluatablePlan,
-        snapshots: t.Dict[SnapshotId, Snapshot],
-        deployability_index: t.Optional[DeployabilityIndex] = None,
-    ) -> CompletionStatus:
-        """Push the snapshots to the state sync.
-
-        As a part of plan pushing, snapshot tables are created.
-
-        Args:
-            plan: The plan to source snapshots from.
-            deployability_index: Indicates which snapshots are deployable in the context of this creation.
-        """
-        self.state_sync.push_snapshots(plan.new_snapshots)
+    def visit_create_snapshot_records_stage(
+        self, stage: stages.CreateSnapshotRecordsStage, plan: EvaluatablePlan
+    ) -> None:
+        self.state_sync.push_snapshots(stage.snapshots)
         analytics.collector.on_snapshots_created(
-            new_snapshots=plan.new_snapshots, plan_id=plan.plan_id
+            new_snapshots=stage.snapshots, plan_id=plan.plan_id
         )
+        # Update the intervals for the new forward-only snapshots
+        self._update_intervals_for_new_snapshots(stage.snapshots)
 
-        snapshots_to_create = get_snapshots_to_create(plan, snapshots)
+    def visit_physical_layer_update_stage(
+        self, stage: stages.PhysicalLayerUpdateStage, plan: EvaluatablePlan
+    ) -> None:
+        skip_message = "" if plan.restatements else "\nSKIP: No physical layer updates to perform"
+
+        snapshots_to_create = stage.snapshots
+        if not snapshots_to_create:
+            self.console.log_success(skip_message)
+            return
 
         completion_status = None
         progress_stopped = False
         try:
             completion_status = self.snapshot_evaluator.create(
                 snapshots_to_create,
-                snapshots,
+                stage.all_snapshots,
                 allow_destructive_snapshots=plan.allow_destructive_models,
-                deployability_index=deployability_index,
+                deployability_index=stage.deployability_index,
                 on_start=lambda x: self.console.start_creation_progress(
                     x, plan.environment, self.default_catalog
                 ),
                 on_complete=self.console.update_creation_progress,
             )
+            if completion_status.is_nothing_to_do:
+                self.console.log_success(skip_message)
+                return
         except SnapshotCreationFailedError as ex:
             self.console.stop_creation_progress(success=False)
             progress_stopped = True
@@ -316,71 +195,125 @@ class BuiltInPlanEvaluator(PlanEvaluator):
                     success=completion_status is not None and completion_status.is_success
                 )
 
-        return completion_status
+    def visit_backfill_stage(self, stage: stages.BackfillStage, plan: EvaluatablePlan) -> None:
+        if plan.empty_backfill:
+            intervals_to_add = []
+            for snapshot in stage.all_snapshots.values():
+                if not snapshot.evaluatable or not plan.is_selected_for_backfill(snapshot.name):
+                    # Skip snapshots that are not evaluatable or not selected for backfill.
+                    continue
+                intervals = [
+                    snapshot.inclusive_exclusive(plan.start, plan.end, strict=False, expand=False)
+                ]
+                is_deployable = stage.deployability_index.is_deployable(snapshot)
+                intervals_to_add.append(
+                    SnapshotIntervals(
+                        name=snapshot.name,
+                        identifier=snapshot.identifier,
+                        version=snapshot.version,
+                        dev_version=snapshot.dev_version,
+                        intervals=intervals if is_deployable else [],
+                        dev_intervals=intervals if not is_deployable else [],
+                    )
+                )
+            self.state_sync.add_snapshots_intervals(intervals_to_add)
+            self.console.log_success("SKIP: No model batches to execute")
+            return
 
-    def _promote(
-        self,
-        plan: EvaluatablePlan,
-        snapshots: t.Dict[SnapshotId, Snapshot],
-        no_gaps_snapshot_names: t.Optional[t.Set[str]] = None,
-        deployability_index: t.Optional[DeployabilityIndex] = None,
-    ) -> PromotionResult:
-        """Promote a plan.
+        if not stage.snapshot_to_intervals:
+            self.console.log_success("SKIP: No model batches to execute")
+            return
 
-        Args:
-            plan: The plan to promote.
-            no_gaps_snapshot_names: The names of snapshots to check for gaps if the no gaps check is enabled in the plan.
-            If not provided, all snapshots are checked.
-        """
-        promotion_result = self.state_sync.promote(
+        scheduler = self.create_scheduler(stage.all_snapshots.values())
+        errors, _ = scheduler.run_merged_intervals(
+            merged_intervals=stage.snapshot_to_intervals,
+            deployability_index=stage.deployability_index,
+            environment_naming_info=plan.environment.naming_info,
+            execution_time=plan.execution_time,
+            circuit_breaker=self._circuit_breaker,
+            start=plan.start,
+            end=plan.end,
+        )
+        if errors:
+            raise PlanError("Plan application failed.")
+
+    def visit_audit_only_run_stage(
+        self, stage: stages.AuditOnlyRunStage, plan: EvaluatablePlan
+    ) -> None:
+        audit_snapshots = stage.snapshots
+        if not audit_snapshots:
+            return
+
+        # If there are any snapshots to be audited, we'll reuse the scheduler's internals to audit them
+        scheduler = self.create_scheduler(audit_snapshots)
+        completion_status = scheduler.audit(
             plan.environment,
-            no_gaps_snapshot_names=no_gaps_snapshot_names if plan.no_gaps else set(),
+            plan.start,
+            plan.end,
+            execution_time=plan.execution_time,
+            end_bounded=plan.end_bounded,
+            interval_end_per_model=plan.interval_end_per_model,
+        )
+
+        if completion_status.is_failure:
+            raise PlanError("Plan application failed.")
+
+    def visit_restatement_stage(
+        self, stage: stages.RestatementStage, plan: EvaluatablePlan
+    ) -> None:
+        snapshot_intervals_to_restate = {(s, i) for s, i in stage.snapshot_intervals.items()}
+
+        # Restating intervals on prod plans should mean that the intervals are cleared across
+        # all environments, not just the version currently in prod
+        # This ensures that work done in dev environments can still be promoted to prod
+        # by forcing dev environments to re-run intervals that changed in prod
+        #
+        # Without this rule, its possible that promoting a dev table to prod will introduce old data to prod
+        snapshot_intervals_to_restate.update(
+            self._restatement_intervals_across_all_environments(
+                prod_restatements=plan.restatements,
+                disable_restatement_models=plan.disabled_restatement_models,
+                loaded_snapshots={s.snapshot_id: s for s in stage.all_snapshots.values()},
+            )
+        )
+
+        self.state_sync.remove_intervals(
+            snapshot_intervals=list(snapshot_intervals_to_restate),
+            remove_shared_versions=plan.is_prod,
+        )
+
+    def visit_environment_record_update_stage(
+        self, stage: stages.EnvironmentRecordUpdateStage, plan: EvaluatablePlan
+    ) -> None:
+        self.state_sync.promote(
+            plan.environment,
+            no_gaps_snapshot_names=stage.no_gaps_snapshot_names if plan.no_gaps else set(),
             environment_statements=plan.environment_statements,
         )
 
-        if not plan.is_dev:
-            try:
-                self.snapshot_evaluator.migrate(
-                    [s for s in snapshots.values() if s.is_paused],
-                    snapshots,
-                    allow_destructive_snapshots=plan.allow_destructive_models,
-                    deployability_index=deployability_index,
-                )
-            except NodeExecutionFailedError as ex:
-                raise PlanError(str(ex.__cause__) if ex.__cause__ else str(ex))
-
-            if not plan.ensure_finalized_snapshots:
-                # Only unpause at this point if we don't have to use the finalized snapshots
-                # for subsequent plan applications. Otherwise, unpause right before finalizing
-                # the environment.
-                self.state_sync.unpause_snapshots(promotion_result.added, plan.end)
-
-        return promotion_result
-
-    def _update_views(
-        self,
-        plan: EvaluatablePlan,
-        snapshots: t.Dict[SnapshotId, Snapshot],
-        promotion_result: PromotionResult,
-        deployability_index: t.Optional[DeployabilityIndex] = None,
+    def visit_migrate_schemas_stage(
+        self, stage: stages.MigrateSchemasStage, plan: EvaluatablePlan
     ) -> None:
-        """Update environment views.
+        try:
+            self.snapshot_evaluator.migrate(
+                stage.snapshots,
+                stage.all_snapshots,
+                allow_destructive_snapshots=plan.allow_destructive_models,
+                deployability_index=stage.deployability_index,
+            )
+        except NodeExecutionFailedError as ex:
+            raise PlanError(str(ex.__cause__) if ex.__cause__ else str(ex))
 
-        Args:
-            plan: The plan to promote.
-            promotion_result: The result of the promotion.
-            deployability_index: Indicates which snapshots are deployable in the context of this promotion.
-        """
-        if not plan.is_dev and plan.ensure_finalized_snapshots:
-            # Unpause right before finalizing the environment in case when
-            # we need to use the finalized snapshots for subsequent plan applications.
-            # Otherwise, unpause right after updatig the environment record.
-            self.state_sync.unpause_snapshots(promotion_result.added, plan.end)
+    def visit_unpause_stage(self, stage: stages.UnpauseStage, plan: EvaluatablePlan) -> None:
+        self.state_sync.unpause_snapshots(stage.promoted_snapshots, plan.end)
 
+    def visit_virtual_layer_update_stage(
+        self, stage: stages.VirtualLayerUpdateStage, plan: EvaluatablePlan
+    ) -> None:
         environment = plan.environment
 
         self.console.start_promotion_progress(
-            promotion_result.added + promotion_result.removed,
+            list(stage.promoted_snapshots) + list(stage.demoted_snapshots),
             environment.naming_info,
             self.default_catalog,
         )
@@ -389,24 +322,27 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         try:
             self._promote_snapshots(
                 plan,
-                [snapshots[s.snapshot_id] for s in promotion_result.added],
+                [stage.all_snapshots[s.snapshot_id] for s in stage.promoted_snapshots],
                 environment.naming_info,
-                deployability_index=deployability_index,
+                deployability_index=stage.deployability_index,
                 on_complete=lambda s: self.console.update_promotion_progress(s, True),
-                snapshots=snapshots,
+                snapshots=stage.all_snapshots,
             )
-            if promotion_result.removed_environment_naming_info:
+            if stage.demoted_environment_naming_info:
                 self._demote_snapshots(
-                    plan,
-                    promotion_result.removed,
-                    promotion_result.removed_environment_naming_info,
+                    stage.demoted_snapshots,
+                    stage.demoted_environment_naming_info,
                     on_complete=lambda s: self.console.update_promotion_progress(s, False),
                 )
 
-            self.state_sync.finalize(environment)
             completed = True
         finally:
             self.console.stop_promotion_progress(success=completed)
+
+    def visit_finalize_environment_stage(
+        self, stage: stages.FinalizeEnvironmentStage, plan: EvaluatablePlan
+    ) -> None:
+        self.state_sync.finalize(plan.environment)
 
     def _promote_snapshots(
         self,
@@ -436,41 +372,12 @@ class BuiltInPlanEvaluator(PlanEvaluator):
 
     def _demote_snapshots(
         self,
-        plan: EvaluatablePlan,
         target_snapshots: t.Iterable[SnapshotTableInfo],
         environment_naming_info: EnvironmentNamingInfo,
         on_complete: t.Optional[t.Callable[[SnapshotInfoLike], None]] = None,
     ) -> None:
         self.snapshot_evaluator.demote(
             target_snapshots, environment_naming_info, on_complete=on_complete
-        )
-
-    def _restate(self, plan: EvaluatablePlan, snapshots_by_name: t.Dict[str, Snapshot]) -> None:
-        if not plan.restatements or plan.is_dev:
-            return
-
-        snapshot_intervals_to_restate = {
-            (snapshots_by_name[name].table_info, intervals)
-            for name, intervals in plan.restatements.items()
-        }
-
-        # Restating intervals on prod plans should mean that the intervals are cleared across
-        # all environments, not just the version currently in prod
-        # This ensures that work done in dev environments can still be promoted to prod
-        # by forcing dev environments to re-run intervals that changed in prod
-        #
-        # Without this rule, its possible that promoting a dev table to prod will introduce old data to prod
-        snapshot_intervals_to_restate.update(
-            self._restatement_intervals_across_all_environments(
-                prod_restatements=plan.restatements,
-                disable_restatement_models=plan.disabled_restatement_models,
-                loaded_snapshots={s.snapshot_id: s for s in snapshots_by_name.values()},
-            )
-        )
-
-        self.state_sync.remove_intervals(
-            snapshot_intervals=list(snapshot_intervals_to_restate),
-            remove_shared_versions=plan.is_prod,
         )
 
     def _restatement_intervals_across_all_environments(
@@ -552,95 +459,19 @@ class BuiltInPlanEvaluator(PlanEvaluator):
 
         return set(snapshots_to_restate.values())
 
-    def _run_audits_for_metadata_snapshots(
-        self,
-        plan: EvaluatablePlan,
-        new_snapshots: t.Dict[SnapshotId, Snapshot],
-    ) -> None:
-        audit_snapshots = get_audit_only_snapshots(new_snapshots, self.state_sync)
-        if not audit_snapshots:
-            return
-
-        # If there are any snapshots to be audited, we'll reuse the scheduler's internals to audit them
-        scheduler = self.create_scheduler(audit_snapshots.values())
-        completion_status = scheduler.audit(
-            plan.environment,
-            plan.start,
-            plan.end,
-            execution_time=plan.execution_time,
-            end_bounded=plan.end_bounded,
-            interval_end_per_model=plan.interval_end_per_model,
-        )
-
-        if completion_status.is_failure:
-            raise PlanError("Plan application failed.")
-
-
-def update_intervals_for_new_snapshots(
-    snapshots: t.Collection[Snapshot], state_sync: StateSync
-) -> None:
-    snapshots_intervals: t.List[SnapshotIntervals] = []
-    for snapshot in state_sync.refresh_snapshot_intervals(snapshots):
-        if snapshot.is_forward_only:
-            snapshot.dev_intervals = snapshot.intervals.copy()
-            snapshots_intervals.append(
-                SnapshotIntervals(
-                    name=snapshot.name,
-                    identifier=snapshot.identifier,
-                    version=snapshot.version,
-                    dev_version=snapshot.dev_version,
-                    dev_intervals=snapshot.dev_intervals,
+    def _update_intervals_for_new_snapshots(self, snapshots: t.Collection[Snapshot]) -> None:
+        snapshots_intervals: t.List[SnapshotIntervals] = []
+        for snapshot in snapshots:
+            if snapshot.is_forward_only:
+                snapshots_intervals.append(
+                    SnapshotIntervals(
+                        name=snapshot.name,
+                        identifier=snapshot.identifier,
+                        version=snapshot.version,
+                        dev_version=snapshot.dev_version,
+                        dev_intervals=snapshot.dev_intervals,
+                    )
                 )
-            )
 
-    if snapshots_intervals:
-        state_sync.add_snapshots_intervals(snapshots_intervals)
-
-
-def get_audit_only_snapshots(
-    new_snapshots: t.Dict[SnapshotId, Snapshot], state_reader: StateReader
-) -> t.Dict[SnapshotId, Snapshot]:
-    metadata_snapshots = []
-    for snapshot in new_snapshots.values():
-        if not snapshot.is_metadata or not snapshot.is_model or not snapshot.evaluatable:
-            continue
-
-        metadata_snapshots.append(snapshot)
-
-    # Bulk load all the previous snapshots
-    previous_snapshots = state_reader.get_snapshots(
-        [s.previous_version.snapshot_id(s.name) for s in metadata_snapshots if s.previous_version]
-    ).values()
-
-    # Check if any of the snapshots have modifications to the audits field by comparing the hashes
-    audit_snapshots = {}
-    for snapshot, previous_snapshot in zip(metadata_snapshots, previous_snapshots):
-        new_audits_hash = snapshot.model.audit_metadata_hash()
-        previous_audit_hash = previous_snapshot.model.audit_metadata_hash()
-
-        if snapshot.model.audits and previous_audit_hash != new_audits_hash:
-            audit_snapshots[snapshot.snapshot_id] = snapshot
-
-    return audit_snapshots
-
-
-def get_snapshots_to_create(
-    plan: EvaluatablePlan, snapshots: t.Dict[SnapshotId, Snapshot]
-) -> t.List[Snapshot]:
-    promoted_snapshot_ids = (
-        set(plan.environment.promoted_snapshot_ids)
-        if plan.environment.promoted_snapshot_ids is not None
-        else None
-    )
-
-    def _should_create(s: Snapshot) -> bool:
-        if not s.is_model or s.is_symbolic:
-            return False
-        # Only create tables for snapshots that we're planning to promote or that were selected for backfill
-        return (
-            plan.is_selected_for_backfill(s.name)
-            or promoted_snapshot_ids is None
-            or s.snapshot_id in promoted_snapshot_ids
-        )
-
-    return [s for s in snapshots.values() if _should_create(s)]
+        if snapshots_intervals:
+            self.state_sync.add_snapshots_intervals(snapshots_intervals)

--- a/sqlmesh/core/plan/explainer.py
+++ b/sqlmesh/core/plan/explainer.py
@@ -227,7 +227,7 @@ class RichExplainerConsole(ExplainerConsole):
             "[bold]Delete views in the virtual layer for models that were removed[/bold]"
         )
         for snapshot in stage.demoted_snapshots:
-            display_name = self._display_name(snapshot)
+            display_name = self._display_name(snapshot, stage.demoted_environment_naming_info)
             demote_tree.add(display_name)
 
         if stage.promoted_snapshots:
@@ -254,9 +254,13 @@ class RichExplainerConsole(ExplainerConsole):
     ) -> t.Optional[Tree]:
         return None
 
-    def _display_name(self, snapshot: SnapshotInfoMixin) -> str:
+    def _display_name(
+        self,
+        snapshot: SnapshotInfoMixin,
+        environment_naming_info: t.Optional[EnvironmentNamingInfo] = None,
+    ) -> str:
         return snapshot.display_name(
-            self.environment_naming_info,
+            environment_naming_info or self.environment_naming_info,
             self.default_catalog if self.verbosity < Verbosity.VERY_VERBOSE else None,
             dialect=self.dialect,
         )

--- a/sqlmesh/core/plan/explainer.py
+++ b/sqlmesh/core/plan/explainer.py
@@ -117,7 +117,9 @@ class RichExplainerConsole(ExplainerConsole):
 
             if snapshot.is_view:
                 create_tree = Tree("Create view if it doesn't exist")
-            elif snapshot.is_forward_only and snapshot.previous_versions:
+            elif (
+                snapshot.is_forward_only and snapshot.previous_versions and not snapshot.is_managed
+            ):
                 prod_table = snapshot.table_name(True)
                 create_tree = Tree(
                     f"Clone {prod_table} into {table_name} and then update its schema if it doesn't exist"

--- a/sqlmesh/core/plan/stages.py
+++ b/sqlmesh/core/plan/stages.py
@@ -1,11 +1,8 @@
 import typing as t
 
 from dataclasses import dataclass
+from sqlmesh.core.environment import EnvironmentStatements, EnvironmentNamingInfo
 from sqlmesh.core.plan.definition import EvaluatablePlan
-from sqlmesh.core.plan.evaluator import (
-    get_audit_only_snapshots,
-    get_snapshots_to_create,
-)
 from sqlmesh.core.state_sync import StateReader
 from sqlmesh.core.scheduler import merged_missing_intervals, SnapshotToIntervals
 from sqlmesh.core.snapshot.definition import (
@@ -19,64 +16,182 @@ from sqlmesh.core.snapshot.definition import (
 
 @dataclass
 class BeforeAllStage:
-    statements: t.List[str]
+    """Run environment statements before every other stage.
+
+    Args:
+        statements: Environment statements to run before every other stage.
+        all_snapshots: All snapshots in the plan by name.
+    """
+
+    statements: t.List[EnvironmentStatements]
+    all_snapshots: t.Dict[str, Snapshot]
 
 
 @dataclass
 class AfterAllStage:
-    statements: t.List[str]
+    """Run environment statements after all other stages.
+
+    Args:
+        statements: Environment statements to run after all other stages.
+        all_snapshots: All snapshots in the plan by name.
+    """
+
+    statements: t.List[EnvironmentStatements]
+    all_snapshots: t.Dict[str, Snapshot]
+
+
+@dataclass
+class CreateSnapshotRecordsStage:
+    """Create new snapshot reecords in the state.
+
+    Args:
+        snapshots: New snapshots to create records for.
+    """
+
+    snapshots: t.List[Snapshot]
 
 
 @dataclass
 class PhysicalLayerUpdateStage:
+    """Update the physical layer by creating physical tables and views for given snapshots.
+
+    Args:
+        snapshots: Snapshots to create physical tables and views for. This collection can be empty in which case
+            no physical layer update is needed. This can be useful to report the lack of physical layer updates
+            back to the user.
+        all_snapshots: All snapshots in the plan by snapshot ID.
+        snapshots_with_missing_intervals: Snapshots that have missing intervals.
+        deployability_index: Deployability index for this stage.
+    """
+
     snapshots: t.List[Snapshot]
+    all_snapshots: t.Dict[SnapshotId, Snapshot]
+    snapshots_with_missing_intervals: t.Set[SnapshotId]
     deployability_index: DeployabilityIndex
 
 
 @dataclass
 class AuditOnlyRunStage:
+    """Run audits only for given snapshots.
+
+    Args:
+        snapshots: Snapshots to run audits for.
+    """
+
     snapshots: t.List[Snapshot]
 
 
 @dataclass
 class RestatementStage:
+    """Restate intervals for given snapshots.
+
+    Args:
+        snapshot_intervals: Intervals to restate.
+        all_snapshots: All snapshots in the plan by name.
+    """
+
     snapshot_intervals: t.Dict[SnapshotTableInfo, Interval]
+    all_snapshots: t.Dict[str, Snapshot]
 
 
 @dataclass
 class BackfillStage:
+    """Backfill given missing intervals.
+
+    Args:
+        snapshot_to_intervals: Intervals to backfill. This collection can be empty in which case no backfill is needed.
+            This can be useful to report the lack of backfills back to the user.
+        all_snapshots: All snapshots in the plan by name.
+        deployability_index: Deployability index for this stage.
+        before_promote: Whether this stage is before the promotion stage.
+    """
+
     snapshot_to_intervals: SnapshotToIntervals
+    all_snapshots: t.Dict[str, Snapshot]
     deployability_index: DeployabilityIndex
     before_promote: bool = True
 
 
 @dataclass
-class MigrateSchemasStage:
-    snapshots: t.List[Snapshot]
+class EnvironmentRecordUpdateStage:
+    """Update the environment record in the state.
+
+    Args:
+        no_gaps_snapshot_names: Names of snapshots for which there should be no interval gaps.
+    """
+
+    no_gaps_snapshot_names: t.Set[str]
 
 
 @dataclass
-class VirtualLayerUpdateStage:
-    promoted_snapshots: t.Set[SnapshotTableInfo]
-    demoted_snapshots: t.Set[SnapshotTableInfo]
+class MigrateSchemasStage:
+    """Migrate schemas of physical tables for given snapshots.
+
+    Args:
+        snapshots: Snapshots to migrate schemas for.
+        all_snapshots: All snapshots in the plan by snapshot ID.
+        deployability_index: Deployability index for this stage.
+    """
+
+    snapshots: t.List[Snapshot]
+    all_snapshots: t.Dict[SnapshotId, Snapshot]
     deployability_index: DeployabilityIndex
 
 
 @dataclass
-class EnvironmentRecordUpdateStage:
+class VirtualLayerUpdateStage:
+    """Update the virtual layer by creating and deleting views for given snapshots.
+
+    Args:
+        promoted_snapshots: Snapshots to create views for.
+        demoted_snapshots: Snapshots to delete views for.
+        demoted_environment_naming_info: Environment naming info of the previous environment record.
+        all_snapshots: All snapshots in the plan by snapshot ID.
+        deployability_index: Deployability index for this stage.
+    """
+
+    promoted_snapshots: t.Set[SnapshotTableInfo]
+    demoted_snapshots: t.Set[SnapshotTableInfo]
+    demoted_environment_naming_info: t.Optional[EnvironmentNamingInfo]
+    all_snapshots: t.Dict[SnapshotId, Snapshot]
+    deployability_index: DeployabilityIndex
+
+
+@dataclass
+class UnpauseStage:
+    """Unpause given snapshots that are being deployed to prod.
+
+    Args:
+        promoted_snapshots: Snapshots to unpause.
+    """
+
+    promoted_snapshots: t.Set[SnapshotTableInfo]
+
+
+@dataclass
+class FinalizeEnvironmentStage:
+    """Finalize the enviornment record in the state.
+
+    Finalization means that all stages have been applied and that the environment has been transitioned
+    to the new state successfully. This should be the last stage in the plan application process.
+    """
+
     pass
 
 
 PlanStage = t.Union[
     BeforeAllStage,
     AfterAllStage,
+    CreateSnapshotRecordsStage,
     PhysicalLayerUpdateStage,
     AuditOnlyRunStage,
     RestatementStage,
     BackfillStage,
+    EnvironmentRecordUpdateStage,
     MigrateSchemasStage,
     VirtualLayerUpdateStage,
-    EnvironmentRecordUpdateStage,
+    UnpauseStage,
+    FinalizeEnvironmentStage,
 ]
 
 
@@ -99,6 +214,8 @@ class PlanStagesBuilder:
             s.snapshot_id for s in snapshots.values() if plan.is_selected_for_backfill(s.name)
         }
 
+        self._adjust_intervals(snapshots_by_name, plan)
+
         deployability_index = DeployabilityIndex.create(snapshots, start=plan.start)
         deployability_index_for_creation = deployability_index
         if plan.is_dev:
@@ -119,8 +236,9 @@ class PlanStagesBuilder:
                 s
                 for s in snapshots.values()
                 if s.is_paused
-                and s.is_materialized
-                and not deployability_index_for_creation.is_representative(s)
+                and s.is_model
+                and not s.is_symbolic
+                and (not deployability_index_for_creation.is_representative(s) or s.is_view)
             ]
 
         snapshots_to_intervals = self._missing_intervals(
@@ -138,11 +256,18 @@ class PlanStagesBuilder:
                 elif snapshot.snapshot_id in after_promote_snapshots:
                     missing_intervals_after_promote[snapshot] = intervals
 
+        promoted_snapshots, demoted_snapshots, demoted_environment_naming_info = (
+            self._get_promoted_demoted_snapshots(plan)
+        )
+
         stages: t.List[PlanStage] = []
 
-        before_all_stage = self._get_before_all_stage(plan)
+        before_all_stage = self._get_before_all_stage(plan, snapshots_by_name)
         if before_all_stage:
             stages.append(before_all_stage)
+
+        if plan.new_snapshots:
+            stages.append(CreateSnapshotRecordsStage(snapshots=plan.new_snapshots))
 
         stages.append(
             self._get_physical_layer_update_stage(
@@ -150,7 +275,7 @@ class PlanStagesBuilder:
             )
         )
 
-        audit_only_snapshots = get_audit_only_snapshots(new_snapshots, self.state_reader)
+        audit_only_snapshots = self._get_audit_only_snapshots(new_snapshots)
         if audit_only_snapshots:
             stages.append(AuditOnlyRunStage(snapshots=list(audit_only_snapshots.values())))
 
@@ -162,53 +287,101 @@ class PlanStagesBuilder:
             stages.append(
                 BackfillStage(
                     snapshot_to_intervals=missing_intervals_before_promote,
+                    all_snapshots=snapshots_by_name,
                     deployability_index=deployability_index,
                 )
             )
         elif not needs_backfill:
             # Append an empty backfill stage so that explainer can show that the stage is skipped
             stages.append(
-                BackfillStage(snapshot_to_intervals={}, deployability_index=deployability_index)
+                BackfillStage(
+                    snapshot_to_intervals={},
+                    all_snapshots=snapshots_by_name,
+                    deployability_index=deployability_index,
+                )
             )
 
-        stages.append(EnvironmentRecordUpdateStage())
+        stages.append(
+            EnvironmentRecordUpdateStage(
+                no_gaps_snapshot_names={s.name for s in before_promote_snapshots}
+            )
+        )
 
         if snapshots_with_schema_migration:
-            stages.append(MigrateSchemasStage(snapshots=snapshots_with_schema_migration))
+            stages.append(
+                MigrateSchemasStage(
+                    snapshots=snapshots_with_schema_migration,
+                    all_snapshots=snapshots,
+                    deployability_index=deployability_index_for_creation,
+                )
+            )
+
+        if not plan.is_dev and not plan.ensure_finalized_snapshots and promoted_snapshots:
+            # Only unpause at this point if we don't have to use the finalized snapshots
+            # for subsequent plan applications. Otherwise, unpause right before updating
+            # the virtual layer.
+            stages.append(UnpauseStage(promoted_snapshots=promoted_snapshots))
 
         if missing_intervals_after_promote:
             stages.append(
                 BackfillStage(
                     snapshot_to_intervals=missing_intervals_after_promote,
+                    all_snapshots=snapshots_by_name,
                     deployability_index=deployability_index,
                 )
             )
 
-        virtual_layer_update_stage = self._get_virtual_layer_update_stage(plan, deployability_index)
+        if not plan.is_dev and plan.ensure_finalized_snapshots and promoted_snapshots:
+            # Unpause right before updating the virtual layer and finalizing the environment in case when
+            # we need to use the finalized snapshots for subsequent plan applications.
+            # Otherwise, unpause right after updatig the environment record.
+            stages.append(UnpauseStage(promoted_snapshots=promoted_snapshots))
+
+        virtual_layer_update_stage = self._get_virtual_layer_update_stage(
+            promoted_snapshots,
+            demoted_snapshots,
+            demoted_environment_naming_info,
+            snapshots,
+            deployability_index,
+        )
         if virtual_layer_update_stage:
             stages.append(virtual_layer_update_stage)
 
-        after_all_stage = self._get_after_all_stage(plan)
+        stages.append(FinalizeEnvironmentStage())
+
+        after_all_stage = self._get_after_all_stage(plan, snapshots_by_name)
         if after_all_stage:
             stages.append(after_all_stage)
 
         return stages
 
-    def _get_before_all_stage(self, plan: EvaluatablePlan) -> t.Optional[BeforeAllStage]:
+    def _get_before_all_stage(
+        self, plan: EvaluatablePlan, snapshots_by_name: t.Dict[str, Snapshot]
+    ) -> t.Optional[BeforeAllStage]:
         before_all = [
-            statement
+            environment_statements
             for environment_statements in plan.environment_statements or []
-            for statement in environment_statements.before_all
+            if environment_statements.before_all
         ]
-        return BeforeAllStage(statements=before_all) if before_all else None
+        return (
+            BeforeAllStage(statements=before_all, all_snapshots=snapshots_by_name)
+            if before_all
+            else None
+        )
 
-    def _get_after_all_stage(self, plan: EvaluatablePlan) -> t.Optional[AfterAllStage]:
+    def _get_after_all_stage(
+        self, plan: EvaluatablePlan, snapshots_by_name: t.Dict[str, Snapshot]
+    ) -> t.Optional[AfterAllStage]:
         after_all = [
-            statement
+            environment_statements
             for environment_statements in plan.environment_statements or []
-            for statement in environment_statements.after_all
+            if environment_statements.after_all
         ]
-        return AfterAllStage(statements=after_all) if after_all else None
+        return (
+            AfterAllStage(statements=after_all, all_snapshots=snapshots_by_name)
+            if after_all
+            else None
+        )
 
     def _get_restatement_stage(
         self, plan: EvaluatablePlan, snapshots_by_name: t.Dict[str, Snapshot]
@@ -220,7 +393,9 @@ class PlanStagesBuilder:
             snapshot_intervals_to_restate[restated_snapshot.table_info] = interval
         if not snapshot_intervals_to_restate or plan.is_dev:
             return None
-        return RestatementStage(snapshot_intervals=snapshot_intervals_to_restate)
+        return RestatementStage(
+            snapshot_intervals=snapshot_intervals_to_restate, all_snapshots=snapshots_by_name
+        )
 
     def _get_physical_layer_update_stage(
         self,
@@ -229,50 +404,80 @@ class PlanStagesBuilder:
         snapshots_to_intervals: SnapshotToIntervals,
         deployability_index: DeployabilityIndex,
     ) -> PhysicalLayerUpdateStage:
-        snapshots_to_create = [
-            s
-            for s in get_snapshots_to_create(plan, snapshots)
-            if s in snapshots_to_intervals and s.is_model and not s.is_symbolic
-        ]
         return PhysicalLayerUpdateStage(
-            snapshots=snapshots_to_create,
+            snapshots=self._get_snapshots_to_create(plan, snapshots),
+            all_snapshots=snapshots,
+            snapshots_with_missing_intervals={s.snapshot_id for s in snapshots_to_intervals},
             deployability_index=deployability_index,
         )
 
     def _get_virtual_layer_update_stage(
-        self, plan: EvaluatablePlan, deployability_index: DeployabilityIndex
+        self,
+        promoted_snapshots: t.Set[SnapshotTableInfo],
+        demoted_snapshots: t.Set[SnapshotTableInfo],
+        demoted_environment_naming_info: t.Optional[EnvironmentNamingInfo],
+        all_snapshots: t.Dict[SnapshotId, Snapshot],
+        deployability_index: DeployabilityIndex,
     ) -> t.Optional[VirtualLayerUpdateStage]:
-        promoted_snapshots, demoted_snapshots = self._get_promoted_demoted_snapshots(plan)
+        promoted_snapshots = {s for s in promoted_snapshots if s.is_model and not s.is_symbolic}
+        demoted_snapshots = {s for s in demoted_snapshots if s.is_model and not s.is_symbolic}
         if not promoted_snapshots and not demoted_snapshots:
             return None
         return VirtualLayerUpdateStage(
             promoted_snapshots=promoted_snapshots,
             demoted_snapshots=demoted_snapshots,
+            demoted_environment_naming_info=demoted_environment_naming_info,
+            all_snapshots=all_snapshots,
             deployability_index=deployability_index,
         )
 
     def _get_promoted_demoted_snapshots(
         self, plan: EvaluatablePlan
-    ) -> t.Tuple[t.Set[SnapshotTableInfo], t.Set[SnapshotTableInfo]]:
+    ) -> t.Tuple[
+        t.Set[SnapshotTableInfo], t.Set[SnapshotTableInfo], t.Optional[EnvironmentNamingInfo]
+    ]:
         existing_environment = self.state_reader.get_environment(plan.environment.name)
         if existing_environment:
-            snapshots_by_name = {s.name: s for s in existing_environment.snapshots}
-            demoted_snapshot_names = {s.name for s in existing_environment.promoted_snapshots} - {
+            new_table_infos = {
+                table_info.name: table_info for table_info in plan.environment.promoted_snapshots
+            }
+            existing_table_infos = {
+                table_info.name: table_info
+                for table_info in existing_environment.promoted_snapshots
+            }
+            views_that_changed_location = {
+                existing_table_info
+                for existing_table_info in existing_environment.promoted_snapshots
+                if existing_table_info.name in new_table_infos
+                and existing_table_info.qualified_view_name.for_environment(
+                    existing_environment.naming_info
+                )
+                != new_table_infos[existing_table_info.name].qualified_view_name.for_environment(
+                    plan.environment.naming_info
+                )
+            }
+            missing_model_names = set(existing_table_infos) - {
                 s.name for s in plan.environment.promoted_snapshots
             }
-            demoted_snapshots = {snapshots_by_name[name] for name in demoted_snapshot_names}
+            demoted_snapshots = {
+                existing_table_infos[name] for name in missing_model_names
+            } | views_that_changed_location
         else:
             demoted_snapshots = set()
+
         promoted_snapshots = set(plan.environment.promoted_snapshots)
         if existing_environment and plan.environment.can_partially_promote(existing_environment):
             promoted_snapshots -= set(existing_environment.promoted_snapshots)
 
-        def _snapshot_filter(snapshot: SnapshotTableInfo) -> bool:
-            return snapshot.is_model and not snapshot.is_symbolic
+        demoted_environment_naming_info = (
+            existing_environment.naming_info if demoted_snapshots and existing_environment else None
+        )
 
-        return {s for s in promoted_snapshots if _snapshot_filter(s)}, {
-            s for s in demoted_snapshots if _snapshot_filter(s)
-        }
+        return (
+            promoted_snapshots,
+            demoted_snapshots,
+            demoted_environment_naming_info,
+        )
 
     def _missing_intervals(
         self,
@@ -293,6 +498,69 @@ class PlanStagesBuilder:
             end_bounded=plan.end_bounded,
             interval_end_per_model=plan.interval_end_per_model,
         )
+
+    def _get_audit_only_snapshots(
+        self, new_snapshots: t.Dict[SnapshotId, Snapshot]
+    ) -> t.Dict[SnapshotId, Snapshot]:
+        metadata_snapshots = []
+        for snapshot in new_snapshots.values():
+            if not snapshot.is_metadata or not snapshot.is_model or not snapshot.evaluatable:
+                continue
+
+            metadata_snapshots.append(snapshot)
+
+        # Bulk load all the previous snapshots
+        previous_snapshots = self.state_reader.get_snapshots(
+            [
+                s.previous_version.snapshot_id(s.name)
+                for s in metadata_snapshots
+                if s.previous_version
+            ]
+        ).values()
+
+        # Check if any of the snapshots have modifications to the audits field by comparing the hashes
+        audit_snapshots = {}
+        for snapshot, previous_snapshot in zip(metadata_snapshots, previous_snapshots):
+            new_audits_hash = snapshot.model.audit_metadata_hash()
+            previous_audit_hash = previous_snapshot.model.audit_metadata_hash()
+
+            if snapshot.model.audits and previous_audit_hash != new_audits_hash:
+                audit_snapshots[snapshot.snapshot_id] = snapshot
+
+        return audit_snapshots
+
+    def _get_snapshots_to_create(
+        self, plan: EvaluatablePlan, snapshots: t.Dict[SnapshotId, Snapshot]
+    ) -> t.List[Snapshot]:
+        promoted_snapshot_ids = (
+            set(plan.environment.promoted_snapshot_ids)
+            if plan.environment.promoted_snapshot_ids is not None
+            else None
+        )
+
+        def _should_create(s: Snapshot) -> bool:
+            if not s.is_model or s.is_symbolic:
+                return False
+            # Only create tables for snapshots that we're planning to promote or that were selected for backfill
+            return (
+                plan.is_selected_for_backfill(s.name)
+                or promoted_snapshot_ids is None
+                or s.snapshot_id in promoted_snapshot_ids
+            )
+
+        return [s for s in snapshots.values() if _should_create(s)]
+
+    def _adjust_intervals(
+        self, snapshots_by_name: t.Dict[str, Snapshot], plan: EvaluatablePlan
+    ) -> None:
+        # Make sure the intervals are up to date and restatements are reflected
+        self.state_reader.refresh_snapshot_intervals(snapshots_by_name.values())
+        for new_snapshot in plan.new_snapshots:
+            if new_snapshot.is_forward_only:
+                # Forward-only snapshots inherit intervals in dev because of cloning
+                new_snapshot.dev_intervals = new_snapshot.intervals.copy()
+        for s_name, interval in plan.restatements.items():
+            snapshots_by_name[s_name].remove_interval(interval)
 
 
 def build_plan_stages(

--- a/sqlmesh/core/plan/stages.py
+++ b/sqlmesh/core/plan/stages.py
@@ -196,6 +196,13 @@ PlanStage = t.Union[
 
 
 class PlanStagesBuilder:
+    """The builder for the plan stages.
+
+    Args:
+        state_reader: The state reader to use to read the snapshots and environment.
+        default_catalog: The default catalog to use for the snapshots.
+    """
+
     def __init__(
         self,
         state_reader: StateReader,
@@ -205,6 +212,16 @@ class PlanStagesBuilder:
         self.default_catalog = default_catalog
 
     def build(self, plan: EvaluatablePlan) -> t.List[PlanStage]:
+        """Builds the plan stages for the given plan.
+
+        NOTE: Building the plan stages should NOT produce any side effects in the state or the data warehouse.
+
+        Args:
+            plan: The plan to build the stages for.
+
+        Returns:
+            A list of plan stages.
+        """
         new_snapshots = {s.snapshot_id: s for s in plan.new_snapshots}
         stored_snapshots = self.state_reader.get_snapshots(plan.environment.snapshots)
         snapshots = {**new_snapshots, **stored_snapshots}

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -109,6 +109,17 @@ class StateReader(abc.ABC):
         """
 
     @abc.abstractmethod
+    def refresh_snapshot_intervals(self, snapshots: t.Collection[Snapshot]) -> t.List[Snapshot]:
+        """Updates given snapshots with latest intervals from the state.
+
+        Args:
+            snapshots: The snapshots to refresh.
+
+        Returns:
+            The updated snapshots.
+        """
+
+    @abc.abstractmethod
     def nodes_exist(self, names: t.Iterable[str], exclude_external: bool = False) -> t.Set[str]:
         """Returns the node names that exist in the state sync.
 
@@ -371,17 +382,6 @@ class StateSync(StateReader, abc.ABC):
         Args:
             snapshot_intervals: The snapshot intervals to remove.
             remove_shared_versions: Whether to remove intervals for snapshots that share the same version with the target snapshots.
-        """
-
-    @abc.abstractmethod
-    def refresh_snapshot_intervals(self, snapshots: t.Collection[Snapshot]) -> t.List[Snapshot]:
-        """Updates given snapshots with latest intervals from the state.
-
-        Args:
-            snapshots: The snapshots to refresh.
-
-        Returns:
-            The updated snapshots.
         """
 
     @abc.abstractmethod

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -376,3 +376,9 @@ class CompletionStatus(Enum):
     @property
     def is_nothing_to_do(self) -> bool:
         return self == CompletionStatus.NOTHING_TO_DO
+
+
+def to_snake_case(name: str) -> str:
+    return "".join(
+        f"_{c.lower()}" if c.isupper() and idx != 0 else c.lower() for idx, c in enumerate(name)
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,6 +257,7 @@ def push_plan(context: Context, plan: Plan) -> None:
         context.create_scheduler,
         context.default_catalog,
     )
+    deployability_index = DeployabilityIndex.create(context.snapshots.values())
     evaluatable_plan = plan.to_evaluatable()
     stages = plan_stages.build_plan_stages(
         evaluatable_plan, context.state_sync, context.default_catalog
@@ -265,12 +266,12 @@ def push_plan(context: Context, plan: Plan) -> None:
         if isinstance(stage, plan_stages.CreateSnapshotRecordsStage):
             plan_evaluator.visit_create_snapshot_records_stage(stage, evaluatable_plan)
         elif isinstance(stage, plan_stages.PhysicalLayerUpdateStage):
-            stage.deployability_index = DeployabilityIndex.all_deployable()
+            stage.deployability_index = deployability_index
             plan_evaluator.visit_physical_layer_update_stage(stage, evaluatable_plan)
         elif isinstance(stage, plan_stages.EnvironmentRecordUpdateStage):
             plan_evaluator.visit_environment_record_update_stage(stage, evaluatable_plan)
         elif isinstance(stage, plan_stages.VirtualLayerUpdateStage):
-            stage.deployability_index = DeployabilityIndex.all_deployable()
+            stage.deployability_index = deployability_index
             plan_evaluator.visit_virtual_layer_update_stage(stage, evaluatable_plan)
         elif isinstance(stage, plan_stages.FinalizeEnvironmentStage):
             plan_evaluator.visit_finalize_environment_stage(stage, evaluatable_plan)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,14 +33,14 @@ from sqlmesh.core import lineage
 from sqlmesh.core.macros import macro
 from sqlmesh.core.model import IncrementalByTimeRangeKind, SqlModel, model
 from sqlmesh.core.model.kind import OnDestructiveChange
-from sqlmesh.core.plan import BuiltInPlanEvaluator, Plan
+from sqlmesh.core.plan import BuiltInPlanEvaluator, Plan, stages as plan_stages
 from sqlmesh.core.snapshot import (
+    DeployabilityIndex,
     Node,
     Snapshot,
     SnapshotChangeCategory,
     SnapshotDataVersion,
     SnapshotFingerprint,
-    DeployabilityIndex,
 )
 from sqlmesh.utils import random_id
 from sqlmesh.utils.date import TimeLike, to_date
@@ -257,12 +257,23 @@ def push_plan(context: Context, plan: Plan) -> None:
         context.create_scheduler,
         context.default_catalog,
     )
-    deployability_index = DeployabilityIndex.create(context.snapshots.values())
-    plan_evaluator._push(plan.to_evaluatable(), plan.snapshots, deployability_index)
-    promotion_result = plan_evaluator._promote(plan.to_evaluatable(), plan.snapshots)
-    plan_evaluator._update_views(
-        plan.to_evaluatable(), plan.snapshots, promotion_result, deployability_index
+    evaluatable_plan = plan.to_evaluatable()
+    stages = plan_stages.build_plan_stages(
+        evaluatable_plan, context.state_sync, context.default_catalog
     )
+    for stage in stages:
+        if isinstance(stage, plan_stages.CreateSnapshotRecordsStage):
+            plan_evaluator.visit_create_snapshot_records_stage(stage, evaluatable_plan)
+        elif isinstance(stage, plan_stages.PhysicalLayerUpdateStage):
+            stage.deployability_index = DeployabilityIndex.all_deployable()
+            plan_evaluator.visit_physical_layer_update_stage(stage, evaluatable_plan)
+        elif isinstance(stage, plan_stages.EnvironmentRecordUpdateStage):
+            plan_evaluator.visit_environment_record_update_stage(stage, evaluatable_plan)
+        elif isinstance(stage, plan_stages.VirtualLayerUpdateStage):
+            stage.deployability_index = DeployabilityIndex.all_deployable()
+            plan_evaluator.visit_virtual_layer_update_stage(stage, evaluatable_plan)
+        elif isinstance(stage, plan_stages.FinalizeEnvironmentStage):
+            plan_evaluator.visit_finalize_environment_stage(stage, evaluatable_plan)
 
 
 @pytest.fixture()

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -41,7 +41,6 @@ from sqlmesh.core.model import load_sql_based_model, model, SqlModel, Model
 from sqlmesh.core.model.cache import OptimizedQueryCache
 from sqlmesh.core.renderer import render_statements
 from sqlmesh.core.model.kind import ModelKindName
-from sqlmesh.core.plan import BuiltInPlanEvaluator, PlanBuilder
 from sqlmesh.core.state_sync.cache import CachingStateSync
 from sqlmesh.core.state_sync.db import EngineAdapterStateSync
 from sqlmesh.utils.connection_pool import SingletonConnectionPool, ThreadLocalSharedConnectionPool
@@ -270,24 +269,6 @@ def test_diff(sushi_context: Context, mocker: MockerFixture):
     sushi_context.console = mock_console
     yesterday = yesterday_ds()
     success = sushi_context.run(start=yesterday, end=yesterday)
-
-    plan_evaluator = BuiltInPlanEvaluator(
-        sushi_context.state_sync,
-        sushi_context.snapshot_evaluator,
-        sushi_context.create_scheduler,
-        sushi_context.default_catalog,
-    )
-
-    plan = PlanBuilder(
-        context_diff=sushi_context._context_diff("prod"),
-    ).build()
-
-    # stringify used to trigger an unhashable exception due to
-    # https://github.com/pydantic/pydantic/issues/8016
-    assert str(plan) != ""
-
-    promotion_result = plan_evaluator._promote(plan.to_evaluatable(), plan.snapshots)
-    plan_evaluator._update_views(plan.to_evaluatable(), plan.snapshots, promotion_result)
 
     sushi_context.upsert_model("sushi.customers", query=parse_one("select 1 as customer_id"))
     sushi_context.diff("test")

--- a/tests/core/test_plan_evaluator.py
+++ b/tests/core/test_plan_evaluator.py
@@ -8,10 +8,9 @@ from sqlmesh.core.plan import (
     BuiltInPlanEvaluator,
     Plan,
     PlanBuilder,
-    update_intervals_for_new_snapshots,
+    stages as plan_stages,
 )
 from sqlmesh.core.snapshot import SnapshotChangeCategory
-from sqlmesh.utils.date import to_timestamp
 
 
 @pytest.fixture
@@ -65,7 +64,14 @@ def test_builtin_evaluator_push(sushi_context: Context, make_snapshot):
         sushi_context.default_catalog,
         console=sushi_context.console,
     )
-    evaluator._push(plan.to_evaluatable(), plan.snapshots)
+    evaluatable_plan = plan.to_evaluatable()
+    stages = plan_stages.build_plan_stages(
+        evaluatable_plan, sushi_context.state_sync, sushi_context.default_catalog
+    )
+    assert isinstance(stages[0], plan_stages.CreateSnapshotRecordsStage)
+    evaluator.visit_create_snapshot_records_stage(stages[0], evaluatable_plan)
+    assert isinstance(stages[1], plan_stages.PhysicalLayerUpdateStage)
+    evaluator.visit_physical_layer_update_stage(stages[1], evaluatable_plan)
 
     assert (
         len(sushi_context.state_sync.get_snapshots([new_model_snapshot, new_view_model_snapshot]))
@@ -73,38 +79,3 @@ def test_builtin_evaluator_push(sushi_context: Context, make_snapshot):
     )
     assert sushi_context.engine_adapter.table_exists(new_model_snapshot.table_name())
     assert sushi_context.engine_adapter.table_exists(new_view_model_snapshot.table_name())
-
-
-@pytest.mark.parametrize(
-    "change_category", [SnapshotChangeCategory.BREAKING, SnapshotChangeCategory.FORWARD_ONLY]
-)
-def test_update_intervals_for_new_snapshots(
-    sushi_context: Context,
-    mocker: MockerFixture,
-    change_category: SnapshotChangeCategory,
-    make_snapshot,
-):
-    model = SqlModel(
-        name="sushi.new_test_model",
-        query=parse_one("SELECT 1::INT AS one"),
-    )
-    snapshot = make_snapshot(model)
-    snapshot.categorize_as(change_category)
-
-    snapshot.add_interval("2023-01-01", "2023-01-01")
-
-    state_sync_mock = mocker.Mock()
-    state_sync_mock.refresh_snapshot_intervals.return_value = [snapshot]
-
-    update_intervals_for_new_snapshots([snapshot], state_sync_mock)
-
-    state_sync_mock.refresh_snapshot_intervals.assert_called_once_with([snapshot])
-
-    if change_category == SnapshotChangeCategory.FORWARD_ONLY:
-        assert snapshot.dev_intervals == [(to_timestamp("2023-01-01"), to_timestamp("2023-01-02"))]
-        expected_intervals = snapshot.snapshot_intervals
-        expected_intervals.intervals.clear()
-        state_sync_mock.add_snapshots_intervals.assert_called_once_with([expected_intervals])
-    else:
-        assert not snapshot.dev_intervals
-        state_sync_mock.add_snapshots_intervals.assert_not_called()


### PR DESCRIPTION
This update unifies plan evaluation and explanation by utilizing a common intermediate step: building the list of plan stages first.

The plan stages now contain a fully precomputed set of evaluation steps, removing dynamic behavior from the evaluation process. As a result, the following evaluation details are known ahead of time, before evaluation begins, and without producing any side effects:
- A set of snapshots for which physical tables will be checked and created if missing
- All missing intervals that will be backfilled
- A set of snapshots for which views will be created / deleted in the virtual layer
- A set of snapshots for which the schema will be migrated
- The order of operations

The only remaining dynamic step is the creation of physical tables, as it requires querying the data warehouse to determine which tables are missing. We want to avoid touch the data warehouse during the stage construction process.

Among the many benefits of the new approach is that plan evaluations and explanations are now always in sync, as they rely on the same underlying logic for deriving plan stages.