### PR TITLE
Fix!: Add project in environment statements for consistent multi-repo plans

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -622,6 +622,15 @@ class GenericContext(BaseContext, t.Generic[C]):
                 BUILTIN_RULES.union(project.user_rules), config.linter
             )
 
+        # Load environment statements from state for projects not in current load
+        if any(self._projects):
+            prod = self.state_reader.get_environment(c.PROD)
+            if prod:
+                existing_statements = self.state_reader.get_environment_statements(c.PROD)
+                for stmt in existing_statements:
+                    if stmt.project and stmt.project not in self._projects:
+                        self._environment_statements.append(stmt)
+
         uncached = set()
 
         if any(self._projects):

--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -311,7 +311,9 @@ class ContextDiff(PydanticModel):
 
     @property
     def has_environment_statements_changes(self) -> bool:
-        return self.environment_statements != self.previous_environment_statements
+        return sorted(self.environment_statements, key=lambda s: s.project or "") != sorted(
+            self.previous_environment_statements, key=lambda s: s.project or ""
+        )
 
     @property
     def has_snapshot_changes(self) -> bool:

--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -266,6 +266,7 @@ class EnvironmentStatements(PydanticModel):
     after_all: t.List[str]
     python_env: t.Dict[str, Executable]
     jinja_macros: t.Optional[JinjaMacroRegistry] = None
+    project: t.Optional[str] = None
 
     def render_before_all(
         self,

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -815,7 +815,11 @@ class SqlMeshLoader(Loader):
                 path=self.config_path,
             )
 
-            return [EnvironmentStatements(**statements, python_env=python_env)]
+            return [
+                EnvironmentStatements(
+                    **statements, python_env=python_env, project=self.config.project or None
+                )
+            ]
         return []
 
     def _load_linting_rules(self) -> RuleSet:

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -277,6 +277,7 @@ class DbtLoader(Loader):
                         ],
                         python_env={},
                         jinja_macros=jinja_registry,
+                        project=package_name,
                     )
                     project_names.add(package_name)
 


### PR DESCRIPTION
This update adds the `project` information if it's available in a multi-repo setup in the environment statements so that plans triggered from one repo retain the other repos statements from state (mirroring the logic we have for models of a multi repo setup), fixes: #4952 