### PR TITLE
Fix: Changes to before_all/after_all alone now trigger virtual updates

### DIFF
--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -835,6 +835,7 @@ class PlanBuilder:
             and not self._include_unmodified
             and self._context_diff.is_new_environment
             and not self._context_diff.has_snapshot_changes
+            and not self._context_diff.has_environment_statements_changes
             and not self._backfill_models
         ):
             raise NoChangesPlanError(

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -41,7 +41,7 @@ from sqlmesh.utils.date import (
     to_timestamp,
     yesterday_ds,
 )
-from sqlmesh.utils.errors import PlanError
+from sqlmesh.utils.errors import PlanError, NoChangesPlanError
 from sqlmesh.utils.rich import strip_ansi_codes
 
 
@@ -3204,3 +3204,88 @@ def test_plan_dates_relative_to_execution_time(
         assert to_datetime(plan.start) == to_datetime(output_start)
         assert to_datetime(plan.end) == to_datetime(output_end)
         assert to_datetime(plan.execution_time) == to_datetime(output_execution_time)
+
+
+def test_environment_statements_change_allows_dev_environment_creation(make_snapshot):
+    snapshot = make_snapshot(
+        SqlModel(
+            name="test_model",
+            dialect="duckdb",
+            query=parse_one("select 1, ds"),
+            kind=dict(name=ModelKindName.INCREMENTAL_BY_TIME_RANGE, time_column="ds"),
+        )
+    )
+
+    # First context diff of a new 'dev' environment without environment statements
+    context_diff_no_statements = ContextDiff(
+        environment="dev",
+        is_new_environment=True,
+        is_unfinalized_environment=False,
+        normalize_environment_name=True,
+        create_from="prod",
+        create_from_env_exists=True,
+        added=set(),
+        removed_snapshots={},
+        modified_snapshots={},
+        snapshots={snapshot.snapshot_id: snapshot},
+        new_snapshots={},
+        previous_plan_id=None,
+        previously_promoted_snapshot_ids={snapshot.snapshot_id},
+        previous_finalized_snapshots=None,
+        previous_gateway_managed_virtual_layer=False,
+        gateway_managed_virtual_layer=False,
+        environment_statements=[],
+        previous_environment_statements=[],
+    )
+
+    # Should fail because no changes
+    plan_builder = PlanBuilder(
+        context_diff_no_statements,
+        is_dev=True,
+    )
+
+    with pytest.raises(NoChangesPlanError, match="Creating a new environment requires a change"):
+        plan_builder.build()
+
+    # Now create context diff with environment statements
+    environment_statements = [
+        EnvironmentStatements(
+            before_all=["CREATE TABLE IF NOT EXISTS test_table (id INT)"],
+            after_all=[],
+            python_env={},
+            jinja_macros=None,
+        )
+    ]
+
+    context_diff_with_statements = ContextDiff(
+        environment="dev",
+        is_new_environment=True,
+        is_unfinalized_environment=False,
+        normalize_environment_name=True,
+        create_from="prod",
+        create_from_env_exists=True,
+        added=set(),
+        removed_snapshots={},
+        modified_snapshots={},
+        snapshots={snapshot.snapshot_id: snapshot},
+        new_snapshots={},
+        previous_plan_id=None,
+        previously_promoted_snapshot_ids={snapshot.snapshot_id},
+        previous_finalized_snapshots=None,
+        previous_gateway_managed_virtual_layer=False,
+        gateway_managed_virtual_layer=False,
+        environment_statements=environment_statements,
+        previous_environment_statements=[],
+    )
+
+    # Should succeed because there are environment statements changes
+    plan_builder_with_statements = PlanBuilder(
+        context_diff_with_statements,
+        is_dev=True,
+    )
+
+    # Test that allows creating a dev environment without other changes
+    plan = plan_builder_with_statements.build()
+    assert plan is not None
+    assert plan.context_diff.has_environment_statements_changes
+    assert plan.context_diff.environment_statements == environment_statements


### PR DESCRIPTION
Previously updating `before_all` or `after_all` or its macros did not trigger a virtual update. Dev environments can now be created even if only environment statements differ from prod, fixes: #4776 
