### PR TITLE
Chore: Remove dbt-sqlserver dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ dev = [
     "dbt-clickhouse",
     "dbt-databricks",
     "dbt-redshift",
-    "dbt-sqlserver>=1.7.0;python_version<'3.13'",
     "dbt-trino",
     "Faker",
     "google-auth",

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -1,6 +1,5 @@
 import base64
 import typing as t
-import sys
 from pathlib import Path
 from shutil import copytree
 
@@ -949,13 +948,6 @@ def test_db_type_to_column_class():
     assert (TARGET_TYPE_TO_CONFIG_CLASS["databricks"].column_class) == DatabricksColumn
     assert (TARGET_TYPE_TO_CONFIG_CLASS["duckdb"].column_class) == Column
     assert (TARGET_TYPE_TO_CONFIG_CLASS["snowflake"].column_class) == SnowflakeColumn
-
-    if sys.version_info < (3, 13):
-        # The dbt-sqlserver package is not currently compatible with Python 3.13
-
-        from dbt.adapters.sqlserver.sqlserver_column import SQLServerColumn
-
-        assert (TARGET_TYPE_TO_CONFIG_CLASS["sqlserver"].column_class) == SQLServerColumn
 
     from dbt.adapters.clickhouse.column import ClickHouseColumn
     from dbt.adapters.trino.column import TrinoColumn


### PR DESCRIPTION
This dependency is problematic because it enforces constraints on the `dbt-core` and `pyodbc` packages, making it difficult to efficiently support Python 3.13. Whatever value it provides isn’t worth the trouble.