### PR TITLE
Feat(cicd_bot): Show models with uncategorized changes instead of a generic error

### DIFF
--- a/sqlmesh/integrations/github/cicd/command.py
+++ b/sqlmesh/integrations/github/cicd/command.py
@@ -116,7 +116,7 @@ def _update_pr_environment(controller: GithubController) -> bool:
         return conclusion is not None and conclusion.is_success
     except Exception as e:
         conclusion = controller.update_pr_environment_check(
-            status=GithubCheckStatus.COMPLETED, exception=e
+            status=GithubCheckStatus.COMPLETED, exception=e, plan=controller.pr_plan_or_none
         )
         return (
             conclusion is not None

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -665,7 +665,7 @@ def test_merge_pr_has_non_breaking_change_no_categorization(
     assert pr_checks_runs[2]["output"]["title"] == "PR Virtual Data Environment: hello_world_2"
     assert (
         pr_checks_runs[2]["output"]["summary"]
-        == ":warning: Action Required to create or update PR Environment `hello_world_2`. There are likely uncateogrized changes. Run `plan` locally to apply these changes. If you want the bot to automatically categorize changes, then check documentation (https://sqlmesh.readthedocs.io/en/stable/integrations/github/) for more information."
+        == """:warning: Action Required to create or update PR Environment `hello_world_2` :warning:\n\nThe following models could not be categorized automatically:\n- "memory"."sushi"."waiter_revenue_by_day"\n\nRun `sqlmesh plan hello_world_2` locally to apply these changes.\n\nIf you would like the bot to automatically categorize changes, check the [documentation](https://sqlmesh.readthedocs.io/en/stable/integrations/github/) for more information."""
     )
 
     assert "SQLMesh - Prod Plan Preview" in controller._check_run_mapping


### PR DESCRIPTION
Prior to this, if the bot couldn't automatically categorize changes, you'd get an error like:
![02 - Action required, guessing at reason  before](https://github.com/user-attachments/assets/3cb374bc-b745-4d2c-8496-a2fff6204c2e)

This PR updates the output to list the models that couldn't be auto categorized and tweaks the message to make it slightly more actionable:
![02 - Show uncategorized models  after](https://github.com/user-attachments/assets/64c6fd12-00c2-446c-b208-8679d18b4005)

