### PR TITLE
Fix: Preserve actual dataframe indices in unit test output

### DIFF
--- a/sqlmesh/utils/rich.py
+++ b/sqlmesh/utils/rich.py
@@ -95,7 +95,7 @@ def df_to_table(
 
         rich_table.add_column(Align.center(column_name))
 
-    for index, value_list in enumerate(df.values.tolist()):
+    for index, value_list in zip(df.index, df.values.tolist()):
         row = [str(index)] if show_index else []
         row += [str(x) for x in value_list]
         center = [Align.center(x) for x in row]


### PR DESCRIPTION
This fixes a bug where unit test output displayed row numbers starting from 0 instead of the actual DataFrame index, making it harder to trace the source of test mismatches. To preserve them moved away from the use of enumerate in `df_to_table` which ignored the original index to zip with df.index. The updated tests show the expected behaviour.