### PR TITLE
fix(vscode): lineage on non model file

### DIFF
--- a/vscode/react/src/pages/lineage.tsx
+++ b/vscode/react/src/pages/lineage.tsx
@@ -110,6 +110,8 @@ function Lineage() {
       fetchFirstTimeModelIfNotSet(models).then(modelName => {
         if (modelName && selectedModel === undefined) {
           setSelectedModel(modelName)
+        } else {
+          setSelectedModel(models[0].name)
         }
       })
     }


### PR DESCRIPTION
- if you opened lineage on a non-model file, it could continue
to load indefinitely as the set model would be set to undefined
- this would stay until you picked a file that was in fact a model
- this instead shows a random model instead
