### PR TITLE
refactor(lsp): references now use paths

### DIFF
--- a/sqlmesh/lsp/main.py
+++ b/sqlmesh/lsp/main.py
@@ -496,10 +496,10 @@ class SQLMeshLanguageServer:
                         target_range = reference.target_range
                         target_selection_range = reference.target_range
 
-                    if reference.uri is not None:
+                    if reference.path is not None:
                         location_links.append(
                             types.LocationLink(
-                                target_uri=reference.uri,
+                                target_uri=URI.from_path(reference.path).value,
                                 target_selection_range=target_selection_range,
                                 target_range=target_range,
                                 origin_selection_range=reference.range,
@@ -523,9 +523,9 @@ class SQLMeshLanguageServer:
 
                 # Convert references to Location objects
                 locations = [
-                    types.Location(uri=ref.uri, range=ref.range)
+                    types.Location(uri=URI.from_path(ref.path).value, range=ref.range)
                     for ref in all_references
-                    if ref.uri is not None
+                    if ref.path is not None
                 ]
 
                 return locations if locations else None

--- a/sqlmesh/lsp/rename.py
+++ b/sqlmesh/lsp/rename.py
@@ -90,7 +90,7 @@ def _rename_cte(cte_references: t.List[LSPCteReference], new_name: str) -> Works
     changes: t.Dict[str, t.List[TextEdit]] = {}
 
     for ref in cte_references:
-        uri = ref.uri
+        uri = URI.from_path(ref.path).value
         if uri not in changes:
             changes[uri] = []
 

--- a/tests/lsp/test_reference.py
+++ b/tests/lsp/test_reference.py
@@ -25,9 +25,9 @@ def test_reference() -> None:
     references = get_model_definitions_for_a_path(lsp_context, active_customers_uri)
 
     assert len(references) == 1
-    uri = references[0].uri
-    assert uri is not None
-    assert URI(uri) == URI.from_path(sushi_customers_path)
+    path = references[0].path
+    assert path is not None
+    assert path == sushi_customers_path
 
     # Check that the reference in the correct range is sushi.customers
     path = active_customers_uri.to_path()
@@ -61,7 +61,7 @@ def test_reference_with_alias() -> None:
     with open(waiter_revenue_by_day_path, "r") as file:
         read_file = file.readlines()
 
-    assert references[0].uri.endswith("orders.py")
+    assert str(references[0].path).endswith("orders.py")
     assert get_string_from_range(read_file, references[0].range) == "sushi.orders"
     assert (
         references[0].markdown_description
@@ -76,9 +76,9 @@ def test_reference_with_alias() -> None:
 | end_ts | INT |  |
 | event_date | DATE |  |"""
     )
-    assert references[1].uri.endswith("order_items.py")
+    assert str(references[1].path).endswith("order_items.py")
     assert get_string_from_range(read_file, references[1].range) == "sushi.order_items"
-    assert references[2].uri.endswith("items.py")
+    assert str(references[2].path).endswith("items.py")
     assert get_string_from_range(read_file, references[2].range) == "sushi.items"
 
 
@@ -102,7 +102,7 @@ def test_standalone_audit_reference() -> None:
     references = get_model_definitions_for_a_path(lsp_context, URI.from_path(audit_path))
 
     assert len(references) == 1
-    assert references[0].uri == URI.from_path(items_path).value
+    assert references[0].path == items_path
 
     # Check that the reference in the correct range is sushi.items
     with open(audit_path, "r") as file:
@@ -161,7 +161,7 @@ def test_filter_references_by_position() -> None:
         position_inside = Position(line=middle_line, character=middle_char)
         filtered = list(filter(by_position(position_inside), all_references))
         assert len(filtered) == 1
-        assert filtered[0].uri == reference.uri
+        assert filtered[0].path == reference.path
         assert filtered[0].range == reference.range
 
         # For testing outside position, use a position before the current reference

--- a/tests/lsp/test_reference_cte.py
+++ b/tests/lsp/test_reference_cte.py
@@ -27,7 +27,7 @@ def test_cte_parsing():
     position = Position(line=ranges[1].start.line, character=ranges[1].start.character + 4)
     references = get_references(lsp_context, URI.from_path(sushi_customers_path), position)
     assert len(references) == 1
-    assert references[0].uri == URI.from_path(sushi_customers_path).value
+    assert references[0].path == sushi_customers_path
     assert isinstance(references[0], LSPCteReference)
     assert (
         references[0].range.start.line == ranges[1].start.line
@@ -42,7 +42,7 @@ def test_cte_parsing():
     position = Position(line=ranges[1].start.line, character=ranges[1].start.character + 4)
     references = get_references(lsp_context, URI.from_path(sushi_customers_path), position)
     assert len(references) == 1
-    assert references[0].uri == URI.from_path(sushi_customers_path).value
+    assert references[0].path == sushi_customers_path
     assert isinstance(references[0], LSPCteReference)
     assert (
         references[0].range.start.line == ranges[1].start.line

--- a/tests/lsp/test_reference_cte_find_all.py
+++ b/tests/lsp/test_reference_cte_find_all.py
@@ -28,7 +28,7 @@ def test_cte_find_all_references():
     references = get_cte_references(lsp_context, URI.from_path(sushi_customers_path), position)
     # Should find the definition, FROM clause, and column prefix usages
     assert len(references) == 4  # definition + FROM + 2 column prefix uses
-    assert all(ref.uri == URI.from_path(sushi_customers_path).value for ref in references)
+    assert all(ref.path == sushi_customers_path for ref in references)
 
     reference_ranges = [ref.range for ref in references]
     for expected_range in ranges:
@@ -46,7 +46,7 @@ def test_cte_find_all_references():
 
     # Should find the same references
     assert len(references) == 4  # definition + FROM + 2 column prefix uses
-    assert all(ref.uri == URI.from_path(sushi_customers_path).value for ref in references)
+    assert all(ref.path == sushi_customers_path for ref in references)
 
     reference_ranges = [ref.range for ref in references]
     for expected_range in ranges:
@@ -82,7 +82,7 @@ def test_cte_find_all_references_outer():
 
     # Should find both the definition and the usage
     assert len(references) == 2
-    assert all(ref.uri == URI.from_path(sushi_customers_path).value for ref in references)
+    assert all(ref.path == sushi_customers_path for ref in references)
 
     # Verify that we found both occurrences
     reference_ranges = [ref.range for ref in references]
@@ -101,7 +101,7 @@ def test_cte_find_all_references_outer():
 
     # Should find the same references
     assert len(references) == 2
-    assert all(ref.uri == URI.from_path(sushi_customers_path).value for ref in references)
+    assert all(ref.path == sushi_customers_path for ref in references)
 
     reference_ranges = [ref.range for ref in references]
     for expected_range in ranges:

--- a/tests/lsp/test_reference_external_model.py
+++ b/tests/lsp/test_reference_external_model.py
@@ -30,20 +30,18 @@ def test_reference() -> None:
     assert len(references) == 1
     reference = references[0]
     assert isinstance(reference, LSPExternalModelReference)
-    uri = reference.uri
-    assert uri is not None
-    assert uri.endswith("external_models.yaml")
+    path = reference.path
+    assert path is not None
+    assert str(path).endswith("external_models.yaml")
 
     source_range = read_range_from_file(customers, to_sqlmesh_range(reference.range))
     assert source_range == "raw.demographics"
 
     if reference.target_range is None:
         raise AssertionError("Reference target range should not be None")
-    uri = reference.uri
-    assert uri is not None
-    target_range = read_range_from_file(
-        URI(uri).to_path(), to_sqlmesh_range(reference.target_range)
-    )
+    path = reference.path
+    assert path is not None
+    target_range = read_range_from_file(path, to_sqlmesh_range(reference.target_range))
     assert target_range == "raw.demographics"
 
 
@@ -60,7 +58,7 @@ def test_unregistered_external_model(tmp_path: Path):
     assert len(references) == 1
     reference = references[0]
     assert isinstance(reference, LSPExternalModelReference)
-    assert reference.uri is None
+    assert reference.path is None
     assert reference.target_range is None
     assert reference.markdown_description == "Unregistered external model"
     assert read_range_from_file(model_path, to_sqlmesh_range(reference.range)) == "external_model"

--- a/tests/lsp/test_reference_macro.py
+++ b/tests/lsp/test_reference_macro.py
@@ -25,5 +25,5 @@ def test_macro_references() -> None:
     # Check that all references point to the utils.py file
     for ref in macro_references:
         assert isinstance(ref, LSPMacroReference)
-        assert ref.uri.endswith("sushi/macros/utils.py")
+        assert URI.from_path(ref.path).value.endswith("sushi/macros/utils.py")
         assert ref.target_range is not None

--- a/tests/lsp/test_reference_macro_find_all.py
+++ b/tests/lsp/test_reference_macro_find_all.py
@@ -41,11 +41,11 @@ def test_find_all_references_for_macro_add_one():
     assert len(all_references) >= 2, f"Expected at least 2 references, found {len(all_references)}"
 
     # Verify the macro definition is included
-    definition_refs = [ref for ref in all_references if "utils.py" in ref.uri]
+    definition_refs = [ref for ref in all_references if "utils.py" in str(ref.path)]
     assert len(definition_refs) >= 1, "Should include the macro definition in utils.py"
 
     # Verify the usage in top_waiters is included
-    usage_refs = [ref for ref in all_references if "top_waiters" in ref.uri]
+    usage_refs = [ref for ref in all_references if "top_waiters" in str(ref.path)]
     assert len(usage_refs) >= 1, "Should include the usage in top_waiters.sql"
 
     expected_files = {
@@ -55,11 +55,11 @@ def test_find_all_references_for_macro_add_one():
     }
 
     for expected_file, expectations in expected_files.items():
-        file_refs = [ref for ref in all_references if expected_file in ref.uri]
+        file_refs = [ref for ref in all_references if expected_file in str(ref.path)]
         assert len(file_refs) >= 1, f"Should find at least one reference in {expected_file}"
 
         file_ref = file_refs[0]
-        file_path = URI(file_ref.uri).to_path()
+        file_path = file_ref.path
 
         sqlmesh_range = SQLMeshRange(
             start=SQLMeshPosition(
@@ -104,8 +104,10 @@ def test_find_all_references_for_macro_multiply():
     assert len(all_references) >= 2, f"Expected at least 2 references, found {len(all_references)}"
 
     # Verify both definition and usage are included
-    assert any("utils.py" in ref.uri for ref in all_references), "Should include macro definition"
-    assert any("top_waiters" in ref.uri for ref in all_references), "Should include usage"
+    assert any("utils.py" in str(ref.path) for ref in all_references), (
+        "Should include macro definition"
+    )
+    assert any("top_waiters" in str(ref.path) for ref in all_references), "Should include usage"
 
 
 def test_find_all_references_for_sql_literal_macro():
@@ -183,9 +185,11 @@ def test_multi_repo_macro_references():
         assert len(all_references) == 2, f"Expected 2 references, found {len(all_references)}"
 
         # Verify references from repo_2
-        assert any("repo_2" in ref.uri for ref in all_references), "Should find macro in repo_2"
+        assert any("repo_2" in str(ref.path) for ref in all_references), (
+            "Should find macro in repo_2"
+        )
 
         # But not references in repo_1 since despite identical name they're different macros
-        assert not any("repo_1" in ref.uri for ref in all_references), (
+        assert not any("repo_1" in str(ref.path) for ref in all_references), (
             "Shouldn't find macro in repo_1"
         )

--- a/tests/lsp/test_reference_macro_multi.py
+++ b/tests/lsp/test_reference_macro_multi.py
@@ -20,5 +20,5 @@ def test_macro_references_multirepo() -> None:
     assert len(macro_references) == 2
     for ref in macro_references:
         assert isinstance(ref, LSPMacroReference)
-        assert ref.uri.endswith("multi/repo_2/macros/__init__.py")
+        assert str(URI.from_path(ref.path).value).endswith("multi/repo_2/macros/__init__.py")
         assert ref.target_range is not None

--- a/tests/lsp/test_reference_model_find_all.py
+++ b/tests/lsp/test_reference_model_find_all.py
@@ -35,7 +35,7 @@ def test_find_references_for_model_usages():
     )
 
     # Verify expected files are present
-    reference_files = {ref.uri for ref in references}
+    reference_files = {str(ref.path) for ref in references}
     expected_patterns = [
         "orders",
         "customers",
@@ -65,7 +65,7 @@ def test_find_references_for_model_usages():
     for ref in references:
         matched_pattern = None
         for pattern in expected_patterns:
-            if pattern in ref.uri:
+            if pattern in str(ref.path):
                 matched_pattern = pattern
                 break
 
@@ -136,7 +136,7 @@ def test_find_references_for_marketing_model():
     )
 
     # Verify files are present
-    reference_files = {ref.uri for ref in references}
+    reference_files = {str(ref.path) for ref in references}
     expected_patterns = ["marketing", "customers"]
     for pattern in expected_patterns:
         assert any(pattern in uri for uri in reference_files), (
@@ -169,7 +169,7 @@ def test_find_references_for_python_model():
     assert len(references) == 5
 
     # Verify expected files
-    reference_files = {ref.uri for ref in references}
+    reference_files = {str(ref.path) for ref in references}
 
     # Models and also the Audit which references it: assert_item_price_above_zero
     expected_patterns = [
@@ -222,13 +222,13 @@ def test_waiter_revenue_by_day_multiple_references():
     )
 
     # Count references in top_waiters file
-    top_waiters_refs = [ref for ref in references if "top_waiters" in ref.uri]
+    top_waiters_refs = [ref for ref in references if "top_waiters" in str(ref.path)]
     assert len(top_waiters_refs) == 3, (
         f"Expected exactly 3 references in top_waiters, found {len(top_waiters_refs)}"
     )
 
     # Verify model definition is included
-    assert any("waiter_revenue_by_day" in ref.uri for ref in references), (
+    assert any("waiter_revenue_by_day" in str(ref.path) for ref in references), (
         "Should include model definition"
     )
 
@@ -296,7 +296,7 @@ def test_audit_model_references():
 
             assert len(references) == 5, "Should find references from audit files as well"
 
-            reference_files = {ref.uri for ref in references}
+            reference_files = {str(ref.path) for ref in references}
 
             # Models and also the Audit which references it: assert_item_price_above_zero
             expected_patterns = [


### PR DESCRIPTION
- to move the references into sqlmesh rather than lsp
want to have the lineage code without any reference to lsp
libraries
- this is a first step before moving the code about

* [x] Test on windows machines
