### PR TITLE
fix: add `'ducklake` prefix if not present

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -238,7 +238,10 @@ class DuckDBAttachOptions(BaseConfig):
             options.append("READ_ONLY")
 
         # DuckLake specific options
+        path = self.path
         if self.type == "ducklake":
+            if not path.startswith("ducklake:"):
+                path = f"ducklake:{path}"
             if self.data_path is not None:
                 options.append(f"DATA_PATH '{self.data_path}'")
             if self.encrypted:
@@ -254,7 +257,7 @@ class DuckDBAttachOptions(BaseConfig):
         alias_sql = (
             f" AS {alias}" if not (self.type == "motherduck" or self.path.startswith("md:")) else ""
         )
-        return f"ATTACH IF NOT EXISTS '{self.path}'{alias_sql}{options_sql}"
+        return f"ATTACH IF NOT EXISTS '{path}'{alias_sql}{options_sql}"
 
 
 class BaseDuckDBConnectionConfig(ConnectionConfig):


### PR DESCRIPTION
Follow up to https://github.com/TobikoData/sqlmesh/pull/4913

Documentation consistently shows including `'ducklake` in the path: https://ducklake.select/docs/stable/duckdb/usage/choosing_a_catalog_database

It seems like if you exclude it from the path but included the type then it would also work. If you include both though you would get an error. Therefore since the last PR excluded it from TYPE we had some users not include it in the path and had an error.

This PR ensures the `'ducklake` prefix is always there if the type of "ducklake" is provided. 