### PR TITLE
Fix docs table formatting

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -82,6 +82,7 @@ Configuration for the `sqlmesh plan` command.
 | `no_diff`                 | Don't show diffs for changed models (Default: False)                                                                                                                                                                                                    | boolean              | N        |
 | `no_prompts`              | Disables interactive prompts in CLI (Default: True)                                                                                                                                                                                                     | boolean              | N        |
 | `always_recreate_environment`              | Always recreates the target environment from the environment specified in `create_from` (by default `prod`) (Default: False)                                                                                                                                                                                                     | boolean              | N        |
+
 ## Run
 
 Configuration for the `sqlmesh run` command. Please note that this is only applicable when configured with the [builtin](#builtin) scheduler.


### PR DESCRIPTION
## Summary
- add a missing blank line so that the `Run` heading isn't treated as a table row

## Testing
- `make style`
- `make fast-test`

------
https://chatgpt.com/codex/tasks/task_e_688350363e7883309f63d58e77221be9