### PR TITLE
feat!: allow the linter to return fixes that affect other files

### DIFF
--- a/sqlmesh/core/linter/rule.py
+++ b/sqlmesh/core/linter/rule.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass
+from pathlib import Path
 
 from sqlmesh.core.model import Model
 
@@ -43,6 +44,7 @@ class Range:
 class TextEdit:
     """A text edit to apply to a file."""
 
+    path: Path
     range: Range
     new_text: str
 

--- a/sqlmesh/core/linter/rules/builtin.py
+++ b/sqlmesh/core/linter/rules/builtin.py
@@ -53,12 +53,16 @@ class NoSelectStar(Rule):
         columns = model.columns_to_types
         if not columns:
             return None
+        path = model._path
+        if path is None:
+            return None
         new_text = ", ".join(columns.keys())
         return [
             Fix(
                 title="Replace SELECT * with explicit column list",
                 edits=[
                     TextEdit(
+                        path=path,
                         range=violation_range,
                         new_text=new_text,
                     )

--- a/sqlmesh/lsp/context.py
+++ b/sqlmesh/lsp/context.py
@@ -269,9 +269,13 @@ class LSPContext:
                 # Create code actions for each fix
                 for fix in found_violation.fixes:
                     # Convert our Fix to LSP TextEdits
-                    text_edits = []
+                    changes: t.Dict[str, t.List[types.TextEdit]] = {}
                     for edit in fix.edits:
-                        text_edits.append(
+                        uri_key = URI.from_path(edit.path).value
+                        if uri_key not in changes:
+                            changes[uri_key] = []
+                        # Create a TextEdit for the LSP
+                        changes[uri_key].append(
                             types.TextEdit(
                                 range=types.Range(
                                     start=types.Position(
@@ -292,7 +296,7 @@ class LSPContext:
                         title=fix.title,
                         kind=types.CodeActionKind.QuickFix,
                         diagnostics=[diagnostic],
-                        edit=types.WorkspaceEdit(changes={params.text_document.uri: text_edits}),
+                        edit=types.WorkspaceEdit(changes=changes),
                     )
                     code_actions.append(code_action)
 


### PR DESCRIPTION
- This change builds the building block to the linter to return violations whose
fixes affect other files.
- This is in preparation for the change where nomissingexternalmodels can add a fix
that will add the model to the external models
