### PR TITLE
Feat: add partitioning for ducklake databases

### DIFF
--- a/tests/core/engine_adapter/test_duckdb.py
+++ b/tests/core/engine_adapter/test_duckdb.py
@@ -1,6 +1,5 @@
 import typing as t
 
-import os
 import pandas as pd  # noqa: TID253
 import pytest
 from pytest_mock.plugin import MockerFixture
@@ -110,12 +109,13 @@ def test_drop_catalog(make_mocked_engine_adapter: t.Callable) -> None:
 
 
 def test_ducklake_partitioning(adapter: EngineAdapter, duck_conn, tmp_path):
-    os.chdir(tmp_path)
     catalog = "a_ducklake_db"
 
     duck_conn.install_extension("ducklake")
     duck_conn.load_extension("ducklake")
-    duck_conn.execute(f"ATTACH 'ducklake:{catalog}';")
+    duck_conn.execute(
+        f"ATTACH 'ducklake:{catalog}.ducklake' AS {catalog} (DATA_PATH '{tmp_path}');"
+    )
 
     # no partitions on catalog creation
     partition_info = duck_conn.execute(

--- a/tests/core/engine_adapter/test_duckdb.py
+++ b/tests/core/engine_adapter/test_duckdb.py
@@ -1,10 +1,11 @@
 import typing as t
 
+import os
 import pandas as pd  # noqa: TID253
 import pytest
+from pytest_mock.plugin import MockerFixture
 from sqlglot import expressions as exp
 from sqlglot import parse_one
-
 from sqlmesh.core.engine_adapter import DuckDBEngineAdapter, EngineAdapter
 from tests.core.engine_adapter import to_sql_calls
 
@@ -77,8 +78,11 @@ def test_set_current_catalog(make_mocked_engine_adapter: t.Callable, duck_conn):
     ]
 
 
-def test_temporary_table(make_mocked_engine_adapter: t.Callable, duck_conn):
+def test_temporary_table(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(DuckDBEngineAdapter)
+
+    mocker.patch.object(adapter, "get_current_catalog", return_value="test_catalog")
+    mocker.patch.object(adapter, "fetchone", return_value=("test_catalog",))
 
     adapter.create_table(
         "test_table",
@@ -103,3 +107,32 @@ def test_drop_catalog(make_mocked_engine_adapter: t.Callable) -> None:
     adapter.drop_catalog(exp.to_identifier("foo"))
 
     assert to_sql_calls(adapter) == ['DETACH DATABASE IF EXISTS "foo"']
+
+
+def test_ducklake_partitioning(adapter: EngineAdapter, duck_conn, tmp_path):
+    os.chdir(tmp_path)
+    catalog = "a_ducklake_db"
+
+    duck_conn.install_extension("ducklake")
+    duck_conn.load_extension("ducklake")
+    duck_conn.execute(f"ATTACH 'ducklake:{catalog}';")
+
+    # no partitions on catalog creation
+    partition_info = duck_conn.execute(
+        f"SELECT * FROM __ducklake_metadata_{catalog}.main.ducklake_partition_info"
+    ).fetchdf()
+    assert partition_info.empty
+
+    adapter.set_current_catalog(catalog)
+    adapter.create_schema("test_schema")
+    adapter.create_table(
+        "test_schema.test_table",
+        {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
+        partitioned_by=[exp.to_column("a"), exp.to_column("b")],
+    )
+
+    # 1 partition after table creation
+    partition_info = duck_conn.execute(
+        f"SELECT * FROM __ducklake_metadata_{catalog}.main.ducklake_partition_info"
+    ).fetchdf()
+    assert partition_info.shape[0] == 1


### PR DESCRIPTION
DuckDB does not natively support partitioning, but the ducklake extension does. 

The extension requires partitioning to be set via `ALTER` after table creation.

This PR updates the DuckDB adapter to execute that `ALTER` if the table is in a ducklake catalog. For other catalog types, partitioned_by is ignored.