### PR TITLE
Chore: Don't support string arguments for the 'config_for_node' API

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -279,6 +279,8 @@ def render(
     **format_kwargs: t.Any,
 ) -> None:
     """Render a model's query, optionally expanding referenced models."""
+    model = ctx.obj.get_model(model, raise_if_missing=True)
+
     rendered = ctx.obj.render(
         model,
         start=start,

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -946,11 +946,8 @@ class GenericContext(BaseContext, t.Generic[C]):
                 pass
         return self.config, self.path
 
-    def config_for_node(self, node: str | Model | Audit) -> Config:
-        if isinstance(node, str):
-            path = self.get_snapshot(node, raise_if_missing=True).node._path
-        else:
-            path = node._path
+    def config_for_node(self, node: Model | Audit) -> Config:
+        path = node._path
         if path is None:
             return self.config
         return self.config_for_path(path)[0]  # type: ignore

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -641,6 +641,8 @@ class SQLMeshMagics(Magics):
         model = render_opts.pop("model")
         dialect = render_opts.pop("dialect", None)
 
+        model = context.get_model(model, raise_if_missing=True)
+
         query = context.render(
             model,
             start=render_opts.pop("start", None),


### PR DESCRIPTION
The `get_snapshot` call is quite expensive, which can lead to poor outcomes when this method is called with a string argument in a loop. However, it appears that no caller actually passes a string argument, so making this change should be safe.