### PR TITLE
fix!: correctly identify keys to make deterministic

### DIFF
--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -153,14 +153,16 @@ def _add_variables_to_python_env(
 
     variables = {k: v for k, v in (variables or {}).items() if k in used_variables}
     if variables:
-        python_env[c.SQLMESH_VARS] = Executable.value(variables)
+        python_env[c.SQLMESH_VARS] = Executable.value(variables, use_deterministic_repr=True)
 
     if blueprint_variables:
         blueprint_variables = {
             k: SqlValue(sql=v.sql(dialect=dialect)) if isinstance(v, exp.Expression) else v
             for k, v in blueprint_variables.items()
         }
-        python_env[c.SQLMESH_BLUEPRINT_VARS] = Executable.value(blueprint_variables)
+        python_env[c.SQLMESH_BLUEPRINT_VARS] = Executable.value(
+            blueprint_variables, use_deterministic_repr=True
+        )
 
     return python_env
 

--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -153,7 +153,7 @@ def _add_variables_to_python_env(
 
     variables = {k: v for k, v in (variables or {}).items() if k in used_variables}
     if variables:
-        python_env[c.SQLMESH_VARS] = Executable.value(variables, use_deterministic_repr=True)
+        python_env[c.SQLMESH_VARS] = Executable.value(variables, sort_root_dict=True)
 
     if blueprint_variables:
         blueprint_variables = {
@@ -161,7 +161,7 @@ def _add_variables_to_python_env(
             for k, v in blueprint_variables.items()
         }
         python_env[c.SQLMESH_BLUEPRINT_VARS] = Executable.value(
-            blueprint_variables, use_deterministic_repr=True
+            blueprint_variables, sort_root_dict=True
         )
 
     return python_env

--- a/sqlmesh/migrations/v0085_deterministic_repr.py
+++ b/sqlmesh/migrations/v0085_deterministic_repr.py
@@ -12,6 +12,9 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
+KEYS_TO_MAKE_DETERMINISTIC = ["__sqlmesh__vars__", "__sqlmesh__blueprint__vars__"]
+
+
 # Make sure `SqlValue` is defined so it can be used by `eval` call in the migration
 @dataclass
 class SqlValue:
@@ -82,6 +85,8 @@ def migrate(state_sync, **kwargs):  # type: ignore
 
         if python_env:
             for key, executable in python_env.items():
+                if key not in KEYS_TO_MAKE_DETERMINISTIC:
+                    continue
                 if isinstance(executable, dict) and executable.get("kind") == "value":
                     old_payload = executable["payload"]
                     try:

--- a/sqlmesh/migrations/v0086_check_deterministic_bug.py
+++ b/sqlmesh/migrations/v0086_check_deterministic_bug.py
@@ -1,0 +1,110 @@
+import json
+import typing as t
+from sqlglot import exp
+
+from sqlmesh.core.console import get_console
+
+
+KEYS_TO_MAKE_DETERMINISTIC = ["__sqlmesh__vars__", "__sqlmesh__blueprint__vars__"]
+
+
+def would_sorting_be_applied(obj: t.Any) -> bool:
+    """
+    Detects if sorting would be applied to an object based on the
+    deterministic_repr logic.
+
+    Returns True if the object is a dictionary or contains a dictionary
+    at any nesting level (in lists or tuples).
+
+    Args:
+        obj: The object to check
+
+    Returns:
+        bool: True if sorting would be applied, False otherwise
+    """
+
+    def _check_for_dict(o: t.Any) -> bool:
+        if isinstance(o, dict):
+            return True
+        if isinstance(o, (list, tuple)):
+            return any(_check_for_dict(item) for item in o)
+
+        return False
+
+    try:
+        return _check_for_dict(obj)
+    except Exception:
+        # If any error occurs during checking, assume no sorting
+        return False
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    versions_table = "_versions"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+        versions_table = f"{schema}.{versions_table}"
+
+    result = engine_adapter.fetchone(
+        exp.select("schema_version").from_(versions_table), quote_identifiers=True
+    )
+    if not result:
+        # This must be the first migration, so we can skip the check since the project was not exposed to 85 migration bug
+        return
+    schema_version = result[0]
+    if schema_version < 85:
+        # The project was not exposed to the bugged 85 migration, so we can skip it.
+        return
+
+    warning = (
+        "SQLMesh detected that it may not be able to fully migrate the state database. This should not impact "
+        "the migration process, but may result in unexpected changes being reported by the next `sqlmesh plan` "
+        "command. Please run `sqlmesh diff prod` after the migration has completed, before making any new "
+        "changes. If any unexpected changes are reported, consider running a forward-only plan to apply these "
+        "changes and avoid unnecessary backfills: sqlmesh plan prod --forward-only. "
+        "See https://sqlmesh.readthedocs.io/en/stable/concepts/plans/#forward-only-plans for more details.\n"
+    )
+
+    for (
+        name,
+        identifier,
+        version,
+        snapshot,
+        kind_name,
+        updated_ts,
+        unpaused_ts,
+        ttl_ms,
+        unrestorable,
+    ) in engine_adapter.fetchall(
+        exp.select(
+            "name",
+            "identifier",
+            "version",
+            "snapshot",
+            "kind_name",
+            "updated_ts",
+            "unpaused_ts",
+            "ttl_ms",
+            "unrestorable",
+        ).from_(snapshots_table),
+        quote_identifiers=True,
+    ):
+        parsed_snapshot = json.loads(snapshot)
+        python_env = parsed_snapshot["node"].get("python_env")
+
+        if python_env:
+            for key, executable in python_env.items():
+                if (
+                    key not in KEYS_TO_MAKE_DETERMINISTIC
+                    and isinstance(executable, dict)
+                    and executable.get("kind") == "value"
+                ):
+                    try:
+                        parsed_value = eval(executable["payload"])
+                        if would_sorting_be_applied(parsed_value):
+                            get_console().log_warning(warning)
+                            return
+                    except Exception:
+                        pass

--- a/sqlmesh/utils/metaprogramming.py
+++ b/sqlmesh/utils/metaprogramming.py
@@ -424,10 +424,11 @@ class Executable(PydanticModel):
         return self.kind == ExecutableKind.VALUE
 
     @classmethod
-    def value(cls, v: t.Any, is_metadata: t.Optional[bool] = None) -> Executable:
-        return Executable(
-            payload=_deterministic_repr(v), kind=ExecutableKind.VALUE, is_metadata=is_metadata
-        )
+    def value(
+        cls, v: t.Any, is_metadata: t.Optional[bool] = None, use_deterministic_repr: bool = False
+    ) -> Executable:
+        payload = _deterministic_repr(v) if use_deterministic_repr else repr(v)
+        return Executable(payload=payload, kind=ExecutableKind.VALUE, is_metadata=is_metadata)
 
 
 def serialize_env(env: t.Dict[str, t.Any], path: Path) -> t.Dict[str, Executable]:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -6116,7 +6116,8 @@ def test_named_variable_macros() -> None:
     )
 
     assert model.python_env[c.SQLMESH_VARS] == Executable.value(
-        {c.GATEWAY: "in_memory", "test_var_a": "test_value", "overridden_var": "initial_value"}
+        {c.GATEWAY: "in_memory", "test_var_a": "test_value", "overridden_var": "initial_value"},
+        use_deterministic_repr=True,
     )
     assert (
         model.render_query_or_raise().sql()
@@ -6142,7 +6143,8 @@ def test_variables_in_templates() -> None:
     )
 
     assert model.python_env[c.SQLMESH_VARS] == Executable.value(
-        {c.GATEWAY: "in_memory", "test_var_a": "test_value", "overridden_var": "initial_value"}
+        {c.GATEWAY: "in_memory", "test_var_a": "test_value", "overridden_var": "initial_value"},
+        use_deterministic_repr=True,
     )
     assert (
         model.render_query_or_raise().sql()
@@ -6166,7 +6168,8 @@ def test_variables_in_templates() -> None:
     )
 
     assert model.python_env[c.SQLMESH_VARS] == Executable.value(
-        {c.GATEWAY: "in_memory", "test_var_a": "test_value", "overridden_var": "initial_value"}
+        {c.GATEWAY: "in_memory", "test_var_a": "test_value", "overridden_var": "initial_value"},
+        use_deterministic_repr=True,
     )
     assert (
         model.render_query_or_raise().sql()
@@ -6305,7 +6308,8 @@ def test_variables_migrated_dbt_package_macro():
         dialect="bigquery",
     )
     assert model.python_env[c.SQLMESH_VARS] == Executable.value(
-        {"test_var_a": "test_var_a_value", "__dbt_packages__.test.test_var_b": "test_var_b_value"}
+        {"test_var_a": "test_var_a_value", "__dbt_packages__.test.test_var_b": "test_var_b_value"},
+        use_deterministic_repr=True,
     )
     assert (
         model.render_query().sql(dialect="bigquery")
@@ -6530,7 +6534,8 @@ def test_unrendered_macros_sql_model(mocker: MockerFixture) -> None:
             "physical_var": "bla",
             "virtual_var": "blb",
             "session_var": "blc",
-        }
+        },
+        use_deterministic_repr=True,
     )
 
     assert "location1" in model.physical_properties
