### PR TITLE
Fix(mssql): Properly quote table and views when dropping in mssql

### DIFF
--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -173,7 +173,7 @@ class MSSQLEngineAdapter(
             objects = self._get_data_objects(schema_name)
             for obj in objects:
                 # Build properly quoted table for MSSQL using square brackets when needed
-                object_name = exp.table_(obj.name, obj.schema_name)
+                object_table = exp.table_(obj.name, obj.schema_name)
 
                 # _get_data_objects is catalog-specific, so these can't accidentally drop view/tables in another catalog
                 if obj.type == DataObjectType.VIEW:

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -173,13 +173,7 @@ class MSSQLEngineAdapter(
             objects = self._get_data_objects(schema_name)
             for obj in objects:
                 # Build properly quoted table for MSSQL using square brackets when needed
-                object_name = ".".join(
-                    [
-                        exp.to_identifier(obj.schema_name).sql(self.dialect),
-                        exp.to_identifier(obj.name).sql(self.dialect),
-                    ]
-                )
-                object_table = exp.to_table(object_name, dialect=self.dialect)
+                object_name = exp.table_(obj.name, obj.schema_name)
 
                 # _get_data_objects is catalog-specific, so these can't accidentally drop view/tables in another catalog
                 if obj.type == DataObjectType.VIEW:

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -172,15 +172,24 @@ class MSSQLEngineAdapter(
         if cascade:
             objects = self._get_data_objects(schema_name)
             for obj in objects:
+                # Build properly quoted table for MSSQL using square brackets when needed
+                object_name = ".".join(
+                    [
+                        exp.to_identifier(obj.schema_name).sql(self.dialect),
+                        exp.to_identifier(obj.name).sql(self.dialect),
+                    ]
+                )
+                object_table = exp.to_table(object_name, dialect=self.dialect)
+
                 # _get_data_objects is catalog-specific, so these can't accidentally drop view/tables in another catalog
                 if obj.type == DataObjectType.VIEW:
                     self.drop_view(
-                        ".".join([obj.schema_name, obj.name]),
+                        object_table,
                         ignore_if_not_exists=ignore_if_not_exists,
                     )
                 else:
                     self.drop_table(
-                        ".".join([obj.schema_name, obj.name]),
+                        object_table,
                         exists=ignore_if_not_exists,
                     )
         super().drop_schema(schema_name, ignore_if_not_exists=ignore_if_not_exists, cascade=False)


### PR DESCRIPTION
This update fixes quoting in mssql's `drop_schema` to correctly handle table and view names containing spaces or special characters. closes #4633 

While this won't be an issue in recent sqlglot versions, the change fool proofs by adding proper square bracket quoting for schema and object names. Also since `_drop_object` does not account for dialect when using `to_table` it is addressed in `drop_schema` and it is passed as a table there.