### PR TITLE
Fix: Use merge when updating auto restatements

### DIFF
--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -373,18 +373,23 @@ class SnapshotState:
         Args:
             next_auto_restatement_ts: A dictionary of snapshot name version to the next auto restatement timestamp.
         """
+        next_auto_restatement_ts_deleted = []
+        next_auto_restatement_ts_filtered = {}
+        for k, v in next_auto_restatement_ts.items():
+            if v is None:
+                next_auto_restatement_ts_deleted.append(k)
+            else:
+                next_auto_restatement_ts_filtered[k] = v
+
         for where in snapshot_name_version_filter(
             self.engine_adapter,
-            next_auto_restatement_ts,
+            next_auto_restatement_ts_deleted,
             column_prefix="snapshot",
             alias=None,
             batch_size=self.SNAPSHOT_BATCH_SIZE,
         ):
             self.engine_adapter.delete_from(self.auto_restatements_table, where=where)
 
-        next_auto_restatement_ts_filtered = {
-            k: v for k, v in next_auto_restatement_ts.items() if v is not None
-        }
         if not next_auto_restatement_ts_filtered:
             return
 

--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -388,10 +388,11 @@ class SnapshotState:
         if not next_auto_restatement_ts_filtered:
             return
 
-        self.engine_adapter.insert_append(
+        self.engine_adapter.merge(
             self.auto_restatements_table,
             _auto_restatements_to_df(next_auto_restatement_ts_filtered),
             columns_to_types=self._auto_restatement_columns_to_types,
+            unique_key=(exp.column("snapshot_name"), exp.column("snapshot_version")),
         )
 
     def count(self) -> int:


### PR DESCRIPTION
This PR prevents a race condition that can occur when two runs update auto restatements at the same time. Although the delete + insert happens in a transaction, certain databases and transaction isolation levels can result in duplicate rows being inserted and violate the primary key constraint on the auto restatements table.

For example, the default transaction isolation level for Postgres is READ COMMITTED, and at that level, [if the first updater commits, the second updater will ignore the row if the first updater deleted it](https://www.postgresql.org/docs/17/transaction-iso.html#XACT-READ-COMMITTED). In this case, the second updater will be blocked when deleting auto restatements until the first updater commits, but then will not delete any rows even though the first updater has re-inserted matching snapshot name versions.

To get prevent it, auto restatements are updated with a MERGE.