### PR TITLE
Fix: Don't fail when cache directories are already removed when clearing

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -2438,7 +2438,9 @@ class GenericContext(BaseContext, t.Generic[C]):
 
     def clear_caches(self) -> None:
         for path in self.configs:
-            rmtree(path / c.CACHE)
+            cache_path = path / c.CACHE
+            if cache_path.exists():
+                rmtree(cache_path)
         if isinstance(self.state_sync, CachingStateSync):
             self.state_sync.clear_cache()
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -640,6 +640,11 @@ def test_clear_caches(tmp_path: pathlib.Path):
     assert not cache_dir.exists()
     assert models_dir.exists()
 
+    # Test clearing caches when cache directory doesn't exist
+    # This should not raise an exception
+    context.clear_caches()
+    assert not cache_dir.exists()
+
 
 def test_ignore_files(mocker: MockerFixture, tmp_path: pathlib.Path):
     mocker.patch.object(


### PR DESCRIPTION
Re-running `sqlmesh clean` or sqlmesh `sqlmesh destroy` caused a FileNotFoundError when rmtree() attempted to delete already removed cache directories. It now checks its existence before attempting removal.