### PR TITLE
fix!: failure instead of neutral missing req approval

### DIFF
--- a/sqlmesh/integrations/github/cicd/command.py
+++ b/sqlmesh/integrations/github/cicd/command.py
@@ -44,7 +44,7 @@ def _check_required_approvers(controller: GithubController) -> bool:
         )
         return True
     controller.update_required_approval_check(
-        status=GithubCheckStatus.COMPLETED, conclusion=GithubCheckConclusion.NEUTRAL
+        status=GithubCheckStatus.COMPLETED, conclusion=GithubCheckConclusion.FAILURE
     )
     return False
 

--- a/tests/integrations/github/cicd/test_github_commands.py
+++ b/tests/integrations/github/cicd/test_github_commands.py
@@ -382,7 +382,7 @@ def test_run_all_missing_approval(
     assert GithubCheckStatus(approval_checks_runs[0]["status"]).is_queued
     assert GithubCheckStatus(approval_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(approval_checks_runs[2]["status"]).is_completed
-    assert GithubCheckConclusion(approval_checks_runs[2]["conclusion"]).is_neutral
+    assert GithubCheckConclusion(approval_checks_runs[2]["conclusion"]).is_failure
 
     assert len(controller._context.apply.call_args_list) == 1
     pr_plan = controller._context.apply.call_args_list[0][0]
@@ -402,7 +402,7 @@ def test_run_all_missing_approval(
         output = f.read()
         assert (
             output
-            == "run_unit_tests=success\nhas_required_approval=neutral\ncreated_pr_environment=true\npr_environment_name=hello_world_2\npr_environment_synced=success\nprod_plan_preview=success\nprod_environment_synced=skipped\n"
+            == "run_unit_tests=success\nhas_required_approval=failure\ncreated_pr_environment=true\npr_environment_name=hello_world_2\npr_environment_synced=success\nprod_plan_preview=success\nprod_environment_synced=skipped\n"
         )
 
 

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -1040,7 +1040,7 @@ def test_no_merge_since_no_deploy_signal(
     assert GithubCheckStatus(approval_checks_runs[0]["status"]).is_queued
     assert GithubCheckStatus(approval_checks_runs[1]["status"]).is_in_progress
     assert GithubCheckStatus(approval_checks_runs[2]["status"]).is_completed
-    assert GithubCheckConclusion(approval_checks_runs[2]["conclusion"]).is_neutral
+    assert GithubCheckConclusion(approval_checks_runs[2]["conclusion"]).is_failure
     assert approval_checks_runs[2]["output"]["title"] == "Need a Required Approval"
     assert (
         approval_checks_runs[2]["output"]["summary"]
@@ -1068,7 +1068,7 @@ def test_no_merge_since_no_deploy_signal(
         output = f.read()
         assert (
             output
-            == "run_unit_tests=success\nhas_required_approval=neutral\ncreated_pr_environment=true\npr_environment_name=hello_world_2\npr_environment_synced=success\nprod_plan_preview=success\nprod_environment_synced=skipped\n"
+            == "run_unit_tests=success\nhas_required_approval=failure\ncreated_pr_environment=true\npr_environment_name=hello_world_2\npr_environment_synced=success\nprod_plan_preview=success\nprod_environment_synced=skipped\n"
         )
 
 


### PR DESCRIPTION
Breaking since this is a behavior change of the bot. This would impact Github CI/CD bot users if they had logic in their workflows that relied on the neutral output. 

Prior to this change, if a user had branch protection rules in-place the neutral status would allow merging. This would not be expected by users since they want to see this check pass before merging. Therefore this PR changes the status to failure instead of neutral to better support this pattern. 