### PR TITLE
fix: don't include type when using ducklake

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -232,7 +232,7 @@ class DuckDBAttachOptions(BaseConfig):
         options = []
         # 'duckdb' is actually not a supported type, but we'd like to allow it for
         # fully qualified attach options or integration testing, similar to duckdb-dbt
-        if self.type not in ("duckdb", "motherduck"):
+        if self.type not in ("duckdb", "ducklake", "motherduck"):
             options.append(f"TYPE {self.type.upper()}")
         if self.read_only:
             options.append("READ_ONLY")


### PR DESCRIPTION
Prior to this PR, would get the following error (confirmed in two different environments):
```
duckdb.duckdb.NotImplementedException: Not implemented Error: Failed to initialize DuckLake:PRIMARY KEY/UNIQUE constraints are not supported in DuckLake
```

Confirmed that if I remove this type then the error goes away and Ducklake works as expected. I don't see anywhere in Ducklake docs that it says to include TYPE when using ducklake. Tested using Ducklake with DuckDB and Postgres.