### PR TITLE
Feat: Customizing migration state tables name

### DIFF
--- a/sqlmesh/core/config/migration.py
+++ b/sqlmesh/core/config/migration.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import typing as t
+from pydantic import root_validator
+
 from sqlmesh.core.config.base import BaseConfig
 
 
@@ -9,6 +12,40 @@ class MigrationConfig(BaseConfig):
     Args:
         promoted_snapshots_only: If True, only snapshots that are part of at least one environment will be migrated.
             Otherwise, all snapshots will be migrated.
+        state_tables: A dict of state tables to migrate.
     """
 
+    _default_state_tables = {
+        "snapshots_table": "_snapshots",
+        "intervals_table": "_intervals",
+        "environments_table": "_environments",
+        "environment_statements_table": "_environment_statements",
+        "auto_restatements_table": "_auto_restatements",
+        "versions_table": "_versions",
+        "seeds_table": "_seeds",
+        "plan_dags_table": "_plan_dags",
+    }
+
     promoted_snapshots_only: bool = True
+    state_tables: t.Optional[dict[str, str]] = None
+
+    @root_validator(pre=True)
+    def validate_and_merge_state_tables(cls, values):
+        external = values.get("state_tables", {})
+        merged = cls._default_state_tables.copy()
+        if isinstance(external, dict):
+            for k, v in external.items():
+                if k in merged:
+                    merged[k] = v
+
+        for k, v in merged.items():
+            if not v or not isinstance(v, str) or v.strip() == "":
+                raise ValueError(f"Table name for '{k}' cannot be empty.")
+
+        seen = set()
+        for v in merged.values():
+            if v in seen:
+                raise ValueError(f"Duplicate table name found: '{v}'.")
+            seen.add(v)
+        values["state_tables"] = merged
+        return values

--- a/sqlmesh/core/config/migration.py
+++ b/sqlmesh/core/config/migration.py
@@ -27,10 +27,10 @@ class MigrationConfig(BaseConfig):
     }
 
     promoted_snapshots_only: bool = True
-    state_tables: t.Optional[dict[str, str]] = None
+    state_tables: dict[str, str] = DEFAULT_STATE_TABLES
 
     @root_validator(pre=True)
-    def validate_and_merge_state_tables(cls, values):
+    def validate_and_merge_state_tables(cls, values: dict) -> dict:
         external = values.get("state_tables", {})
         merged = cls.DEFAULT_STATE_TABLES.copy()
         if isinstance(external, dict):

--- a/sqlmesh/core/config/migration.py
+++ b/sqlmesh/core/config/migration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pydantic import root_validator
 import typing as t
 

--- a/sqlmesh/core/config/migration.py
+++ b/sqlmesh/core/config/migration.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
-import typing as t
 from pydantic import root_validator
+import typing as t
 
 from sqlmesh.core.config.base import BaseConfig
 
@@ -15,7 +13,7 @@ class MigrationConfig(BaseConfig):
         state_tables: A dict of state tables to migrate.
     """
 
-    _default_state_tables = {
+    DEFAULT_STATE_TABLES: t.ClassVar[dict[str, str]] = {
         "snapshots_table": "_snapshots",
         "intervals_table": "_intervals",
         "environments_table": "_environments",
@@ -32,16 +30,14 @@ class MigrationConfig(BaseConfig):
     @root_validator(pre=True)
     def validate_and_merge_state_tables(cls, values):
         external = values.get("state_tables", {})
-        merged = cls._default_state_tables.copy()
+        merged = cls.DEFAULT_STATE_TABLES.copy()
         if isinstance(external, dict):
             for k, v in external.items():
                 if k in merged:
                     merged[k] = v
-
         for k, v in merged.items():
             if not v or not isinstance(v, str) or v.strip() == "":
                 raise ValueError(f"Table name for '{k}' cannot be empty.")
-
         seen = set()
         for v in merged.values():
             if v in seen:

--- a/sqlmesh/core/config/root.py
+++ b/sqlmesh/core/config/root.py
@@ -185,6 +185,7 @@ class Config(BaseConfig):
         "before_all": UpdateStrategy.EXTEND,
         "after_all": UpdateStrategy.EXTEND,
         "linter": UpdateStrategy.NESTED_UPDATE,
+        "migration": UpdateStrategy.KEY_UPDATE,
     }
 
     _connection_config_validator = connection_config_validator

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -9,6 +9,7 @@ import typing as t
 from sqlglot import __version__ as SQLGLOT_VERSION
 
 from sqlmesh import migrations
+from sqlmesh.core.config.migration import MigrationConfig
 from sqlmesh.core.environment import (
     Environment,
     EnvironmentNamingInfo,
@@ -315,6 +316,8 @@ class StateReader(abc.ABC):
 
 class StateSync(StateReader, abc.ABC):
     """Abstract base class for snapshot and environment state management."""
+    def __init__(self, config: MigrationConfig):
+        self.state_tables = config.state_tables
 
     @abc.abstractmethod
     def push_snapshots(self, snapshots: t.Iterable[Snapshot]) -> None:

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -316,6 +316,7 @@ class StateReader(abc.ABC):
 
 class StateSync(StateReader, abc.ABC):
     """Abstract base class for snapshot and environment state management."""
+
     def __init__(self, config: MigrationConfig):
         self.state_tables = config.state_tables
 

--- a/sqlmesh/core/state_sync/db/environment.py
+++ b/sqlmesh/core/state_sync/db/environment.py
@@ -33,10 +33,10 @@ class EnvironmentState:
         self.engine_adapter = engine_adapter
         config = MigrationConfig()
         self.environments_table = exp.table_(
-            config.state_tables["environments_table"], db=schema
+            config.state_tables.get("environments_table", "_environments"), db=schema
         )
         self.environment_statements_table = exp.table_(
-            config.state_tables["environment_statements_table"], db=schema
+            config.state_tables.get("environment_statements_table", "_environment_statements"), db=schema
         )
 
         index_type = index_text_type(engine_adapter.dialect)

--- a/sqlmesh/core/state_sync/db/environment.py
+++ b/sqlmesh/core/state_sync/db/environment.py
@@ -6,6 +6,7 @@ import logging
 from sqlglot import exp
 
 from sqlmesh.core import constants as c
+from sqlmesh.core.config.migration import MigrationConfig
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.state_sync.db.utils import (
     fetchall,
@@ -30,8 +31,13 @@ class EnvironmentState:
         schema: t.Optional[str] = None,
     ):
         self.engine_adapter = engine_adapter
-        self.environments_table = exp.table_("_environments", db=schema)
-        self.environment_statements_table = exp.table_("_environment_statements", db=schema)
+        config = MigrationConfig()
+        self.environments_table = exp.table_(
+            config.state_tables["environments_table"], db=schema
+        )
+        self.environment_statements_table = exp.table_(
+            config.state_tables["environment_statements_table"], db=schema
+        )
 
         index_type = index_text_type(engine_adapter.dialect)
         blob_type = blob_text_type(engine_adapter.dialect)

--- a/sqlmesh/core/state_sync/db/environment.py
+++ b/sqlmesh/core/state_sync/db/environment.py
@@ -36,7 +36,8 @@ class EnvironmentState:
             config.state_tables.get("environments_table", "_environments"), db=schema
         )
         self.environment_statements_table = exp.table_(
-            config.state_tables.get("environment_statements_table", "_environment_statements"), db=schema
+            config.state_tables.get("environment_statements_table", "_environment_statements"),
+            db=schema,
         )
 
         index_type = index_text_type(engine_adapter.dialect)

--- a/sqlmesh/core/state_sync/db/facade.py
+++ b/sqlmesh/core/state_sync/db/facade.py
@@ -91,7 +91,7 @@ class EngineAdapterStateSync(StateSync):
         cache_dir: Path = Path(),
     ):
         config = MigrationConfig()
