### PR TITLE
feat: allow linter to return multiple violations

### DIFF
--- a/sqlmesh/core/linter/definition.py
+++ b/sqlmesh/core/linter/definition.py
@@ -108,9 +108,10 @@ class RuleSet(Mapping[str, type[Rule]]):
 
         for rule in self._underlying.values():
             violation = rule(context).check_model(model)
-
+            if isinstance(violation, RuleViolation):
+                violation = [violation]
             if violation:
-                violations.append(violation)
+                violations.extend(violation)
 
         return violations
 

--- a/sqlmesh/core/linter/rule.py
+++ b/sqlmesh/core/linter/rule.py
@@ -70,7 +70,9 @@ class Rule(abc.ABC, metaclass=_Rule):
         self.context = context
 
     @abc.abstractmethod
-    def check_model(self, model: Model) -> t.Optional[RuleViolation]:
+    def check_model(
+        self, model: Model
+    ) -> t.Optional[t.Union[RuleViolation, t.List[RuleViolation]]]:
         """The evaluation function that'll check for a violation of this rule."""
 
     @property

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1952,7 +1952,7 @@ def test_model_linting(tmp_path: pathlib.Path, sushi_context) -> None:
             ctx.plan(environment="dev", auto_apply=True, no_prompts=True)
 
             assert (
-                """noselectstar: Query should not contain SELECT * on its outer most projections"""
+                """noselectstar - Query should not contain SELECT * on its outer most projections"""
                 in mock_logger.call_args[0][0]
             )
 


### PR DESCRIPTION
- also printed the line numbers

```
❯ sqlmesh lint
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/models/customers.sql:
 - nomissingaudits at line 1: Model `audits` must be configured to test data quality.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/models/marketing.sql:
 - nomissingaudits at line 1: Model `audits` must be configured to test data quality.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/models/active_customers.sql:
 - nomissingaudits at line 1: Model `audits` must be configured to test data quality.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/models/customer_revenue_lifetime.sql:
 - nomissingaudits at line 6: Model `audits` must be configured to test data quality.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/models/blueprint.sql:
 - nomissingowner: All models should have an owner specified.
 - nomissingaudits at line 1: Model `audits` must be configured to test data quality.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/models/blueprint.sql:
 - nomissingowner: All models should have an owner specified.
 - nomissingaudits at line 1: Model `audits` must be configured to test data quality.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/models/customer_revenue_by_day.sql:
 - nomissingaudits at line 2: Model `audits` must be configured to test data quality.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/models/latest_order.sql:
 - nomissingowner: All models should have an owner specified.
 - nomissingaudits at line 1: Model `audits` must be configured to test data quality.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/external_models.yaml:
 - nomissingowner: All models should have an owner specified.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/external_models/model1/model1.yaml:
 - nomissingowner: All models should have an owner specified.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/external_models/model2/model2.yaml:
 - nomissingowner: All models should have an owner specified.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/models/order_items.py:
 - nomissingowner: All models should have an owner specified.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/models/orders.py:
 - nomissingaudits: Model `audits` must be configured to test data quality.
 - nomissingowner: All models should have an owner specified.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/models/raw_marketing.py:
 - nomissingaudits: Model `audits` must be configured to test data quality.
 - nomissingowner: All models should have an owner specified.
Linter errors for /Users/benjaminking/Developer/sqlmesh/examples/sushi/models/items.py:
 - nomissingowner: All models should have an owner specified.
Error: Linter detected errors in the code. Please fix them before proceeding.
```
