### PR TITLE
Chore: Fix dbt import to prevent cicd failures

### DIFF
--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -21,7 +21,14 @@ from dbt.config import Profile, Project, RuntimeConfig
 from dbt.config.profile import read_profile
 from dbt.config.renderer import DbtProjectYamlRenderer, ProfileRenderer
 from dbt.parser.manifest import ManifestLoader
-from dbt.parser.sources import merge_freshness
+
+try:
+    from dbt.parser.sources import merge_freshness  # type: ignore[attr-defined]
+except ImportError:
+    # merge_freshness was renamed to merge_source_freshness in dbt 1.10
+    # ref: https://github.com/dbt-labs/dbt-core/commit/14fc39a76ff4830cdf2fcbe73f57ca27db500018#diff-1f09db95588f46879a83378c2a86d6b16b7cdfcaddbfe46afc5d919ee5e9a4d9R430
+    from dbt.parser.sources import merge_source_freshness as merge_freshness  # type: ignore[no-redef,attr-defined]
+
 from dbt.tracking import do_not_track
 
 from sqlmesh.core import constants as c


### PR DESCRIPTION
CircleCI started resolving dbt 1.10 which includes a [rename](https://github.com/dbt-labs/dbt-core/commit/14fc39a76ff4830cdf2fcbe73f57ca27db500018#diff-1f09db95588f46879a83378c2a86d6b16b7cdfcaddbfe46afc5d919ee5e9a4d9R430) of the `merge_freshness` function to `merge_source_freshness`.

This is causing `make py-style` to fail with a mypy error:
```
sqlmesh/dbt/manifest.py:24: error: Module "dbt.parser.sources" has no attribute "merge_freshness"; maybe "merge_source_freshness"?  [attr-defined]
```

[(example failed job)](https://app.circleci.com/pipelines/github/TobikoData/sqlmesh/21845/workflows/4b478685-1865-4235-90ff-4a3b36d20ce7/jobs/229341)

This PR updates the import to try importing `merge_source_freshness` if importing `merge_freshness` results in an `ImportError`