-        self.plan_dags_table = exp.table_(config.state_tables["plan_dags_table"], db=schema)
+        self.plan_dags_table = exp.table_(config.state_tables.get("plan_dags_table", "_plan_dags"), db=schema)
         self.interval_state = IntervalState(engine_adapter, schema=schema)
         self.environment_state = EnvironmentState(engine_adapter, schema=schema)
         self.snapshot_state = SnapshotState(engine_adapter, schema=schema, cache_dir=cache_dir)

--- a/sqlmesh/core/state_sync/db/facade.py
+++ b/sqlmesh/core/state_sync/db/facade.py
@@ -24,6 +24,7 @@ from datetime import datetime
 
 from sqlglot import exp
 
+from sqlmesh.core.config.migration import MigrationConfig
 from sqlmesh.core.console import Console, get_console
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.environment import Environment, EnvironmentStatements, EnvironmentSummary
@@ -89,7 +90,8 @@ class EngineAdapterStateSync(StateSync):
         console: t.Optional[Console] = None,
         cache_dir: Path = Path(),
     ):
-        self.plan_dags_table = exp.table_("_plan_dags", db=schema)
+        config = MigrationConfig()
+        self.plan_dags_table = exp.table_(config.state_tables["plan_dags_table"], db=schema)
         self.interval_state = IntervalState(engine_adapter, schema=schema)
         self.environment_state = EnvironmentState(engine_adapter, schema=schema)
         self.snapshot_state = SnapshotState(engine_adapter, schema=schema, cache_dir=cache_dir)
