### PR TITLE
Fix: Reporting the absence of physical layer updates when explaining a plan

### DIFF
--- a/sqlmesh/core/plan/explainer.py
+++ b/sqlmesh/core/plan/explainer.py
@@ -90,16 +90,16 @@ class RichExplainerConsole(ExplainerConsole):
         return Tree("[bold]Execute after all statements[/bold]")
 
     def visit_physical_layer_update_stage(self, stage: stages.PhysicalLayerUpdateStage) -> Tree:
-        if not stage.snapshots:
+        snapshots = [
+            s for s in stage.snapshots if s.snapshot_id in stage.snapshots_with_missing_intervals
+        ]
+        if not snapshots:
             return Tree("[bold]SKIP: No physical layer updates to perform[/bold]")
 
         tree = Tree(
             "[bold]Validate SQL and create physical layer tables and views if they do not exist[/bold]"
         )
-        for snapshot in stage.snapshots:
-            if snapshot.snapshot_id not in stage.snapshots_with_missing_intervals:
-                continue
-
+        for snapshot in snapshots:
             is_deployable = (
                 stage.deployability_index.is_deployable(snapshot)
                 if self.environment_naming_info.name != c.PROD

--- a/sqlmesh/core/plan/stages.py
+++ b/sqlmesh/core/plan/stages.py
@@ -8,6 +8,7 @@ from sqlmesh.core.scheduler import merged_missing_intervals, SnapshotToIntervals
 from sqlmesh.core.snapshot.definition import (
     DeployabilityIndex,
     Snapshot,
+    SnapshotChangeCategory,
     SnapshotTableInfo,
     SnapshotId,
     Interval,
@@ -255,7 +256,13 @@ class PlanStagesBuilder:
                 if s.is_paused
                 and s.is_model
                 and not s.is_symbolic
-                and (not deployability_index_for_creation.is_representative(s) or s.is_view)
+                and (
+                    not deployability_index_for_creation.is_representative(s)
+                    or (
+                        s.is_view
+                        and s.change_category == SnapshotChangeCategory.INDIRECT_NON_BREAKING
+                    )
+                )
             ]
 
         snapshots_to_intervals = self._missing_intervals(


### PR DESCRIPTION
The explainer was incorrectly printing
```
Validate SQL and create physical layer tables and views if they do not exist
```
with an empty list of models if there were no physical updates to perform. This fix makes it so that 
```
SKIP: No physical layer updates to perform
```
is printed instead.