### PR TITLE
Implement vscode test controller

### DIFF
--- a/vscode/extension/src/extension.ts
+++ b/vscode/extension/src/extension.ts
@@ -21,6 +21,7 @@ import { selector, completionProvider } from './completion/completion'
 import { LineagePanel } from './webviews/lineagePanel'
 import { RenderedModelProvider } from './providers/renderedModelProvider'
 import { sleep } from './utilities/sleep'
+import { controller as testController, setupTestController } from './tests/tests'
 
 let lspClient: LSPClient | undefined
 
@@ -128,6 +129,7 @@ export async function activate(context: vscode.ExtensionContext) {
         )
       }
       context.subscriptions.push(lspClient)
+      setupTestController(lspClient)
     } else {
       lspClient = new LSPClient()
       const result = await lspClient.start()
@@ -140,6 +142,7 @@ export async function activate(context: vscode.ExtensionContext) {
         )
       } else {
         context.subscriptions.push(lspClient)
+        setupTestController(lspClient)
       }
     }
   }
@@ -175,6 +178,8 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   } else {
     context.subscriptions.push(lspClient)
+    setupTestController(lspClient)
+    context.subscriptions.push(testController)
   }
 
   if (lspClient && !lspClient.hasCompletionCapability()) {

--- a/vscode/extension/src/lsp/custom.ts
+++ b/vscode/extension/src/lsp/custom.ts
@@ -32,6 +32,7 @@ export type CustomLSPMethods =
   | AllModelsForRenderMethod
   | SupportedMethodsMethod
   | FormatProjectMethod
+  | ListWorkspaceTests
 
 interface AllModelsRequest {
   textDocument: {

--- a/vscode/extension/src/lsp/lsp.ts
+++ b/vscode/extension/src/lsp/lsp.ts
@@ -252,8 +252,8 @@ export class LSPClient implements Disposable {
 
     try {
       const result = await this.client.sendRequest<Response>(method, request)
-      if (result.response_error) {
-        return err(result.response_error)
+      if ((result as any).response_error) {
+        return err((result as any).response_error)
       }
       return ok(result)
     } catch (error) {


### PR DESCRIPTION
## Summary
- list workspace tests via new `sqlmesh/list_workspace_tests` LSP method
- provide a run profile that executes selected tests using the SQLMesh CLI
- hook the test controller into extension activation and restart

## Testing
- `pnpm run lint`
- `pnpm run compile`
- `pnpm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6883595e9db483309b1130b2b7ccadb8