### PR TITLE
chore: prevent bad imports from lsp module elsewhere

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,9 +280,20 @@ select = [
 ]
 extend-select = ["TID"]
 
+
 [tool.ruff.lint.flake8-tidy-imports]
 banned-module-level-imports = [
     "duckdb",
     "numpy",
     "pandas",
 ]
+
+# Bans imports from sqlmesh.lsp in files outside of sqlmesh/lsp
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"sqlmesh.lsp".msg = "Only files within sqlmesh/lsp can import from sqlmesh.lsp"
+
+[tool.ruff.lint.per-file-ignores]
+# TID251 is used to ignore the import of sqlmesh.lsp in files outside sqlmesh/lsp
+"sqlmesh/lsp/**/*.py" = ["TID251"]
+"tests/lsp/**/*.py" = ["TID251"]
+"benchmarks/lsp*.py" = ["TID251"]


### PR DESCRIPTION
- was doing a refactor for a listing rule and ended up importing lsp into other modules which we don't want to happen, this configures the linter to avoid this. 