### PR TITLE
Fix: do not display signal progress if a project has no signals

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -912,6 +912,7 @@ class TerminalConsole(Console):
         self.table_diff_model_tasks: t.Dict[str, TaskID] = {}
         self.table_diff_progress_live: t.Optional[Live] = None
 
+        self.signal_progress_logged = False
         self.signal_status_tree: t.Optional[Tree] = None
 
         self.verbosity = verbosity
@@ -956,7 +957,8 @@ class TerminalConsole(Console):
     ) -> None:
         """Indicates that a new snapshot evaluation/auditing progress has begun."""
         # Add a newline to separate signal checking from evaluation
-        self._print("")
+        if self.signal_progress_logged:
+            self._print("")
 
         if not self.evaluation_progress_live:
             self.evaluation_total_progress = make_progress_bar(
@@ -1188,6 +1190,7 @@ class TerminalConsole(Console):
         if self.signal_status_tree is not None:
             self._print(self.signal_status_tree)
             self.signal_status_tree = None
+            self.signal_progress_logged = True
 
     def start_creation_progress(
         self,

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -754,7 +754,7 @@ class Scheduler:
         """
         signals = snapshot.is_model and snapshot.model.render_signal_calls()
 
-        if not signals:
+        if not (signals and signals.signals_to_kwargs):
             return intervals
 
         self.console.start_signal_progress(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2175,3 +2175,18 @@ WHERE ds::DATE BETWEEN @start_ds AND @end_ds
 
     # Only one model was executed
     assert "100.0% • 1/1 • 0:00:00" in result.output
+
+    rmtree(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+
+    create_example_project(tmp_path)
+
+    # Example project models have start dates, so there are no date prompts
+    # for the `prod` environment.
+    # Input: `y` to apply and backfill
+    result = runner.invoke(
+        cli, ["--log-file-dir", str(tmp_path), "--paths", str(tmp_path), "plan"], input="y\n"
+    )
+    assert_plan_success(result)
+
+    assert "Checking signals" not in result.output


### PR DESCRIPTION
This [commit](https://github.com/TobikoData/sqlmesh/commit/6db990da222a62830d5d11855a8ba058c665f488) introduced `EvaluatableSignals`, so this [check](https://github.com/TobikoData/sqlmesh/blob/537a31187a56eda1faae8e033b2440f75ca79805/sqlmesh/core/scheduler.py#L757-L758) no longer guards from logging signal-related progress, when there are no signals. See [before](https://github.com/user-attachments/assets/b749176c-c52d-4bdf-979d-6692bbbfe725) vs [after](https://github.com/user-attachments/assets/16f2c19e-5680-47d3-aded-8fd55d1f75e0).