### PR TITLE
fix(build): add semantic version tag regex to setuptools_scm config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ include-package-data = false
 version_file = "sqlmesh/_version.py"
 fallback_version = "0.0.0"
 local_scheme = "no-local-version"
+tag_regex = "^v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)"
 
 [tool.setuptools.packages.find]
 include = ["sqlmesh", "sqlmesh.*", "web*"]


### PR DESCRIPTION
- Add tag_regex pattern to properly parse version tags starting with 'v' prefix.
- This ensures setuptools_scm correctly extracts version numbers from git tags
like v1.2.3, preventing build failures in CI/CD pipelines and ignores
other tags.