@@ -6617,7 +6622,8 @@ def test_unrendered_macros_python_model(mocker: MockerFixture) -> None:
             "physical_var": "bla",
             "virtual_var": "blb",
             "session_var": "blc",
-        }
+        },
+        use_deterministic_repr=True,
     )
     assert python_sql_model.enabled
 
@@ -10576,9 +10582,12 @@ def test_resolve_interpolated_variables_when_parsing_python_deps():
     )
 
     assert m.python_env.get(c.SQLMESH_VARS) == Executable.value(
-        {"selector": "bla", "bla_variable": 1, "baz_variable": 2}
+        {"selector": "bla", "bla_variable": 1, "baz_variable": 2},
+        use_deterministic_repr=True,
     )
-    assert m.python_env.get(c.SQLMESH_BLUEPRINT_VARS) == Executable.value({"selector": "baz"})
+    assert m.python_env.get(c.SQLMESH_BLUEPRINT_VARS) == Executable.value(
+        {"selector": "baz"}, use_deterministic_repr=True
+    )
 
 
 def test_extract_schema_in_post_statement(tmp_path: Path) -> None:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -6117,7 +6117,7 @@ def test_named_variable_macros() -> None:
 
     assert model.python_env[c.SQLMESH_VARS] == Executable.value(
         {c.GATEWAY: "in_memory", "test_var_a": "test_value", "overridden_var": "initial_value"},
-        use_deterministic_repr=True,
+        sort_root_dict=True,
     )
     assert (
         model.render_query_or_raise().sql()
@@ -6144,7 +6144,7 @@ def test_variables_in_templates() -> None:
 
     assert model.python_env[c.SQLMESH_VARS] == Executable.value(
         {c.GATEWAY: "in_memory", "test_var_a": "test_value", "overridden_var": "initial_value"},
-        use_deterministic_repr=True,
+        sort_root_dict=True,
     )
     assert (
         model.render_query_or_raise().sql()
@@ -6169,7 +6169,7 @@ def test_variables_in_templates() -> None:
 
     assert model.python_env[c.SQLMESH_VARS] == Executable.value(
         {c.GATEWAY: "in_memory", "test_var_a": "test_value", "overridden_var": "initial_value"},
-        use_deterministic_repr=True,
+        sort_root_dict=True,
     )
     assert (
         model.render_query_or_raise().sql()
@@ -6309,7 +6309,7 @@ def test_variables_migrated_dbt_package_macro():
     )
     assert model.python_env[c.SQLMESH_VARS] == Executable.value(
         {"test_var_a": "test_var_a_value", "__dbt_packages__.test.test_var_b": "test_var_b_value"},
-        use_deterministic_repr=True,
+        sort_root_dict=True,
     )
     assert (
         model.render_query().sql(dialect="bigquery")
@@ -6535,7 +6535,7 @@ def test_unrendered_macros_sql_model(mocker: MockerFixture) -> None:
             "virtual_var": "blb",
             "session_var": "blc",
         },
-        use_deterministic_repr=True,
+        sort_root_dict=True,
     )
 
     assert "location1" in model.physical_properties
@@ -6623,7 +6623,7 @@ def test_unrendered_macros_python_model(mocker: MockerFixture) -> None:
             "virtual_var": "blb",
             "session_var": "blc",
         },
