### PR TITLE
Fix!: Add model default audits in the model preserving their args

### DIFF
--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -594,7 +594,6 @@ class SqlMeshLoader(Loader):
                 macros=macros,
                 jinja_macros=jinja_macros,
                 audit_definitions=audits,
-                default_audits=self.config.model_defaults.audits,
                 module_path=self.config_path,
                 dialect=self.config.model_defaults.dialect,
                 time_column_format=self.config.time_column_format,

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2539,21 +2539,8 @@ def _create_model(
             used_variables.update(extract_macro_references_and_variables(jinja_macro.definition)[1])
 
     # Merge model-specific audits with default audits
-    model_audits = kwargs.pop("audits", [])
-    default_audits = defaults.pop("audits", [])
-
-    if isinstance(model_audits, (exp.Tuple, exp.Array)):
-        model_audits_list = [d.extract_func_call(i) for i in model_audits.expressions]
-    elif isinstance(model_audits, exp.Paren):
-        model_audits_list = [d.extract_func_call(model_audits.this)]
-    elif isinstance(model_audits, exp.Expression):
-        model_audits_list = [d.extract_func_call(model_audits)]
-    elif isinstance(model_audits, list):
-        model_audits_list = model_audits
-    else:
-        model_audits_list = []
-    merged_audits = default_audits + model_audits_list
-    kwargs["audits"] = merged_audits
+    if default_audits := defaults.pop("audits", None):
+        kwargs["audits"] = default_audits + d.extract_function_calls(kwargs.pop("audits", []))
 
     model = klass(
         name=name,

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -32,7 +32,7 @@ from sqlmesh.core.model.common import (
     sorted_python_env_payloads,
     validate_extra_and_required_fields,
 )
-from sqlmesh.core.model.meta import ModelMeta, FunctionCall
+from sqlmesh.core.model.meta import ModelMeta
 from sqlmesh.core.model.kind import (
     ModelKindName,
     SeedKind,
@@ -2038,7 +2038,6 @@ def load_sql_based_model(
     macros: t.Optional[MacroRegistry] = None,
     jinja_macros: t.Optional[JinjaMacroRegistry] = None,
     audits: t.Optional[t.Dict[str, ModelAudit]] = None,
-    default_audits: t.Optional[t.List[FunctionCall]] = None,
     python_env: t.Optional[t.Dict[str, Executable]] = None,
     dialect: t.Optional[str] = None,
     physical_schema_mapping: t.Optional[t.Dict[re.Pattern, str]] = None,
@@ -2211,7 +2210,6 @@ Learn more at https://sqlmesh.readthedocs.io/en/stable/concepts/models/overview
         physical_schema_mapping=physical_schema_mapping,
         default_catalog=default_catalog,
         variables=variables,
-        default_audits=default_audits,
         inline_audits=inline_audits,
         blueprint_variables=blueprint_variables,
         **meta_fields,
@@ -2431,7 +2429,6 @@ def _create_model(
     physical_schema_mapping: t.Optional[t.Dict[re.Pattern, str]] = None,
     python_env: t.Optional[t.Dict[str, Executable]] = None,
     audit_definitions: t.Optional[t.Dict[str, ModelAudit]] = None,
-    default_audits: t.Optional[t.List[FunctionCall]] = None,
     inline_audits: t.Optional[t.Dict[str, ModelAudit]] = None,
     module_path: Path = Path(),
     macros: t.Optional[MacroRegistry] = None,
@@ -2541,6 +2538,8 @@ def _create_model(
         for jinja_macro in jinja_macros.root_macros.values():
             used_variables.update(extract_macro_references_and_variables(jinja_macro.definition)[1])
 
+    default_audits = defaults.get("audits", None) if kwargs.get("audits") else None
+
     model = klass(
         name=name,
         **{
@@ -2558,12 +2557,10 @@ def _create_model(
         **(inline_audits or {}),
     }
 
-    # TODO: default_audits needs to be merged with model.audits; the former's arguments
-    # are silently dropped today because we add them in audit_definitions. We also need
-    # to check for duplicates when we implement this merging logic.
-    used_audits: t.Set[str] = set()
-    used_audits.update(audit_name for audit_name, _ in default_audits or [])
-    used_audits.update(audit_name for audit_name, _ in model.audits)
+    if default_audits:
+        model = model.copy(update={"audits": default_audits + model.audits})
+
+    used_audits: t.Set[str] = {audit_name for audit_name, _ in model.audits}
 
     audit_definitions = {
         audit_name: audit_definitions[audit_name]

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -11,7 +11,7 @@ from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 
 from sqlmesh.core import dialect as d
 from sqlmesh.core.config.linter import LinterConfig
-from sqlmesh.core.dialect import normalize_model_name, extract_func_call
+from sqlmesh.core.dialect import normalize_model_name
 from sqlmesh.core.model.common import (
     bool_validator,
     default_catalog_validator,
@@ -94,37 +94,7 @@ class ModelMeta(_Node):
     def _func_call_validator(cls, v: t.Any, field: t.Any) -> t.Any:
         is_signal = getattr(field, "name" if hasattr(field, "name") else "field_name") == "signals"
 
-        if isinstance(v, (exp.Tuple, exp.Array)):
-            return [extract_func_call(i, allow_tuples=is_signal) for i in v.expressions]
-        if isinstance(v, exp.Paren):
-            return [extract_func_call(v.this, allow_tuples=is_signal)]
-        if isinstance(v, exp.Expression):
-            return [extract_func_call(v, allow_tuples=is_signal)]
-        if isinstance(v, list):
-            audits = []
-
-            for entry in v:
-                if isinstance(entry, dict):
-                    args = entry
-                    name = "" if is_signal else entry.pop("name")
-                elif isinstance(entry, (tuple, list)):
-                    name, args = entry
-                else:
-                    raise ConfigError(f"Audit must be a dictionary or named tuple. Got {entry}.")
-
-                audits.append(
-                    (
-                        name.lower(),
-                        {
-                            key: d.parse_one(value) if isinstance(value, str) else value
-                            for key, value in args.items()
-                        },
-                    )
-                )
-
-            return audits
-
-        return v or []
+        return d.extract_function_calls(v, allow_tuples=is_signal)
 
     @field_validator("tags", mode="before")
     def _value_or_tuple_validator(cls, v: t.Any, info: ValidationInfo) -> t.Any:

--- a/sqlmesh/migrations/v0088_include_default_audits_in_model.py
+++ b/sqlmesh/migrations/v0088_include_default_audits_in_model.py
@@ -1,0 +1,5 @@
+"""Include the model defaults audits along with their args in the model."""
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0088_include_default_audits_in_model.py
+++ b/sqlmesh/migrations/v0088_include_default_audits_in_model.py
@@ -1,5 +1,0 @@
-"""Include the model defaults audits along with their args in the model."""
-
-
-def migrate(state_sync, **kwargs):  # type: ignore
-    pass


### PR DESCRIPTION
This update ensures that audit arguments from default_audits are no longer dropped when model audits are present.
Previously, if a model defined its own audits, only those were retained and the arguments from default_audits were silently dropped (since we used the audit_definitions with empty args). This adds both in the model's audits, preserving them along with their arguments.