### PR TITLE
Fix!: Always recreate materialized view

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -1876,6 +1876,9 @@ class ViewStrategy(PromotableStrategy):
         )
         snapshot = kwargs["snapshot"]
         snapshots = kwargs["snapshots"]
+
+        # We must replace a materialized view if its query has changed or if it depends on a table.
+        # The latter is because if the underlying table is replaced, the materialized view is invalidated in some of the engines.
         if (
             (
                 isinstance(query_or_df, exp.Expression)
@@ -1887,6 +1890,7 @@ class ViewStrategy(PromotableStrategy):
                     engine_adapter=self.adapter,
                 )
                 == query_or_df
+                and not model.depends_on
             )
             or self.adapter.HAS_VIEW_BINDING
         ) and self.adapter.table_exists(table_name):

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -516,25 +516,8 @@ def test_evaluate_materialized_view(
         snapshots={},
     )
 
-    adapter_mock.table_exists.assert_called_once_with(snapshot.table_name())
-
-    if view_exists:
-        # Evaluation shouldn't take place because the rendered query hasn't changed
-        # since the last view creation.
-        assert not adapter_mock.create_view.called
-    else:
-        # If the view doesn't exist, it should be created even if the rendered query
-        # hasn't changed since the last view creation.
-        adapter_mock.create_view.assert_called_once_with(
-            snapshot.table_name(),
-            model.render_query(),
-            model.columns_to_types,
-            replace=True,
-            materialized=True,
-            view_properties={},
-            table_description=None,
-            column_descriptions={},
-        )
+    # Ensure that the materialized view is recreated even if it exists
+    assert adapter_mock.create_view.assert_called
 
 
 def test_evaluate_materialized_view_with_partitioned_by_cluster_by(


### PR DESCRIPTION
Materialized views in engines like BigQuery and Snowflake are invalidated if the underlying table(s) are replaced. Toy repro scenario:

```SQL
1. CREATE TABLE tbl AS (SELECT 1 AS col);

2. CREATE MATERIALIZED VIEW mview AS (SELECT * FROM tbl);

3. CREATE OR REPLACE TABLE tbl AS (SELECT 2 AS col);

4. SELECT * FROM mview;
```

<br />

This flow can be mirrored in the following toy SQLMesh project:

```SQL
# Full model
MODEL (name example_schema.t1, kind FULL); SELECT 1 AS col;

# Materialized view
MODEL (
  name example_schema.t2,
  kind VIEW (
    materialized true
  )
);

SELECT * FROM example_schema.t1;

```

<br />

Running the very first plan will yield the following error in either engine, e.g:
```
google.api_core.exceptions.BadRequest: 400 Materialized view <t2> references table <t1> which was deleted and recreated. The view must be deleted and recreated as well
```

<br />


This is because, during the plan:
1. The physical table for `t1` is created as a dry run
2. The materalized view for `t2` is created as a dry run
3. The physical table for `t1` is recreated/replaced as part of the `FULL` insertion strategy
4. The materialized view exists, and based on the pre-existing `ViewStrategy` it is not recreated


This PR alters (4) such that any materialized view with upstream dependencies is recreated from scratch in order to restore correctness.