-        use_deterministic_repr=True,
+        sort_root_dict=True,
     )
     assert python_sql_model.enabled
 
@@ -10583,10 +10583,10 @@ def test_resolve_interpolated_variables_when_parsing_python_deps():
 
     assert m.python_env.get(c.SQLMESH_VARS) == Executable.value(
         {"selector": "bla", "bla_variable": 1, "baz_variable": 2},
-        use_deterministic_repr=True,
+        sort_root_dict=True,
     )
     assert m.python_env.get(c.SQLMESH_BLUEPRINT_VARS) == Executable.value(
-        {"selector": "baz"}, use_deterministic_repr=True
+        {"selector": "baz"}, sort_root_dict=True
     )
 
 

--- a/tests/utils/test_metaprogramming.py
+++ b/tests/utils/test_metaprogramming.py
@@ -563,8 +563,8 @@ def test_deterministic_repr_executable_integration():
     variables1 = {"env": "dev", "debug": True, "timeout": 30}
     variables2 = {"timeout": 30, "debug": True, "env": "dev"}
 
-    exec1 = Executable.value(variables1)
-    exec2 = Executable.value(variables2)
+    exec1 = Executable.value(variables1, use_deterministic_repr=True)
+    exec2 = Executable.value(variables2, use_deterministic_repr=True)
 
     # Should produce identical payloads despite different input ordering
     assert exec1.payload == exec2.payload
