### PR TITLE
Fix: clean signal registry before loading signals for the given project

### DIFF
--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -710,6 +710,8 @@ class SqlMeshLoader(Loader):
     def _load_signals(self) -> UniqueKeyDict[str, signal]:
         """Loads signals for the built-in scheduler."""
 
+        base_signals = signal.get_registry()
+
         signals_max_mtime: t.Optional[float] = None
 
         for path in self._glob_paths(
@@ -729,7 +731,10 @@ class SqlMeshLoader(Loader):
 
         self._signals_max_mtime = signals_max_mtime
 
-        return signal.get_registry()
+        signals = signal.get_registry()
+        signal.set_registry(base_signals)
+
+        return signals
 
     def _load_audits(
         self, macros: MacroRegistry, jinja_macros: JinjaMacroRegistry


### PR DESCRIPTION
Signals for a given project are registered explicitly by importing files in `./signals`.  In macros, the global registry of "standard macros" is copied out at the beginning of load, and user defined macros are loaded, then registry is set back to its old state. We do the same here now.

the issue is when you copy paste a signal from project A to project B
https://github.com/z3z1ma/sqlmesh/blob/6ed83334ef95cc23146eef6ff76731d1252e6665/sqlmesh/utils/__init__.py#L135-L140
this code will not raise a ValueError in the unique key dict subtly masking the fact that the signal that will persist is from project A. this mean project B in metaprogramming will not share subpath with __module__ and will be registered as an import payload