@@ -166,17 +168,11 @@ class EngineAdapterStateSync(StateSync):
         """
         logger.info("Promoting environment '%s'", environment.name)
 
-        missing = {s.snapshot_id for s in environment.snapshots} - self.snapshots_exist(
-            environment.snapshots
-        )
+        missing = {s.snapshot_id for s in environment.snapshots} - self.snapshots_exist(environment.snapshots)
         if missing:
-            raise SQLMeshError(
-                f"Missing snapshots {missing}. Make sure to push and backfill your snapshots."
-            )
+            raise SQLMeshError(f"Missing snapshots {missing}. Make sure to push and backfill your snapshots.")
 
-        existing_environment = self.environment_state.get_environment(
-            environment.name, lock_for_update=True
-        )
+        existing_environment = self.environment_state.get_environment(environment.name, lock_for_update=True)
 
         existing_table_infos = (
             {table_info.name: table_info for table_info in existing_environment.promoted_snapshots}
@@ -190,9 +186,7 @@ class EngineAdapterStateSync(StateSync):
                 existing_table_info
                 for name, existing_table_info in existing_table_infos.items()
                 if name in table_infos
-                and existing_table_info.qualified_view_name.for_environment(
-                    existing_environment.naming_info
-                )
+                and existing_table_info.qualified_view_name.for_environment(existing_environment.naming_info)
                 != table_infos[name].qualified_view_name.for_environment(environment.naming_info)
             }
             if not existing_environment.expired:
@@ -212,9 +206,7 @@ class EngineAdapterStateSync(StateSync):
             # Update the updated_at attribute.
             self.snapshot_state.touch_snapshots(demoted_snapshots)
 
-        missing_models = set(existing_table_infos) - {
-            snapshot.name for snapshot in environment.promoted_snapshots
-        }
+        missing_models = set(existing_table_infos) - {snapshot.name for snapshot in environment.promoted_snapshots}
 
         added_table_infos = set(table_infos.values())
         if existing_environment and environment.can_partially_promote(existing_environment):
@@ -230,9 +222,7 @@ class EngineAdapterStateSync(StateSync):
                 environment.name, environment.plan_id, environment_statements
             )
 
-        removed = {existing_table_infos[name] for name in missing_models}.union(
-            views_that_changed_location
-        )
+        removed = {existing_table_infos[name] for name in missing_models}.union(views_that_changed_location)
 
         return PromotionResult(
             added=sorted(added_table_infos),
@@ -253,17 +243,13 @@ class EngineAdapterStateSync(StateSync):
         self.environment_state.finalize(environment)
 
     @transactional()
-    def unpause_snapshots(
-        self, snapshots: t.Collection[SnapshotInfoLike], unpaused_dt: TimeLike
-    ) -> None:
+    def unpause_snapshots(self, snapshots: t.Collection[SnapshotInfoLike], unpaused_dt: TimeLike) -> None:
         self.snapshot_state.unpause_snapshots(snapshots, unpaused_dt, self.interval_state)
 
     def invalidate_environment(self, name: str, protect_prod: bool = True) -> None:
         self.environment_state.invalidate_environment(name, protect_prod)
 
-    def get_expired_snapshots(
-        self, current_ts: int, ignore_ttl: bool = False
-    ) -> t.List[SnapshotTableCleanupTask]:
+    def get_expired_snapshots(self, current_ts: int, ignore_ttl: bool = False) -> t.List[SnapshotTableCleanupTask]:
         return self.snapshot_state.get_expired_snapshots(
             self.environment_state.get_environments(), current_ts=current_ts, ignore_ttl=ignore_ttl
         )
@@ -286,9 +272,7 @@ class EngineAdapterStateSync(StateSync):
         return cleanup_targets
 
     @transactional()
-    def delete_expired_environments(
-        self, current_ts: t.Optional[int] = None
-    ) -> t.List[EnvironmentSummary]:
+    def delete_expired_environments(self, current_ts: t.Optional[int] = None) -> t.List[EnvironmentSummary]:
         current_ts = current_ts or now_timestamp()
         return self.environment_state.delete_expired_environments(current_ts=current_ts)
 
@@ -324,9 +308,7 @@ class EngineAdapterStateSync(StateSync):
         self.migrate(default_catalog)
 
     @transactional()
-    def update_auto_restatements(
-        self, next_auto_restatement_ts: t.Dict[SnapshotNameVersion, t.Optional[int]]
-    ) -> None:
+    def update_auto_restatements(self, next_auto_restatement_ts: t.Dict[SnapshotNameVersion, t.Optional[int]]) -> None:
         self.snapshot_state.update_auto_restatements(next_auto_restatement_ts)
 
     def get_environment(self, environment: str) -> t.Optional[Environment]:
@@ -424,9 +406,7 @@ class EngineAdapterStateSync(StateSync):
         if not env:
             return {}
 
-        snapshots = (
-            env.snapshots if not ensure_finalized_snapshots else env.finalized_or_current_snapshots
-        )
+        snapshots = env.snapshots if not ensure_finalized_snapshots else env.finalized_or_current_snapshots
         if models is not None:
             snapshots = [s for s in snapshots if s.name in models]
 
@@ -487,9 +467,7 @@ class EngineAdapterStateSync(StateSync):
 
         def _export_environments() -> t.Iterator[EnvironmentWithStatements]:
             for env in selected_environments:
-                yield EnvironmentWithStatements(
-                    environment=env, statements=self.get_environment_statements(env.name)
-                )
+                yield EnvironmentWithStatements(environment=env, statements=self.get_environment_statements(env.name))
 
         return StateStream.from_iterators(
             versions=versions,
@@ -507,10 +485,7 @@ class EngineAdapterStateSync(StateSync):
                 # is compatible with our Pydantic model definitions. Patch versions dont need to match because the assumption
                 # is that they dont contain any breaking changes
                 incoming_versions = state_chunk.versions
-                if (
-                    incoming_versions.minor_sqlmesh_version
-                    != existing_versions.minor_sqlmesh_version
-                ):
+                if incoming_versions.minor_sqlmesh_version != existing_versions.minor_sqlmesh_version:
                     raise SQLMeshError(
                         f"SQLMesh version mismatch. You are running '{existing_versions.sqlmesh_version}' but the state file was created with '{incoming_versions.sqlmesh_version}'.\n"
                         "Please upgrade/downgrade your SQLMesh version to match the state file before performing the import."
@@ -522,16 +497,12 @@ class EngineAdapterStateSync(StateSync):
             if isinstance(state_chunk, SnapshotsChunk):
                 auto_restatements: t.Dict[SnapshotNameVersion, t.Optional[int]] = {}
 
-                for snapshot_chunk in chunk_iterable(
-                    state_chunk, SnapshotState.SNAPSHOT_BATCH_SIZE
-                ):
+                for snapshot_chunk in chunk_iterable(state_chunk, SnapshotState.SNAPSHOT_BATCH_SIZE):
                     snapshot_chunk = list(snapshot_chunk)
                     overwrite_existing_snapshots = (
                         not clear
                     )  # if clear=True, all existing snapshots were dropped anyway
-                    self.snapshot_state.push_snapshots(
-                        snapshot_chunk, overwrite=overwrite_existing_snapshots
-                    )
+                    self.snapshot_state.push_snapshots(snapshot_chunk, overwrite=overwrite_existing_snapshots)
                     self.add_snapshots_intervals((s.snapshot_intervals for s in snapshot_chunk))
 
                     auto_restatements.update(
@@ -571,13 +542,10 @@ class EngineAdapterStateSync(StateSync):
         changed_version_prev_snapshots_by_name = {
             s.name: s
             for s in target_environment.snapshots
-            if s.name in target_snapshots_by_name
-            and target_snapshots_by_name[s.name].version != s.version
+            if s.name in target_snapshots_by_name and target_snapshots_by_name[s.name].version != s.version
         }
 
-        prev_snapshots = self.get_snapshots(
-            changed_version_prev_snapshots_by_name.values()
-        ).values()
+        prev_snapshots = self.get_snapshots(changed_version_prev_snapshots_by_name.values()).values()
         cache: t.Dict[str, datetime] = {}
 
         for prev_snapshot in prev_snapshots:
@@ -588,15 +556,11 @@ class EngineAdapterStateSync(StateSync):
                 and prev_snapshot.is_incremental
                 and prev_snapshot.intervals
             ):
-                start = to_timestamp(
-                    start_date(target_snapshot, target_snapshots_by_name.values(), cache)
-                )
+                start = to_timestamp(start_date(target_snapshot, target_snapshots_by_name.values(), cache))
                 end = prev_snapshot.intervals[-1][1]
 
                 if start < end:
-                    missing_intervals = target_snapshot.missing_intervals(
-                        start, end, end_bounded=True
-                    )
+                    missing_intervals = target_snapshot.missing_intervals(start, end, end_bounded=True)
 
                     if missing_intervals:
                         raise SQLMeshError(

--- a/sqlmesh/core/state_sync/db/interval.py
+++ b/sqlmesh/core/state_sync/db/interval.py
@@ -48,7 +48,7 @@ class IntervalState:
         config = MigrationConfig()
         self.intervals_table = exp.table_(
             config.state_tables.get("intervals_table", "_intervals"),
-            db=self.engine_adapter.schema,
+            db=schema,
         )
 
         index_type = index_text_type(engine_adapter.dialect)

--- a/sqlmesh/core/state_sync/db/interval.py
+++ b/sqlmesh/core/state_sync/db/interval.py
@@ -46,7 +46,10 @@ class IntervalState:
     ):
         self.engine_adapter = engine_adapter
         config = MigrationConfig()
-        self.intervals_table = exp.table_(table_name or config.state_tables["intervals_table"], db=schema)
+        self.intervals_table = exp.table_(
+            config.state_tables.get("intervals_table", "_intervals"),
+            db=self.engine_adapter.schema,
+        )
 
         index_type = index_text_type(engine_adapter.dialect)
         self._interval_columns_to_types = {

--- a/sqlmesh/core/state_sync/db/interval.py
+++ b/sqlmesh/core/state_sync/db/interval.py
@@ -5,6 +5,7 @@ import logging
 
 from sqlglot import exp
 
+from sqlmesh.core.config.migration import MigrationConfig
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.state_sync.db.utils import (
     snapshot_name_version_filter,
@@ -44,7 +45,8 @@ class IntervalState:
         table_name: t.Optional[str] = None,
     ):
         self.engine_adapter = engine_adapter
-        self.intervals_table = exp.table_(table_name or "_intervals", db=schema)
+        config = MigrationConfig()
+        self.intervals_table = exp.table_(table_name or config.state_tables["intervals_table"], db=schema)
 
         index_type = index_text_type(engine_adapter.dialect)
         self._interval_columns_to_types = {

--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from sqlglot import exp
 from pydantic import Field
 
+from sqlmesh.core.config.migration import MigrationConfig
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.state_sync.db.utils import (
     snapshot_name_version_filter,
@@ -55,8 +56,11 @@ class SnapshotState:
         cache_dir: Path = Path(),
     ):
         self.engine_adapter = engine_adapter
-        self.snapshots_table = exp.table_("_snapshots", db=schema)
-        self.auto_restatements_table = exp.table_("_auto_restatements", db=schema)
+        config = MigrationConfig()
+        self.snapshots_table = exp.table_(config.state_tables["snapshots_table"], db=schema)
+        self.auto_restatements_table = exp.table_(
+            config.state_tables["auto_restatements_table"], db=schema
+        )
 
         index_type = index_text_type(engine_adapter.dialect)
         blob_type = blob_text_type(engine_adapter.dialect)

--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -57,7 +57,9 @@ class SnapshotState:
     ):
         self.engine_adapter = engine_adapter
         config = MigrationConfig()
-        self.snapshots_table = exp.table_(config.state_tables.get("snapshots_table", "_snapshots"), db=schema)
+        self.snapshots_table = exp.table_(
+            config.state_tables.get("snapshots_table", "_snapshots"), db=schema
+        )
         self.auto_restatements_table = exp.table_(
             config.state_tables.get("auto_restatements_table", "_auto_restatements"), db=schema
         )

--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -57,9 +57,9 @@ class SnapshotState:
     ):
         self.engine_adapter = engine_adapter
         config = MigrationConfig()
-        self.snapshots_table = exp.table_(config.state_tables["snapshots_table"], db=schema)
+        self.snapshots_table = exp.table_(config.state_tables.get("snapshots_table", "_snapshots"), db=schema)
         self.auto_restatements_table = exp.table_(
-            config.state_tables["auto_restatements_table"], db=schema
+            config.state_tables.get("auto_restatements_table", "_auto_restatements"), db=schema
         )
 
         index_type = index_text_type(engine_adapter.dialect)

--- a/sqlmesh/core/state_sync/db/version.py
+++ b/sqlmesh/core/state_sync/db/version.py
@@ -26,7 +26,9 @@ class VersionState:
     def __init__(self, engine_adapter: EngineAdapter, schema: t.Optional[str] = None):
         self.engine_adapter = engine_adapter
         config = MigrationConfig()
-        self.versions_table = exp.table_(config.state_tables.get("versions_table", "_versions"), db=schema)
+        self.versions_table = exp.table_(
+            config.state_tables.get("versions_table", "_versions"), db=schema
+        )
 
         index_type = index_text_type(engine_adapter.dialect)
         self._version_columns_to_types = {

--- a/sqlmesh/core/state_sync/db/version.py
+++ b/sqlmesh/core/state_sync/db/version.py
@@ -7,6 +7,7 @@ from sqlglot import __version__ as SQLGLOT_VERSION
 from sqlglot import exp
 from sqlglot.helper import seq_get
 
+from sqlmesh.core.config.migration import MigrationConfig
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.state_sync.db.utils import (
     fetchone,
@@ -24,7 +25,10 @@ logger = logging.getLogger(__name__)
 class VersionState:
     def __init__(self, engine_adapter: EngineAdapter, schema: t.Optional[str] = None):
         self.engine_adapter = engine_adapter
-        self.versions_table = exp.table_("_versions", db=schema)
+        config = MigrationConfig()
+        self.versions_table = exp.table_(
+            config.state_tables["versions_table"], db=schema
+        )
 
         index_type = index_text_type(engine_adapter.dialect)
         self._version_columns_to_types = {

--- a/sqlmesh/core/state_sync/db/version.py
+++ b/sqlmesh/core/state_sync/db/version.py
@@ -26,9 +26,7 @@ class VersionState:
     def __init__(self, engine_adapter: EngineAdapter, schema: t.Optional[str] = None):
         self.engine_adapter = engine_adapter
         config = MigrationConfig()
-        self.versions_table = exp.table_(
-            config.state_tables["versions_table"], db=schema
-        )
+        self.versions_table = exp.table_(config.state_tables.get("versions_table", "_versions"), db=schema)
 
         index_type = index_text_type(engine_adapter.dialect)
         self._version_columns_to_types = {

--- a/sqlmesh/migrations/v0001_init.py
+++ b/sqlmesh/migrations/v0001_init.py
@@ -12,9 +12,10 @@ from sqlmesh.utils.migration import index_text_type
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
-    environments_table = "_environments"
-    versions_table = "_versions"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
+    environments_table = state_tables.get("environments_table", "_environments")
+    versions_table = state_tables.get("versions_table", "_versions")
 
     if schema:
         engine_adapter.create_schema(schema)

--- a/sqlmesh/migrations/v0003_move_batch_size.py
+++ b/sqlmesh/migrations/v0003_move_batch_size.py
@@ -6,7 +6,8 @@ from sqlglot import exp
 
 
 def migrate(state_sync, **kwargs):  # type: ignore
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if state_sync.schema:
         snapshots_table = f"{state_sync.schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
+++ b/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
@@ -5,7 +5,8 @@ from sqlglot import exp
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    environments_table = "_environments"
+    state_tables = getattr(state_sync, "state_tables", {})
+    environments_table = state_tables.get("environments_table", "_environments")
     if state_sync.schema:
         environments_table = f"{state_sync.schema}.{environments_table}"
 

--- a/sqlmesh/migrations/v0005_create_seed_table.py
+++ b/sqlmesh/migrations/v0005_create_seed_table.py
@@ -7,7 +7,8 @@ from sqlmesh.utils.migration import index_text_type
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    seeds_table = "_seeds"
+    state_tables = getattr(state_sync, "state_tables", {})
+    seeds_table = state_tables.get("seeds_table", "_seeds")
     if state_sync.schema:
         seeds_table = f"{state_sync.schema}.{seeds_table}"
 

--- a/sqlmesh/migrations/v0007_env_table_info_to_kind.py
+++ b/sqlmesh/migrations/v0007_env_table_info_to_kind.py
@@ -17,8 +17,9 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    environments_table = "_environments"
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    environments_table = state_tables.get("environments_table", "_environments")
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         environments_table = f"{schema}.{environments_table}"
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0008_create_intervals_table.py
+++ b/sqlmesh/migrations/v0008_create_intervals_table.py
@@ -7,7 +7,8 @@ from sqlmesh.utils.migration import index_text_type
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    intervals_table = "_intervals"
+    state_tables = getattr(state_sync, "state_tables", {})
+    intervals_table = state_tables.get("intervals_table", "_intervals")
     if state_sync.schema:
         intervals_table = f"{state_sync.schema}.{intervals_table}"
 

--- a/sqlmesh/migrations/v0009_remove_pre_post_hooks.py
+++ b/sqlmesh/migrations/v0009_remove_pre_post_hooks.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0011_add_model_kind_name.py
+++ b/sqlmesh/migrations/v0011_add_model_kind_name.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0012_update_jinja_expressions.py
+++ b/sqlmesh/migrations/v0012_update_jinja_expressions.py
@@ -14,7 +14,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0013_serde_using_model_dialects.py
+++ b/sqlmesh/migrations/v0013_serde_using_model_dialects.py
@@ -14,7 +14,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0014_fix_dev_intervals.py
+++ b/sqlmesh/migrations/v0014_fix_dev_intervals.py
@@ -3,7 +3,8 @@
 
 def migrate(state_sync, **kwargs):  # type: ignore
     schema = state_sync.schema
-    intervals_table = "_intervals"
+    state_tables = getattr(state_sync, "state_tables", {})
+    intervals_table = state_tables.get("intervals_table", "_intervals")
     if schema:
         intervals_table = f"{schema}.{intervals_table}"
 

--- a/sqlmesh/migrations/v0015_environment_add_promoted_snapshot_ids.py
+++ b/sqlmesh/migrations/v0015_environment_add_promoted_snapshot_ids.py
@@ -6,7 +6,8 @@ from sqlmesh.utils.migration import blob_text_type
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    environments_table = "_environments"
+    state_tables = getattr(state_sync, "state_tables", {})
+    environments_table = state_tables.get("environments_table", "_environments")
     if state_sync.schema:
         environments_table = f"{state_sync.schema}.{environments_table}"
 

--- a/sqlmesh/migrations/v0016_fix_windows_path.py
+++ b/sqlmesh/migrations/v0016_fix_windows_path.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0017_fix_windows_seed_path.py
+++ b/sqlmesh/migrations/v0017_fix_windows_seed_path.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0018_rename_snapshot_model_to_node.py
+++ b/sqlmesh/migrations/v0018_rename_snapshot_model_to_node.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0019_add_env_suffix_target.py
+++ b/sqlmesh/migrations/v0019_add_env_suffix_target.py
@@ -5,7 +5,8 @@ from sqlglot import exp
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    environments_table = "_environments"
+    state_tables = getattr(state_sync, "state_tables", {})
+    environments_table = state_tables.get("environments_table", "_environments")
     if state_sync.schema:
         environments_table = f"{state_sync.schema}.{environments_table}"
 

--- a/sqlmesh/migrations/v0020_remove_redundant_attributes_from_dbt_models.py
+++ b/sqlmesh/migrations/v0020_remove_redundant_attributes_from_dbt_models.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0021_fix_table_properties.py
+++ b/sqlmesh/migrations/v0021_fix_table_properties.py
@@ -13,7 +13,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0022_move_project_to_model.py
+++ b/sqlmesh/migrations/v0022_move_project_to_model.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0023_fix_added_models_with_forward_only_parents.py
+++ b/sqlmesh/migrations/v0023_fix_added_models_with_forward_only_parents.py
@@ -11,8 +11,9 @@ from sqlmesh.utils.dag import DAG
 def migrate(state_sync: t.Any, **kwargs) -> None:  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
-    environments_table = "_environments"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
+    environments_table = state_tables.get("environments_table", "_environments")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
         environments_table = f"{schema}.{environments_table}"

--- a/sqlmesh/migrations/v0024_replace_model_kind_name_enum_with_value.py
+++ b/sqlmesh/migrations/v0024_replace_model_kind_name_enum_with_value.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0025_fix_intervals_and_missing_change_category.py
+++ b/sqlmesh/migrations/v0025_fix_intervals_and_missing_change_category.py
@@ -15,8 +15,9 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
-    intervals_table = "_intervals"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
+    intervals_table = state_tables.get("intervals_table", "_intervals")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
         intervals_table = f"{schema}.{intervals_table}"

--- a/sqlmesh/migrations/v0026_remove_dialect_from_seed.py
+++ b/sqlmesh/migrations/v0026_remove_dialect_from_seed.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0027_minute_interval_to_five.py
+++ b/sqlmesh/migrations/v0027_minute_interval_to_five.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0028_add_plan_dags_table.py
+++ b/sqlmesh/migrations/v0028_add_plan_dags_table.py
@@ -8,7 +8,8 @@ from sqlmesh.utils.migration import index_text_type
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    plan_dags_table = "_plan_dags"
+    state_tables = getattr(state_sync, "state_tables", {})
+    plan_dags_table = state_tables.get("plan_dags_table", "_plan_dags")
 
     if schema:
         engine_adapter.create_schema(schema)

--- a/sqlmesh/migrations/v0029_generate_schema_types_using_dialect.py
+++ b/sqlmesh/migrations/v0029_generate_schema_types_using_dialect.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0030_update_unrestorable_snapshots.py
+++ b/sqlmesh/migrations/v0030_update_unrestorable_snapshots.py
@@ -14,7 +14,8 @@ def migrate(state_sync: t.Any, **kwargs: t.Any) -> None:  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0031_remove_dbt_target_fields.py
+++ b/sqlmesh/migrations/v0031_remove_dbt_target_fields.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0032_add_sqlmesh_version.py
+++ b/sqlmesh/migrations/v0032_add_sqlmesh_version.py
@@ -7,7 +7,8 @@ from sqlmesh.utils.migration import index_text_type
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    versions_table = "_versions"
+    state_tables = getattr(state_sync, "state_tables", {})
+    versions_table = state_tables.get("versions_table", "_versions")
     if state_sync.schema:
         versions_table = f"{state_sync.schema}.{versions_table}"
     index_type = index_text_type(engine_adapter.dialect)

--- a/sqlmesh/migrations/v0033_mysql_fix_blob_text_type.py
+++ b/sqlmesh/migrations/v0033_mysql_fix_blob_text_type.py
@@ -11,10 +11,11 @@ def migrate(state_sync, **kwargs):  # type: ignore
         return
 
     schema = state_sync.schema
-    environments_table = "_environments"
-    snapshots_table = "_snapshots"
-    seeds_table = "_seeds"
-    plan_dags_table = "_plan_dags"
+    state_tables = getattr(state_sync, "state_tables", {})
+    environments_table = state_tables.get("environments_table", "_environments")
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
+    seeds_table = state_tables.get("seeds_table", "_seeds")
+    plan_dags_table = state_tables.get("plan_dags_table", "_plan_dags")
 
     if schema:
         environments_table = f"{schema}.{environments_table}"

--- a/sqlmesh/migrations/v0034_add_default_catalog.py
+++ b/sqlmesh/migrations/v0034_add_default_catalog.py
@@ -68,10 +68,11 @@ def migrate(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ig
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
-    environments_table = "_environments"
-    intervals_table = "_intervals"
-    seeds_table = "_seeds"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
+    environments_table = state_tables.get("environments_table", "_environments")
+    intervals_table = state_tables.get("intervals_table", "_intervals")
+    seeds_table = state_tables.get("seeds_table", "_seeds")
 
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0035_add_catalog_name_override.py
+++ b/sqlmesh/migrations/v0035_add_catalog_name_override.py
@@ -5,7 +5,8 @@ from sqlglot import exp
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    environments_table = "_environments"
+    state_tables = getattr(state_sync, "state_tables", {})
+    environments_table = state_tables.get("environments_table", "_environments")
     if state_sync.schema:
         environments_table = f"{state_sync.schema}.{environments_table}"
 

--- a/sqlmesh/migrations/v0036_delete_plan_dags_bug_fix.py
+++ b/sqlmesh/migrations/v0036_delete_plan_dags_bug_fix.py
@@ -4,7 +4,8 @@
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    plan_dags_table = "_plan_dags"
+    state_tables = getattr(state_sync, "state_tables", {})
+    plan_dags_table = state_tables.get("plan_dags_table", "_plan_dags")
     if state_sync.schema:
         plan_dags_table = f"{schema}.{plan_dags_table}"
 

--- a/sqlmesh/migrations/v0037_remove_dbt_is_incremental_macro.py
+++ b/sqlmesh/migrations/v0037_remove_dbt_is_incremental_macro.py
@@ -13,7 +13,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0038_add_expiration_ts_to_snapshot.py
+++ b/sqlmesh/migrations/v0038_add_expiration_ts_to_snapshot.py
@@ -14,7 +14,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0039_include_environment_in_plan_dag_spec.py
+++ b/sqlmesh/migrations/v0039_include_environment_in_plan_dag_spec.py
@@ -13,7 +13,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    plan_dags_table = "_plan_dags"
+    state_tables = getattr(state_sync, "state_tables", {})
+    plan_dags_table = state_tables.get("plan_dags_table", "_plan_dags")
     if state_sync.schema:
         plan_dags_table = f"{schema}.{plan_dags_table}"
 

--- a/sqlmesh/migrations/v0040_add_previous_finalized_snapshots.py
+++ b/sqlmesh/migrations/v0040_add_previous_finalized_snapshots.py
@@ -7,7 +7,8 @@ from sqlmesh.utils.migration import blob_text_type
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    environments_table = "_environments"
+    state_tables = getattr(state_sync, "state_tables", {})
+    environments_table = state_tables.get("environments_table", "_environments")
     if state_sync.schema:
         environments_table = f"{state_sync.schema}.{environments_table}"
 

--- a/sqlmesh/migrations/v0041_remove_hash_raw_query_attribute.py
+++ b/sqlmesh/migrations/v0041_remove_hash_raw_query_attribute.py
@@ -13,7 +13,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0042_trim_indirect_versions.py
+++ b/sqlmesh/migrations/v0042_trim_indirect_versions.py
@@ -13,7 +13,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0043_fix_remove_obsolete_attributes_in_plan_dags.py
+++ b/sqlmesh/migrations/v0043_fix_remove_obsolete_attributes_in_plan_dags.py
@@ -13,7 +13,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    plan_dags_table = "_plan_dags"
+    state_tables = getattr(state_sync, "state_tables", {})
+    plan_dags_table = state_tables.get("plan_dags_table", "_plan_dags")
     if schema:
         plan_dags_table = f"{schema}.{plan_dags_table}"
 

--- a/sqlmesh/migrations/v0045_move_gateway_variable.py
+++ b/sqlmesh/migrations/v0045_move_gateway_variable.py
@@ -14,7 +14,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0048_drop_indirect_versions.py
+++ b/sqlmesh/migrations/v0048_drop_indirect_versions.py
@@ -13,7 +13,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0049_replace_identifier_with_version_in_seeds_table.py
+++ b/sqlmesh/migrations/v0049_replace_identifier_with_version_in_seeds_table.py
@@ -8,8 +8,9 @@ from sqlmesh.utils.migration import index_text_type
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
 
-    snapshots_table = "_snapshots"
-    seeds_table = "_seeds"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
+    seeds_table = state_tables.get("seeds_table", "_seeds")
     new_seeds_table = f"{seeds_table}_v49"
 
     if state_sync.schema:

--- a/sqlmesh/migrations/v0050_drop_seeds_table.py
+++ b/sqlmesh/migrations/v0050_drop_seeds_table.py
@@ -4,7 +4,8 @@
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
 
-    seeds_table = "_seeds"
+    state_tables = getattr(state_sync, "state_tables", {})
+    seeds_table = state_tables.get("seeds_table", "_seeds")
     if state_sync.schema:
         seeds_table = f"{state_sync.schema}.{seeds_table}"
 

--- a/sqlmesh/migrations/v0051_rename_column_descriptions.py
+++ b/sqlmesh/migrations/v0051_rename_column_descriptions.py
@@ -13,7 +13,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0052_add_normalize_name_in_environment_naming_info.py
+++ b/sqlmesh/migrations/v0052_add_normalize_name_in_environment_naming_info.py
@@ -5,7 +5,8 @@ from sqlglot import exp
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    environments_table = "_environments"
+    state_tables = getattr(state_sync, "state_tables", {})
+    environments_table = state_tables.get("environments_table", "_environments")
     if state_sync.schema:
         environments_table = f"{state_sync.schema}.{environments_table}"
 

--- a/sqlmesh/migrations/v0055_add_updated_ts_unpaused_ts_ttl_ms_unrestorable_to_snapshot.py
+++ b/sqlmesh/migrations/v0055_add_updated_ts_unpaused_ts_ttl_ms_unrestorable_to_snapshot.py
@@ -14,7 +14,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0056_restore_table_indexes.py
+++ b/sqlmesh/migrations/v0056_restore_table_indexes.py
@@ -12,9 +12,10 @@ def migrate(state_sync, **kwargs):  # type: ignore
     if not engine_adapter.SUPPORTS_INDEXES:
         return
 
-    intervals_table = "_intervals"
-    snapshots_table = "_snapshots"
-    environments_table = "_environments"
+    state_tables = getattr(state_sync, "state_tables", {})
+    intervals_table = state_tables.get("intervals_table", "_intervals")
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
+    environments_table = state_tables.get("environments_table", "_environments")
     if state_sync.schema:
         intervals_table = f"{schema}.{intervals_table}"
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0058_add_requirements.py
+++ b/sqlmesh/migrations/v0058_add_requirements.py
@@ -7,7 +7,8 @@ from sqlmesh.utils.migration import blob_text_type
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    environments_table = "_environments"
+    state_tables = getattr(state_sync, "state_tables", {})
+    environments_table = state_tables.get("environments_table", "_environments")
     if state_sync.schema:
         environments_table = f"{state_sync.schema}.{environments_table}"
 

--- a/sqlmesh/migrations/v0060_move_audits_to_model.py
+++ b/sqlmesh/migrations/v0060_move_audits_to_model.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     index_type = index_text_type(engine_adapter.dialect)
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0061_mysql_fix_blob_text_type.py
+++ b/sqlmesh/migrations/v0061_mysql_fix_blob_text_type.py
@@ -15,9 +15,10 @@ def migrate(state_sync, **kwargs):  # type: ignore
         return
 
     schema = state_sync.schema
-    environments_table = "_environments"
-    snapshots_table = "_snapshots"
-    plan_dags_table = "_plan_dags"
+    state_tables = getattr(state_sync, "state_tables", {})
+    environments_table = state_tables.get("environments_table", "_environments")
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
+    plan_dags_table = state_tables.get("plan_dags_table", "_plan_dags")
 
     if schema:
         environments_table = f"{schema}.{environments_table}"

--- a/sqlmesh/migrations/v0063_change_signals.py
+++ b/sqlmesh/migrations/v0063_change_signals.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     index_type = index_text_type(engine_adapter.dialect)
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0064_join_when_matched_strings.py
+++ b/sqlmesh/migrations/v0064_join_when_matched_strings.py
@@ -12,7 +12,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     index_type = index_text_type(engine_adapter.dialect)
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0066_add_auto_restatements.py
+++ b/sqlmesh/migrations/v0066_add_auto_restatements.py
@@ -8,8 +8,9 @@ from sqlmesh.utils.migration import index_text_type
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    auto_restatements_table = "_auto_restatements"
-    intervals_table = "_intervals"
+    state_tables = getattr(state_sync, "state_tables", {})
+    auto_restatements_table = state_tables.get("auto_restatements_table", "_auto_restatements")
+    intervals_table = state_tables.get("intervals_table", "_intervals")
 
     if schema:
         auto_restatements_table = f"{schema}.{auto_restatements_table}"

--- a/sqlmesh/migrations/v0069_update_dev_table_suffix.py
+++ b/sqlmesh/migrations/v0069_update_dev_table_suffix.py
@@ -12,8 +12,9 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
-    environments_table = "_environments"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
+    environments_table = state_tables.get("environments_table", "_environments")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
         environments_table = f"{schema}.{environments_table}"

--- a/sqlmesh/migrations/v0071_add_dev_version_to_intervals.py
+++ b/sqlmesh/migrations/v0071_add_dev_version_to_intervals.py
@@ -11,8 +11,9 @@ from sqlmesh.utils.migration import index_text_type, blob_text_type
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    intervals_table = "_intervals"
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    intervals_table = state_tables.get("intervals_table", "_intervals")
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         intervals_table = f"{schema}.{intervals_table}"
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0072_add_environment_statements.py
+++ b/sqlmesh/migrations/v0072_add_environment_statements.py
@@ -8,7 +8,8 @@ from sqlmesh.utils.migration import blob_text_type, index_text_type
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    environment_statements_table = "_environment_statements"
+    state_tables = getattr(state_sync, "state_tables", {})
+    environment_statements_table = state_tables.get("environment_statements_table", "_environment_statements")
 
     if schema:
         environment_statements_table = f"{schema}.{environment_statements_table}"

--- a/sqlmesh/migrations/v0072_add_environment_statements.py
+++ b/sqlmesh/migrations/v0072_add_environment_statements.py
@@ -9,7 +9,9 @@ def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     state_tables = getattr(state_sync, "state_tables", {})
-    environment_statements_table = state_tables.get("environment_statements_table", "_environment_statements")
+    environment_statements_table = state_tables.get(
+        "environment_statements_table", "_environment_statements"
+    )
 
     if schema:
         environment_statements_table = f"{schema}.{environment_statements_table}"

--- a/sqlmesh/migrations/v0073_remove_symbolic_disable_restatement.py
+++ b/sqlmesh/migrations/v0073_remove_symbolic_disable_restatement.py
@@ -11,7 +11,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0075_remove_validate_query.py
+++ b/sqlmesh/migrations/v0075_remove_validate_query.py
@@ -13,7 +13,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     index_type = index_text_type(engine_adapter.dialect)
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0078_warn_if_non_migratable_python_env.py
+++ b/sqlmesh/migrations/v0078_warn_if_non_migratable_python_env.py
@@ -27,7 +27,8 @@ from sqlmesh.core.console import get_console
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 

--- a/sqlmesh/migrations/v0079_add_gateway_managed_property.py
+++ b/sqlmesh/migrations/v0079_add_gateway_managed_property.py
@@ -5,7 +5,8 @@ from sqlglot import exp
 
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
-    environments_table = "_environments"
+    state_tables = getattr(state_sync, "state_tables", {})
+    environments_table = state_tables.get("environments_table", "_environments")
     if state_sync.schema:
         environments_table = f"{state_sync.schema}.{environments_table}"
 

--- a/sqlmesh/migrations/v0081_update_partitioned_by.py
+++ b/sqlmesh/migrations/v0081_update_partitioned_by.py
@@ -13,7 +13,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     index_type = index_text_type(engine_adapter.dialect)
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0082_warn_if_incorrectly_duplicated_statements.py
+++ b/sqlmesh/migrations/v0082_warn_if_incorrectly_duplicated_statements.py
@@ -37,7 +37,8 @@ from sqlmesh.core.console import get_console
 def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
-    snapshots_table = "_snapshots"
+    state_tables = getattr(state_sync, "state_tables", {})
+    snapshots_table = state_tables.get("snapshots_table", "_snapshots")
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
 


### PR DESCRIPTION
For this: https://github.com/TobikoData/sqlmesh/issues/4902

This PR adds support for customizing the names of following tables in `config.yaml`:
- snapshots_table
- intervals_table
- environment_table
- environment_statement_table
- auto_restatements_table
- seeds_table
- plan_dags_table