### PR TITLE
Fix: Prevent snapshots with shared versions in dev environments from expanding restatement intervals for prod snapshots

### DIFF
--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -35,6 +35,7 @@ from sqlmesh.core.snapshot import (
     SnapshotInfoLike,
     SnapshotTableInfo,
     SnapshotCreationFailedError,
+    SnapshotNameVersion,
 )
 from sqlmesh.utils import to_snake_case
 from sqlmesh.core.state_sync import StateSync
@@ -427,6 +428,10 @@ class BuiltInPlanEvaluator(PlanEvaluator):
         if not prod_restatements:
             return set()
 
+        prod_name_versions: t.Set[SnapshotNameVersion] = {
+            s.name_version for s in loaded_snapshots.values()
+        }
+
         snapshots_to_restate: t.Dict[SnapshotId, t.Tuple[SnapshotTableInfo, Interval]] = {}
 
         for env_summary in self.state_sync.get_environments_summary():
@@ -454,6 +459,8 @@ class BuiltInPlanEvaluator(PlanEvaluator):
                     {
                         keyed_snapshots[a].snapshot_id: (keyed_snapshots[a], intervals)
                         for a in affected_snapshot_names
+                        # Don't restate a snapshot if it shares the version with a snapshot in prod
+                        if keyed_snapshots[a].name_version not in prod_name_versions
                     }
                 )
 


### PR DESCRIPTION
Example scenario: 
1. The kind of a model changed from `INCREMENTAL_UNMANAGED` to `INCREMENTAL_BY_TIME_RANGE` while the physical version remained the same
2. The kind changed is deployed to prod. At the same time a snapshot of this model with the old kind is still promoted in one or more dev environments
3. The model snapshot with the new kind is restated in prod
4. Because there's an old snapshot with previous kind deployed to some dev environment, the original restatement interval gets expanded and applied to the shared physical version
5. The user ends up restating full history instead of just the specified interval