### PR TITLE
Feat!: cancel submitted BigQuery jobs on keyboard interrupts

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -192,6 +192,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
             if not self._db_call(query_job.done):
                 self._db_call(query_job.cancel)
 
+        self._query_jobs.clear()
         return super().close()
 
     def _begin_session(self, properties: SessionProperties) -> None:

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -1102,6 +1102,9 @@ def test_job_cancellation_on_keyboard_interrupt_job_still_running(mocker: Mocker
     with pytest.raises(KeyboardInterrupt):
         adapter.execute("SELECT 1")
 
+    # Ensure the adapter's closed, so that the job can be aborted
+    adapter.close()
+
     # Verify the job was created
     connection_mock._client.query.assert_called_once()
 
@@ -1137,6 +1140,9 @@ def test_job_cancellation_on_keyboard_interrupt_job_already_done(mocker: MockerF
     # Execute a query and expect KeyboardInterrupt
     with pytest.raises(KeyboardInterrupt):
         adapter.execute("SELECT 1")
+
+    # Ensure the adapter's closed, so that the job can be aborted
+    adapter.close()
 
     # Verify the job was created
     connection_mock._client.query.assert_called_once()


### PR DESCRIPTION
This PR aims to address the following problem: suppose a plan is submitted, resulting in a BigQuery job submission to evaluate a model, followed by a keyboard interrupt issued by the user (e.g., CTRL-C / SIGINT is sent from the terminal).

Today we don't cancel the job, meaning that long-running jobs will be left orphaned to run in BigQuery, despite the plan being cancelled. This may result in needless computation (i.e., cost), and so in this PR we ~intercept the keyboard interrupt~ keep track of pending jobs and send a cancellation request upon closing the adapter, unless the jobs are already completed by that point.