### PR TITLE
Fix: model evaluation progress bar timer

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -1060,6 +1060,7 @@ class TerminalConsole(Console):
         """Update the snapshot evaluation progress."""
         if (
             self.evaluation_total_progress
+            and self.evaluation_total_task is not None
             and self.evaluation_model_progress
             and self.evaluation_progress_live
         ):
@@ -1102,7 +1103,7 @@ class TerminalConsole(Console):
                 self.evaluation_progress_live.console.print(msg)
 
             self.evaluation_total_progress.update(
-                self.evaluation_total_task or TaskID(0), refresh=True, advance=1
+                self.evaluation_total_task, refresh=True, advance=1
             )
 
             model_task_id = self.evaluation_model_tasks[snapshot.name]


### PR DESCRIPTION
In the Terminal console, a progress bar is displayed when SQLMesh is evaluating models. 

The bar includes elapsed time over all models being evaluated, but in some scenarios that timer resets before all models had been evaluated.

The cause of the timer reset was:
- The `start_evaluation_progress` method creates the progress bar and assigns the "task" containing the timer. The task is assigned a `TaskID` that is stored in a console instance field for later usage.
- The `update_snapshot_evaluation_progress` method incrementally updates the progress bar as model evaluations complete. That includes updating the task containing the timer, which requires the Task ID stored previously.
- In the update method, our code defends against a missing Task ID by providing `TaskID(0)` instead. It appears that this fallback resets the timer, even if the originally assigned task ID was 0.
- It is not totally clear why update would be called without a task ID assigned - possibly a race condition across threads?

This PR fixes that issue by conditioning the update call on the existence of a progress bar task ID. 