### PR TITLE
fix: check sqlmesh version before sqlglot/schema

### DIFF
--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -245,6 +245,15 @@ class StateReader(abc.ABC):
                     f"{lib} (local) is using version '{local}' which is behind '{remote}' (remote).{upgrade_suggestion}"
                 )
 
+            if major_minor(SQLMESH_VERSION) != major_minor(versions.sqlmesh_version):
+                raise_error(
+                    "SQLMesh",
+                    SQLMESH_VERSION,
+                    versions.sqlmesh_version,
+                    remote_package_version=versions.sqlmesh_version,
+                    ahead=major_minor(SQLMESH_VERSION) > major_minor(versions.sqlmesh_version),
+                )
+
             if SCHEMA_VERSION != versions.schema_version:
                 raise_error(
                     "SQLMesh",
@@ -261,15 +270,6 @@ class StateReader(abc.ABC):
                     versions.sqlglot_version,
                     remote_package_version=versions.sqlglot_version,
                     ahead=major_minor(SQLGLOT_VERSION) > major_minor(versions.sqlglot_version),
-                )
-
-            if major_minor(SQLMESH_VERSION) != major_minor(versions.sqlmesh_version):
-                raise_error(
-                    "SQLMesh",
-                    SQLMESH_VERSION,
-                    versions.sqlmesh_version,
-                    remote_package_version=versions.sqlmesh_version,
-                    ahead=major_minor(SQLMESH_VERSION) > major_minor(versions.sqlmesh_version),
                 )
 
         return versions

--- a/tests/core/state_sync/test_state_sync.py
+++ b/tests/core/state_sync/test_state_sync.py
@@ -2091,7 +2091,7 @@ def test_version_schema(state_sync: EngineAdapterStateSync, tmp_path) -> None:
 
     with pytest.raises(
         SQLMeshError,
-        match=rf"SQLMesh \(local\) is using version '{SCHEMA_VERSION}' which is ahead of '0'",
+        match=rf"SQLMesh \(local\) is using version '{SQLMESH_VERSION}' which is ahead of '0.0.0' \(remote\). Please run a migration \('sqlmesh migrate' command\).",
     ):
         state_sync.get_versions()
 


### PR DESCRIPTION
Prior to this PR, if a user was running a version that didn't match the remote SQLMesh version, they would likely see a schema or sqlglot version mismatched error before SQLMesh. Erroring on SQLMesh is more useful since it makes it more clear what the issue is - version/SQLGLot should just be backup checks. 