### PR TITLE
Feat: Add support for configurable cache directory

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -288,6 +288,34 @@ Conceptually, we can group the root level parameters into the following types. E
 
 The rest of this page provides additional detail for some of the configuration options and provides brief examples. Comprehensive lists of configuration options are at the [configuration reference page](../reference/configuration.md).
 
+### Cache directory
+
+By default, the SQLMesh cache is stored in a `.cache` directory within your project folder. You can customize the cache location using the `cache_dir` configuration option:
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    # Relative path to project directory
+    cache_dir: my_custom_cache
+
+    # Absolute path
+    cache_dir: /tmp/sqlmesh_cache
+
+    ```
+
+=== "Python"
+
+    ```python linenums="1"
+    from sqlmesh.core.config import Config, ModelDefaultsConfig
+
+    config = Config(
+        model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+        cache_dir="/tmp/sqlmesh_cache",
+    )
+    ```
+
+The cache directory is automatically created if it doesn't exist. You can clear the cache using the `sqlmesh clean` command.
+
 ### Table/view storage locations
 
 SQLMesh creates schemas, physical tables, and views in the data warehouse/engine. Learn more about why and how SQLMesh creates schema in the ["Why does SQLMesh create schemas?" FAQ](../faq/faq.md#schema-question).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -20,6 +20,7 @@ Configuration options for SQLMesh project directories.
 | ------------------ | ------------------------------------------------------------------------------------------------------------------ | :----------: | :------: |
 | `ignore_patterns`  | Files that match glob patterns specified in this list are ignored when scanning the project folder (Default: `[]`) | list[string] |    N     |
 | `project`          | The project name of this config. Used for [multi-repo setups](../guides/multi_repo.md).                            | string       |    N     |
+| `cache_dir`        | The directory to store the SQLMesh cache. Can be an absolute path or relative to the project directory. (Default: `.cache`) | string       |    N     |
 
 ### Environments
 

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -120,6 +120,7 @@ class Config(BaseConfig):
         disable_anonymized_analytics: Whether to disable the anonymized analytics collection.
         before_all: SQL statements or macros to be executed at the start of the `sqlmesh plan` and `sqlmesh run` commands.
         after_all: SQL statements or macros to be executed at the end of the `sqlmesh plan` and `sqlmesh run` commands.
+        cache_dir: The directory to store the SQLMesh cache. Defaults to .cache in the project folder.
     """
 
     gateways: GatewayDict = {"": GatewayConfig()}
@@ -165,6 +166,7 @@ class Config(BaseConfig):
     after_all: t.Optional[t.List[str]] = None
     linter: LinterConfig = LinterConfig()
     janitor: JanitorConfig = JanitorConfig()
+    cache_dir: t.Optional[str] = None
 
     _FIELD_UPDATE_STRATEGY: t.ClassVar[t.Dict[str, UpdateStrategy]] = {
         "gateways": UpdateStrategy.NESTED_UPDATE,

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -105,7 +105,7 @@ class _EngineAdapterStateSyncSchedulerConfig(SchedulerConfig):
 
         schema = context.config.get_state_schema(context.gateway)
         return EngineAdapterStateSync(
-            engine_adapter, schema=schema, context_path=context.cache_dir, console=context.console
+            engine_adapter, schema=schema, cache_dir=context.cache_dir, console=context.console
         )
 
     def state_sync_fingerprint(self, context: GenericContext) -> str:

--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -105,7 +105,7 @@ class _EngineAdapterStateSyncSchedulerConfig(SchedulerConfig):
 
         schema = context.config.get_state_schema(context.gateway)
         return EngineAdapterStateSync(
-            engine_adapter, schema=schema, context_path=context.path, console=context.console
+            engine_adapter, schema=schema, context_path=context.cache_dir, console=context.console
         )
 
     def state_sync_fingerprint(self, context: GenericContext) -> str:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -507,7 +507,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         update_model_schemas(
             self.dag,
             models=self._models,
-            cache_path=self.cache_dir,
+            cache_dir=self.cache_dir,
         )
 
         if model.dialect:
@@ -647,7 +647,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             update_model_schemas(
                 self.dag,
                 models=self._models,
-                cache_path=self.cache_dir,
+                cache_dir=self.cache_dir,
             )
 
             models = self.models.values()
@@ -2757,7 +2757,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             dag=dag,
             default_catalog=self.default_catalog,
             dialect=self.default_dialect,
-            cache_path=self.cache_dir,
+            cache_dir=self.cache_dir,
         )
 
     def _register_notification_targets(self) -> None:

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -887,7 +887,7 @@ class SqlMeshLoader(Loader):
         def __init__(self, loader: SqlMeshLoader, config_path: Path):
             self._loader = loader
             self.config_path = config_path
-            self._model_cache = ModelCache(self.config_path / c.CACHE)
+            self._model_cache = ModelCache(self._loader.context.cache_dir)
 
         def get_or_load_models(
             self, target_path: Path, loader: t.Callable[[], t.List[Model]]

--- a/sqlmesh/core/model/schema.py
+++ b/sqlmesh/core/model/schema.py
@@ -22,10 +22,10 @@ if t.TYPE_CHECKING:
 def update_model_schemas(
     dag: DAG[str],
     models: UniqueKeyDict[str, Model],
-    cache_path: Path,
+    cache_dir: Path,
 ) -> None:
     schema = MappingSchema(normalize=False)
-    optimized_query_cache: OptimizedQueryCache = OptimizedQueryCache(cache_path)
+    optimized_query_cache: OptimizedQueryCache = OptimizedQueryCache(cache_dir)
 
     _update_model_schemas(dag, models, schema, optimized_query_cache)
 

--- a/sqlmesh/core/model/schema.py
+++ b/sqlmesh/core/model/schema.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from sqlglot.errors import SchemaError
 from sqlglot.schema import MappingSchema
 
-from sqlmesh.core import constants as c
 from sqlmesh.core.model.cache import (
     load_optimized_query_and_mapping,
     optimized_query_cache_pool,
@@ -23,10 +22,10 @@ if t.TYPE_CHECKING:
 def update_model_schemas(
     dag: DAG[str],
     models: UniqueKeyDict[str, Model],
-    context_path: Path,
+    cache_path: Path,
 ) -> None:
     schema = MappingSchema(normalize=False)
-    optimized_query_cache: OptimizedQueryCache = OptimizedQueryCache(context_path / c.CACHE)
+    optimized_query_cache: OptimizedQueryCache = OptimizedQueryCache(cache_path)
 
     _update_model_schemas(dag, models, schema, optimized_query_cache)
 

--- a/sqlmesh/core/selector.py
+++ b/sqlmesh/core/selector.py
@@ -35,12 +35,12 @@ class Selector:
         dag: t.Optional[DAG[str]] = None,
         default_catalog: t.Optional[str] = None,
         dialect: t.Optional[str] = None,
-        cache_path: t.Optional[Path] = None,
+        cache_dir: t.Optional[Path] = None,
     ):
         self._state_reader = state_reader
         self._models = models
         self._context_path = context_path
-        self._cache_path = cache_path if cache_path else context_path / c.CACHE
+        self._cache_dir = cache_dir if cache_dir else context_path / c.CACHE
         self._default_catalog = default_catalog
         self._dialect = dialect
         self._git_client = GitClient(context_path)
@@ -160,7 +160,7 @@ class Selector:
             models[model.fqn] = model
 
         if needs_update:
-            update_model_schemas(dag, models=models, cache_path=self._cache_path)
+            update_model_schemas(dag, models=models, cache_dir=self._cache_dir)
 
         return models
 

--- a/sqlmesh/core/selector.py
+++ b/sqlmesh/core/selector.py
@@ -10,6 +10,7 @@ from sqlglot.tokens import Token, TokenType, Tokenizer as BaseTokenizer
 from sqlglot.dialects.dialect import Dialect, DialectType
 from sqlglot.helper import seq_get
 
+from sqlmesh.core import constants as c
 from sqlmesh.core.dialect import normalize_model_name
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.model import update_model_schemas
@@ -34,10 +35,12 @@ class Selector:
         dag: t.Optional[DAG[str]] = None,
         default_catalog: t.Optional[str] = None,
         dialect: t.Optional[str] = None,
+        cache_path: t.Optional[Path] = None,
     ):
         self._state_reader = state_reader
         self._models = models
         self._context_path = context_path
+        self._cache_path = cache_path if cache_path else context_path / c.CACHE
         self._default_catalog = default_catalog
         self._dialect = dialect
         self._git_client = GitClient(context_path)
@@ -157,7 +160,7 @@ class Selector:
             models[model.fqn] = model
 
         if needs_update:
-            update_model_schemas(dag, models=models, context_path=self._context_path)
+            update_model_schemas(dag, models=models, cache_path=self._cache_path)
 
         return models
 

--- a/sqlmesh/core/state_sync/db/facade.py
+++ b/sqlmesh/core/state_sync/db/facade.py
@@ -79,7 +79,7 @@ class EngineAdapterStateSync(StateSync):
         engine_adapter: The EngineAdapter to use to store and fetch snapshots.
         schema: The schema to store state metadata in. If None or empty string then no schema is defined
         console: The console to log information to.
-        context_path: The context path, used for caching snapshot models.
+        cache_dir: The cache path, used for caching snapshot models.
     """
 
     def __init__(
@@ -87,14 +87,12 @@ class EngineAdapterStateSync(StateSync):
         engine_adapter: EngineAdapter,
         schema: t.Optional[str],
         console: t.Optional[Console] = None,
-        context_path: Path = Path(),
+        cache_dir: Path = Path(),
     ):
         self.plan_dags_table = exp.table_("_plan_dags", db=schema)
         self.interval_state = IntervalState(engine_adapter, schema=schema)
         self.environment_state = EnvironmentState(engine_adapter, schema=schema)
-        self.snapshot_state = SnapshotState(
-            engine_adapter, schema=schema, context_path=context_path
-        )
+        self.snapshot_state = SnapshotState(engine_adapter, schema=schema, cache_dir=cache_dir)
         self.version_state = VersionState(engine_adapter, schema=schema)
         self.migrator = StateMigrator(
             engine_adapter,

--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from sqlglot import exp
 from pydantic import Field
 
-from sqlmesh.core import constants as c
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.state_sync.db.utils import (
     snapshot_name_version_filter,
@@ -79,7 +78,7 @@ class SnapshotState:
             "next_auto_restatement_ts": exp.DataType.build("bigint"),
         }
 
-        self._snapshot_cache = SnapshotCache(context_path / c.CACHE)
+        self._snapshot_cache = SnapshotCache(context_path)
 
     def push_snapshots(self, snapshots: t.Iterable[Snapshot], overwrite: bool = False) -> None:
         """Pushes snapshots to the state store.

--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -52,7 +52,7 @@ class SnapshotState:
         self,
         engine_adapter: EngineAdapter,
         schema: t.Optional[str] = None,
-        context_path: Path = Path(),
+        cache_dir: Path = Path(),
     ):
         self.engine_adapter = engine_adapter
         self.snapshots_table = exp.table_("_snapshots", db=schema)
@@ -78,7 +78,7 @@ class SnapshotState:
             "next_auto_restatement_ts": exp.DataType.build("bigint"),
         }
 
-        self._snapshot_cache = SnapshotCache(context_path)
+        self._snapshot_cache = SnapshotCache(cache_dir)
 
     def push_snapshots(self, snapshots: t.Iterable[Snapshot], overwrite: bool = False) -> None:
         """Pushes snapshots to the state store.

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -5,7 +5,6 @@ import sys
 import typing as t
 import sqlmesh.core.dialect as d
 from pathlib import Path
-from sqlmesh.core import constants as c
 from sqlmesh.core.config import (
     Config,
     ConnectionConfig,
@@ -330,7 +329,7 @@ class DbtLoader(Loader):
             self._yaml_max_mtimes = yaml_max_mtimes
 
             target = t.cast(TargetConfig, project.context.target)
-            cache_path = loader.config_path / c.CACHE / target.name
+            cache_path = loader.context.cache_dir / target.name
             self._model_cache = ModelCache(cache_path)
 
         def get_or_load_models(

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -329,8 +329,8 @@ class DbtLoader(Loader):
             self._yaml_max_mtimes = yaml_max_mtimes
 
             target = t.cast(TargetConfig, project.context.target)
-            cache_path = loader.context.cache_dir / target.name
-            self._model_cache = ModelCache(cache_path)
+            cache_dir = loader.context.cache_dir / target.name
+            self._model_cache = ModelCache(cache_dir)
 
         def get_or_load_models(
             self, target_path: Path, loader: t.Callable[[], t.List[Model]]

--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -77,7 +77,7 @@ class ManifestHelper:
         profile_name: str,
         target: TargetConfig,
         variable_overrides: t.Optional[t.Dict[str, t.Any]] = None,
-        cache_path: t.Optional[str] = None,
+        cache_dir: t.Optional[str] = None,
     ):
         self.project_path = project_path
         self.profiles_path = profiles_path
@@ -101,15 +101,15 @@ class ManifestHelper:
         self._disabled_refs: t.Optional[t.Set[str]] = None
         self._disabled_sources: t.Optional[t.Set[str]] = None
 
-        if cache_path is not None:
-            cache_dir = Path(cache_path)
-            if not cache_dir.is_absolute():
-                cache_dir = self.project_path / cache_dir
+        if cache_dir is not None:
+            cache_path = Path(cache_dir)
+            if not cache_path.is_absolute():
+                cache_path = self.project_path / cache_path
         else:
-            cache_dir = self.project_path / c.CACHE
+            cache_path = self.project_path / c.CACHE
 
         self._call_cache: FileCache[t.Dict[str, t.List[CallNames]]] = FileCache(
-            cache_dir, "jinja_calls"
+            cache_path, "jinja_calls"
         )
 
         self._on_run_start_per_package: t.Dict[str, HookConfigs] = defaultdict(dict)

--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -77,6 +77,7 @@ class ManifestHelper:
         profile_name: str,
         target: TargetConfig,
         variable_overrides: t.Optional[t.Dict[str, t.Any]] = None,
+        cache_path: t.Optional[str] = None,
     ):
         self.project_path = project_path
         self.profiles_path = profiles_path
@@ -99,8 +100,16 @@ class ManifestHelper:
         self._tests_by_owner: t.Dict[str, t.List[TestConfig]] = defaultdict(list)
         self._disabled_refs: t.Optional[t.Set[str]] = None
         self._disabled_sources: t.Optional[t.Set[str]] = None
+
+        if cache_path is not None:
+            cache_dir = Path(cache_path)
+            if not cache_dir.is_absolute():
+                cache_dir = self.project_path / cache_dir
+        else:
+            cache_dir = self.project_path / c.CACHE
+
         self._call_cache: FileCache[t.Dict[str, t.List[CallNames]]] = FileCache(
-            self.project_path / c.CACHE, "jinja_calls"
+            cache_dir, "jinja_calls"
         )
 
         self._on_run_start_per_package: t.Dict[str, HookConfigs] = defaultdict(dict)

--- a/sqlmesh/dbt/project.py
+++ b/sqlmesh/dbt/project.py
@@ -75,6 +75,7 @@ class Project:
             profile_name,
             target=profile.target,
             variable_overrides=variable_overrides,
+            cache_path=context.sqlmesh_config.cache_dir,
         )
 
         extra_fields = profile.target.extra

--- a/sqlmesh/dbt/project.py
+++ b/sqlmesh/dbt/project.py
@@ -75,7 +75,7 @@ class Project:
             profile_name,
             target=profile.target,
             variable_overrides=variable_overrides,
-            cache_path=context.sqlmesh_config.cache_dir,
+            cache_dir=context.sqlmesh_config.cache_dir,
         )
 
         extra_fields = profile.target.extra

--- a/tests/core/state_sync/test_export_import.py
+++ b/tests/core/state_sync/test_export_import.py
@@ -33,7 +33,7 @@ def state_sync(tmp_path: Path, example_project_config: Config) -> StateSync:
     return EngineAdapterStateSync(
         engine_adapter=example_project_config.get_state_connection("main").create_engine_adapter(),  # type: ignore
         schema=c.SQLMESH,
-        context_path=tmp_path,
+        cache_dir=tmp_path / c.CACHE,
     )
 
 

--- a/tests/core/state_sync/test_state_sync.py
+++ b/tests/core/state_sync/test_state_sync.py
@@ -55,7 +55,9 @@ pytestmark = pytest.mark.slow
 @pytest.fixture
 def state_sync(duck_conn, tmp_path):
     state_sync = EngineAdapterStateSync(
-        create_engine_adapter(lambda: duck_conn, "duckdb"), schema=c.SQLMESH, context_path=tmp_path
+        create_engine_adapter(lambda: duck_conn, "duckdb"),
+        schema=c.SQLMESH,
+        cache_dir=tmp_path / c.CACHE,
     )
     state_sync.migrate(default_catalog=None)
     return state_sync
@@ -2082,7 +2084,9 @@ def test_version_schema(state_sync: EngineAdapterStateSync, tmp_path) -> None:
 
     # Start with a clean slate.
     state_sync = EngineAdapterStateSync(
-        create_engine_adapter(duckdb.connect, "duckdb"), schema=c.SQLMESH, context_path=tmp_path
+        create_engine_adapter(duckdb.connect, "duckdb"),
+        schema=c.SQLMESH,
+        cache_dir=tmp_path / c.CACHE,
     )
 
     with pytest.raises(
@@ -2203,7 +2207,9 @@ def test_migrate(state_sync: EngineAdapterStateSync, mocker: MockerFixture, tmp_
 
     # Start with a clean slate.
     state_sync = EngineAdapterStateSync(
-        create_engine_adapter(duckdb.connect, "duckdb"), schema=c.SQLMESH, context_path=tmp_path
+        create_engine_adapter(duckdb.connect, "duckdb"),
+        schema=c.SQLMESH,
+        cache_dir=tmp_path / c.CACHE,
     )
 
     state_sync.migrate(default_catalog=None)
@@ -2254,7 +2260,9 @@ def test_rollback(state_sync: EngineAdapterStateSync, mocker: MockerFixture) -> 
 
 def test_first_migration_failure(duck_conn, mocker: MockerFixture, tmp_path) -> None:
     state_sync = EngineAdapterStateSync(
-        create_engine_adapter(lambda: duck_conn, "duckdb"), schema=c.SQLMESH, context_path=tmp_path
+        create_engine_adapter(lambda: duck_conn, "duckdb"),
+        schema=c.SQLMESH,
+        cache_dir=tmp_path / c.CACHE,
     )
     mocker.patch.object(state_sync.migrator, "_migrate_rows", side_effect=Exception("mocked error"))
     with pytest.raises(

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -696,7 +696,7 @@ def test_plan_apply_populates_cache(copy_to_temp_path, mocker):
         )
     ),
     model_defaults=model_defaults,
-    cache_dir="{custom_cache_dir}",
+    cache_dir="{custom_cache_dir.as_posix()}",
 )""",
     )
 

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -30,7 +30,10 @@ async def watch_project() -> None:
         (settings.project_path / c.SEEDS).resolve(),
     ]
     ignore_dirs = [".env"]
-    ignore_paths: t.List[t.Union[str, Path]] = [(settings.project_path / c.CACHE).resolve()]
+    cache_path = (
+        context.cache_dir.resolve() if context else (settings.project_path / c.CACHE).resolve()
+    )
+    ignore_paths: t.List[t.Union[str, Path]] = [cache_path]
     ignore_entity_patterns = context.config.ignore_patterns if context else c.IGNORE_PATTERNS
     ignore_entity_patterns.append("^.*\\.db(\\.wal)?$")
 


### PR DESCRIPTION
By default SQLMesh stores its cache in a `.cache` folder inside the project directory. This introduces a configuration option to specify a custom cache location, either as a relative path or an absolute path. Fixes: #4307 

```yaml
# Relative path to project directory
cache_dir: .my_custom_cache

# Absolute path
cache_dir: /tmp/sqlmesh_cache
```