### PR TITLE
Feat: Tag BigQuery queries with their correlation ID as label

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -134,6 +134,10 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
         }
         if self._extra_config.get("maximum_bytes_billed"):
             params["maximum_bytes_billed"] = self._extra_config.get("maximum_bytes_billed")
+        if self.correlation_id:
+            # BigQuery label keys must be lowercase
+            key = self.correlation_id.job_type.value.lower()
+            params["labels"] = {key: self.correlation_id.job_id}
         return params
 
     @property
@@ -202,6 +206,11 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
         elif query_label_property is not None:
             raise SQLMeshError(
                 "Invalid value for `session_properties.query_label`. Must be an array or tuple."
+            )
+
+        if self.correlation_id:
+            parsed_query_label.append(
+                (self.correlation_id.job_type.value.lower(), self.correlation_id.job_id)
             )
 
         if parsed_query_label:


### PR DESCRIPTION
Follow up of https://github.com/TobikoData/sqlmesh/pull/4832 to also add the `correlation_id` as a BigQuery label at each query (i.e job) executed.


Docs
-------
[BQ Labels](https://cloud.google.com/bigquery/docs/adding-labels#python_2)