### PR TITLE
Chore: do not fail if sqlglot optimization rules raise an exception

### DIFF
--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -639,14 +639,12 @@ class QueryRenderer(BaseExpressionRenderer):
                 )
         except SqlglotError as ex:
             self._violated_rules[AmbiguousOrInvalidColumn] = ex
-
             query = original
-
         except Exception as ex:
-            raise_config_error(
-                f"Failed to optimize query, please file an issue at https://github.com/TobikoData/sqlmesh/issues/new. {ex}",
-                self._path,
+            logger.warning(
+                f"Failed to optimize query, please file an issue at https://github.com/TobikoData/sqlmesh/issues/new. {ex} at '{self._path}'",
             )
+            query = original
 
         if not query.type:
             for select in query.expressions:


### PR DESCRIPTION
Sometimes, rendering may fail without raising a `SqlglotError`, e.g., if there is a bug and one of `qualify`, `annotate_types` or `simplify` fail. I believe logging those errors is helpful, but failing to load altogether seems too abrupt. This PR intercepts those exceptions and logs a warning instead of re-raising them.
