### PR TITLE
Fix: display_name should not exclude the default catalog when environment_suffix_target is set to CATALOG

### DIFF
--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -15,6 +15,7 @@ from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
 from sqlmesh.core import constants as c
 from sqlmesh.core.audit import StandaloneAudit
+from sqlmesh.core.environment import EnvironmentSuffixTarget
 from sqlmesh.core.macros import call_macro
 from sqlmesh.core.model import Model, ModelKindMixin, ModelKindName, ViewKind, CustomKind
 from sqlmesh.core.model.definition import _Model
@@ -1589,12 +1590,18 @@ def display_name(
     if snapshot_info_like.is_audit:
         return snapshot_info_like.name
     view_name = exp.to_table(snapshot_info_like.name)
+
+    catalog = (
+        None
+        if (
+            environment_naming_info.suffix_target != EnvironmentSuffixTarget.CATALOG
+            and view_name.catalog == default_catalog
+        )
+        else view_name.catalog
+    )
+
     qvn = QualifiedViewName(
-        catalog=(
-            view_name.catalog
-            if view_name.catalog and view_name.catalog != default_catalog
-            else None
-        ),
+        catalog=catalog,
         schema_name=view_name.db or None,
         table=view_name.name,
     )

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -2178,6 +2178,21 @@ def test_deployability_index_missing_parent(make_snapshot):
             "snowflake",
             "CATALOG_OVERRIDE.test_db.test_model__DEV",
         ),
+        # EnvironmentSuffixTarget.CATALOG
+        (
+            "test_db.test_model",
+            EnvironmentNamingInfo(name="dev", suffix_target=EnvironmentSuffixTarget.CATALOG),
+            "default_catalog",
+            "duckdb",
+            "default_catalog__dev.test_db.test_model",
+        ),
+        (
+            "test_db.test_model",
+            EnvironmentNamingInfo(name="dev", suffix_target=EnvironmentSuffixTarget.CATALOG),
+            "default_catalog",
+            "snowflake",
+            "DEFAULT_CATALOG__DEV.test_db.test_model",
+        ),
     ),
 )
 def test_display_name(


### PR DESCRIPTION
Prior to this, when using `environment_suffix_target: catalog` against a model in the default catalog, the CLI would give output like:

```
$ sqlmesh plan erin
...SNIP...
Models needing backfill:
└── none__erin.sqlmesh_example.incremental_model: [2020-01-01 - 2025-04-07]
Apply - Backfill Tables [y/n]: y
```

This was due to an output optimisation where we hid the catalog as unnecessary information if it matched the default catalog.

However, `environment_suffix_target: catalog` relies on the default catalog being present because it needs it to generate the catalog name for the virtual environment.

This PR fixes the output:

```
$ sqlmesh plan erin
...SNIP...
Models needing backfill:
└── tobiko-1__erin.sqlmesh_example.incremental_model: [2020-01-01 - 2025-04-07]
Apply - Backfill Tables [y/n]: y
```

Note that this was a display-only issue, the SQL queries being executed in the background still contained the correct catalog