### PR TITLE
feat(vscode): startup extension on external models files

### DIFF
--- a/vscode/extension/package.json
+++ b/vscode/extension/package.json
@@ -18,7 +18,8 @@
   ],
   "activationEvents": [
     "onLanguage:sql",
-    "onLanguage:python"
+    "onLanguage:python",
+    "onLanguage:yaml"
   ],
   "extensionKind": [
     "workspace"

--- a/vscode/extension/src/lsp/lsp.ts
+++ b/vscode/extension/src/lsp/lsp.ts
@@ -96,7 +96,17 @@ export class LSPClient implements Disposable {
       },
     }
     const clientOptions: LanguageClientOptions = {
-      documentSelector: [{ scheme: 'file', pattern: `**/*.sql` }],
+      documentSelector: [
+        { scheme: 'file', pattern: `**/*.sql` },
+        {
+          scheme: 'file',
+          pattern: '**/external_models.yaml',
+        },
+        {
+          scheme: 'file',
+          pattern: '**/external_models.yml',
+        },
+      ],
       diagnosticCollectionName: 'sqlmesh',
       outputChannel: outputChannel,
     }

--- a/vscode/extension/tests/external_models.spec.ts
+++ b/vscode/extension/tests/external_models.spec.ts
@@ -53,7 +53,7 @@ test.describe('External model files trigger lsp', () => {
     await createPythonInterpreterSettingsSpecifier(tempDir)
     await openServerPage(page, tempDir, sharedCodeServer)
 
-    //   Wait for the models folder to be visible
+    // Wait for the models folder to be visible
     await page.waitForSelector('text=models')
 
     // Click on the models folder, excluding external_models

--- a/vscode/extension/tests/external_models.spec.ts
+++ b/vscode/extension/tests/external_models.spec.ts
@@ -56,7 +56,7 @@ test.describe('External model files trigger lsp', () => {
     // Wait for the models folder to be visible
     await page.waitForSelector('text=models')
 
-    // Click on the models folder, excluding external_models
+    // Click on the external_models.yml file
     await page
       .getByRole('treeitem', { name: file, exact: true })
       .locator('a')

--- a/vscode/extension/tests/external_models.spec.ts
+++ b/vscode/extension/tests/external_models.spec.ts
@@ -24,7 +24,7 @@ test.describe('External model files trigger lsp', () => {
     // Wait for the models folder to be visible
     await page.waitForSelector('text=models')
 
-    // Click on the models folder, excluding external_models
+    // Click on the external_models file (e.g., external_models.yaml or external_models.yml)
     await page
       .getByRole('treeitem', { name: file, exact: true })
       .locator('a')

--- a/vscode/extension/tests/external_models.spec.ts
+++ b/vscode/extension/tests/external_models.spec.ts
@@ -21,7 +21,7 @@ test.describe('External model files trigger lsp', () => {
     await createPythonInterpreterSettingsSpecifier(tempDir)
     await openServerPage(page, tempDir, sharedCodeServer)
 
-    //   Wait for the models folder to be visible
+    // Wait for the models folder to be visible
     await page.waitForSelector('text=models')
 
     // Click on the models folder, excluding external_models


### PR DESCRIPTION
- before if you were to open vscode and an external models file, the extension would not start automatically