### PR TITLE
Fix: simplify complex expressions when validating boolean pydantic fields

### DIFF
--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -336,10 +336,18 @@ def parse_expression(
 
 
 def parse_bool(v: t.Any) -> bool:
-    if isinstance(v, exp.Boolean):
-        return v.this
     if isinstance(v, exp.Expression):
+        if not isinstance(v, exp.Boolean):
+            from sqlglot.optimizer.simplify import simplify
+
+            # Try to reduce expressions like (1 = 1) (see: T-SQL boolean generation)
+            v = simplify(v)
+
+        if isinstance(v, exp.Boolean):
+            return v.this
+
         return str_to_bool(v.name)
+
     return str_to_bool(str(v or ""))
 
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -10445,7 +10445,7 @@ def test_invalid_sql_model_query() -> None:
             load_sql_based_model(expressions)
 
 
-def test_query_label_and_authorization_macro():
+def test_query_label_and_authorization_macro() -> None:
     @macro()
     def test_query_label_macro(evaluator):
         return "[('key', 'value')]"
@@ -10478,3 +10478,19 @@ def test_query_label_and_authorization_macro():
         "query_label": d.parse_one("[('key', 'value')]"),
         "authorization": d.parse_one("'test_authorization'"),
     }
+
+
+def test_boolean_property_validation() -> None:
+    expressions = d.parse(
+        """
+        MODEL (
+           name db.table,
+           enabled @IF(TRUE, TRUE, FALSE),
+           dialect tsql
+        );
+
+        SELECT 1 AS c;
+        """
+    )
+    model = load_sql_based_model(expressions, dialect="tsql")
+    assert model.enabled


### PR DESCRIPTION
Addresses the bug reported in this Slack thread: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1750228449327769.

T-SQL generates `Boolean` values like `TRUE` into `(1 = 1)`, which causes issues when it is used in the context of a `MODEL` property, such as `enabled`.

For example, if a macro is used and the meta block is rendered, the resulting `Model` expression is generated and re-parsed in the macro evaluator, resulting in a new `Paren(Eq(Literal(1), Literal(1))` expression for the `enabled` field, which resulted in a falsey value with the old logic.