### PR TITLE
Fix: In blueprint vars handle the case sensitive case in lookup

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -314,7 +314,9 @@ class ExecutionContext(BaseContext):
 
     def blueprint_var(self, var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
         """Returns a blueprint variable value."""
-        return self._blueprint_variables.get(var_name.lower(), default)
+        return self._blueprint_variables.get(var_name) or self._blueprint_variables.get(
+            var_name.lower(), default
+        )
 
     def with_variables(
         self,

--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -254,14 +254,20 @@ class MacroEvaluator:
                 changed = True
                 variables = self.variables
 
-                if node.name not in self.locals and node.name.lower() not in variables:
+                if (
+                    node.name not in self.locals
+                    and node.name.lower() not in variables
+                    and node.name not in variables
+                ):
                     if not isinstance(node.parent, StagedFilePath):
                         raise SQLMeshError(f"Macro variable '{node.name}' is undefined.")
 
                     return node
 
                 # Precedence order is locals (e.g. @DEF) > blueprint variables > config variables
-                value = self.locals.get(node.name, variables.get(node.name.lower()))
+                value = self.locals.get(
+                    node.name, variables.get(node.name, variables.get(node.name.lower()))
+                )
                 if isinstance(value, list):
                     return exp.convert(
                         tuple(
@@ -532,7 +538,9 @@ class MacroEvaluator:
 
     def blueprint_var(self, var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
         """Returns the value of the specified blueprint variable, or the default value if it doesn't exist."""
-        return (self.locals.get(c.SQLMESH_BLUEPRINT_VARS) or {}).get(var_name.lower(), default)
+        return (self.locals.get(c.SQLMESH_BLUEPRINT_VARS) or {}).get(var_name) or (
+            self.locals.get(c.SQLMESH_BLUEPRINT_VARS) or {}
+        ).get(var_name.lower(), default)
 
     @property
     def variables(self) -> t.Dict[str, t.Any]:

--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -199,7 +199,9 @@ def parse_dependencies(
 
         @staticmethod
         def blueprint_var(var_name: str, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
-            return (blueprint_variables or {}).get(var_name.lower(), default)
+            return (blueprint_variables or {}).get(var_name) or (blueprint_variables or {}).get(
+                var_name.lower(), default
+            )
 
     env = prepare_env(python_env)
     local_env = dict.fromkeys(("context", "evaluator"), VariableResolutionContext)


### PR DESCRIPTION
Blueprint variables with mixed case (e.g., Customer_Name) were not recognized when referenced in certain places we look up with lower name (as the rest of the variables). This caused a mismatch between the stored variable names (which are stored not lower case) and the lookup logic. This fix updates the blueprint variable lookup to check exact case first then fall back to lowercase instead of storing as lowercase as the less intrusive fix, but let me know @georgesittas what you think