### PR TITLE
Fix(cicd_bot): Include namespace in deploy command hint

### DIFF
--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -751,9 +751,8 @@ class GithubController:
         vde_title = "- :eyes: To **review** this PR's changes, use virtual data environment:"
         comment_value = f"{vde_title}\n  - `{self.pr_environment_name}`"
         if self.bot_config.enable_deploy_command:
-            comment_value += (
-                "\n- :arrow_forward: To **apply** this PR's plan to prod, comment:\n  - `/deploy`"
-            )
+            full_command = f"{self.bot_config.command_namespace or ''}/deploy"
+            comment_value += f"\n- :arrow_forward: To **apply** this PR's plan to prod, comment:\n  - `{full_command}`"
         dedup_regex = vde_title.replace("*", r"\*") + r".*"
         updated_comment, _ = self.update_sqlmesh_comment_info(
             value=comment_value,


### PR DESCRIPTION
Closes #4998 

This PR adds the command namespace (if it exists) to the `/deploy` command in the comment the bot writes against the PR:

<img width="535" height="263" alt="Screenshot From 2025-07-24 13-25-51" src="https://github.com/user-attachments/assets/fa10fd8c-9f44-49c0-878e-931849193843" />

