### PR TITLE
Fix: Propagation of snapshots with missing intervals into the physical layer update stage

### DIFF
--- a/sqlmesh/core/plan/stages.py
+++ b/sqlmesh/core/plan/stages.py
@@ -431,7 +431,11 @@ class PlanStagesBuilder:
         return PhysicalLayerUpdateStage(
             snapshots=self._get_snapshots_to_create(plan, snapshots),
             all_snapshots=snapshots,
-            snapshots_with_missing_intervals={s.snapshot_id for s in snapshots_to_intervals},
+            snapshots_with_missing_intervals={
+                s.snapshot_id
+                for s in snapshots_to_intervals
+                if plan.is_selected_for_backfill(s.name)
+            },
             deployability_index=deployability_index,
         )
 

--- a/tests/core/test_plan_stages.py
+++ b/tests/core/test_plan_stages.py
@@ -141,6 +141,10 @@ def test_build_plan_stages_basic(
         snapshot_a.snapshot_id,
         snapshot_b.snapshot_id,
     }
+    assert {s.snapshot_id for s in physical_stage.snapshots_with_missing_intervals} == {
+        snapshot_a.snapshot_id,
+        snapshot_b.snapshot_id,
+    }
     assert physical_stage.deployability_index == DeployabilityIndex.all_deployable()
 
     # Verify BackfillStage
@@ -357,6 +361,7 @@ def test_build_plan_stages_select_models(
     assert len(physical_stage.snapshots) == 1
     assert {s.snapshot_id for s in physical_stage.snapshots} == {snapshot_a.snapshot_id}
     assert physical_stage.deployability_index == DeployabilityIndex.all_deployable()
+    assert physical_stage.snapshots_with_missing_intervals == {snapshot_a.snapshot_id}
 
     # Verify BackfillStage
     backfill_stage = stages[2]


### PR DESCRIPTION
This can sometimes cause a misleading output in the plan explainer. The `snapshots_with_missing_intervals` should only reflect snapshots selected for backfill.