### PR TITLE
fix: put limit on lru cache

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -1175,7 +1175,7 @@ def set_default_catalog(
     return table
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=16384)
 def normalize_model_name(
     table: str | exp.Table | exp.Column,
     default_catalog: t.Optional[str],

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -1558,6 +1558,6 @@ def _convert_sql(v: t.Any, dialect: DialectType) -> t.Any:
     return v
 
 
-@lru_cache(maxsize=1028)
+@lru_cache(maxsize=16384)
 def _cache_convert_sql(v: t.Any, dialect: DialectType, t: type) -> t.Any:
     return _convert_sql(v, dialect)

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1905,7 +1905,7 @@ def missing_intervals(
     return missing
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=16384)
 def expand_range(start_ts: int, end_ts: int, interval_unit: IntervalUnit) -> t.List[int]:
     croniter = interval_unit.croniter(start_ts)
     timestamps = [start_ts]
@@ -1922,7 +1922,7 @@ def expand_range(start_ts: int, end_ts: int, interval_unit: IntervalUnit) -> t.L
     return timestamps
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=16384)
 def compute_missing_intervals(
     interval_unit: IntervalUnit,
     intervals: t.Tuple[Interval, ...],
@@ -1984,7 +1984,7 @@ def compute_missing_intervals(
     return sorted(missing)
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=16384)
 def inclusive_exclusive(
     start: TimeLike,
     end: TimeLike,

--- a/sqlmesh/utils/cron.py
+++ b/sqlmesh/utils/cron.py
@@ -10,7 +10,7 @@ from sqlglot.helper import first
 from sqlmesh.utils.date import TimeLike, now, to_datetime
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=16384)
 def interval_seconds(cron: str) -> int:
     """Computes the interval seconds of a cron statement if it is deterministic.
 


### PR DESCRIPTION
In situations where SQLMesh is long running (like in a service) the memory can grow indefinitely with the current caching approach. Therefore we are now setting a limit. The value of 500 is picked arbitrarily. 