### PR TITLE
docs: move all vens to use .venv

### DIFF
--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -27,18 +27,18 @@ To create a project from the command line, follow these steps:
 1. To scaffold a project, it is recommended that you use a python virtual environment by running the following commands:
 
     ```bash
-    python -m venv .env
+    python -m venv .venv
     ```
 
     ```bash
-    source .env/bin/activate
+    source .venv/bin/activate
     ```
 
     ```bash
     pip install sqlmesh
     ```
 
-    **Note:** When using a python virtual environment, you must ensure that it is activated first. You should see `(.env)` in your command line; if you don't, run `source .env/bin/activate` from your project directory to activate your environment.
+    **Note:** When using a python virtual environment, you must ensure that it is activated first. You should see `(.venv)` in your command line; if you don't, run `source .venv/bin/activate` from your project directory to activate your environment.
 
 1. Once you have activated your environment, run the following command and SQLMesh will build out your project:
 

--- a/docs/guides/ui.md
+++ b/docs/guides/ui.md
@@ -24,7 +24,7 @@ For development work, we recommend using the SQLMesh UI alongside an IDE. The UI
 
 Before beginning, ensure that you meet all the [prerequisites](../prerequisites.md) for using SQLMesh. The SQLMesh browser UI requires additional Python libraries not included in the base SQLMesh installation.
 
-To use the UI, install SQLMesh with the `web` add-on. First, if using a python virtual environment, ensure it's activated by running `source .env/bin/activate` command from the folder used during [installation](../installation.md).
+To use the UI, install SQLMesh with the `web` add-on. First, if using a python virtual environment, ensure it's activated by running `source .venv/bin/activate` command from the folder used during [installation](../installation.md).
 
 Next, install the UI with `pip`:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,12 +8,12 @@ It is recommended, but not required, that you use a python virtual environment w
 
 First, create the virtual environment:
 ```bash
-python -m venv .env
+python -m venv .venv
 ```
 
 Then activate it:
 ```bash
-source .env/bin/activate
+source .venv/bin/activate
 ```
 
 ## Install SQLMesh core

--- a/docs/quickstart/cli.md
+++ b/docs/quickstart/cli.md
@@ -41,7 +41,7 @@ mkdir sqlmesh-example
 cd sqlmesh-example
 ```
 
-If using a Python virtual environment, ensure it's activated first by running the `source .env/bin/activate` command from the folder used during [installation](../installation.md).
+If using a Python virtual environment, ensure it's activated first by running the `source .venv/bin/activate` command from the folder used during [installation](../installation.md).
 
 ### 1.1 Initialize the project
 

--- a/docs/quickstart/notebook.md
+++ b/docs/quickstart/notebook.md
@@ -34,7 +34,7 @@ The notebook interface works with both Jupyter and Databricks notebooks. Learn m
 ## 1. Create the SQLMesh project
 First, create a SQLMesh project directory with your operating system's graphical or command-line tools. Next, create a Jupyter or Databricks notebook file - it does not need to be in the SQLMesh project directory.
 
-If using a python virtual environment, ensure it's activated first by running the `source .env/bin/activate` command from the folder used during [installation](../installation.md).
+If using a python virtual environment, ensure it's activated first by running the `source .venv/bin/activate` command from the folder used during [installation](../installation.md).
 
 Import the SQLMesh library to load the notebook magic commands:
 

--- a/docs/quickstart/ui.md
+++ b/docs/quickstart/ui.md
@@ -31,7 +31,7 @@ In this quickstart, you'll use the SQLMesh browser user interface to get up and 
 
 Before beginning, ensure that you meet all the [prerequisites](../prerequisites.md) for using SQLMesh. The SQLMesh browser UI requires additional Python libraries not included in the base SQLMesh installation.
 
-To use the UI, install SQLMesh with the `web` add-on. First, if using a python virtual environment, ensure it's activated by running `source .env/bin/activate` command from the folder used during [installation](../installation.md).
+To use the UI, install SQLMesh with the `web` add-on. First, if using a python virtual environment, ensure it's activated by running `source .venv/bin/activate` command from the folder used during [installation](../installation.md).
 
 Next, install the UI with `pip`:
 
@@ -52,7 +52,7 @@ Navigate to the directory on the command line:
 cd sqlmesh-example
 ```
 
-If using a python virtual environment, ensure it's activated by running `source .env/bin/activate` from the folder used during [installation](../installation.md).
+If using a python virtual environment, ensure it's activated by running `source .venv/bin/activate` from the folder used during [installation](../installation.md).
 
 Create a SQLMesh scaffold with the following command, specifying a default SQL dialect for your models. The dialect should correspond to the dialect most of your models are written in; it can be overridden for specific models in the model's `MODEL` specification. All SQL dialects [supported by the SQLGlot library](https://github.com/tobymao/sqlglot/blob/main/sqlglot/dialects/dialect.py) are allowed.
 


### PR DESCRIPTION
Avoid confusion between `.env` for environment variables and `.venv` for python virtual environments.