@@ -573,6 +573,10 @@ def test_deterministic_repr_executable_integration():
     # Should be valid Python
     reconstructed = eval(exec1.payload)
     assert reconstructed == variables1
+
+    # non-deterministic repr should not change the payload
+    exec3 = Executable.value(variables1)
+    assert exec3.payload == "{'env': 'dev', 'debug': True, 'timeout': 30}"
 
 
 def test_deterministic_repr_complex_example():

--- a/tests/utils/test_metaprogramming.py
+++ b/tests/utils/test_metaprogramming.py
@@ -22,7 +22,7 @@ from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.metaprogramming import (
     Executable,
     ExecutableKind,
-    _deterministic_repr,
+    _dict_sort,
     build_env,
     func_globals,
     normalize_source,
@@ -460,39 +460,39 @@ def test_serialize_env_with_enum_import_appearing_in_two_functions() -> None:
     assert serialized_env == expected_env
 
 
-def test_deterministic_repr_basic_types():
-    """Test _deterministic_repr with basic Python types."""
+def test_dict_sort_basic_types():
+    """Test dict_sort with basic Python types."""
     # Test basic types that should use standard repr
-    assert _deterministic_repr(42) == "42"
-    assert _deterministic_repr("hello") == "'hello'"
-    assert _deterministic_repr(True) == "True"
-    assert _deterministic_repr(None) == "None"
-    assert _deterministic_repr(3.14) == "3.14"
+    assert _dict_sort(42) == "42"
+    assert _dict_sort("hello") == "'hello'"
+    assert _dict_sort(True) == "True"
+    assert _dict_sort(None) == "None"
+    assert _dict_sort(3.14) == "3.14"
 
 
-def test_deterministic_repr_dict_ordering():
-    """Test that _deterministic_repr produces consistent output for dicts with different key ordering."""
+def test_dict_sort_dict_ordering():
+    """Test that dict_sort produces consistent output for dicts with different key ordering."""
     # Same dict with different key ordering
     dict1 = {"c": 3, "a": 1, "b": 2}
     dict2 = {"a": 1, "b": 2, "c": 3}
     dict3 = {"b": 2, "c": 3, "a": 1}
 
-    repr1 = _deterministic_repr(dict1)
-    repr2 = _deterministic_repr(dict2)
-    repr3 = _deterministic_repr(dict3)
+    repr1 = _dict_sort(dict1)
+    repr2 = _dict_sort(dict2)
+    repr3 = _dict_sort(dict3)
 
     # All should produce the same representation
     assert repr1 == repr2 == repr3
     assert repr1 == "{'a': 1, 'b': 2, 'c': 3}"
 
 
-def test_deterministic_repr_mixed_key_types():
-    """Test _deterministic_repr with mixed key types (strings and numbers)."""
+def test_dict_sort_mixed_key_types():
+    """Test dict_sort with mixed key types (strings and numbers)."""
     dict1 = {42: "number", "string": "text", 1: "one"}
     dict2 = {"string": "text", 1: "one", 42: "number"}
 
-    repr1 = _deterministic_repr(dict1)
-    repr2 = _deterministic_repr(dict2)
+    repr1 = _dict_sort(dict1)
+    repr2 = _dict_sort(dict2)
 
     # Should produce consistent ordering despite mixed key types
     assert repr1 == repr2
@@ -500,45 +500,47 @@ def test_deterministic_repr_mixed_key_types():
     assert repr1 == "{1: 'one', 42: 'number', 'string': 'text'}"
 
 
-def test_deterministic_repr_nested_structures():
-    """Test _deterministic_repr with deeply nested dictionaries."""
+def test_dict_sort_nested_structures():
+    """Test dict_sort with deeply nested dictionaries."""
     nested1 = {"outer": {"z": 26, "a": 1}, "list": [3, {"y": 2, "x": 1}], "simple": "value"}
 
     nested2 = {"simple": "value", "list": [3, {"x": 1, "y": 2}], "outer": {"a": 1, "z": 26}}
 
-    repr1 = _deterministic_repr(nested1)
-    repr2 = _deterministic_repr(nested2)
+    repr1 = _dict_sort(nested1)
+    repr2 = _dict_sort(nested2)
 
-    assert repr1 == repr2
+    assert repr1 != repr2
     # Verify structure is maintained with sorted keys
-    expected = "{'list': [3, {'x': 1, 'y': 2}], 'outer': {'a': 1, 'z': 26}, 'simple': 'value'}"
-    assert repr1 == expected
+    expected1 = "{'list': [3, {'y': 2, 'x': 1}], 'outer': {'z': 26, 'a': 1}, 'simple': 'value'}"
+    expected2 = "{'list': [3, {'x': 1, 'y': 2}], 'outer': {'a': 1, 'z': 26}, 'simple': 'value'}"
+    assert repr1 == expected1
+    assert repr2 == expected2
 
 
-def test_deterministic_repr_lists_and_tuples():
-    """Test _deterministic_repr preserves order for lists/tuples but sorts nested dicts."""
-    # Lists should maintain their order
-    list_with_dicts = [{"b": 2, "a": 1}, {"d": 4, "c": 3}]
-    list_repr = _deterministic_repr(list_with_dicts)
-    expected_list = "[{'a': 1, 'b': 2}, {'c': 3, 'd': 4}]"
+def test_dict_sort_lists_and_tuples():
+    """Test dict_sort preserves order for lists/tuples and doesn't sort nested dicts."""
+    # Lists should be unchanged
+    list_with_dicts = [{"z": 26, "a": 1}, {"y": 25, "b": 2}]
+    list_repr = _dict_sort(list_with_dicts)
+    expected_list = "[{'z': 26, 'a': 1}, {'y': 25, 'b': 2}]"
     assert list_repr == expected_list
 
-    # Tuples should maintain their order
+    # Tuples should be unchanged
     tuple_with_dicts = ({"z": 26, "a": 1}, {"y": 25, "b": 2})
-    tuple_repr = _deterministic_repr(tuple_with_dicts)
-    expected_tuple = "({'a': 1, 'z': 26}, {'b': 2, 'y': 25})"
+    tuple_repr = _dict_sort(tuple_with_dicts)
+    expected_tuple = "({'z': 26, 'a': 1}, {'y': 25, 'b': 2})"
     assert tuple_repr == expected_tuple
 
 
-def test_deterministic_repr_empty_containers():
-    """Test _deterministic_repr with empty containers."""
-    assert _deterministic_repr({}) == "{}"
-    assert _deterministic_repr([]) == "[]"
-    assert _deterministic_repr(()) == "()"
+def test_dict_sort_empty_containers():
+    """Test dict_sort with empty containers."""
+    assert _dict_sort({}) == "{}"
+    assert _dict_sort([]) == "[]"
+    assert _dict_sort(()) == "()"
 
 
-def test_deterministic_repr_special_characters():
-    """Test _deterministic_repr handles special characters correctly."""
+def test_dict_sort_special_characters():
+    """Test dict_sort handles special characters correctly."""
     special_dict = {
         "quotes": "text with 'single' and \"double\" quotes",
         "unicode": "unicode: ñáéíóú",
@@ -546,25 +548,25 @@ def test_deterministic_repr_special_characters():
         "backslashes": "path\\to\\file",
     }
 
-    result = _deterministic_repr(special_dict)
+    result = _dict_sort(special_dict)
 
     # Should be valid Python that can be evaluated
     reconstructed = eval(result)
     assert reconstructed == special_dict
 
     # Should be deterministic - same input produces same output
-    result2 = _deterministic_repr(special_dict)
+    result2 = _dict_sort(special_dict)
     assert result == result2
 
 
-def test_deterministic_repr_executable_integration():
-    """Test that _deterministic_repr works correctly with Executable.value()."""
+def test_dict_sort_executable_integration():
+    """Test that dict_sort works correctly with Executable.value()."""
     # Test the integration with Executable.value which is the main use case
     variables1 = {"env": "dev", "debug": True, "timeout": 30}
     variables2 = {"timeout": 30, "debug": True, "env": "dev"}
 
-    exec1 = Executable.value(variables1, use_deterministic_repr=True)
-    exec2 = Executable.value(variables2, use_deterministic_repr=True)
+    exec1 = Executable.value(variables1, sort_root_dict=True)
+    exec2 = Executable.value(variables2, sort_root_dict=True)
 
     # Should produce identical payloads despite different input ordering
     assert exec1.payload == exec2.payload
@@ -577,47 +579,3 @@ def test_deterministic_repr_executable_integration():
     # non-deterministic repr should not change the payload
     exec3 = Executable.value(variables1)
     assert exec3.payload == "{'env': 'dev', 'debug': True, 'timeout': 30}"
-
-
-def test_deterministic_repr_complex_example():
-    """Test _deterministic_repr with a complex real-world-like structure."""
-    complex_vars = {
-        "database_config": {
-            "host": "localhost",
-            "port": 5432,
-            "credentials": {"username": "admin", "password": "secret"},
-        },
-        "feature_flags": ["flag_b", "flag_a"],
-        "metadata": {
-            "version": "1.0.0",
-            "environment": "production",
-            "tags": {"team": "data", "project": "analytics"},
-        },
-        42: "numeric_key",
-        "arrays": [{"config": {"nested": True, "level": 2}}, {"simple": "value"}],
-    }
-
-    expected_structure = {
-        42: "numeric_key",
-        "arrays": [{"config": {"level": 2, "nested": True}}, {"simple": "value"}],
-        "database_config": {
-            "credentials": {"password": "secret", "username": "admin"},
-            "host": "localhost",
-            "port": 5432,
-        },
-        "feature_flags": ["flag_b", "flag_a"],
-        "metadata": {
-            "environment": "production",
-            "tags": {"project": "analytics", "team": "data"},
-            "version": "1.0.0",
-        },
-    }
-
-    actual_repr = _deterministic_repr(complex_vars)
-    expected_repr = repr(expected_structure)
-    assert actual_repr == expected_repr
-
-    # Should be valid Python
-    reconstructed = eval(actual_repr)
-    assert isinstance(reconstructed, dict)
-    assert reconstructed == complex_vars


### PR DESCRIPTION
Fixing a mistake in this PR: https://github.com/TobikoData/sqlmesh/pull/4925

The issue is that the user could have defined a variable in the global namespace and this PR would sort the dictionary which would cause an issue for the user if they rely on the dictionary order. Therefore this PR makes the sorting logic focused just on the known dictionaries that we control: sqlmesh vars and sqlmesh blueprint vars. It also changes the sorting to only sort on the root level dict instead of doing a recursive sort. This is because a user could define a dict as a value in variable/blueprint variables and we don't want to change that. 

The previous 85 migration is updated to do the correct thing. 86 migration was added to try to detect if the user may have been impacted by this bug and if so it will log a warning. 