### PR TITLE
Fix(cicd_bot): Don't truncate backfill model list

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -3107,7 +3107,9 @@ class MarkdownConsole(CaptureTerminalConsole):
     AUDIT_PADDING = 7
 
     def __init__(self, **kwargs: t.Any) -> None:
-        super().__init__(**{**kwargs, "console": RichConsole(no_color=True)})
+        super().__init__(
+            **{**kwargs, "console": RichConsole(no_color=True, width=kwargs.pop("width", None))}
+        )
 
     def show_environment_difference_summary(
         self,

--- a/sqlmesh/integrations/github/cicd/command.py
+++ b/sqlmesh/integrations/github/cicd/command.py
@@ -28,7 +28,9 @@ logger = logging.getLogger(__name__)
 @click.pass_context
 def github(ctx: click.Context, token: str) -> None:
     """Github Action CI/CD Bot. See https://sqlmesh.readthedocs.io/en/stable/integrations/github/ for details"""
-    set_console(MarkdownConsole())
+    # set a larger width because if none is specified, it auto-detects 80 characters when running in GitHub Actions
+    # which can result in surprise newlines when outputting dates to backfill
+    set_console(MarkdownConsole(width=1000))
     ctx.obj["github"] = GithubController(
         paths=ctx.obj["paths"],
         token=token,

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -486,7 +486,7 @@ class GithubController:
 
     def get_plan_summary(self, plan: Plan) -> str:
         # use Verbosity.VERY_VERBOSE to prevent the list of models from being truncated
-        # this is particularly importanmt for the "Models needing backfill" list because
+        # this is particularly important for the "Models needing backfill" list because
         # there is no easy way to tell this otherwise
         orig_verbosity = self._console.verbosity
         self._console.verbosity = Verbosity.VERY_VERBOSE

--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -485,6 +485,12 @@ class GithubController:
                 print(f"{key}={value}", file=fh)
 
     def get_plan_summary(self, plan: Plan) -> str:
+        # use Verbosity.VERY_VERBOSE to prevent the list of models from being truncated
+        # this is particularly importanmt for the "Models needing backfill" list because
+        # there is no easy way to tell this otherwise
+        orig_verbosity = self._console.verbosity
+        self._console.verbosity = Verbosity.VERY_VERBOSE
+
         try:
             # Clear out any output that might exist from prior steps
             self._console.clear_captured_outputs()
@@ -517,7 +523,10 @@ class GithubController:
 
             return f"{difference_summary}\n{missing_dates}{plan_flags_section}"
         except PlanError as e:
+            logger.exception("Plan failed to generate")
             return f"Plan failed to generate. Check for pending or unresolved changes. Error: {e}"
+        finally:
+            self._console.verbosity = orig_verbosity
 
     def run_tests(self) -> t.Tuple[ModelTextTestResult, str]:
         """

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -298,7 +298,7 @@ def test_merge_pr_has_non_breaking_change(
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
 
     expected_prod_plan_directly_modified_summary = """**Directly Modified:**
-* `sushi.waiter_revenue_by_day` (Non-breaking)
+* `memory.sushi.waiter_revenue_by_day` (Non-breaking)
   
   ```diff
   --- 
@@ -318,10 +318,10 @@ def test_merge_pr_has_non_breaking_change(
      ON o.id = oi.order_id AND o.event_date = oi.event_date
   ```
   Indirectly Modified Children:
-    - `sushi.top_waiters` (Indirect Non-breaking)
+    - `memory.sushi.top_waiters` (Indirect Non-breaking)
 """
     expected_prod_plan_indirectly_modified_summary = """**Indirectly Modified:**
-- `sushi.top_waiters` (Indirect Non-breaking)
+- `memory.sushi.top_waiters` (Indirect Non-breaking)
 """
 
     assert prod_plan_preview_checks_runs[2]["output"]["title"] == "Prod Plan Preview"
@@ -509,7 +509,7 @@ def test_merge_pr_has_non_breaking_change_diff_start(
     assert prod_plan_preview_checks_runs[2]["output"]["title"] == "Prod Plan Preview"
 
     expected_prod_plan_directly_modified_summary = """**Directly Modified:**
-* `sushi.waiter_revenue_by_day` (Non-breaking)
+* `memory.sushi.waiter_revenue_by_day` (Non-breaking)
   
   ```diff
   --- 
@@ -529,10 +529,10 @@ def test_merge_pr_has_non_breaking_change_diff_start(
      ON o.id = oi.order_id AND o.event_date = oi.event_date
   ```
   Indirectly Modified Children:
-    - `sushi.top_waiters` (Indirect Non-breaking)
+    - `memory.sushi.top_waiters` (Indirect Non-breaking)
 """
     expected_prod_plan_indirectly_modified_summary = """**Indirectly Modified:**
-- `sushi.top_waiters` (Indirect Non-breaking)
+- `memory.sushi.top_waiters` (Indirect Non-breaking)
 """
 
     prod_plan_preview_summary = prod_plan_preview_checks_runs[2]["output"]["summary"]
@@ -1032,7 +1032,7 @@ def test_no_merge_since_no_deploy_signal(
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
 
     expected_prod_plan_directly_modified_summary = """**Directly Modified:**
-* `sushi.waiter_revenue_by_day` (Non-breaking)
+* `memory.sushi.waiter_revenue_by_day` (Non-breaking)
   
   ```diff
   --- 
@@ -1052,10 +1052,10 @@ def test_no_merge_since_no_deploy_signal(
      ON o.id = oi.order_id AND o.event_date = oi.event_date
   ```
   Indirectly Modified Children:
-    - `sushi.top_waiters` (Indirect Non-breaking)"""
+    - `memory.sushi.top_waiters` (Indirect Non-breaking)"""
 
     expected_prod_plan_indirectly_modified_summary = """**Indirectly Modified:**
-- `sushi.top_waiters` (Indirect Non-breaking)
+- `memory.sushi.top_waiters` (Indirect Non-breaking)
 """
 
     assert prod_plan_preview_checks_runs[2]["output"]["title"] == "Prod Plan Preview"
@@ -1232,7 +1232,7 @@ def test_no_merge_since_no_deploy_signal_no_approvers_defined(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
     expected_prod_plan_directly_modified_summary = """**Directly Modified:**
-* `sushi.waiter_revenue_by_day` (Non-breaking)
+* `memory.sushi.waiter_revenue_by_day` (Non-breaking)
   
   ```diff
   --- 
@@ -1252,10 +1252,10 @@ def test_no_merge_since_no_deploy_signal_no_approvers_defined(
      ON o.id = oi.order_id AND o.event_date = oi.event_date
   ```
   Indirectly Modified Children:
-    - `sushi.top_waiters` (Indirect Non-breaking)
+    - `memory.sushi.top_waiters` (Indirect Non-breaking)
 """
     expected_prod_plan_indirectly_modified_summary = """**Indirectly Modified:**
-- `sushi.top_waiters` (Indirect Non-breaking)
+- `memory.sushi.top_waiters` (Indirect Non-breaking)
 """
     assert prod_plan_preview_checks_runs[2]["output"]["title"] == "Prod Plan Preview"
     prod_plan_preview_summary = prod_plan_preview_checks_runs[2]["output"]["summary"]
@@ -1414,7 +1414,7 @@ def test_deploy_comment_pre_categorized(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
     expected_prod_plan_directly_modified_summary = """**Directly Modified:**
-* `sushi.waiter_revenue_by_day` (Non-breaking)
+* `memory.sushi.waiter_revenue_by_day` (Non-breaking)
   
   ```diff
   --- 
@@ -1434,10 +1434,10 @@ def test_deploy_comment_pre_categorized(
      ON o.id = oi.order_id AND o.event_date = oi.event_date
   ```
   Indirectly Modified Children:
-    - `sushi.top_waiters` (Indirect Non-breaking)
+    - `memory.sushi.top_waiters` (Indirect Non-breaking)
 """
     expected_prod_plan_indirectly_modified_summary = """**Indirectly Modified:**
-- `sushi.top_waiters` (Indirect Non-breaking)
+- `memory.sushi.top_waiters` (Indirect Non-breaking)
 """
     assert prod_plan_preview_checks_runs[2]["output"]["title"] == "Prod Plan Preview"
     prod_plan_preview_summary = prod_plan_preview_checks_runs[2]["output"]["summary"]
@@ -1781,7 +1781,7 @@ def test_overlapping_changes_models(
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
 
     expected_prod_plan_directly_modified_summary = """**Directly Modified:**
-* `sushi.customers` (Non-breaking)
+* `memory.sushi.customers` (Non-breaking)
   
   ```diff
   --- 
@@ -1801,23 +1801,23 @@ def test_overlapping_changes_models(
      WITH current_marketing AS (
   ```
   Indirectly Modified Children:
-    - `sushi.active_customers` (Indirect Non-breaking)
-    - `sushi.count_customers_active` (Indirect Non-breaking)
-    - `sushi.count_customers_inactive` (Indirect Non-breaking)
-    - `sushi.waiter_as_customer_by_day` (Indirect Breaking)
+    - `memory.sushi.active_customers` (Indirect Non-breaking)
+    - `memory.sushi.count_customers_active` (Indirect Non-breaking)
+    - `memory.sushi.count_customers_inactive` (Indirect Non-breaking)
+    - `memory.sushi.waiter_as_customer_by_day` (Indirect Breaking)
 
 
-* `sushi.waiter_names` (Breaking)
+* `memory.sushi.waiter_names` (Breaking)
 
 
   Indirectly Modified Children:
-    - `sushi.waiter_as_customer_by_day` (Indirect Breaking)"""
+    - `memory.sushi.waiter_as_customer_by_day` (Indirect Breaking)"""
 
     expected_prod_plan_indirectly_modified_summary = """**Indirectly Modified:**
-- `sushi.active_customers` (Indirect Non-breaking)
-- `sushi.count_customers_active` (Indirect Non-breaking)
-- `sushi.count_customers_inactive` (Indirect Non-breaking)
-- `sushi.waiter_as_customer_by_day` (Indirect Breaking)"""
+- `memory.sushi.active_customers` (Indirect Non-breaking)
+- `memory.sushi.count_customers_active` (Indirect Non-breaking)
+- `memory.sushi.count_customers_inactive` (Indirect Non-breaking)
+- `memory.sushi.waiter_as_customer_by_day` (Indirect Breaking)"""
 
     assert prod_plan_preview_checks_runs[2]["output"]["title"] == "Prod Plan Preview"
     prod_plan_preview_summary = prod_plan_preview_checks_runs[2]["output"]["summary"]
@@ -1993,7 +1993,7 @@ def test_pr_add_model(
     )
 
     expected_prod_plan_summary = """**Added Models:**
-- `sushi.cicd_test_model` (Breaking)"""
+- `memory.sushi.cicd_test_model` (Breaking)"""
 
     assert "SQLMesh - Prod Plan Preview" in controller._check_run_mapping
     prod_plan_preview_checks_runs = controller._check_run_mapping[
@@ -2144,7 +2144,7 @@ def test_pr_delete_model(
     )
 
     expected_prod_plan_summary = """**Removed Models:**
-- `sushi.top_waiters` (Breaking)"""
+- `memory.sushi.top_waiters` (Breaking)"""
 
     assert "SQLMesh - Prod Plan Preview" in controller._check_run_mapping
     prod_plan_preview_checks_runs = controller._check_run_mapping[
@@ -2330,7 +2330,7 @@ def test_has_required_approval_but_not_base_branch(
     assert GithubCheckStatus(prod_plan_preview_checks_runs[2]["status"]).is_completed
     assert GithubCheckConclusion(prod_plan_preview_checks_runs[2]["conclusion"]).is_success
     expected_prod_plan_directly_modified_summary = """**Directly Modified:**
-* `sushi.waiter_revenue_by_day` (Non-breaking)
+* `memory.sushi.waiter_revenue_by_day` (Non-breaking)
   
   ```diff
   --- 
@@ -2350,10 +2350,10 @@ def test_has_required_approval_but_not_base_branch(
      ON o.id = oi.order_id AND o.event_date = oi.event_date
   ```
   Indirectly Modified Children:
-    - `sushi.top_waiters` (Indirect Non-breaking)"""
+    - `memory.sushi.top_waiters` (Indirect Non-breaking)"""
 
     expected_prod_plan_indirectly_modified_summary = """**Indirectly Modified:**
-- `sushi.top_waiters` (Indirect Non-breaking)"""
+- `memory.sushi.top_waiters` (Indirect Non-breaking)"""
 
     assert prod_plan_preview_checks_runs[2]["output"]["title"] == "Prod Plan Preview"
     prod_plan_preview_summary = prod_plan_preview_checks_runs[2]["output"]["summary"]


### PR DESCRIPTION
Related to #4120 

Currently, if there are lots of models to backfill, we "helpfully" truncate the list in the `Prod Plan Preview` step:
![01 - Prod Plan Preview -  Before, truncated](https://github.com/user-attachments/assets/e6898499-2580-494c-8f2d-b4b5b0b3112d)

However, this is undesirable in the CI/CD bot because there is no equivalent of the `-vv` option to set the output verbosity. This means anyone reviewing the bot output has no way of actually knowing the full extent of the models to be backfilled.

This PR updates the CI/CD bot to always show the full list of models affected:
![01 - Prod Plan Preview -  After](https://github.com/user-attachments/assets/3312e0c4-fd9a-42f8-875b-9d6ea820163a)
