### PR TITLE
Feat: Add signal listener and methods in scheduler

### DIFF
--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -60,13 +60,6 @@ def _expression_encoder(e: exp.Expression) -> str:
     return e.meta.get("sql") or e.sql(dialect=e.meta.get("dialect"))
 
 
-def serialize_expressions(kwargs: t.Dict[str, t.Optional[exp.Expression]]) -> t.Dict[str, str]:
-    serialized_kwargs: t.Dict[str, str] = {}
-    for key, value in kwargs.items():
-        serialized_kwargs[key] = _expression_encoder(value) if value else str(value)
-    return serialized_kwargs
-
-
 AuditQueryTypes = t.Union[exp.Query, d.JinjaQuery]
 ModelQueryTypes = t.Union[exp.Query, d.JinjaQuery, d.MacroFunc]
 

--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -60,6 +60,16 @@ def _expression_encoder(e: exp.Expression) -> str:
     return e.meta.get("sql") or e.sql(dialect=e.meta.get("dialect"))
 
 
+def serialize_expressions(kwargs: t.Dict[str, t.Optional[exp.Expression]]) -> t.Dict[str, str]:
+    serialized_kwargs: t.Dict[str, str] = {}
+    for key, value in kwargs.items():
+        if isinstance(value, exp.Expression):
+            serialized_kwargs[key] = _expression_encoder(value)
+        else:
+            serialized_kwargs[key] = str(value)
+    return serialized_kwargs
+
+
 AuditQueryTypes = t.Union[exp.Query, d.JinjaQuery]
 ModelQueryTypes = t.Union[exp.Query, d.JinjaQuery, d.MacroFunc]
 

--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -63,10 +63,7 @@ def _expression_encoder(e: exp.Expression) -> str:
 def serialize_expressions(kwargs: t.Dict[str, t.Optional[exp.Expression]]) -> t.Dict[str, str]:
     serialized_kwargs: t.Dict[str, str] = {}
     for key, value in kwargs.items():
-        if isinstance(value, exp.Expression):
-            serialized_kwargs[key] = _expression_encoder(value)
-        else:
-            serialized_kwargs[key] = str(value)
+        serialized_kwargs[key] = _expression_encoder(value) if value else str(value)
     return serialized_kwargs
 
 


### PR DESCRIPTION
This adds the provisionally called `SignalListener` class with methods which are called when signals are registered (`on_signal_register`), when a signal starts (`on_signal_start`) and when it finishes with success or failure (`on_signal_end`).