### PR TITLE
Fix: Prevent formatting=false throwing an error

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2886,6 +2886,7 @@ META_FIELD_CONVERTER: t.Dict[str, t.Callable] = {
             for name, args in values
         )
     ),
+    "formatting": lambda value: str(value),
 }
 
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -9973,9 +9973,9 @@ def test_formatting_flag_serde():
     )
 
     model = load_sql_based_model(expressions)
+    assert model.render_definition()[0].sql() == "MODEL (\nname test_model,\nformatting False\n)"
 
     model_json = model.json()
-
     assert "formatting" not in json.loads(model_json)
 
     deserialized_model = SqlModel.parse_raw(model_json)


### PR DESCRIPTION
Prior to this, if you tried to use the `formatting` property to disable formatting on your model, the following would occur:

```
$ sqlmesh plan
Differences from the `prod` environment:

Models:
└── Directly Modified:
    └── sqlmesh_example.full_model
Error: Name needs to be a string or an Identifier, got: <class 'bool'>
```

This is because when `model.render_definition()` was called, there was no entry in `META_FIELD_CONVERTER` for the `formatting` property, so it tried to use a default that was expecting a SQLGlot expression or string.

This PR adds the entry to `META_FIELD_CONVERTER` and checks that `render_definition()` now works