### PR TITLE
Fix(table_diff): Properly handle null check for array types in data sample

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -2711,8 +2711,16 @@ def _cells_match(x: t.Any, y: t.Any) -> bool:
     def _normalize(val: t.Any) -> t.Any:
         # Convert Pandas null to Python null for the purposes of comparison to prevent errors like the following on boolean fields:
         # - TypeError: boolean value of NA is ambiguous
-        if pd.isnull(val):
+        # note pd.isnull() returns either a bool or a ndarray[bool] depending on if the input
+        # is scalar or an array
+        isnull = pd.isnull(val)
+
+        if isinstance(isnull, bool):  # scalar
+            if isnull:
+                val = None
+        elif all(isnull):  # array
             val = None
+
         return list(val) if isinstance(val, (pd.Series, np.ndarray)) else val
 
     return _normalize(x) == _normalize(y)


### PR DESCRIPTION
Prior to this, showing the row_diff sample on a table where Pandas had coerced a value to an `ndarray` would return the following error:

```
[ValueError: The truth value of an array with more than one element is ambiguous.
```

The cause is that the current code assumed `pd.isnull()` would always return a `bool`, when actually it returns an `array[bool]` if it gets passed an array.

This PR updates the code to handle arrays and say "arrays are considered null (python None) if all their items are null"