### PR TITLE
Fix(athena): Properly extend Athena dialect

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -297,16 +297,16 @@ workflows:
           matrix:
             parameters:
               engine:
-                - snowflake
-                - databricks
-                - redshift
-                - bigquery
-                - clickhouse-cloud
+                #- snowflake
+                #- databricks
+                #- redshift
+                #- bigquery
+                #- clickhouse-cloud
                 - athena
-          filters:
-            branches:
-              only:
-                - main
+          #filters:
+          #  branches:
+          #    only:
+          #      - main
       - ui_style
       - ui_test
       - vscode_test

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -297,16 +297,16 @@ workflows:
           matrix:
             parameters:
               engine:
-                #- snowflake
-                #- databricks
-                #- redshift
-                #- bigquery
-                #- clickhouse-cloud
+                - snowflake
+                - databricks
+                - redshift
+                - bigquery
+                - clickhouse-cloud
                 - athena
-          #filters:
-          #  branches:
-          #    only:
-          #      - main
+          filters:
+            branches:
+              only:
+                - main
       - ui_style
       - ui_test
       - vscode_test

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -13,6 +13,7 @@ from functools import lru_cache
 from sqlglot import Dialect, Generator, ParseError, Parser, Tokenizer, TokenType, exp
 from sqlglot.dialects.dialect import DialectType
 from sqlglot.dialects import DuckDB, Snowflake
+import sqlglot.dialects.athena as athena
 from sqlglot.helper import seq_get
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 from sqlglot.optimizer.qualify_columns import quote_identifiers
@@ -1014,6 +1015,14 @@ def extend_sqlglot() -> None:
     generators = {Generator}
 
     for dialect in Dialect.classes.values():
+        # Athena picks a different Tokenizer / Parser / Generator depending on the query
+        # so this ensures that the extra ones it defines are also extended
+        if dialect == athena.Athena:
+            tokenizers.add(athena._TrinoTokenizer)
+            parsers.add(athena._TrinoParser)
+            generators.add(athena._TrinoGenerator)
+            generators.add(athena._HiveGenerator)
+
         if hasattr(dialect, "Tokenizer"):
             tokenizers.add(dialect.Tokenizer)
         if hasattr(dialect, "Parser"):

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -704,7 +704,7 @@ def test_parse_snowflake_create_schema_ddl():
     assert parse_one("CREATE SCHEMA d.s", dialect="snowflake").sql() == "CREATE SCHEMA d.s"
 
 
-@pytest.mark.parametrize("dialect", set(DIALECT_TO_TYPE.values()))
+@pytest.mark.parametrize("dialect", sorted(set(DIALECT_TO_TYPE.values())))
 def test_sqlglot_extended_correctly(dialect: str) -> None:
     # MODEL is a SQLMesh extension and not part of SQLGlot
     # If we can roundtrip an expression containing MODEL across every dialect, then the SQLMesh extensions have been registered correctly


### PR DESCRIPTION
Closes #5065 

I think Athena has been broken since SQLMesh `v0.198.0` were we [upgraded](https://github.com/TobikoData/sqlmesh/commit/4a44d8952f1ed7a2192dbbceceab4927adffc2ba) SQLGlot to `v26.32.0`.

With that upgrade:
 - Athena stopped extending Trino and became its own top-level Dialect
 - It also defined some extra top-level Parser/Tokenizer/Generator classes that could not be reached directly from `<dialect>.Parser`, `<dialect>.Tokenizer` etc

This PR includes the extra set of top-level classes when extending the Athena dialect and adds a test that checks `MODEL (...)` can be roundtripped across every dialect