### PR TITLE
Fix: Don't remove dev intervals when restating in production environment

### DIFF
--- a/sqlmesh/core/state_sync/db/interval.py
+++ b/sqlmesh/core/state_sync/db/interval.py
@@ -111,12 +111,11 @@ class IntervalState:
             snapshot_ids = ", ".join(str(s.snapshot_id) for s, _ in intervals_to_remove)
             logger.info("Removing interval for snapshots: %s", snapshot_ids)
 
-        for is_dev in (True, False):
-            self.engine_adapter.insert_append(
-                self.intervals_table,
-                _intervals_to_df(intervals_to_remove, is_dev=is_dev, is_removed=True),
-                columns_to_types=self._interval_columns_to_types,
-            )
+        self.engine_adapter.insert_append(
+            self.intervals_table,
+            _intervals_to_df(intervals_to_remove, is_dev=False, is_removed=True),
+            columns_to_types=self._interval_columns_to_types,
+        )
 
     def get_snapshot_intervals(
         self, snapshots: t.Collection[SnapshotNameVersionLike]

--- a/tests/core/state_sync/test_state_sync.py
+++ b/tests/core/state_sync/test_state_sync.py
@@ -326,9 +326,7 @@ def test_remove_interval(state_sync: EngineAdapterStateSync, make_snapshot: t.Ca
     remove_records_count = state_sync.engine_adapter.fetchone(
         "SELECT COUNT(*) FROM sqlmesh._intervals WHERE name = '\"a\"' AND version = 'a' AND is_removed"
     )[0]  # type: ignore
-    assert (
-        remove_records_count == num_of_removals * 4
-    )  # (1 dev record + 1 prod record) * 2 snapshots
+    assert remove_records_count == num_of_removals * 2  # 2 * snapshots
 
     snapshots = state_sync.get_snapshots([snapshot_a, snapshot_b])
 
@@ -1634,7 +1632,7 @@ def test_delete_expired_snapshots_cleanup_intervals_shared_dev_version(
         (to_timestamp("2023-01-01"), to_timestamp("2023-01-04")),
     ]
     assert stored_new_snapshot.dev_intervals == [
-        (to_timestamp("2023-01-04"), to_timestamp("2023-01-10")),
+        (to_timestamp("2023-01-04"), to_timestamp("2023-01-11")),
     ]
 
     # Check old snapshot's intervals
@@ -1643,7 +1641,7 @@ def test_delete_expired_snapshots_cleanup_intervals_shared_dev_version(
         (to_timestamp("2023-01-01"), to_timestamp("2023-01-04")),
     ]
     assert stored_snapshot.dev_intervals == [
-        (to_timestamp("2023-01-04"), to_timestamp("2023-01-10")),
+        (to_timestamp("2023-01-04"), to_timestamp("2023-01-11")),
     ]
 
     # Check all intervals
@@ -1665,7 +1663,7 @@ def test_delete_expired_snapshots_cleanup_intervals_shared_dev_version(
                 identifier=new_snapshot.identifier,
                 version=snapshot.version,
                 dev_version=new_snapshot.dev_version,
-                dev_intervals=[(to_timestamp("2023-01-08"), to_timestamp("2023-01-10"))],
+                dev_intervals=[(to_timestamp("2023-01-08"), to_timestamp("2023-01-11"))],
             ),
         ],
         key=compare_snapshot_intervals,
@@ -1681,7 +1679,7 @@ def test_delete_expired_snapshots_cleanup_intervals_shared_dev_version(
         (to_timestamp("2023-01-01"), to_timestamp("2023-01-04")),
     ]
     assert stored_new_snapshot.dev_intervals == [
-        (to_timestamp("2023-01-04"), to_timestamp("2023-01-10")),
+        (to_timestamp("2023-01-04"), to_timestamp("2023-01-11")),
     ]
 
     # Check all intervals
@@ -1709,7 +1707,7 @@ def test_delete_expired_snapshots_cleanup_intervals_shared_dev_version(
                 identifier=new_snapshot.identifier,
                 version=snapshot.version,
                 dev_version=new_snapshot.dev_version,
-                dev_intervals=[(to_timestamp("2023-01-08"), to_timestamp("2023-01-10"))],
+                dev_intervals=[(to_timestamp("2023-01-08"), to_timestamp("2023-01-11"))],
             ),
         ],
         key=compare_snapshot_intervals,


### PR DESCRIPTION
There’s no point in removing dev intervals, since that data won’t be reused in prod anyway. At the same time, removing them can be very disruptive to users' development flows when something is being restated in prod.