### PR TITLE
Chore: Validate start and end dates during plan build time

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1621,7 +1621,7 @@ class GenericContext(BaseContext, t.Generic[C]):
                                 or to_timestamp(snapshot.node.start) > end_ts
                             ):
                                 raise SQLMeshError(
-                                    f"Start date / time ({to_datetime(start_ts)}) can't be greater than end date / time ({to_datetime(end_ts)}).\n"
+                                    f"Model '{model_name}': Start date / time ({to_datetime(start_ts)}) can't be greater than end date / time ({to_datetime(end_ts)}).\n"
                                     f"Set the `start` attribute in your project config model defaults to avoid this issue."
                                 )
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1603,28 +1603,6 @@ class GenericContext(BaseContext, t.Generic[C]):
                 execution_time or now(),
             )
 
-            # Validate that the start is not greater than the end date / time
-            effective_start = start or default_start
-            effective_end = end or default_end
-            if effective_start is not None and effective_end is not None:
-                start_ts = to_timestamp(effective_start)
-                end_ts = to_timestamp(effective_end)
-                if start_ts > end_ts:
-                    for model_name in (
-                        set(backfill_models or {})
-                        | set(modified_model_names)
-                        | set(max_interval_end_per_model)
-                    ):
-                        if snapshot := snapshots.get(model_name):
-                            if (
-                                snapshot.node.start is None
-                                or to_timestamp(snapshot.node.start) > end_ts
-                            ):
-                                raise SQLMeshError(
-                                    f"Model '{model_name}': Start date / time ({to_datetime(start_ts)}) can't be greater than end date / time ({to_datetime(end_ts)}).\n"
-                                    f"Set the `start` attribute in your project config model defaults to avoid this issue."
-                                )
-
             # Refresh snapshot intervals to ensure that they are up to date with values reflected in the max_interval_end_per_model.
             self.state_sync.refresh_snapshot_intervals(context_diff.snapshots.values())
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1603,6 +1603,28 @@ class GenericContext(BaseContext, t.Generic[C]):
                 execution_time or now(),
             )
 
+            # Validate that the start is not greater than the end date / time
+            effective_start = start or default_start
+            effective_end = end or default_end
+            if effective_start is not None and effective_end is not None:
+                start_ts = to_timestamp(effective_start)
+                end_ts = to_timestamp(effective_end)
+                if start_ts > end_ts:
+                    for model_name in (
+                        set(backfill_models or {})
+                        | set(modified_model_names)
+                        | set(max_interval_end_per_model)
+                    ):
+                        if snapshot := snapshots.get(model_name):
+                            if (
+                                snapshot.node.start is None
+                                or to_timestamp(snapshot.node.start) > end_ts
+                            ):
+                                raise SQLMeshError(
+                                    f"Start date / time ({to_datetime(start_ts)}) can't be greater than end date / time ({to_datetime(end_ts)}).\n"
+                                    f"Set the `start` attribute in your project config model defaults to avoid this issue."
+                                )
+
             # Refresh snapshot intervals to ensure that they are up to date with values reflected in the max_interval_end_per_model.
             self.state_sync.refresh_snapshot_intervals(context_diff.snapshots.values())
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -3059,7 +3059,7 @@ def test_plan_no_start_configured():
 
     # This should raise an error because the model has no start configured and the end time is less than the start time which will be calculated from the intervals
     with pytest.raises(
-        SQLMeshError,
+        PlanError,
         match=r"Model '.*xvg.*': Start date / time .* can't be greater than end date / time .*\.\nSet the `start` attribute in your project config model defaults to avoid this issue",
     ):
         context.plan("dev", execution_time="1999-01-05")

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -3060,6 +3060,6 @@ def test_plan_no_start_configured():
     # This should raise an error because the model has no start configured and the end time is less than the start time which will be calculated from the intervals
     with pytest.raises(
         SQLMeshError,
-        match=r"Set the `start` attribute in your project config model defaults to avoid this issue",
+        match=r"Model '.*xvg.*': Start date / time .* can't be greater than end date / time .*\.\nSet the `start` attribute in your project config model defaults to avoid this issue",
     ):
         context.plan("dev", execution_time="1999-01-05")

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -3007,3 +3007,59 @@ SELECT * FROM test_db.uppercase_gateway_table;
     assert len(uppercase_in_yaml_models) == 1, (
         f"External model with uppercase gateway in YAML should be found. Found {len(uppercase_in_yaml_models)} models"
     )
+
+
+def test_plan_no_start_configured():
+    context = Context(config=Config())
+    context.upsert_model(
+        load_sql_based_model(
+            parse(
+                """
+                MODEL(
+                    name db.xvg,
+                    kind INCREMENTAL_BY_TIME_RANGE (
+                        time_column ds
+                    ),
+                    cron '@daily'
+                );
+
+                SELECT id, ds FROM (VALUES
+                    ('1', '2020-01-01'),
+                ) data(id, ds)
+                WHERE ds BETWEEN @start_ds AND @end_ds
+                """
+            )
+        )
+    )
+
+    prod_plan = context.plan(auto_apply=True)
+    assert len(prod_plan.new_snapshots) == 1
+
+    context.upsert_model(
+        load_sql_based_model(
+            parse(
+                """
+                MODEL(
+                    name db.xvg,
+                    kind INCREMENTAL_BY_TIME_RANGE (
+                        time_column ds
+                    ),
+                    cron '@daily',
+                    physical_properties ('some_prop' = 1),
+                );
+
+                SELECT id, ds FROM (VALUES
+                    ('1', '2020-01-01'),
+                ) data(id, ds)
+                WHERE ds BETWEEN @start_ds AND @end_ds
+                """
+            )
+        )
+    )
+
+    # This should raise an error because the model has no start configured and the end time is less than the start time which will be calculated from the intervals
+    with pytest.raises(
+        SQLMeshError,
+        match=r"Set the `start` attribute in your project config model defaults to avoid this issue",
+    ):
+        context.plan("dev", execution_time="1999-01-05")


### PR DESCRIPTION
Update to validate start is less than end date/time early during plan build time in the event that the user hasn't provided a start date in the config or in all models explicitly, fixes: #4916 