### PR TITLE
Chore: log rendered jinja right before parsing it to improve debugging

### DIFF
--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -215,6 +215,9 @@ class BaseExpressionRenderer:
             try:
                 expressions = []
                 rendered_expression = jinja_env.from_string(self._expression.name).render()
+                logger.debug(
+                    f"Rendered Jinja expression for model '{self._model_fqn}' at '{self._path}': '{rendered_expression}'"
+                )
                 if rendered_expression.strip():
                     expressions = [e for e in parse(rendered_expression, read=self._dialect) if e]
 


### PR DESCRIPTION
There have been quite a few occasions in the wild where the parser fails to process a rendered Jinja string, while at the same time displaying a limited query context in the exception, making debugging difficult. This PR debug-logs the rendered Jinja string right before it is parsed.
