### PR TITLE
Feat: correctly handle the generation of VALUES expressions using macros

### DIFF
--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -575,6 +575,26 @@ def test_ast_correctness(macro_evaluator):
             "SELECT 3",
             {},
         ),
+        (
+            "SELECT * FROM (VALUES @EACH([1, 2, 3], v -> (v)) ) AS v",
+            "SELECT * FROM (VALUES (1), (2), (3)) AS v",
+            {},
+        ),
+        (
+            "SELECT * FROM (VALUES (@EACH([1, 2, 3], v -> (v))) ) AS v",
+            "SELECT * FROM (VALUES ((1), (2), (3))) AS v",
+            {},
+        ),
+        (
+            "SELECT * FROM (VALUES @EACH([1, 2, 3], v -> (v, @EVAL(@v + 1))) ) AS v",
+            "SELECT * FROM (VALUES (1, 2), (2, 3), (3, 4)) AS v",
+            {},
+        ),
+        (
+            "SELECT * FROM (VALUES (@EACH([1, 2, 3], v -> (v, @EVAL(@v + 1)))) ) AS v",
+            "SELECT * FROM (VALUES ((1, 2), (2, 3), (3, 4))) AS v",
+            {},
+        ),
     ],
 )
 def test_macro_functions(macro_evaluator: MacroEvaluator, assert_exp_eq, sql, expected, args):


### PR DESCRIPTION
This PR aims to address a feature gap. This is the behavior in main today:

```python
>>> from sqlglot import parse_one
>>> from sqlmesh.core.macros import MacroEvaluator
>>>
>>> MacroEvaluator().transform(parse_one("SELECT * FROM (VALUES @EACH([1, 2, 3], v -> (v)) ) as v")).sql()
'SELECT * FROM (VALUES ((1), (2), (3))) AS v'
>>> MacroEvaluator().transform(parse_one("SELECT * FROM (VALUES (@EACH([1, 2, 3], v -> (v))) ) as v")).sql()
'SELECT * FROM (VALUES ((1), (2), (3))) AS v'
```

Notice how both inputs result in the same output, which produces a single row with three columns. There is no obvious way to produce three _columns_, using `@EACH`, due to how the `VALUES` parsing works today.
