### PR TITLE
Fix(cicd_bot): When enable_deploy_command: true, dont show message about required approvers

### DIFF
--- a/sqlmesh/integrations/github/cicd/command.py
+++ b/sqlmesh/integrations/github/cicd/command.py
@@ -276,7 +276,9 @@ def _run_all(controller: GithubController) -> None:
     if has_required_approval and prod_plan_generated and controller.pr_targets_prod_branch:
         deployed_to_prod = _deploy_production(controller)
     elif is_auto_deploying_prod:
-        if not has_required_approval:
+        if controller.deploy_command_enabled and not has_required_approval:
+            skip_reason = "Skipped Deploying to Production because a `/deploy` command has not been detected yet"
+        elif controller.do_required_approval_check and not has_required_approval:
             skip_reason = (
                 "Skipped Deploying to Production because a required approver has not approved"
             )

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -1022,7 +1022,7 @@ class GithubController:
             conclusion_to_title = {
                 GithubCheckConclusion.SUCCESS: "Deployed to Prod",
                 GithubCheckConclusion.CANCELLED: "Cancelled deploying to prod",
-                GithubCheckConclusion.SKIPPED: skip_reason,
+                GithubCheckConclusion.SKIPPED: "Skipped deployment",
                 GithubCheckConclusion.FAILURE: "Failed to deploy to prod",
                 GithubCheckConclusion.ACTION_REQUIRED: "Failed due to error applying plan",
             }
@@ -1031,7 +1031,7 @@ class GithubController:
                 or f"Got an unexpected conclusion: {conclusion.value}"
             )
             if conclusion.is_skipped:
-                summary = title
+                summary = skip_reason
             elif conclusion.is_failure:
                 captured_errors = self._console.consume_captured_errors()
                 summary = (

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -691,9 +691,11 @@ def test_merge_pr_has_non_breaking_change_no_categorization(
     assert GithubCheckStatus(prod_checks_runs[0]["status"]).is_queued
     assert GithubCheckStatus(prod_checks_runs[1]["status"]).is_completed
     assert GithubCheckConclusion(prod_checks_runs[1]["conclusion"]).is_skipped
-    skip_reason = "Skipped Deploying to Production because the PR environment was not updated"
-    assert prod_checks_runs[1]["output"]["title"] == skip_reason
-    assert prod_checks_runs[1]["output"]["summary"] == skip_reason
+    assert prod_checks_runs[1]["output"]["title"] == "Skipped deployment"
+    assert (
+        prod_checks_runs[1]["output"]["summary"]
+        == "Skipped Deploying to Production because the PR environment was not updated"
+    )
 
     assert "SQLMesh - Has Required Approval" in controller._check_run_mapping
     approval_checks_runs = controller._check_run_mapping[
@@ -1024,9 +1026,11 @@ def test_no_merge_since_no_deploy_signal(
     assert GithubCheckStatus(prod_checks_runs[0]["status"]).is_queued
     assert GithubCheckStatus(prod_checks_runs[1]["status"]).is_completed
     assert GithubCheckConclusion(prod_checks_runs[1]["conclusion"]).is_skipped
-    skip_reason = "Skipped Deploying to Production because a required approver has not approved"
-    assert prod_checks_runs[1]["output"]["title"] == skip_reason
-    assert prod_checks_runs[1]["output"]["summary"] == skip_reason
+    assert prod_checks_runs[1]["output"]["title"] == "Skipped deployment"
+    assert (
+        prod_checks_runs[1]["output"]["summary"]
+        == "Skipped Deploying to Production because a required approver has not approved"
+    )
 
     assert "SQLMesh - Has Required Approval" in controller._check_run_mapping
     approval_checks_runs = controller._check_run_mapping[
@@ -1528,9 +1532,11 @@ def test_error_msg_when_applying_plan_with_bug(
     assert GithubCheckStatus(prod_checks_runs[0]["status"]).is_queued
     assert GithubCheckStatus(prod_checks_runs[1]["status"]).is_completed
     assert GithubCheckConclusion(prod_checks_runs[1]["conclusion"]).is_skipped
-    skip_reason = "Skipped Deploying to Production because the PR environment was not updated"
-    assert prod_checks_runs[1]["output"]["title"] == skip_reason
-    assert prod_checks_runs[1]["output"]["summary"] == skip_reason
+    assert prod_checks_runs[1]["output"]["title"] == "Skipped deployment"
+    assert (
+        prod_checks_runs[1]["output"]["summary"]
+        == "Skipped Deploying to Production because the PR environment was not updated"
+    )
 
     assert "SQLMesh - Has Required Approval" in controller._check_run_mapping
     approval_checks_runs = controller._check_run_mapping[


### PR DESCRIPTION
Prior to this PR, if you had `enable_deploy_command: true` in your `cicd_bot` config and no `users` configured in `required_approver` roles, you'd still get GitHub output like:

![01 - Deploy command enabled, misleading required approvers message  before](https://github.com/user-attachments/assets/baa97e08-91c7-4d46-8580-8e43231b069e)

The problem with the message `Skipped Deploying to Production because a required approver has not approved` is that it's incorrect because it shows even when there are no required approvers configured.

This PR updates the output to the following:
![01 - Deploy command enabled, now shows correct message  after](https://github.com/user-attachments/assets/38136e4c-02b3-4088-94d8-29b0fdd4d0ba)
