### PR TITLE
ci: make regex for circle ci stricter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,14 @@ on_main_or_tag_filter: &on_main_or_tag_filter
     branches:
       only: main
     tags:
-      only: /^v.+/
+      only: /^v\d+\.\d+\.\d+$/
 
 on_tag_filter: &on_tag_filter
   filters:
     branches:
       ignore: /.*/
     tags:
-      only: /^v.+/
+      only: /^v\d+\.\d+\.\d+$/
 
 orbs:
   path-filtering: circleci/path-filtering@1.2.0


### PR DESCRIPTION
- this is so that any other tags like the one to launch vscode does not get picked up