### PR TITLE
feat!: add ignore destructive support

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -305,10 +305,10 @@ workflows:
                 - clickhouse-cloud
                 - athena
                 - gcp-postgres
-#          filters:
-#            branches:
-#              only:
-#                - main
+          filters:
+            branches:
+              only:
+                - main
       - ui_style
       - ui_test
       - vscode_test

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -305,10 +305,10 @@ workflows:
                 - clickhouse-cloud
                 - athena
                 - gcp-postgres
-          filters:
-            branches:
-              only:
-                - main
+#          filters:
+#            branches:
+#              only:
+#                - main
       - ui_style
       - ui_test
       - vscode_test

--- a/docs/concepts/models/overview.md
+++ b/docs/concepts/models/overview.md
@@ -507,11 +507,15 @@ Some properties are only available in specific model kinds - see the [model conf
 :   Set this to true to indicate that all changes to this model should be [forward-only](../plans.md#forward-only-plans).
 
 ### on_destructive_change
-:   What should happen when a change to a [forward-only model](../../guides/incremental_time.md#forward-only-models) or incremental model in a [forward-only plan](../plans.md#forward-only-plans) causes a destructive modification to the table schema (i.e., requires dropping an existing column).
+:   What should happen when a change to a [forward-only model](../../guides/incremental_time.md#forward-only-models) or incremental model in a [forward-only plan](../plans.md#forward-only-plans) causes a destructive modification to the table schema (i.e., requires dropping an existing column or modifying column constraints in ways that could cause data loss).
 
     SQLMesh checks for destructive changes at plan time based on the model definition and run time based on the model's underlying physical tables.
 
-    Must be one of the following values: `allow`, `warn`, or `error` (default).
+    Must be one of the following values: `allow`, `warn`, `error` (default), or `ignore`.
+
+!!! warning "Ignore is Dangerous"
+
+    `ignore` is dangerous since it can result in error or data loss. It likely should never be used but could be useful as an "escape-hatch" or a way to workaround unexpected behavior.
 
 ### disable_restatement
 :   Set this to true to indicate that [data restatement](../plans.md#restatement-plans) is disabled for this model.

--- a/docs/guides/custom_materializations.md
+++ b/docs/guides/custom_materializations.md
@@ -64,6 +64,7 @@ class CustomFullMaterialization(CustomMaterialization):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         self.adapter.replace_query(table_name, query_or_df)
@@ -78,6 +79,7 @@ Let's unpack this materialization:
     * `query_or_df` - a query (of SQLGlot expression type) or DataFrame (Pandas, PySpark, or Snowpark) instance to be inserted
     * `model` - the model definition object used to access model parameters and user-specified materialization arguments
     * `is_first_insert` - whether this is the first insert for the current version of the model (used with batched or multi-step inserts)
+    * `render_kwargs` - a dictionary of arguments used to render the model query
     * `kwargs` - additional and future arguments
 * The `self.adapter` instance is used to interact with the target engine. It comes with a set of useful high-level APIs like `replace_query`, `columns`, and `table_exists`, but also supports executing arbitrary SQL expressions with its `execute` method.
 
@@ -150,6 +152,7 @@ class CustomFullMaterialization(CustomMaterialization):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         config_value = model.custom_materialization_properties["config_key"]
@@ -232,6 +235,7 @@ class CustomFullMaterialization(CustomMaterialization[MyCustomKind]):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         assert isinstance(model.kind, MyCustomKind)

--- a/docs/guides/incremental_time.md
+++ b/docs/guides/incremental_time.md
@@ -171,7 +171,12 @@ The check is performed at plan time based on the model definition. SQLMesh may n
 
 A model's `on_destructive_change` [configuration setting](../reference/model_configuration.md#incremental-models) determines what happens when SQLMesh detects a destructive change.
 
-By default, SQLMesh will error so no data is lost. You can set `on_destructive_change` to `warn` or `allow` in the model's `MODEL` block to allow destructive changes.
+By default, SQLMesh will error so no data is lost. You can set `on_destructive_change` to `warn` or `allow` in the model's `MODEL` block to allow destructive changes. 
+`ignore` can be used to not perform the schema change and allow the table's definition to diverge from the model definition.
+
+!!! warning "Ignore is Dangerous"
+
+    `ignore` is dangerous since it can result in error or data loss. It likely should never be used but could be useful as an "escape-hatch" or a way to workaround unexpected behavior.
 
 This example configures a model to silently `allow` destructive changes:
 

--- a/examples/custom_materializations/custom_materializations/custom_kind.py
+++ b/examples/custom_materializations/custom_materializations/custom_kind.py
@@ -24,8 +24,9 @@ class CustomFullWithCustomKindMaterialization(CustomMaterialization[ExtendedCust
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         assert type(model.kind).__name__ == "ExtendedCustomKind"
 
-        self._replace_query_for_model(model, table_name, query_or_df)
+        self._replace_query_for_model(model, table_name, query_or_df, render_kwargs)

--- a/examples/custom_materializations/custom_materializations/full.py
+++ b/examples/custom_materializations/custom_materializations/full.py
@@ -17,6 +17,7 @@ class CustomFullMaterialization(CustomMaterialization):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
-        self._replace_query_for_model(model, table_name, query_or_df)
+        self._replace_query_for_model(model, table_name, query_or_df, render_kwargs)

--- a/sqlmesh/core/engine_adapter/_typing.py
+++ b/sqlmesh/core/engine_adapter/_typing.py
@@ -13,7 +13,7 @@ if t.TYPE_CHECKING:
 
     snowpark = optional_import("snowflake.snowpark")
 
-    Query = t.Union[exp.Query, exp.DerivedTable]
+    Query = exp.Query
     PySparkSession = t.Union[pyspark.sql.SparkSession, pyspark.sql.connect.dataframe.SparkSession]
     PySparkDataFrame = t.Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame]
 

--- a/sqlmesh/core/engine_adapter/athena.py
+++ b/sqlmesh/core/engine_adapter/athena.py
@@ -84,12 +84,12 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
     def create_state_table(
         self,
         table_name: str,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         primary_key: t.Optional[t.Tuple[str, ...]] = None,
     ) -> None:
         self.create_table(
             table_name,
-            columns_to_types,
+            target_columns_to_types,
             primary_key=primary_key,
             # it's painfully slow, but it works
             table_format="iceberg",
@@ -178,7 +178,7 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
         expression: t.Optional[exp.Expression],
         exists: bool = True,
         replace: bool = False,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         table_kind: t.Optional[str] = None,
         partitioned_by: t.Optional[t.List[exp.Expression]] = None,
@@ -198,7 +198,7 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
         properties = self._build_table_properties_exp(
             table=table,
             expression=expression,
-            columns_to_types=columns_to_types,
+            target_columns_to_types=target_columns_to_types,
             partitioned_by=partitioned_by,
             table_properties=table_properties,
             table_description=table_description,
@@ -237,7 +237,7 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
         partition_interval_unit: t.Optional[IntervalUnit] = None,
         clustered_by: t.Optional[t.List[exp.Expression]] = None,
         table_properties: t.Optional[t.Dict[str, exp.Expression]] = None,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         table_kind: t.Optional[str] = None,
         table: t.Optional[exp.Table] = None,
@@ -265,12 +265,12 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
 
         if partitioned_by:
             schema_expressions: t.List[exp.Expression] = []
-            if is_hive and columns_to_types:
+            if is_hive and target_columns_to_types:
                 # For Hive-style tables, you cannot include the partitioned by columns in the main set of columns
                 # In the PARTITIONED BY expression, you also cant just include the column names, you need to include the data type as well
                 # ref: https://docs.aws.amazon.com/athena/latest/ug/partitions.html
                 for match_name, match_dtype in self._find_matching_columns(
-                    partitioned_by, columns_to_types
+                    partitioned_by, target_columns_to_types
                 ):
                     column_def = exp.ColumnDef(this=exp.to_identifier(match_name), kind=match_dtype)
                     schema_expressions.append(column_def)
@@ -431,7 +431,7 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
         self,
         table_name: TableName,
         query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         source_columns: t.Optional[t.List[str]] = None,
@@ -445,7 +445,7 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
         return super().replace_query(
             table_name=table,
             query_or_df=query_or_df,
-            columns_to_types=columns_to_types,
+            target_columns_to_types=target_columns_to_types,
             table_description=table_description,
             column_descriptions=column_descriptions,
             source_columns=source_columns,
@@ -456,7 +456,7 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
         self,
         table_name: TableName,
         source_queries: t.List[SourceQuery],
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         where: exp.Condition,
         **kwargs: t.Any,
     ) -> None:
@@ -467,7 +467,7 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
         if table_type == "iceberg":
             # Iceberg tables work as expected, we can use the default behaviour
             return super()._insert_overwrite_by_time_partition(
-                table, source_queries, columns_to_types, where, **kwargs
+                table, source_queries, target_columns_to_types, where, **kwargs
             )
 
         # For Hive tables, we need to drop all the partitions covered by the query and delete the data from S3
@@ -477,7 +477,7 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
         return super()._insert_overwrite_by_time_partition(
             table,
             source_queries,
-            columns_to_types,
+            target_columns_to_types,
             where,
             insert_overwrite_strategy_override=InsertOverwriteStrategy.INTO_IS_OVERWRITE,  # since we already cleared the data
             **kwargs,

--- a/sqlmesh/core/engine_adapter/athena.py
+++ b/sqlmesh/core/engine_adapter/athena.py
@@ -434,6 +434,7 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
+        source_columns: t.Optional[t.List[str]] = None,
         **kwargs: t.Any,
     ) -> None:
         table = exp.to_table(table_name)
@@ -447,6 +448,7 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
             columns_to_types=columns_to_types,
             table_description=table_description,
             column_descriptions=column_descriptions,
+            source_columns=source_columns,
             **kwargs,
         )
 

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -206,21 +206,23 @@ class EngineAdapter:
     @classmethod
     def _casted_columns(
         cls,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         source_columns: t.Optional[t.List[str]] = None,
     ) -> t.List[exp.Alias]:
-        source_columns = source_columns or list(columns_to_types)
+        source_columns_lookup = set(source_columns or target_columns_to_types)
         return [
             exp.alias_(
                 exp.cast(
-                    exp.column(column, quoted=True) if column in source_columns else exp.Null(),
+                    exp.column(column, quoted=True)
+                    if column in source_columns_lookup
+                    else exp.Null(),
                     to=kind,
                 ),
                 column,
                 copy=False,
                 quoted=True,
             )
-            for column, kind in columns_to_types.items()
+            for column, kind in target_columns_to_types.items()
         ]
 
     @property
@@ -241,7 +243,7 @@ class EngineAdapter:
     def _get_source_queries(
         self,
         query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         target_table: TableName,
         *,
         batch_size: t.Optional[int] = None,
@@ -253,16 +255,17 @@ class EngineAdapter:
         if isinstance(query_or_df, exp.Query):
             query_factory = lambda: query_or_df
             if source_columns:
-                if not columns_to_types:
+                source_columns_lookup = set(source_columns)
+                if not target_columns_to_types:
                     raise SQLMeshError("columns_to_types must be set if source_columns is set")
-                if not set(columns_to_types).issubset(set(source_columns)):
+                if not set(target_columns_to_types).issubset(source_columns_lookup):
                     select_columns = [
                         exp.column(c, quoted=True)
-                        if c in source_columns
-                        else exp.cast(exp.Null(), columns_to_types[c], copy=False).as_(
+                        if c in source_columns_lookup
+                        else exp.cast(exp.Null(), target_columns_to_types[c], copy=False).as_(
                             c, copy=False, quoted=True
                         )
-                        for c in columns_to_types
+                        for c in target_columns_to_types
                     ]
                     query_factory = (
                         lambda: exp.Select()
@@ -271,7 +274,7 @@ class EngineAdapter:
                     )
             return [SourceQuery(query_factory=query_factory)]  # type: ignore
 
-        if not columns_to_types:
+        if not target_columns_to_types:
             raise SQLMeshError(
                 "It is expected that if a DataFrame is passed in then columns_to_types is set"
             )
@@ -285,7 +288,7 @@ class EngineAdapter:
 
         return self._df_to_source_queries(
             query_or_df,
-            columns_to_types,
+            target_columns_to_types,
             batch_size,
             target_table=target_table,
             source_columns=source_columns,
@@ -294,7 +297,7 @@ class EngineAdapter:
     def _df_to_source_queries(
         self,
         df: DF,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         batch_size: int,
         target_table: TableName,
         source_columns: t.Optional[t.List[str]] = None,
@@ -307,7 +310,7 @@ class EngineAdapter:
 
         # we need to ensure that the order of the columns in columns_to_types columns matches the order of the values
         # they can differ if a user specifies columns() on a python model in a different order than what's in the DataFrame's emitted by that model
-        df = df[list(source_columns or columns_to_types)]
+        df = df[list(source_columns or target_columns_to_types)]
         values = list(df.itertuples(index=False, name=None))
 
         return [
@@ -315,7 +318,7 @@ class EngineAdapter:
                 query_factory=partial(
                     self._values_to_sql,
                     values=values,  # type: ignore
-                    columns_to_types=columns_to_types,
+                    target_columns_to_types=target_columns_to_types,
                     batch_start=i,
                     batch_end=min(i + batch_size, num_rows),
                     source_columns=source_columns,
@@ -327,29 +330,29 @@ class EngineAdapter:
     def _get_source_queries_and_columns_to_types(
         self,
         query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         target_table: TableName,
         *,
         batch_size: t.Optional[int] = None,
         source_columns: t.Optional[t.List[str]] = None,
     ) -> t.Tuple[t.List[SourceQuery], t.Optional[t.Dict[str, exp.DataType]]]:
-        columns_to_types, source_columns = self._columns_to_types(
-            query_or_df, columns_to_types, source_columns
+        target_columns_to_types, source_columns = self._columns_to_types(
+            query_or_df, target_columns_to_types, source_columns
         )
         source_queries = self._get_source_queries(
             query_or_df,
-            columns_to_types,
+            target_columns_to_types,
             target_table=target_table,
             batch_size=batch_size,
             source_columns=source_columns,
         )
-        return source_queries, columns_to_types
+        return source_queries, target_columns_to_types
 
     @t.overload
     def _columns_to_types(
         self,
         query_or_df: DF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         source_columns: t.Optional[t.List[str]] = None,
     ) -> t.Tuple[t.Dict[str, exp.DataType], t.List[str]]: ...
 
@@ -357,23 +360,23 @@ class EngineAdapter:
     def _columns_to_types(
         self,
         query_or_df: Query,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         source_columns: t.Optional[t.List[str]] = None,
     ) -> t.Tuple[t.Optional[t.Dict[str, exp.DataType]], t.Optional[t.List[str]]]: ...
 
     def _columns_to_types(
         self,
         query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         source_columns: t.Optional[t.List[str]] = None,
     ) -> t.Tuple[t.Optional[t.Dict[str, exp.DataType]], t.Optional[t.List[str]]]:
         import pandas as pd
 
-        if not columns_to_types and isinstance(query_or_df, pd.DataFrame):
-            columns_to_types = columns_to_types_from_df(t.cast(pd.DataFrame, query_or_df))
-        if not source_columns and columns_to_types:
-            source_columns = list(columns_to_types)
-        return columns_to_types, source_columns
+        if not target_columns_to_types and isinstance(query_or_df, pd.DataFrame):
+            target_columns_to_types = columns_to_types_from_df(t.cast(pd.DataFrame, query_or_df))
+        if not source_columns and target_columns_to_types:
+            source_columns = list(target_columns_to_types)
+        return target_columns_to_types, source_columns
 
     def recycle(self) -> None:
         """Closes all open connections and releases all allocated resources associated with any thread
@@ -410,7 +413,7 @@ class EngineAdapter:
         self,
         table_name: TableName,
         query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         source_columns: t.Optional[t.List[str]] = None,
@@ -423,7 +426,7 @@ class EngineAdapter:
         Args:
             table_name: The name of the table (eg. prod.table)
             query_or_df: The SQL query to run or a dataframe.
-            columns_to_types: Only used if a dataframe is provided. A mapping between the column name and its data type.
+            target_columns_to_types: Only used if a dataframe is provided. A mapping between the column name and its data type.
                 Expected to be ordered to match the order of values in the dataframe.
             kwargs: Optional create table properties.
         """
@@ -434,14 +437,14 @@ class EngineAdapter:
         if self.drop_data_object_on_type_mismatch(target_data_object, DataObjectType.TABLE):
             table_exists = False
 
-        source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
+        source_queries, target_columns_to_types = self._get_source_queries_and_columns_to_types(
             query_or_df,
-            columns_to_types,
+            target_columns_to_types,
             target_table=target_table,
             source_columns=source_columns,
         )
         query = source_queries[0].query_factory()
-        columns_to_types = columns_to_types or self.columns(target_table)
+        target_columns_to_types = target_columns_to_types or self.columns(target_table)
         self_referencing = any(
             quote_identifiers(table) == quote_identifiers(target_table)
             for table in query.find_all(exp.Table)
@@ -450,7 +453,7 @@ class EngineAdapter:
         if self_referencing:
             self._create_table_from_columns(
                 target_table,
-                columns_to_types,
+                target_columns_to_types,
                 exists=True,
                 table_description=table_description,
                 column_descriptions=column_descriptions,
@@ -462,7 +465,7 @@ class EngineAdapter:
             return self._create_table_from_source_queries(
                 target_table,
                 source_queries,
-                columns_to_types,
+                target_columns_to_types,
                 replace=self.SUPPORTS_REPLACE_TABLE,
                 table_description=table_description,
                 column_descriptions=column_descriptions,
@@ -470,9 +473,9 @@ class EngineAdapter:
             )
         if self_referencing:
             with self.temp_table(
-                self._select_columns(columns_to_types).from_(target_table),
+                self._select_columns(target_columns_to_types).from_(target_table),
                 name=target_table,
-                columns_to_types=columns_to_types,
+                target_columns_to_types=target_columns_to_types,
                 **kwargs,
             ) as temp_table:
                 for source_query in source_queries:
@@ -487,12 +490,12 @@ class EngineAdapter:
                 return self._insert_overwrite_by_condition(
                     target_table,
                     source_queries,
-                    columns_to_types,
+                    target_columns_to_types,
                 )
         return self._insert_overwrite_by_condition(
             target_table,
             source_queries,
-            columns_to_types,
+            target_columns_to_types,
         )
 
     def create_index(
@@ -554,7 +557,7 @@ class EngineAdapter:
     def create_table(
         self,
         table_name: TableName,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         primary_key: t.Optional[t.Tuple[str, ...]] = None,
         exists: bool = True,
         table_description: t.Optional[str] = None,
@@ -565,7 +568,7 @@ class EngineAdapter:
 
         Args:
             table_name: The name of the table to create. Can be fully qualified or just table name.
-            columns_to_types: A mapping between the column name and its data type.
+            target_columns_to_types: A mapping between the column name and its data type.
             primary_key: Determines the table primary key.
             exists: Indicates whether to include the IF NOT EXISTS check.
             table_description: Optional table description from MODEL DDL.
@@ -574,7 +577,7 @@ class EngineAdapter:
         """
         self._create_table_from_columns(
             table_name,
-            columns_to_types,
+            target_columns_to_types,
             primary_key,
             exists,
             table_description,
@@ -586,7 +589,7 @@ class EngineAdapter:
         self,
         table_name: TableName,
         query: Query,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         partitioned_by: t.Optional[t.List[exp.Expression]] = None,
         clustered_by: t.Optional[t.List[exp.Expression]] = None,
         table_properties: t.Optional[t.Dict[str, exp.Expression]] = None,
@@ -602,7 +605,7 @@ class EngineAdapter:
         Args:
             table_name: The name of the table to create. Can be fully qualified or just table name.
             query: The SQL query for the engine to base the managed table on
-            columns_to_types: A mapping between the column name and its data type.
+            target_columns_to_types: A mapping between the column name and its data type.
             partitioned_by: The partition columns or engine specific expressions, only applicable in certain engines. (eg. (ds, hour))
             clustered_by: The cluster columns or engine specific expressions, only applicable in certain engines. (eg. (ds, hour))
             table_properties: Optional mapping of engine-specific properties to be set on the managed table
@@ -616,7 +619,7 @@ class EngineAdapter:
         self,
         table_name: TableName,
         query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         exists: bool = True,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
@@ -628,19 +631,22 @@ class EngineAdapter:
         Args:
             table_name: The name of the table to create. Can be fully qualified or just table name.
             query_or_df: The SQL query to run or a dataframe for the CTAS.
-            columns_to_types: A mapping between the column name and its data type. Required if using a DataFrame.
+            target_columns_to_types: A mapping between the column name and its data type. Required if using a DataFrame.
             exists: Indicates whether to include the IF NOT EXISTS check.
             table_description: Optional table description from MODEL DDL.
             column_descriptions: Optional column descriptions from model query.
             kwargs: Optional create table properties.
         """
-        source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
-            query_or_df, columns_to_types, target_table=table_name, source_columns=source_columns
+        source_queries, target_columns_to_types = self._get_source_queries_and_columns_to_types(
+            query_or_df,
+            target_columns_to_types,
+            target_table=table_name,
+            source_columns=source_columns,
         )
         return self._create_table_from_source_queries(
             table_name,
             source_queries,
-            columns_to_types,
+            target_columns_to_types,
             exists,
             table_description=table_description,
             column_descriptions=column_descriptions,
@@ -650,26 +656,26 @@ class EngineAdapter:
     def create_state_table(
         self,
         table_name: str,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         primary_key: t.Optional[t.Tuple[str, ...]] = None,
     ) -> None:
         """Create a table to store SQLMesh internal state.
 
         Args:
             table_name: The name of the table to create. Can be fully qualified or just table name.
-            columns_to_types: A mapping between the column name and its data type.
+            target_columns_to_types: A mapping between the column name and its data type.
             primary_key: Determines the table primary key.
         """
         self.create_table(
             table_name,
-            columns_to_types,
+            target_columns_to_types,
             primary_key=primary_key,
         )
 
     def _create_table_from_columns(
         self,
         table_name: TableName,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         primary_key: t.Optional[t.Tuple[str, ...]] = None,
         exists: bool = True,
         table_description: t.Optional[str] = None,
@@ -681,7 +687,7 @@ class EngineAdapter:
 
         Args:
             table_name: The name of the table to create. Can be fully qualified or just table name.
-            columns_to_types: Mapping between the column name and its data type.
+            target_columns_to_types: Mapping between the column name and its data type.
             primary_key: Determines the table primary key.
             exists: Indicates whether to include the IF NOT EXISTS check.
             table_description: Optional table description from MODEL DDL.
@@ -690,14 +696,14 @@ class EngineAdapter:
         """
         table = exp.to_table(table_name)
 
-        if not columns_to_types_all_known(columns_to_types):
+        if not columns_to_types_all_known(target_columns_to_types):
             # It is ok if the columns types are not known if the table already exists and IF NOT EXISTS is set
             if exists and self.table_exists(table_name):
                 return
             raise SQLMeshError(
                 "Cannot create a table without knowing the column types. "
                 "Try casting the columns to an expected type or defining the columns in the model metadata. "
-                f"Columns to types: {columns_to_types}"
+                f"Columns to types: {target_columns_to_types}"
             )
 
         primary_key_expression = (
@@ -708,7 +714,7 @@ class EngineAdapter:
 
         schema = self._build_schema_exp(
             table,
-            columns_to_types,
+            target_columns_to_types,
             column_descriptions,
             primary_key_expression,
         )
@@ -717,7 +723,7 @@ class EngineAdapter:
             schema,
             None,
             exists=exists,
-            columns_to_types=columns_to_types,
+            target_columns_to_types=target_columns_to_types,
             table_description=table_description,
             **kwargs,
         )
@@ -739,7 +745,7 @@ class EngineAdapter:
     def _build_schema_exp(
         self,
         table: exp.Table,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         expressions: t.Optional[t.List[exp.PrimaryKey]] = None,
         is_view: bool = False,
@@ -752,7 +758,7 @@ class EngineAdapter:
         return exp.Schema(
             this=table,
             expressions=self._build_column_defs(
-                columns_to_types=columns_to_types,
+                target_columns_to_types=target_columns_to_types,
                 column_descriptions=column_descriptions,
                 is_view=is_view,
             )
@@ -761,7 +767,7 @@ class EngineAdapter:
 
     def _build_column_defs(
         self,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         is_view: bool = False,
     ) -> t.List[exp.ColumnDef]:
@@ -777,7 +783,7 @@ class EngineAdapter:
                 engine_supports_schema_comments=engine_supports_schema_comments,
                 col_type=None if is_view else kind,  # don't include column data type for views
             )
-            for column, kind in columns_to_types.items()
+            for column, kind in target_columns_to_types.items()
         ]
 
     def _build_column_def(
@@ -816,7 +822,7 @@ class EngineAdapter:
         self,
         table_name: TableName,
         source_queries: t.List[SourceQuery],
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         exists: bool = True,
         replace: bool = False,
         table_description: t.Optional[str] = None,
@@ -840,27 +846,29 @@ class EngineAdapter:
         # types, and for evaluation methods like `LogicalReplaceQueryMixin.replace_query()`
         # calls and SCD Type 2 model calls.
         schema = None
-        columns_to_types_known = columns_to_types and columns_to_types_all_known(columns_to_types)
+        target_columns_to_types_known = target_columns_to_types and columns_to_types_all_known(
+            target_columns_to_types
+        )
         if (
             column_descriptions
-            and columns_to_types_known
+            and target_columns_to_types_known
             and self.COMMENT_CREATION_TABLE.is_in_schema_def_ctas
             and self.comments_enabled
         ):
-            schema = self._build_schema_exp(table, columns_to_types, column_descriptions)  # type: ignore
+            schema = self._build_schema_exp(table, target_columns_to_types, column_descriptions)  # type: ignore
 
         with self.transaction(condition=len(source_queries) > 1):
             for i, source_query in enumerate(source_queries):
                 with source_query as query:
-                    if columns_to_types and columns_to_types_known:
+                    if target_columns_to_types and target_columns_to_types_known:
                         query = self._order_projections_and_filter(
-                            query, columns_to_types, coerce_types=True
+                            query, target_columns_to_types, coerce_types=True
                         )
                     if i == 0:
                         self._create_table(
                             schema if schema else table,
                             query,
-                            columns_to_types=columns_to_types,
+                            target_columns_to_types=target_columns_to_types,
                             exists=exists,
                             replace=replace,
                             table_description=table_description,
@@ -869,7 +877,7 @@ class EngineAdapter:
                         )
                     else:
                         self._insert_append_query(
-                            table_name, query, columns_to_types or self.columns(table)
+                            table_name, query, target_columns_to_types or self.columns(table)
                         )
 
         # Register comments with commands if the engine supports comments and we weren't able to
@@ -889,7 +897,7 @@ class EngineAdapter:
         expression: t.Optional[exp.Expression],
         exists: bool = True,
         replace: bool = False,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         table_kind: t.Optional[str] = None,
@@ -901,7 +909,7 @@ class EngineAdapter:
                 expression=expression,
                 exists=exists,
                 replace=replace,
-                columns_to_types=columns_to_types,
+                target_columns_to_types=target_columns_to_types,
                 table_description=(
                     table_description
                     if self.COMMENT_CREATION_TABLE.supports_schema_def and self.comments_enabled
@@ -918,7 +926,7 @@ class EngineAdapter:
         expression: t.Optional[exp.Expression],
         exists: bool = True,
         replace: bool = False,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         table_kind: t.Optional[str] = None,
         **kwargs: t.Any,
@@ -936,7 +944,7 @@ class EngineAdapter:
             self._build_table_properties_exp(
                 **kwargs,
                 catalog_name=catalog_name,
-                columns_to_types=columns_to_types,
+                target_columns_to_types=target_columns_to_types,
                 table_description=table_description,
                 table_kind=table_kind,
             )
@@ -1091,7 +1099,7 @@ class EngineAdapter:
         self,
         view_name: TableName,
         query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         replace: bool = True,
         materialized: bool = False,
         materialized_properties: t.Optional[t.Dict[str, t.Any]] = None,
@@ -1109,7 +1117,7 @@ class EngineAdapter:
         Args:
             view_name: The view name.
             query_or_df: A query or dataframe.
-            columns_to_types: Columns to use in the view statement.
+            target_columns_to_types: Columns to use in the view statement.
             replace: Whether or not to replace an existing view defaults to True.
             materialized: Whether to create a a materialized view. Only used for engines that support this feature.
             materialized_properties: Optional materialized view properties to add to the view.
@@ -1129,12 +1137,14 @@ class EngineAdapter:
             values: t.List[t.Tuple[t.Any, ...]] = list(
                 query_or_df.itertuples(index=False, name=None)
             )
-            columns_to_types, source_columns = self._columns_to_types(
-                query_or_df, columns_to_types, source_columns
+            target_columns_to_types, source_columns = self._columns_to_types(
+                query_or_df, target_columns_to_types, source_columns
             )
-            if not columns_to_types:
+            if not target_columns_to_types:
                 raise SQLMeshError("columns_to_types must be provided for dataframes")
-            source_columns_to_types = get_source_columns_to_types(columns_to_types, source_columns)
+            source_columns_to_types = get_source_columns_to_types(
+                target_columns_to_types, source_columns
+            )
             query_or_df = self._values_to_sql(
                 values,
                 source_columns_to_types,
@@ -1142,9 +1152,9 @@ class EngineAdapter:
                 batch_end=len(values),
             )
 
-        source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
+        source_queries, target_columns_to_types = self._get_source_queries_and_columns_to_types(
             query_or_df,
-            columns_to_types,
+            target_columns_to_types,
             batch_size=0,
             target_table=view_name,
             source_columns=source_columns,
@@ -1153,9 +1163,9 @@ class EngineAdapter:
             raise SQLMeshError("Only one source query is supported for creating views")
 
         schema: t.Union[exp.Table, exp.Schema] = exp.to_table(view_name)
-        if columns_to_types:
+        if target_columns_to_types:
             schema = self._build_schema_exp(
-                exp.to_table(view_name), columns_to_types, column_descriptions, is_view=True
+                exp.to_table(view_name), target_columns_to_types, column_descriptions, is_view=True
             )
 
         properties = create_kwargs.pop("properties", None)
@@ -1255,7 +1265,7 @@ class EngineAdapter:
                 self.COMMENT_CREATION_VIEW.is_comment_command_only
                 or (
                     self.COMMENT_CREATION_VIEW.is_in_schema_def_and_commands
-                    and not columns_to_types
+                    and not target_columns_to_types
                 )
             )
             and self.comments_enabled
@@ -1381,61 +1391,64 @@ class EngineAdapter:
         self,
         table_name: TableName,
         query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         source_columns: t.Optional[t.List[str]] = None,
     ) -> None:
-        source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
-            query_or_df, columns_to_types, target_table=table_name, source_columns=source_columns
+        source_queries, target_columns_to_types = self._get_source_queries_and_columns_to_types(
+            query_or_df,
+            target_columns_to_types,
+            target_table=table_name,
+            source_columns=source_columns,
         )
-        self._insert_append_source_queries(table_name, source_queries, columns_to_types)
+        self._insert_append_source_queries(table_name, source_queries, target_columns_to_types)
 
     def _insert_append_source_queries(
         self,
         table_name: TableName,
         source_queries: t.List[SourceQuery],
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
     ) -> None:
         with self.transaction(condition=len(source_queries) > 0):
-            columns_to_types = columns_to_types or self.columns(table_name)
+            target_columns_to_types = target_columns_to_types or self.columns(table_name)
             for source_query in source_queries:
                 with source_query as query:
-                    self._insert_append_query(table_name, query, columns_to_types)
+                    self._insert_append_query(table_name, query, target_columns_to_types)
 
     def _insert_append_query(
         self,
         table_name: TableName,
         query: Query,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         order_projections: bool = True,
     ) -> None:
         if order_projections:
-            query = self._order_projections_and_filter(query, columns_to_types)
-        self.execute(exp.insert(query, table_name, columns=list(columns_to_types)))
+            query = self._order_projections_and_filter(query, target_columns_to_types)
+        self.execute(exp.insert(query, table_name, columns=list(target_columns_to_types)))
 
     def insert_overwrite_by_partition(
         self,
         table_name: TableName,
         query_or_df: QueryOrDF,
         partitioned_by: t.List[exp.Expression],
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         source_columns: t.Optional[t.List[str]] = None,
     ) -> None:
         if self.INSERT_OVERWRITE_STRATEGY.is_insert_overwrite:
             target_table = exp.to_table(table_name)
-            source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
+            source_queries, target_columns_to_types = self._get_source_queries_and_columns_to_types(
                 query_or_df,
-                columns_to_types,
+                target_columns_to_types,
                 target_table=target_table,
                 source_columns=source_columns,
             )
             self._insert_overwrite_by_condition(
-                table_name, source_queries, columns_to_types=columns_to_types
+                table_name, source_queries, target_columns_to_types=target_columns_to_types
             )
         else:
             self._replace_by_key(
                 table_name,
                 query_or_df,
-                columns_to_types,
+                target_columns_to_types,
                 partitioned_by,
                 is_unique_key=False,
                 source_columns=source_columns,
@@ -1451,17 +1464,21 @@ class EngineAdapter:
             [TimeLike, t.Optional[t.Dict[str, exp.DataType]]], exp.Expression
         ],
         time_column: TimeColumn | exp.Expression | str,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         source_columns: t.Optional[t.List[str]] = None,
         **kwargs: t.Any,
     ) -> None:
-        source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
-            query_or_df, columns_to_types, target_table=table_name, source_columns=source_columns
+        source_queries, target_columns_to_types = self._get_source_queries_and_columns_to_types(
+            query_or_df,
+            target_columns_to_types,
+            target_table=table_name,
+            source_columns=source_columns,
         )
-        if not columns_to_types or not columns_to_types_all_known(columns_to_types):
-            columns_to_types = self.columns(table_name)
+        if not target_columns_to_types or not columns_to_types_all_known(target_columns_to_types):
+            target_columns_to_types = self.columns(table_name)
         low, high = [
-            time_formatter(dt, columns_to_types) for dt in make_inclusive(start, end, self.dialect)
+            time_formatter(dt, target_columns_to_types)
+            for dt in make_inclusive(start, end, self.dialect)
         ]
         if isinstance(time_column, TimeColumn):
             time_column = time_column.column
@@ -1471,25 +1488,25 @@ class EngineAdapter:
             high=high,
         )
         return self._insert_overwrite_by_time_partition(
-            table_name, source_queries, columns_to_types, where, **kwargs
+            table_name, source_queries, target_columns_to_types, where, **kwargs
         )
 
     def _insert_overwrite_by_time_partition(
         self,
         table_name: TableName,
         source_queries: t.List[SourceQuery],
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         where: exp.Condition,
         **kwargs: t.Any,
     ) -> None:
         return self._insert_overwrite_by_condition(
-            table_name, source_queries, columns_to_types, where
+            table_name, source_queries, target_columns_to_types, where
         )
 
     def _values_to_sql(
         self,
         values: t.List[t.Tuple[t.Any, ...]],
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         batch_start: int,
         batch_end: int,
         alias: str = "t",
@@ -1497,7 +1514,7 @@ class EngineAdapter:
     ) -> Query:
         return select_from_values_for_batch_range(
             values=values,
-            columns_to_types=columns_to_types,
+            target_columns_to_types=target_columns_to_types,
             batch_start=batch_start,
             batch_end=batch_end,
             alias=alias,
@@ -1508,7 +1525,7 @@ class EngineAdapter:
         self,
         table_name: TableName,
         source_queries: t.List[SourceQuery],
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         where: t.Optional[exp.Condition] = None,
         insert_overwrite_strategy_override: t.Optional[InsertOverwriteStrategy] = None,
         **kwargs: t.Any,
@@ -1520,17 +1537,19 @@ class EngineAdapter:
         with self.transaction(
             condition=len(source_queries) > 0 or insert_overwrite_strategy.is_delete_insert
         ):
-            columns_to_types = columns_to_types or self.columns(table_name)
+            target_columns_to_types = target_columns_to_types or self.columns(table_name)
             for i, source_query in enumerate(source_queries):
                 with source_query as query:
-                    query = self._order_projections_and_filter(query, columns_to_types, where=where)
+                    query = self._order_projections_and_filter(
+                        query, target_columns_to_types, where=where
+                    )
                     if i > 0 or insert_overwrite_strategy.is_delete_insert:
                         if i == 0:
                             self.delete_from(table_name, where=where or exp.true())
                         self._insert_append_query(
                             table_name,
                             query,
-                            columns_to_types=columns_to_types,
+                            target_columns_to_types=target_columns_to_types,
                             order_projections=False,
                         )
                     else:
@@ -1538,7 +1557,7 @@ class EngineAdapter:
                             query,
                             table,
                             columns=(
-                                list(columns_to_types)
+                                list(target_columns_to_types)
                                 if not insert_overwrite_strategy.is_replace_where
                                 else None
                             ),
@@ -1580,7 +1599,7 @@ class EngineAdapter:
         updated_at_col: exp.Column,
         invalidate_hard_deletes: bool = True,
         updated_at_as_valid_from: bool = False,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         truncate: bool = False,
@@ -1597,7 +1616,7 @@ class EngineAdapter:
             updated_at_col=updated_at_col,
             invalidate_hard_deletes=invalidate_hard_deletes,
             updated_at_as_valid_from=updated_at_as_valid_from,
-            columns_to_types=columns_to_types,
+            target_columns_to_types=target_columns_to_types,
             table_description=table_description,
             column_descriptions=column_descriptions,
             truncate=truncate,
@@ -1616,7 +1635,7 @@ class EngineAdapter:
         check_columns: t.Union[exp.Star, t.Sequence[exp.Column]],
         invalidate_hard_deletes: bool = True,
         execution_time_as_valid_from: bool = False,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         truncate: bool = False,
@@ -1631,7 +1650,7 @@ class EngineAdapter:
             valid_to_col=valid_to_col,
             execution_time=execution_time,
             check_columns=check_columns,
-            columns_to_types=columns_to_types,
+            target_columns_to_types=target_columns_to_types,
             invalidate_hard_deletes=invalidate_hard_deletes,
             execution_time_as_valid_from=execution_time_as_valid_from,
             table_description=table_description,
@@ -1654,7 +1673,7 @@ class EngineAdapter:
         check_columns: t.Optional[t.Union[exp.Star, t.Sequence[exp.Column]]] = None,
         updated_at_as_valid_from: bool = False,
         execution_time_as_valid_from: bool = False,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         truncate: bool = False,
@@ -1670,15 +1689,15 @@ class EngineAdapter:
 
         valid_from_name = valid_from_col.name
         valid_to_name = valid_to_col.name
-        columns_to_types = columns_to_types or self.columns(target_table)
+        target_columns_to_types = target_columns_to_types or self.columns(target_table)
         if (
-            valid_from_name not in columns_to_types
-            or valid_to_name not in columns_to_types
-            or not columns_to_types_all_known(columns_to_types)
+            valid_from_name not in target_columns_to_types
+            or valid_to_name not in target_columns_to_types
+            or not columns_to_types_all_known(target_columns_to_types)
         ):
-            columns_to_types = self.columns(target_table)
+            target_columns_to_types = self.columns(target_table)
         unmanaged_columns_to_types = (
-            remove_managed_columns(columns_to_types) if columns_to_types else None
+            remove_managed_columns(target_columns_to_types) if target_columns_to_types else None
         )
         source_queries, unmanaged_columns_to_types = self._get_source_queries_and_columns_to_types(
             source_table,
@@ -1688,10 +1707,10 @@ class EngineAdapter:
             source_columns=source_columns,
         )
         updated_at_name = updated_at_col.name if updated_at_col else None
-        if not columns_to_types:
+        if not target_columns_to_types:
             raise SQLMeshError(f"Could not get columns_to_types. Does {target_table} exist?")
         unmanaged_columns_to_types = unmanaged_columns_to_types or remove_managed_columns(
-            columns_to_types
+            target_columns_to_types
         )
         if not unique_key:
             raise SQLMeshError("unique_key must be provided for SCD Type 2")
@@ -1707,15 +1726,15 @@ class EngineAdapter:
             raise SQLMeshError(
                 "Cannot use `execution_time_as_valid_from` without `check_columns` for SCD Type 2"
             )
-        if updated_at_name and updated_at_name not in columns_to_types:
+        if updated_at_name and updated_at_name not in target_columns_to_types:
             raise SQLMeshError(
                 f"Column {updated_at_name} not found in {target_table}. Table must contain an `updated_at` timestamp for SCD Type 2"
             )
-        time_data_type = columns_to_types[valid_from_name]
+        time_data_type = target_columns_to_types[valid_from_name]
         select_source_columns: t.List[t.Union[str, exp.Alias]] = [
             col for col in unmanaged_columns_to_types if col != updated_at_name
         ]
-        table_columns = [exp.column(c, quoted=True) for c in columns_to_types]
+        table_columns = [exp.column(c, quoted=True) for c in target_columns_to_types]
         if updated_at_name:
             select_source_columns.append(
                 exp.cast(updated_at_col, time_data_type).as_(updated_at_col.this)  # type: ignore
@@ -1852,7 +1871,7 @@ class EngineAdapter:
 
         with source_queries[0] as source_query:
             prefixed_columns_to_types = []
-            for column in columns_to_types:
+            for column in target_columns_to_types:
                 prefixed_col = exp.column(column).copy()
                 prefixed_col.this.set("this", f"t_{prefixed_col.name}")
                 prefixed_columns_to_types.append(prefixed_col)
@@ -1896,7 +1915,7 @@ class EngineAdapter:
                 # Deleted records which can be used to determine `valid_from` for undeleted source records
                 .with_(
                     "deleted",
-                    exp.select(*[exp.column(col, "static") for col in columns_to_types])
+                    exp.select(*[exp.column(col, "static") for col in target_columns_to_types])
                     .from_("static")
                     .join(
                         "latest",
@@ -1931,7 +1950,7 @@ class EngineAdapter:
                         exp.column("_exists", table="source").as_("_exists"),
                         *(
                             exp.column(col, table="latest").as_(prefixed_columns_to_types[i].this)
-                            for i, col in enumerate(columns_to_types)
+                            for i, col in enumerate(target_columns_to_types)
                         ),
                         *(
                             exp.column(col, table="source").as_(col)
@@ -1956,7 +1975,7 @@ class EngineAdapter:
                                 exp.column(col, table="latest").as_(
                                     prefixed_columns_to_types[i].this
                                 )
-                                for i, col in enumerate(columns_to_types)
+                                for i, col in enumerate(target_columns_to_types)
                             ),
                             *(
                                 exp.column(col, table="source").as_(col)
@@ -2025,7 +2044,7 @@ class EngineAdapter:
             self.replace_query(
                 target_table,
                 self.ensure_nulls_for_unmatched_after_join(query),
-                columns_to_types=columns_to_types,
+                target_columns_to_types=target_columns_to_types,
                 table_description=table_description,
                 column_descriptions=column_descriptions,
                 **kwargs,
@@ -2035,17 +2054,20 @@ class EngineAdapter:
         self,
         target_table: TableName,
         source_table: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
         merge_filter: t.Optional[exp.Expression] = None,
         source_columns: t.Optional[t.List[str]] = None,
         **kwargs: t.Any,
     ) -> None:
-        source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
-            source_table, columns_to_types, target_table=target_table, source_columns=source_columns
+        source_queries, target_columns_to_types = self._get_source_queries_and_columns_to_types(
+            source_table,
+            target_columns_to_types,
+            target_table=target_table,
+            source_columns=source_columns,
         )
-        columns_to_types = columns_to_types or self.columns(target_table)
+        target_columns_to_types = target_columns_to_types or self.columns(target_table)
         on = exp.and_(
             *(
                 add_table(part, MERGE_TARGET_ALIAS).eq(add_table(part, MERGE_SOURCE_ALIAS))
@@ -2065,7 +2087,7 @@ class EngineAdapter:
                             exp.column(col, MERGE_TARGET_ALIAS).eq(
                                 exp.column(col, MERGE_SOURCE_ALIAS)
                             )
-                            for col in columns_to_types
+                            for col in target_columns_to_types
                         ],
                     ),
                 )
@@ -2078,10 +2100,12 @@ class EngineAdapter:
                 matched=False,
                 source=False,
                 then=exp.Insert(
-                    this=exp.Tuple(expressions=[exp.column(col) for col in columns_to_types]),
+                    this=exp.Tuple(
+                        expressions=[exp.column(col) for col in target_columns_to_types]
+                    ),
                     expression=exp.Tuple(
                         expressions=[
-                            exp.column(col, MERGE_SOURCE_ALIAS) for col in columns_to_types
+                            exp.column(col, MERGE_SOURCE_ALIAS) for col in target_columns_to_types
                         ]
                     ),
                 ),
@@ -2365,7 +2389,7 @@ class EngineAdapter:
         self,
         query_or_df: QueryOrDF,
         name: TableName = "diff",
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         source_columns: t.Optional[t.List[str]] = None,
         **kwargs: t.Any,
     ) -> t.Iterator[exp.Table]:
@@ -2376,7 +2400,7 @@ class EngineAdapter:
         Args:
             query_or_df: The query or df to create a temp table for.
             name: The base name of the temp table.
-            columns_to_types: A mapping between the column name and its data type.
+            target_columns_to_types: A mapping between the column name and its data type.
 
         Yields:
             The table expression
@@ -2386,9 +2410,9 @@ class EngineAdapter:
         if isinstance(name, exp.Table) and not name.catalog and name.db and self.default_catalog:
             name.set("catalog", exp.parse_identifier(self.default_catalog))
 
-        source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
+        source_queries, target_columns_to_types = self._get_source_queries_and_columns_to_types(
             query_or_df,
-            columns_to_types=columns_to_types,
+            target_columns_to_types=target_columns_to_types,
             target_table=name,
             source_columns=source_columns,
         )
@@ -2400,7 +2424,7 @@ class EngineAdapter:
             self._create_table_from_source_queries(
                 table,
                 source_queries,
-                columns_to_types,
+                target_columns_to_types,
                 exists=True,
                 table_description=None,
                 column_descriptions=None,
@@ -2428,7 +2452,7 @@ class EngineAdapter:
         partitioned_by: t.List[exp.Expression],
         *,
         partition_interval_unit: t.Optional[IntervalUnit] = None,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         catalog_name: t.Optional[str] = None,
         **kwargs: t.Any,
     ) -> t.Optional[t.Union[exp.PartitionedByProperty, exp.Property]]:
@@ -2450,7 +2474,7 @@ class EngineAdapter:
         partition_interval_unit: t.Optional[IntervalUnit] = None,
         clustered_by: t.Optional[t.List[exp.Expression]] = None,
         table_properties: t.Optional[t.Dict[str, exp.Expression]] = None,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         table_kind: t.Optional[str] = None,
         **kwargs: t.Any,
@@ -2551,12 +2575,12 @@ class EngineAdapter:
     def _order_projections_and_filter(
         self,
         query: Query,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         where: t.Optional[exp.Expression] = None,
         coerce_types: bool = False,
     ) -> Query:
         if not isinstance(query, exp.Query) or (
-            not where and not coerce_types and query.named_selects == list(columns_to_types)
+            not where and not coerce_types and query.named_selects == list(target_columns_to_types)
         ):
             return query
 
@@ -2564,12 +2588,12 @@ class EngineAdapter:
         with_ = query.args.pop("with", None)
 
         select_exprs: t.List[exp.Expression] = [
-            exp.column(c, quoted=True) for c in columns_to_types
+            exp.column(c, quoted=True) for c in target_columns_to_types
         ]
-        if coerce_types and columns_to_types_all_known(columns_to_types):
+        if coerce_types and columns_to_types_all_known(target_columns_to_types):
             select_exprs = [
                 exp.cast(select_exprs[i], col_tpe).as_(col, quoted=True)
-                for i, (col, col_tpe) in enumerate(columns_to_types.items())
+                for i, (col, col_tpe) in enumerate(target_columns_to_types.items())
             ]
 
         query = exp.select(*select_exprs).from_(query.subquery("_subquery", copy=False), copy=False)
@@ -2613,30 +2637,30 @@ class EngineAdapter:
         self,
         target_table: TableName,
         source_table: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         key: t.Sequence[exp.Expression],
         is_unique_key: bool,
         source_columns: t.Optional[t.List[str]] = None,
     ) -> None:
-        if columns_to_types is None:
-            columns_to_types = self.columns(target_table)
+        if target_columns_to_types is None:
+            target_columns_to_types = self.columns(target_table)
 
         temp_table = self._get_temp_table(target_table)
         key_exp = exp.func("CONCAT_WS", "'__SQLMESH_DELIM__'", *key) if len(key) > 1 else key[0]
-        column_names = list(columns_to_types or [])
+        column_names = list(target_columns_to_types or [])
 
         with self.transaction():
             self.ctas(
                 temp_table,
                 source_table,
-                columns_to_types=columns_to_types,
+                target_columns_to_types=target_columns_to_types,
                 exists=False,
                 source_columns=source_columns,
             )
 
             try:
                 delete_query = exp.select(key_exp).from_(temp_table)
-                insert_query = self._select_columns(columns_to_types).from_(temp_table)
+                insert_query = self._select_columns(target_columns_to_types).from_(temp_table)
                 if not is_unique_key:
                     delete_query = delete_query.distinct()
                 else:
@@ -2757,17 +2781,6 @@ class EngineAdapter:
                 raise SQLMeshError(
                     f"Identifier name '{name}' (length {name_length}) exceeds {self.dialect.capitalize()}'s max identifier limit of {self.MAX_IDENTIFIER_LENGTH} characters"
                 )
-
-    @classmethod
-    def get_source_columns_to_types(
-        cls,
-        columns_to_types: t.Dict[str, exp.DataType],
-        source_columns: t.Optional[t.List[str]],
-    ) -> t.Dict[str, exp.DataType]:
-        """Returns the source columns to types mapping."""
-        return {
-            k: v for k, v in columns_to_types.items() if not source_columns or k in source_columns
-        }
 
 
 class EngineAdapterWithIndexSupport(EngineAdapter):

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -91,7 +91,7 @@ class BasePostgresEngineAdapter(EngineAdapter):
         self,
         view_name: TableName,
         query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         replace: bool = True,
         materialized: bool = False,
         materialized_properties: t.Optional[t.Dict[str, t.Any]] = None,
@@ -114,7 +114,7 @@ class BasePostgresEngineAdapter(EngineAdapter):
             super().create_view(
                 view_name,
                 query_or_df,
-                columns_to_types=columns_to_types,
+                target_columns_to_types=target_columns_to_types,
                 replace=False,
                 materialized=materialized,
                 materialized_properties=materialized_properties,

--- a/sqlmesh/core/engine_adapter/base_postgres.py
+++ b/sqlmesh/core/engine_adapter/base_postgres.py
@@ -98,6 +98,7 @@ class BasePostgresEngineAdapter(EngineAdapter):
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         view_properties: t.Optional[t.Dict[str, exp.Expression]] = None,
+        source_columns: t.Optional[t.List[str]] = None,
         **create_kwargs: t.Any,
     ) -> None:
         """
@@ -120,6 +121,7 @@ class BasePostgresEngineAdapter(EngineAdapter):
                 table_description=table_description,
                 column_descriptions=column_descriptions,
                 view_properties=view_properties,
+                source_columns=source_columns,
                 **create_kwargs,
             )
 

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -22,7 +22,7 @@ from sqlmesh.core.engine_adapter.shared import (
 )
 from sqlmesh.core.node import IntervalUnit
 from sqlmesh.core.schema_diff import SchemaDiffer
-from sqlmesh.utils import optional_import
+from sqlmesh.utils import optional_import, get_source_columns_to_types
 from sqlmesh.utils.date import to_datetime
 from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.pandas import columns_to_types_from_dtypes
@@ -151,11 +151,14 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
         columns_to_types: t.Dict[str, exp.DataType],
         batch_size: int,
         target_table: TableName,
+        source_columns: t.Optional[t.List[str]] = None,
     ) -> t.List[SourceQuery]:
         import pandas as pd
 
+        source_columns_to_types = get_source_columns_to_types(columns_to_types, source_columns)
+
         temp_bq_table = self.__get_temp_bq_table(
-            self._get_temp_table(target_table or "pandas"), columns_to_types
+            self._get_temp_table(target_table or "pandas"), source_columns_to_types
         )
         temp_table = exp.table_(
             temp_bq_table.table_id,
@@ -174,11 +177,13 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
                 assert isinstance(df, pd.DataFrame)
                 self._db_call(self.client.create_table, table=temp_bq_table, exists_ok=False)
                 result = self.__load_pandas_to_table(
-                    temp_bq_table, df, columns_to_types, replace=False
+                    temp_bq_table, df, source_columns_to_types, replace=False
                 )
                 if result.errors:
                     raise SQLMeshError(result.errors)
-            return self._select_columns(columns_to_types).from_(temp_table)
+            return exp.select(
+                *self._casted_columns(columns_to_types, source_columns=source_columns)
+            ).from_(temp_table)
 
         return [
             SourceQuery(
@@ -674,6 +679,7 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
         query_or_df: QueryOrDF,
         partitioned_by: t.List[exp.Expression],
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        source_columns: t.Optional[t.List[str]] = None,
     ) -> None:
         if len(partitioned_by) != 1:
             raise SQLMeshError(
@@ -695,7 +701,10 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
         with (
             self.session({}),
             self.temp_table(
-                query_or_df, name=table_name, partitioned_by=partitioned_by
+                query_or_df,
+                name=table_name,
+                partitioned_by=partitioned_by,
+                source_columns=source_columns,
             ) as temp_table_name,
         ):
             if columns_to_types is None or columns_to_types[
@@ -1204,17 +1213,26 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
 
     @t.overload
     def _columns_to_types(
-        self, query_or_df: DF, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
-    ) -> t.Dict[str, exp.DataType]: ...
+        self,
+        query_or_df: DF,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        source_columns: t.Optional[t.List[str]] = None,
+    ) -> t.Tuple[t.Dict[str, exp.DataType], t.List[str]]: ...
 
     @t.overload
     def _columns_to_types(
-        self, query_or_df: Query, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
-    ) -> t.Optional[t.Dict[str, exp.DataType]]: ...
+        self,
+        query_or_df: Query,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        source_columns: t.Optional[t.List[str]] = None,
+    ) -> t.Tuple[t.Optional[t.Dict[str, exp.DataType]], t.Optional[t.List[str]]]: ...
 
     def _columns_to_types(
-        self, query_or_df: QueryOrDF, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
-    ) -> t.Optional[t.Dict[str, exp.DataType]]:
+        self,
+        query_or_df: QueryOrDF,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        source_columns: t.Optional[t.List[str]] = None,
+    ) -> t.Tuple[t.Optional[t.Dict[str, exp.DataType]], t.Optional[t.List[str]]]:
         if (
             not columns_to_types
             and bigframes
@@ -1222,9 +1240,12 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
         ):
             # using dry_run=True attempts to prevent the DataFrame from being materialized just to read the column types from it
             dtypes = query_or_df.to_pandas(dry_run=True).columnDtypes
-            return columns_to_types_from_dtypes(dtypes.items())
+            columns_to_types = columns_to_types_from_dtypes(dtypes.items())
+            return columns_to_types, list(source_columns or columns_to_types)
 
-        return super()._columns_to_types(query_or_df, columns_to_types)
+        return super()._columns_to_types(
+            query_or_df, columns_to_types, source_columns=source_columns
+        )
 
     def _native_df_to_pandas_df(
         self,

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -64,10 +64,11 @@ class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin,
         columns_to_types: t.Dict[str, exp.DataType],
         batch_size: int,
         target_table: TableName,
+        source_columns: t.Optional[t.List[str]] = None,
     ) -> t.List[SourceQuery]:
         temp_table = self._get_temp_table(target_table)
         temp_table_sql = (
-            exp.select(*self._casted_columns(columns_to_types))
+            exp.select(*self._casted_columns(columns_to_types, source_columns))
             .from_("df")
             .sql(dialect=self.dialect)
         )

--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -61,21 +61,23 @@ class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin,
     def _df_to_source_queries(
         self,
         df: DF,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         batch_size: int,
         target_table: TableName,
         source_columns: t.Optional[t.List[str]] = None,
     ) -> t.List[SourceQuery]:
         temp_table = self._get_temp_table(target_table)
         temp_table_sql = (
-            exp.select(*self._casted_columns(columns_to_types, source_columns))
+            exp.select(*self._casted_columns(target_columns_to_types, source_columns))
             .from_("df")
             .sql(dialect=self.dialect)
         )
         self.cursor.sql(f"CREATE TABLE {temp_table} AS {temp_table_sql}")
         return [
             SourceQuery(
-                query_factory=lambda: self._select_columns(columns_to_types).from_(temp_table),  # type: ignore
+                query_factory=lambda: self._select_columns(target_columns_to_types).from_(
+                    temp_table
+                ),  # type: ignore
                 cleanup_func=lambda: self.drop_table(temp_table),
             )
         ]
@@ -150,7 +152,7 @@ class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin,
         expression: t.Optional[exp.Expression],
         exists: bool = True,
         replace: bool = False,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         table_kind: t.Optional[str] = None,
@@ -173,7 +175,7 @@ class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin,
             expression,
             exists,
             replace,
-            columns_to_types,
+            target_columns_to_types,
             table_description,
             column_descriptions,
             table_kind,

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -31,6 +31,7 @@ from sqlmesh.core.engine_adapter.shared import (
     set_catalog,
 )
 from sqlmesh.core.schema_diff import SchemaDiffer
+from sqlmesh.utils import get_source_columns_to_types
 
 if t.TYPE_CHECKING:
     from sqlmesh.core._typing import SchemaName, TableName
@@ -198,12 +199,13 @@ class MSSQLEngineAdapter(
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
         merge_filter: t.Optional[exp.Expression] = None,
+        source_columns: t.Optional[t.List[str]] = None,
         **kwargs: t.Any,
     ) -> None:
         mssql_merge_exists = kwargs.get("physical_properties", {}).get("mssql_merge_exists")
 
         source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
-            source_table, columns_to_types, target_table=target_table
+            source_table, columns_to_types, target_table=target_table, source_columns=source_columns
         )
         columns_to_types = columns_to_types or self.columns(target_table)
         on = exp.and_(
@@ -306,6 +308,7 @@ class MSSQLEngineAdapter(
         columns_to_types: t.Dict[str, exp.DataType],
         batch_size: int,
         target_table: TableName,
+        source_columns: t.Optional[t.List[str]] = None,
     ) -> t.List[SourceQuery]:
         import pandas as pd
         import numpy as np
@@ -315,25 +318,31 @@ class MSSQLEngineAdapter(
 
         # Return the superclass implementation if the connection pool doesn't support bulk_copy
         if not hasattr(self._connection_pool.get(), "bulk_copy"):
-            return super()._df_to_source_queries(df, columns_to_types, batch_size, target_table)
+            return super()._df_to_source_queries(
+                df, columns_to_types, batch_size, target_table, source_columns=source_columns
+            )
 
         def query_factory() -> Query:
             # It is possible for the factory to be called multiple times and if so then the temp table will already
             # be created so we skip creating again. This means we are assuming the first call is the same result
             # as later calls.
             if not self.table_exists(temp_table):
-                columns_to_types_create = columns_to_types.copy()
+                source_columns_to_types = get_source_columns_to_types(
+                    columns_to_types, source_columns
+                )
                 ordered_df = df[
-                    list(columns_to_types_create)
+                    list(source_columns_to_types)
                 ]  # reorder DataFrame so it matches columns_to_types
-                self._convert_df_datetime(ordered_df, columns_to_types_create)
-                self.create_table(temp_table, columns_to_types_create)
+                self._convert_df_datetime(ordered_df, source_columns_to_types)
+                self.create_table(temp_table, source_columns_to_types)
                 rows: t.List[t.Tuple[t.Any, ...]] = list(
                     ordered_df.replace({np.nan: None}).itertuples(index=False, name=None)  # type: ignore
                 )
                 conn = self._connection_pool.get()
                 conn.bulk_copy(temp_table.sql(dialect=self.dialect), rows)
-            return exp.select(*self._casted_columns(columns_to_types)).from_(temp_table)  # type: ignore
+            return exp.select(
+                *self._casted_columns(columns_to_types, source_columns=source_columns)
+            ).from_(temp_table)  # type: ignore
 
         return [
             SourceQuery(

--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -195,7 +195,7 @@ class MSSQLEngineAdapter(
         self,
         target_table: TableName,
         source_table: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
         merge_filter: t.Optional[exp.Expression] = None,
@@ -204,10 +204,13 @@ class MSSQLEngineAdapter(
     ) -> None:
         mssql_merge_exists = kwargs.get("physical_properties", {}).get("mssql_merge_exists")
 
-        source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
-            source_table, columns_to_types, target_table=target_table, source_columns=source_columns
+        source_queries, target_columns_to_types = self._get_source_queries_and_columns_to_types(
+            source_table,
+            target_columns_to_types,
+            target_table=target_table,
+            source_columns=source_columns,
         )
-        columns_to_types = columns_to_types or self.columns(target_table)
+        target_columns_to_types = target_columns_to_types or self.columns(target_table)
         on = exp.and_(
             *(
                 add_table(part, MERGE_TARGET_ALIAS).eq(add_table(part, MERGE_SOURCE_ALIAS))
@@ -220,7 +223,9 @@ class MSSQLEngineAdapter(
         match_expressions = []
         if not when_matched:
             unique_key_names = [y.name for y in unique_key]
-            columns_to_types_no_keys = [c for c in columns_to_types if c not in unique_key_names]
+            columns_to_types_no_keys = [
+                c for c in target_columns_to_types if c not in unique_key_names
+            ]
 
             target_columns_no_keys = [
                 exp.column(c, MERGE_TARGET_ALIAS) for c in columns_to_types_no_keys
@@ -263,10 +268,12 @@ class MSSQLEngineAdapter(
                 matched=False,
                 source=False,
                 then=exp.Insert(
-                    this=exp.Tuple(expressions=[exp.column(col) for col in columns_to_types]),
+                    this=exp.Tuple(
+                        expressions=[exp.column(col) for col in target_columns_to_types]
+                    ),
                     expression=exp.Tuple(
                         expressions=[
-                            exp.column(col, MERGE_SOURCE_ALIAS) for col in columns_to_types
+                            exp.column(col, MERGE_SOURCE_ALIAS) for col in target_columns_to_types
                         ]
                     ),
                 ),
@@ -305,7 +312,7 @@ class MSSQLEngineAdapter(
     def _df_to_source_queries(
         self,
         df: DF,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         batch_size: int,
         target_table: TableName,
         source_columns: t.Optional[t.List[str]] = None,
@@ -319,7 +326,7 @@ class MSSQLEngineAdapter(
         # Return the superclass implementation if the connection pool doesn't support bulk_copy
         if not hasattr(self._connection_pool.get(), "bulk_copy"):
             return super()._df_to_source_queries(
-                df, columns_to_types, batch_size, target_table, source_columns=source_columns
+                df, target_columns_to_types, batch_size, target_table, source_columns=source_columns
             )
 
         def query_factory() -> Query:
@@ -328,7 +335,7 @@ class MSSQLEngineAdapter(
             # as later calls.
             if not self.table_exists(temp_table):
                 source_columns_to_types = get_source_columns_to_types(
-                    columns_to_types, source_columns
+                    target_columns_to_types, source_columns
                 )
                 ordered_df = df[
                     list(source_columns_to_types)
@@ -341,7 +348,7 @@ class MSSQLEngineAdapter(
                 conn = self._connection_pool.get()
                 conn.bulk_copy(temp_table.sql(dialect=self.dialect), rows)
             return exp.select(
-                *self._casted_columns(columns_to_types, source_columns=source_columns)
+                *self._casted_columns(target_columns_to_types, source_columns=source_columns)
             ).from_(temp_table)  # type: ignore
 
         return [
@@ -402,7 +409,7 @@ class MSSQLEngineAdapter(
         self,
         table_name: TableName,
         source_queries: t.List[SourceQuery],
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         where: t.Optional[exp.Condition] = None,
         insert_overwrite_strategy_override: t.Optional[InsertOverwriteStrategy] = None,
         **kwargs: t.Any,
@@ -414,7 +421,7 @@ class MSSQLEngineAdapter(
                 self,
                 table_name=table_name,
                 source_queries=source_queries,
-                columns_to_types=columns_to_types,
+                target_columns_to_types=target_columns_to_types,
                 where=where,
                 insert_overwrite_strategy_override=InsertOverwriteStrategy.DELETE_INSERT,
                 **kwargs,
@@ -424,7 +431,7 @@ class MSSQLEngineAdapter(
         return super()._insert_overwrite_by_condition(
             table_name=table_name,
             source_queries=source_queries,
-            columns_to_types=columns_to_types,
+            target_columns_to_types=target_columns_to_types,
             where=where,
             insert_overwrite_strategy_override=insert_overwrite_strategy_override,
             **kwargs,

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -106,7 +106,7 @@ class PostgresEngineAdapter(
         self,
         target_table: TableName,
         source_table: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
         merge_filter: t.Optional[exp.Expression] = None,
@@ -119,7 +119,7 @@ class PostgresEngineAdapter(
         merge_impl(  # type: ignore
             target_table,
             source_table,
-            columns_to_types,
+            target_columns_to_types,
             unique_key,
             when_matched=when_matched,
             merge_filter=merge_filter,

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -110,6 +110,7 @@ class PostgresEngineAdapter(
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
         merge_filter: t.Optional[exp.Expression] = None,
+        source_columns: t.Optional[t.List[str]] = None,
         **kwargs: t.Any,
     ) -> None:
         # Merge isn't supported until Postgres 15
@@ -122,6 +123,7 @@ class PostgresEngineAdapter(
             unique_key,
             when_matched=when_matched,
             merge_filter=merge_filter,
+            source_columns=source_columns,
         )
 
     @cached_property

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -214,6 +214,7 @@ class RedshiftEngineAdapter(
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         view_properties: t.Optional[t.Dict[str, exp.Expression]] = None,
+        source_columns: t.Optional[t.List[str]] = None,
         **create_kwargs: t.Any,
     ) -> None:
         """
@@ -240,6 +241,7 @@ class RedshiftEngineAdapter(
             column_descriptions=column_descriptions,
             no_schema_binding=no_schema_binding,
             view_properties=view_properties,
+            source_columns=source_columns,
             **create_kwargs,
         )
 
@@ -250,6 +252,7 @@ class RedshiftEngineAdapter(
         columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
+        source_columns: t.Optional[t.List[str]] = None,
         **kwargs: t.Any,
     ) -> None:
         """
@@ -274,10 +277,14 @@ class RedshiftEngineAdapter(
                 columns_to_types,
                 table_description,
                 column_descriptions,
+                source_columns=source_columns,
                 **kwargs,
             )
         source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
-            query_or_df, columns_to_types, target_table=table_name
+            query_or_df,
+            columns_to_types,
+            target_table=table_name,
+            source_columns=source_columns,
         )
         columns_to_types = columns_to_types or self.columns(table_name)
         target_table = exp.to_table(table_name)
@@ -358,6 +365,7 @@ class RedshiftEngineAdapter(
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
         merge_filter: t.Optional[exp.Expression] = None,
+        source_columns: t.Optional[t.List[str]] = None,
         **kwargs: t.Any,
     ) -> None:
         if self.enable_merge:
@@ -369,6 +377,7 @@ class RedshiftEngineAdapter(
                 unique_key=unique_key,
                 when_matched=when_matched,
                 merge_filter=merge_filter,
+                source_columns=source_columns,
             )
         else:
             logical_merge(
@@ -379,6 +388,7 @@ class RedshiftEngineAdapter(
                 unique_key,
                 when_matched=when_matched,
                 merge_filter=merge_filter,
+                source_columns=source_columns,
             )
 
     def _merge(

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -168,7 +168,7 @@ class RedshiftEngineAdapter(
         self,
         table_name: TableName,
         source_queries: t.List[SourceQuery],
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         exists: bool = True,
         replace: bool = False,
         table_description: t.Optional[str] = None,
@@ -186,7 +186,7 @@ class RedshiftEngineAdapter(
             return super()._create_table_from_source_queries(
                 table_name,
                 source_queries,
-                columns_to_types,
+                target_columns_to_types,
                 exists,
                 table_description=table_description,
                 column_descriptions=column_descriptions,
@@ -207,7 +207,7 @@ class RedshiftEngineAdapter(
         self,
         view_name: TableName,
         query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         replace: bool = True,
         materialized: bool = False,
         materialized_properties: t.Optional[t.Dict[str, t.Any]] = None,
@@ -233,7 +233,7 @@ class RedshiftEngineAdapter(
         return super().create_view(
             view_name,
             query_or_df,
-            columns_to_types,
+            target_columns_to_types,
             replace,
             materialized,
             materialized_properties,
@@ -249,7 +249,7 @@ class RedshiftEngineAdapter(
         self,
         table_name: TableName,
         query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         source_columns: t.Optional[t.List[str]] = None,
@@ -274,32 +274,32 @@ class RedshiftEngineAdapter(
             return super().replace_query(
                 table_name,
                 query_or_df,
-                columns_to_types,
+                target_columns_to_types,
                 table_description,
                 column_descriptions,
                 source_columns=source_columns,
                 **kwargs,
             )
-        source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
+        source_queries, target_columns_to_types = self._get_source_queries_and_columns_to_types(
             query_or_df,
-            columns_to_types,
+            target_columns_to_types,
             target_table=table_name,
             source_columns=source_columns,
         )
-        columns_to_types = columns_to_types or self.columns(table_name)
+        target_columns_to_types = target_columns_to_types or self.columns(table_name)
         target_table = exp.to_table(table_name)
         with self.transaction():
             temp_table = self._get_temp_table(target_table)
             old_table = self._get_temp_table(target_table)
             self.create_table(
                 temp_table,
-                columns_to_types,
+                target_columns_to_types,
                 exists=False,
                 table_description=table_description,
                 column_descriptions=column_descriptions,
                 **kwargs,
             )
-            self._insert_append_source_queries(temp_table, source_queries, columns_to_types)
+            self._insert_append_source_queries(temp_table, source_queries, target_columns_to_types)
             self.rename_table(target_table, old_table)
             self.rename_table(temp_table, target_table)
             self.drop_table(old_table)
@@ -361,7 +361,7 @@ class RedshiftEngineAdapter(
         self,
         target_table: TableName,
         source_table: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
         unique_key: t.Sequence[exp.Expression],
         when_matched: t.Optional[exp.Whens] = None,
         merge_filter: t.Optional[exp.Expression] = None,
@@ -373,7 +373,7 @@ class RedshiftEngineAdapter(
             super().merge(
                 target_table=target_table,
                 source_table=source_table,
-                columns_to_types=columns_to_types,
+                target_columns_to_types=target_columns_to_types,
                 unique_key=unique_key,
                 when_matched=when_matched,
                 merge_filter=merge_filter,
@@ -384,7 +384,7 @@ class RedshiftEngineAdapter(
                 self,
                 target_table,
                 source_table,
-                columns_to_types,
+                target_columns_to_types,
                 unique_key,
                 when_matched=when_matched,
                 merge_filter=merge_filter,

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -24,7 +24,7 @@ from sqlmesh.core.engine_adapter.shared import (
     set_catalog,
 )
 from sqlmesh.core.schema_diff import SchemaDiffer
-from sqlmesh.utils import optional_import
+from sqlmesh.utils import optional_import, get_source_columns_to_types
 from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils.pandas import columns_to_types_from_dtypes
 
@@ -198,6 +198,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
         table_properties: t.Optional[t.Dict[str, exp.Expression]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
+        source_columns: t.Optional[t.List[str]] = None,
         **kwargs: t.Any,
     ) -> None:
         target_table = exp.to_table(table_name)
@@ -218,7 +219,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
             )
 
         source_queries, columns_to_types = self._get_source_queries_and_columns_to_types(
-            query, columns_to_types, target_table=target_table
+            query, columns_to_types, target_table=target_table, source_columns=source_columns
         )
 
         self._create_table_from_source_queries(
@@ -246,6 +247,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         view_properties: t.Optional[t.Dict[str, exp.Expression]] = None,
+        source_columns: t.Optional[t.List[str]] = None,
         **create_kwargs: t.Any,
     ) -> None:
         properties = create_kwargs.pop("properties", None)
@@ -265,6 +267,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
             column_descriptions=column_descriptions,
             view_properties=view_properties,
             properties=properties,
+            source_columns=source_columns,
             **create_kwargs,
         )
 
@@ -324,9 +327,12 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
         columns_to_types: t.Dict[str, exp.DataType],
         batch_size: int,
         target_table: TableName,
+        source_columns: t.Optional[t.List[str]] = None,
     ) -> t.List[SourceQuery]:
         import pandas as pd
         from pandas.api.types import is_datetime64_any_dtype
+
+        source_columns_to_types = get_source_columns_to_types(columns_to_types, source_columns)
 
         temp_table = self._get_temp_table(
             target_table or "pandas", quoted=False
@@ -358,7 +364,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
                     local_df = df.rename(
                         {
                             col: exp.to_identifier(col).sql(dialect=self.dialect, identify=True)
-                            for col in columns_to_types
+                            for col in source_columns_to_types
                         }
                     )  # type: ignore
                 local_df.createOrReplaceTempView(
@@ -376,7 +382,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
                 self.set_current_schema(schema)
 
                 # See: https://stackoverflow.com/a/75627721
-                for column, kind in columns_to_types.items():
+                for column, kind in source_columns_to_types.items():
                     if is_datetime64_any_dtype(df.dtypes[column]):
                         if kind.is_type("date"):  # type: ignore
                             df[column] = pd.to_datetime(df[column]).dt.date  # type: ignore
@@ -392,7 +398,7 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
 
                 # create the table first using our usual method ensure the column datatypes match what we parsed with sqlglot
                 # otherwise we would be trusting `write_pandas()` from the snowflake lib to do this correctly
-                self.create_table(temp_table, columns_to_types, table_kind="TEMPORARY TABLE")
+                self.create_table(temp_table, source_columns_to_types, table_kind="TEMPORARY TABLE")
 
                 write_pandas(
                     self._connection_pool.get(),
@@ -409,7 +415,9 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
                     f"Unknown dataframe type: {type(df)} for {target_table}. Expecting pandas or snowpark."
                 )
 
-            return exp.select(*self._casted_columns(columns_to_types)).from_(temp_table)
+            return exp.select(
+                *self._casted_columns(columns_to_types, source_columns=source_columns)
+            ).from_(temp_table)
 
         def cleanup() -> None:
             if is_snowpark_dataframe:
@@ -616,21 +624,35 @@ class SnowflakeEngineAdapter(GetCurrentCatalogFromFunctionMixin, ClusteredByMixi
 
     @t.overload
     def _columns_to_types(
-        self, query_or_df: DF, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
-    ) -> t.Dict[str, exp.DataType]: ...
+        self,
+        query_or_df: DF,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        source_columns: t.Optional[t.List[str]] = None,
+    ) -> t.Tuple[t.Dict[str, exp.DataType], t.List[str]]: ...
 
     @t.overload
     def _columns_to_types(
-        self, query_or_df: Query, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
-    ) -> t.Optional[t.Dict[str, exp.DataType]]: ...
+        self,
+        query_or_df: Query,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        source_columns: t.Optional[t.List[str]] = None,
+    ) -> t.Tuple[t.Optional[t.Dict[str, exp.DataType]], t.Optional[t.List[str]]]: ...
 
     def _columns_to_types(
-        self, query_or_df: QueryOrDF, columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
-    ) -> t.Optional[t.Dict[str, exp.DataType]]:
+        self,
+        query_or_df: QueryOrDF,
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        source_columns: t.Optional[t.List[str]] = None,
+    ) -> t.Tuple[t.Optional[t.Dict[str, exp.DataType]], t.Optional[t.List[str]]]:
         if not columns_to_types and snowpark and isinstance(query_or_df, snowpark.DataFrame):
-            return columns_to_types_from_dtypes(query_or_df.sample(n=1).to_pandas().dtypes.items())
+            columns_to_types = columns_to_types_from_dtypes(
+                query_or_df.sample(n=1).to_pandas().dtypes.items()
+            )
+            return columns_to_types, list(source_columns or columns_to_types)
 
-        return super()._columns_to_types(query_or_df, columns_to_types)
+        return super()._columns_to_types(
+            query_or_df, columns_to_types, source_columns=source_columns
+        )
 
     def close(self) -> t.Any:
         if snowpark_session := self._connection_pool.get_attribute(self.SNOWPARK):

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -23,7 +23,7 @@ from sqlmesh.core.engine_adapter.shared import (
     set_catalog,
 )
 from sqlmesh.core.schema_diff import SchemaDiffer
-from sqlmesh.utils import classproperty
+from sqlmesh.utils import classproperty, get_source_columns_to_types
 from sqlmesh.utils.errors import SQLMeshError
 
 if t.TYPE_CHECKING:
@@ -242,7 +242,7 @@ class SparkEngineAdapter(
     def _columns_to_types(
         self,
         query_or_df: DF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         source_columns: t.Optional[t.List[str]] = None,
     ) -> t.Tuple[t.Dict[str, exp.DataType], t.List[str]]: ...
 
@@ -250,64 +250,64 @@ class SparkEngineAdapter(
     def _columns_to_types(
         self,
         query_or_df: Query,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         source_columns: t.Optional[t.List[str]] = None,
     ) -> t.Tuple[t.Optional[t.Dict[str, exp.DataType]], t.Optional[t.List[str]]]: ...
 
     def _columns_to_types(
         self,
         query_or_df: QueryOrDF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         source_columns: t.Optional[t.List[str]] = None,
     ) -> t.Tuple[t.Optional[t.Dict[str, exp.DataType]], t.Optional[t.List[str]]]:
-        if columns_to_types:
-            return columns_to_types, list(source_columns or columns_to_types)
+        if target_columns_to_types:
+            return target_columns_to_types, list(source_columns or target_columns_to_types)
         if self.is_pyspark_df(query_or_df):
             from pyspark.sql import DataFrame
 
-            columns_to_types = self.spark_to_sqlglot_types(t.cast(DataFrame, query_or_df).schema)
-            return columns_to_types, list(source_columns or columns_to_types)
+            target_columns_to_types = self.spark_to_sqlglot_types(
+                t.cast(DataFrame, query_or_df).schema
+            )
+            return target_columns_to_types, list(source_columns or target_columns_to_types)
         return super()._columns_to_types(
-            query_or_df, columns_to_types, source_columns=source_columns
+            query_or_df, target_columns_to_types, source_columns=source_columns
         )
 
     def _df_to_source_queries(
         self,
         df: DF,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         batch_size: int,
         target_table: TableName,
         source_columns: t.Optional[t.List[str]] = None,
     ) -> t.List[SourceQuery]:
-        df = self._ensure_pyspark_df(df, columns_to_types, source_columns=source_columns)
+        df = self._ensure_pyspark_df(df, target_columns_to_types, source_columns=source_columns)
 
         def query_factory() -> Query:
             temp_table = self._get_temp_table(target_table or "spark", table_only=True)
             df.createOrReplaceGlobalTempView(temp_table.sql(dialect=self.dialect))  # type: ignore
             temp_table.set("db", "global_temp")
-            return exp.select(*self._select_columns(columns_to_types)).from_(temp_table)
+            return exp.select(*self._select_columns(target_columns_to_types)).from_(temp_table)
 
         return [SourceQuery(query_factory=query_factory)]
 
     def _ensure_pyspark_df(
         self,
         generic_df: DF,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         source_columns: t.Optional[t.List[str]] = None,
     ) -> PySparkDataFrame:
-        def _get_pyspark_df() -> PySparkDataFrame:
-            pyspark_df = self.try_get_pyspark_df(generic_df)
-            if pyspark_df:
-                return pyspark_df
+        pyspark_df = self.try_get_pyspark_df(generic_df)
+        if not pyspark_df:
             df = self.try_get_pandas_df(generic_df)
             if df is None:
                 raise SQLMeshError(
                     "Ensure PySpark DF can only be run on a PySpark or Pandas DataFrame"
                 )
 
-            if columns_to_types:
-                source_columns_to_types = self.get_source_columns_to_types(
-                    columns_to_types, source_columns
+            if target_columns_to_types:
+                source_columns_to_types = get_source_columns_to_types(
+                    target_columns_to_types, source_columns
                 )
                 # ensure Pandas dataframe column order matches columns_to_types
                 df = df[list(source_columns_to_types)]
@@ -318,13 +318,13 @@ class SparkEngineAdapter(
                 if source_columns_to_types
                 else {}
             )
-            return self.spark.createDataFrame(df, **kwargs)  # type: ignore
-
-        df_result = _get_pyspark_df()
-        if columns_to_types:
-            select_columns = self._casted_columns(columns_to_types, source_columns=source_columns)
-            df_result = df_result.selectExpr(*[x.sql(self.dialect) for x in select_columns])  # type: ignore
-        return df_result
+            pyspark_df = self.spark.createDataFrame(df, **kwargs)  # type: ignore
+        if target_columns_to_types:
+            select_columns = self._casted_columns(
+                target_columns_to_types, source_columns=source_columns
+            )
+            pyspark_df = pyspark_df.selectExpr(*[x.sql(self.dialect) for x in select_columns])  # type: ignore
+        return pyspark_df
 
     def _get_temp_table(
         self, table: TableName, table_only: bool = False, quoted: bool = True
@@ -405,12 +405,12 @@ class SparkEngineAdapter(
     def create_state_table(
         self,
         table_name: str,
-        columns_to_types: t.Dict[str, exp.DataType],
+        target_columns_to_types: t.Dict[str, exp.DataType],
         primary_key: t.Optional[t.Tuple[str, ...]] = None,
     ) -> None:
         self.create_table(
             table_name,
-            columns_to_types,
+            target_columns_to_types,
             partitioned_by=[exp.column(x) for x in primary_key] if primary_key else None,
         )
 
@@ -429,7 +429,7 @@ class SparkEngineAdapter(
         expression: t.Optional[exp.Expression],
         exists: bool = True,
         replace: bool = False,
-        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         table_kind: t.Optional[str] = None,
@@ -458,7 +458,7 @@ class SparkEngineAdapter(
             expression,
             exists=exists,
             replace=replace,
-            columns_to_types=columns_to_types,
+            target_columns_to_types=target_columns_to_types,
             table_description=table_description,
             column_descriptions=column_descriptions,
             **kwargs,

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -189,6 +189,7 @@ class OnDestructiveChange(str, Enum):
     ERROR = "ERROR"
     WARN = "WARN"
     ALLOW = "ALLOW"
+    IGNORE = "IGNORE"
 
     @property
     def is_error(self) -> bool:
@@ -201,6 +202,10 @@ class OnDestructiveChange(str, Enum):
     @property
     def is_allow(self) -> bool:
         return self == OnDestructiveChange.ALLOW
+
+    @property
+    def is_ignore(self) -> bool:
+        return self == OnDestructiveChange.IGNORE
 
 
 def _on_destructive_change_validator(

--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -558,6 +558,7 @@ class PlanBuilder:
                     new.name,
                     old_columns_to_types,
                     new_columns_to_types,
+                    ignore_destructive=new.model.on_destructive_change.is_ignore,
                 )
 
                 if has_drop_alteration(schema_diff):

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -694,6 +694,7 @@ class SnapshotEvaluator:
                     end=end,
                     execution_time=execution_time,
                     physical_properties=rendered_physical_properties,
+                    render_kwargs=render_statements_kwargs,
                 )
             else:
                 logger.info(
@@ -715,6 +716,7 @@ class SnapshotEvaluator:
                     end=end,
                     execution_time=execution_time,
                     physical_properties=rendered_physical_properties,
+                    render_kwargs=render_statements_kwargs,
                 )
 
         with (
@@ -865,7 +867,9 @@ class SnapshotEvaluator:
                         rendered_physical_properties=rendered_physical_properties,
                     )
                     alter_expressions = adapter.get_alter_expressions(
-                        target_table_name, tmp_table_name
+                        target_table_name,
+                        tmp_table_name,
+                        ignore_destructive=snapshot.model.on_destructive_change.is_ignore,
                     )
                     _check_destructive_schema_change(
                         snapshot, alter_expressions, allow_destructive_snapshots
@@ -940,9 +944,9 @@ class SnapshotEvaluator:
                 evaluation_strategy = _evaluation_strategy(snapshot, adapter)
                 tmp_table_name = snapshot.table_name(is_deployable=False)
                 logger.info(
-                    "Migrating table schema from '%s' to '%s'",
-                    tmp_table_name,
+                    "Migrating table schema '%s' to match '%s'",
                     target_table_name,
+                    tmp_table_name,
                 )
                 evaluation_strategy.migrate(
                     target_table_name=target_table_name,
@@ -950,6 +954,7 @@ class SnapshotEvaluator:
                     snapshot=snapshot,
                     snapshots=parent_snapshots_by_name(snapshot, snapshots),
                     allow_destructive_snapshots=allow_destructive_snapshots,
+                    ignore_destructive=snapshot.model.on_destructive_change.is_ignore,
                 )
             else:
                 logger.info(
@@ -1291,6 +1296,7 @@ class EvaluationStrategy(abc.ABC):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         """Inserts the given query or a DataFrame into the target table or a view.
@@ -1303,6 +1309,7 @@ class EvaluationStrategy(abc.ABC):
                 if no data has been previously inserted into the target table, or when the entire history of the target model has
                 been restated. Note that in the latter case, the table might contain data from previous executions, and it is the
                 responsibility of a specific evaluation strategy to handle the truncation of the table if necessary.
+            render_kwargs: Additional key-value arguments to pass when rendering the model's query.
         """
 
     @abc.abstractmethod
@@ -1311,6 +1318,7 @@ class EvaluationStrategy(abc.ABC):
         table_name: str,
         query_or_df: QueryOrDF,
         model: Model,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         """Appends the given query or a DataFrame to the existing table.
@@ -1319,6 +1327,7 @@ class EvaluationStrategy(abc.ABC):
             table_name: The target table name.
             query_or_df: A query or a DataFrame to insert.
             model: The target model.
+            render_kwargs: Additional key-value arguments to pass when rendering the model's query.
         """
 
     @abc.abstractmethod
@@ -1349,6 +1358,8 @@ class EvaluationStrategy(abc.ABC):
         target_table_name: str,
         source_table_name: str,
         snapshot: Snapshot,
+        *,
+        ignore_destructive: bool,
         **kwargs: t.Any,
     ) -> None:
         """Migrates the target table schema so that it corresponds to the source table schema.
@@ -1357,6 +1368,8 @@ class EvaluationStrategy(abc.ABC):
             target_table_name: The target table name.
             source_table_name: The source table name.
             snapshot: The target snapshot.
+            ignore_destructive: If True, destructive changes are not created when migrating.
+                This is used for forward-only models that are being migrated to a new version.
         """
 
     @abc.abstractmethod
@@ -1393,36 +1406,6 @@ class EvaluationStrategy(abc.ABC):
             view_name: The name of the target view in the virtual layer.
         """
 
-    def _replace_query_for_model(
-        self, model: Model, name: str, query_or_df: QueryOrDF, **kwargs: t.Any
-    ) -> None:
-        """Replaces the table for the given model.
-
-        Args:
-            model: The target model.
-            name: The name of the target table.
-            query_or_df: The query or DataFrame to replace the target table with.
-        """
-        # Source columns from the underlying table to prevent unintentional table schema changes during restatement of incremental models.
-        columns_to_types = (
-            model.columns_to_types
-            if (model.is_seed or model.kind.is_full) and model.annotated
-            else self.adapter.columns(name)
-        )
-        self.adapter.replace_query(
-            name,
-            query_or_df,
-            table_format=model.table_format,
-            storage_format=model.storage_format,
-            partitioned_by=model.partitioned_by,
-            partition_interval_unit=model.partition_interval_unit,
-            clustered_by=model.clustered_by,
-            table_properties=kwargs.get("physical_properties", model.physical_properties),
-            table_description=model.description,
-            column_descriptions=model.column_descriptions,
-            columns_to_types=columns_to_types,
-        )
-
 
 class SymbolicStrategy(EvaluationStrategy):
     def insert(
@@ -1431,6 +1414,7 @@ class SymbolicStrategy(EvaluationStrategy):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         pass
@@ -1440,6 +1424,7 @@ class SymbolicStrategy(EvaluationStrategy):
         table_name: str,
         query_or_df: QueryOrDF,
         model: Model,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         pass
@@ -1459,6 +1444,8 @@ class SymbolicStrategy(EvaluationStrategy):
         target_table_name: str,
         source_table_name: str,
         snapshot: Snapshot,
+        *,
+        ignore_destructive: bool,
         **kwarg: t.Any,
     ) -> None:
         pass
@@ -1493,7 +1480,7 @@ class EmbeddedStrategy(SymbolicStrategy):
         self.adapter.drop_view(view_name, cascade=False)
 
 
-class PromotableStrategy(EvaluationStrategy):
+class PromotableStrategy(EvaluationStrategy, abc.ABC):
     def promote(
         self,
         table_name: str,
@@ -1527,15 +1514,23 @@ class PromotableStrategy(EvaluationStrategy):
         self.adapter.drop_view(view_name, cascade=False)
 
 
-class MaterializableStrategy(PromotableStrategy):
+class MaterializableStrategy(PromotableStrategy, abc.ABC):
     def append(
         self,
         table_name: str,
         query_or_df: QueryOrDF,
         model: Model,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
-        self.adapter.insert_append(table_name, query_or_df, columns_to_types=model.columns_to_types)
+        columns_to_types = kwargs.pop("columns_to_types", model.columns_to_types)
+        source_columns = kwargs.pop("source_columns", None)
+        self.adapter.insert_append(
+            table_name,
+            query_or_df,
+            columns_to_types=columns_to_types,
+            source_columns=source_columns,
+        )
 
     def create(
         self,
@@ -1592,10 +1587,14 @@ class MaterializableStrategy(PromotableStrategy):
         target_table_name: str,
         source_table_name: str,
         snapshot: Snapshot,
+        *,
+        ignore_destructive: bool,
         **kwargs: t.Any,
     ) -> None:
         logger.info(f"Altering table '{target_table_name}'")
-        alter_expressions = self.adapter.get_alter_expressions(target_table_name, source_table_name)
+        alter_expressions = self.adapter.get_alter_expressions(
+            target_table_name, source_table_name, ignore_destructive=ignore_destructive
+        )
         _check_destructive_schema_change(
             snapshot, alter_expressions, kwargs["allow_destructive_snapshots"]
         )
@@ -1606,6 +1605,66 @@ class MaterializableStrategy(PromotableStrategy):
         self.adapter.drop_table(name)
         logger.info("Dropped table '%s'", name)
 
+    def _replace_query_for_model(
+        self,
+        model: Model,
+        name: str,
+        query_or_df: QueryOrDF,
+        render_kwargs: t.Dict[str, t.Any],
+        **kwargs: t.Any,
+    ) -> None:
+        """Replaces the table for the given model.
+
+        Args:
+            model: The target model.
+            name: The name of the target table.
+            query_or_df: The query or DataFrame to replace the target table with.
+        """
+        if (model.is_seed or model.kind.is_full) and model.annotated:
+            columns_to_types = model.columns_to_types_or_raise
+            source_columns: t.Optional[t.List[str]] = list(columns_to_types)
+        else:
+            # Source columns from the underlying table to prevent unintentional table schema changes during restatement of incremental models.
+            columns_to_types, source_columns = self._get_target_and_source_columns(
+                model, name, render_kwargs, columns_to_types=self.adapter.columns(name)
+            )
+
+        self.adapter.replace_query(
+            name,
+            query_or_df,
+            table_format=model.table_format,
+            storage_format=model.storage_format,
+            partitioned_by=model.partitioned_by,
+            partition_interval_unit=model.partition_interval_unit,
+            clustered_by=model.clustered_by,
+            table_properties=kwargs.get("physical_properties", model.physical_properties),
+            table_description=model.description,
+            column_descriptions=model.column_descriptions,
+            columns_to_types=columns_to_types,
+            source_columns=source_columns,
+        )
+
+    def _get_target_and_source_columns(
+        self,
+        model: Model,
+        table_name: str,
+        render_kwargs: t.Dict[str, t.Any],
+        columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None,
+    ) -> t.Tuple[t.Dict[str, exp.DataType], t.Optional[t.List[str]]]:
+        if not columns_to_types:
+            columns_to_types = (
+                model.columns_to_types if model.annotated else self.adapter.columns(table_name)
+            )
+            assert columns_to_types is not None
+        if model.on_destructive_change.is_ignore:
+            # We need to identify the columns that are only in the source so we create an empty table with
+            # the user query to determine that
+            with self.adapter.temp_table(model.ctas_query(**render_kwargs)) as temp_table:
+                source_columns = list(self.adapter.columns(temp_table))
+        else:
+            source_columns = None
+        return columns_to_types, source_columns
+
 
 class IncrementalByPartitionStrategy(MaterializableStrategy):
     def insert(
@@ -1614,16 +1673,21 @@ class IncrementalByPartitionStrategy(MaterializableStrategy):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         if is_first_insert:
-            self._replace_query_for_model(model, table_name, query_or_df, **kwargs)
+            self._replace_query_for_model(model, table_name, query_or_df, render_kwargs, **kwargs)
         else:
+            columns_to_types, source_columns = self._get_target_and_source_columns(
+                model, table_name, render_kwargs=render_kwargs
+            )
             self.adapter.insert_overwrite_by_partition(
                 table_name,
                 query_or_df,
                 partitioned_by=model.partitioned_by,
-                columns_to_types=model.columns_to_types,
+                columns_to_types=columns_to_types,
+                source_columns=source_columns,
             )
 
 
@@ -1634,15 +1698,20 @@ class IncrementalByTimeRangeStrategy(MaterializableStrategy):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         assert model.time_column
+        columns_to_types, source_columns = self._get_target_and_source_columns(
+            model, table_name, render_kwargs=render_kwargs
+        )
         self.adapter.insert_overwrite_by_time_partition(
             table_name,
             query_or_df,
             time_formatter=model.convert_to_time_column,
             time_column=model.time_column,
-            columns_to_types=model.columns_to_types,
+            columns_to_types=columns_to_types,
+            source_columns=source_columns,
             **kwargs,
         )
 
@@ -1654,15 +1723,21 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         if is_first_insert:
-            self._replace_query_for_model(model, table_name, query_or_df, **kwargs)
+            self._replace_query_for_model(model, table_name, query_or_df, render_kwargs, **kwargs)
         else:
+            columns_to_types, source_columns = self._get_target_and_source_columns(
+                model,
+                table_name,
+                render_kwargs=render_kwargs,
+            )
             self.adapter.merge(
                 table_name,
                 query_or_df,
-                columns_to_types=model.columns_to_types,
+                columns_to_types=columns_to_types,
                 unique_key=model.unique_key,
                 when_matched=model.when_matched,
                 merge_filter=model.render_merge_filter(
@@ -1671,6 +1746,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
                     execution_time=kwargs.get("execution_time"),
                 ),
                 physical_properties=kwargs.get("physical_properties", model.physical_properties),
+                source_columns=source_columns,
             )
 
     def append(
@@ -1678,12 +1754,16 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
         table_name: str,
         query_or_df: QueryOrDF,
         model: Model,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
+        columns_to_types, source_columns = self._get_target_and_source_columns(
+            model, table_name, render_kwargs=render_kwargs
+        )
         self.adapter.merge(
             table_name,
             query_or_df,
-            columns_to_types=model.columns_to_types,
+            columns_to_types=columns_to_types,
             unique_key=model.unique_key,
             when_matched=model.when_matched,
             merge_filter=model.render_merge_filter(
@@ -1692,6 +1772,7 @@ class IncrementalByUniqueKeyStrategy(MaterializableStrategy):
                 execution_time=kwargs.get("execution_time"),
             ),
             physical_properties=kwargs.get("physical_properties", model.physical_properties),
+            source_columns=source_columns,
         )
 
 
@@ -1702,24 +1783,36 @@ class IncrementalUnmanagedStrategy(MaterializableStrategy):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         if is_first_insert:
-            self._replace_query_for_model(model, table_name, query_or_df, **kwargs)
-        elif isinstance(model.kind, IncrementalUnmanagedKind) and model.kind.insert_overwrite:
-            self.adapter.insert_overwrite_by_partition(
+            return self._replace_query_for_model(
+                model, table_name, query_or_df, render_kwargs, **kwargs
+            )
+        columns_to_types, source_columns = self._get_target_and_source_columns(
+            model,
+            table_name,
+            render_kwargs=render_kwargs,
+            columns_to_types=kwargs.pop("columns_to_types", None),
+        )
+        if isinstance(model.kind, IncrementalUnmanagedKind) and model.kind.insert_overwrite:
+            return self.adapter.insert_overwrite_by_partition(
                 table_name,
                 query_or_df,
                 model.partitioned_by,
-                columns_to_types=model.columns_to_types,
+                columns_to_types=columns_to_types,
+                source_columns=source_columns,
             )
-        else:
-            self.append(
-                table_name,
-                query_or_df,
-                model,
-                **kwargs,
-            )
+        return self.append(
+            table_name,
+            query_or_df,
+            model,
+            render_kwargs=render_kwargs,
+            columns_to_types=columns_to_types,
+            source_columns=source_columns,
+            **kwargs,
+        )
 
 
 class FullRefreshStrategy(MaterializableStrategy):
@@ -1729,9 +1822,10 @@ class FullRefreshStrategy(MaterializableStrategy):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
-        self._replace_query_for_model(model, table_name, query_or_df, **kwargs)
+        self._replace_query_for_model(model, table_name, query_or_df, render_kwargs, **kwargs)
 
 
 class SeedStrategy(MaterializableStrategy):
@@ -1760,7 +1854,9 @@ class SeedStrategy(MaterializableStrategy):
             try:
                 for index, df in enumerate(model.render_seed()):
                     if index == 0:
-                        self._replace_query_for_model(model, table_name, df, **kwargs)
+                        self._replace_query_for_model(
+                            model, table_name, df, render_kwargs, **kwargs
+                        )
                     else:
                         self.adapter.insert_append(
                             table_name, df, columns_to_types=model.columns_to_types
@@ -1775,6 +1871,7 @@ class SeedStrategy(MaterializableStrategy):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         # Data has already been inserted at the time of table creation.
@@ -1826,10 +1923,16 @@ class SCDType2Strategy(MaterializableStrategy):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
-        # Source columns from the underlying table to prevent unintentional table schema changes during the insert.
-        columns_to_types = self.adapter.columns(table_name)
+        # Source columns from the underlying table to prevent unintentional table schema changes during restatement of incremental models.
+        columns_to_types, source_columns = self._get_target_and_source_columns(
+            model,
+            table_name,
+            render_kwargs=render_kwargs,
+            columns_to_types=self.adapter.columns(table_name),
+        )
         if isinstance(model.kind, SCDType2ByTimeKind):
             self.adapter.scd_type_2_by_time(
                 target_table=table_name,
@@ -1846,6 +1949,7 @@ class SCDType2Strategy(MaterializableStrategy):
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
                 truncate=is_first_insert,
+                source_columns=source_columns,
             )
         elif isinstance(model.kind, SCDType2ByColumnKind):
             self.adapter.scd_type_2_by_column(
@@ -1863,6 +1967,7 @@ class SCDType2Strategy(MaterializableStrategy):
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
                 truncate=is_first_insert,
+                source_columns=source_columns,
             )
         else:
             raise SQLMeshError(
@@ -1874,10 +1979,16 @@ class SCDType2Strategy(MaterializableStrategy):
         table_name: str,
         query_or_df: QueryOrDF,
         model: Model,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
-        # Source columns from the underlying table to prevent unintentional table schema changes during the insert.
-        columns_to_types = self.adapter.columns(table_name)
+        # Source columns from the underlying table to prevent unintentional table schema changes during restatement of incremental models.
+        columns_to_types, source_columns = self._get_target_and_source_columns(
+            model,
+            table_name,
+            render_kwargs=render_kwargs,
+            columns_to_types=self.adapter.columns(table_name),
+        )
         if isinstance(model.kind, SCDType2ByTimeKind):
             self.adapter.scd_type_2_by_time(
                 target_table=table_name,
@@ -1892,6 +2003,7 @@ class SCDType2Strategy(MaterializableStrategy):
                 table_format=model.table_format,
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
+                source_columns=source_columns,
                 **kwargs,
             )
         elif isinstance(model.kind, SCDType2ByColumnKind):
@@ -1908,6 +2020,7 @@ class SCDType2Strategy(MaterializableStrategy):
                 execution_time_as_valid_from=model.kind.execution_time_as_valid_from,
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
+                source_columns=source_columns,
                 **kwargs,
             )
         else:
@@ -1923,6 +2036,7 @@ class ViewStrategy(PromotableStrategy):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         deployability_index = (
@@ -1956,6 +2070,7 @@ class ViewStrategy(PromotableStrategy):
         table_name: str,
         query_or_df: QueryOrDF,
         model: Model,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         raise ConfigError(f"Cannot append to a view '{table_name}'.")
@@ -2011,6 +2126,8 @@ class ViewStrategy(PromotableStrategy):
         target_table_name: str,
         source_table_name: str,
         snapshot: Snapshot,
+        *,
+        ignore_destructive: bool,
         **kwargs: t.Any,
     ) -> None:
         logger.info("Migrating view '%s'", target_table_name)
@@ -2057,6 +2174,7 @@ class CustomMaterialization(MaterializableStrategy, t.Generic[C]):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         """Inserts the given query or a DataFrame into the target table or a view.
@@ -2069,6 +2187,7 @@ class CustomMaterialization(MaterializableStrategy, t.Generic[C]):
                 if no data has been previously inserted into the target table, or when the entire history of the target model has
                 been restated. Note that in the latter case, the table might contain data from previous executions, and it is the
                 responsibility of a specific evaluation strategy to handle the truncation of the table if necessary.
+            render_kwargs: Additional key-value arguments to pass when rendering the model's query.
         """
         raise NotImplementedError(
             "Custom materialization strategies must implement the 'insert' method."
@@ -2204,6 +2323,7 @@ class EngineManagedStrategy(MaterializableStrategy):
         query_or_df: QueryOrDF,
         model: Model,
         is_first_insert: bool,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         deployability_index: DeployabilityIndex = kwargs["deployability_index"]
@@ -2231,7 +2351,11 @@ class EngineManagedStrategy(MaterializableStrategy):
                 model.name,
             )
             self._replace_query_for_model(
-                model=model, name=table_name, query_or_df=query_or_df, **kwargs
+                model=model,
+                name=table_name,
+                query_or_df=query_or_df,
+                render_kwargs=render_kwargs,
+                **kwargs,
             )
 
     def append(
@@ -2239,6 +2363,7 @@ class EngineManagedStrategy(MaterializableStrategy):
         table_name: str,
         query_or_df: QueryOrDF,
         model: Model,
+        render_kwargs: t.Dict[str, t.Any],
         **kwargs: t.Any,
     ) -> None:
         raise ConfigError(f"Cannot append to a managed table '{table_name}'.")
@@ -2248,10 +2373,12 @@ class EngineManagedStrategy(MaterializableStrategy):
         target_table_name: str,
         source_table_name: str,
         snapshot: Snapshot,
+        *,
+        ignore_destructive: bool,
         **kwargs: t.Any,
     ) -> None:
         potential_alter_expressions = self.adapter.get_alter_expressions(
-            target_table_name, source_table_name
+            target_table_name, source_table_name, ignore_destructive=ignore_destructive
         )
         if len(potential_alter_expressions) > 0:
             # this can happen if a user changes a managed model and deliberately overrides a plan to be forward only, eg `sqlmesh plan --forward-only`

--- a/sqlmesh/core/state_sync/db/environment.py
+++ b/sqlmesh/core/state_sync/db/environment.py
@@ -77,7 +77,7 @@ class EnvironmentState:
         self.engine_adapter.insert_append(
             self.environments_table,
             _environment_to_df(environment),
-            columns_to_types=self._environment_columns_to_types,
+            target_columns_to_types=self._environment_columns_to_types,
         )
 
     def update_environment_statements(
@@ -107,7 +107,7 @@ class EnvironmentState:
             self.engine_adapter.insert_append(
                 self.environment_statements_table,
                 _environment_statements_to_df(environment_name, plan_id, environment_statements),
-                columns_to_types=self._environment_statements_columns_to_types,
+                target_columns_to_types=self._environment_statements_columns_to_types,
             )
 
     def invalidate_environment(self, name: str, protect_prod: bool = True) -> None:

--- a/sqlmesh/core/state_sync/db/interval.py
+++ b/sqlmesh/core/state_sync/db/interval.py
@@ -114,7 +114,7 @@ class IntervalState:
         self.engine_adapter.insert_append(
             self.intervals_table,
             _intervals_to_df(intervals_to_remove, is_dev=False, is_removed=True),
-            columns_to_types=self._interval_columns_to_types,
+            target_columns_to_types=self._interval_columns_to_types,
         )
 
     def get_snapshot_intervals(
@@ -242,7 +242,7 @@ class IntervalState:
             self.engine_adapter.insert_append(
                 self.intervals_table,
                 pd.DataFrame(new_intervals),
-                columns_to_types=self._interval_columns_to_types,
+                target_columns_to_types=self._interval_columns_to_types,
             )
 
     def _get_snapshot_intervals(

--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -102,7 +102,7 @@ class SnapshotState:
         self.engine_adapter.insert_append(
             self.snapshots_table,
             _snapshots_to_df(snapshots_to_store),
-            columns_to_types=self._snapshot_columns_to_types,
+            target_columns_to_types=self._snapshot_columns_to_types,
         )
 
         for snapshot in snapshots:
@@ -363,7 +363,7 @@ class SnapshotState:
         self.engine_adapter.merge(
             self.auto_restatements_table,
             _auto_restatements_to_df(next_auto_restatement_ts_filtered),
-            columns_to_types=self._auto_restatement_columns_to_types,
+            target_columns_to_types=self._auto_restatement_columns_to_types,
             unique_key=(exp.column("snapshot_name"), exp.column("snapshot_version")),
         )
 
@@ -405,7 +405,7 @@ class SnapshotState:
         self.engine_adapter.insert_append(
             self.snapshots_table,
             _snapshots_to_df(snapshots_to_store),
-            columns_to_types=self._snapshot_columns_to_types,
+            target_columns_to_types=self._snapshot_columns_to_types,
         )
 
     def _get_snapshots(

--- a/sqlmesh/core/state_sync/db/version.py
+++ b/sqlmesh/core/state_sync/db/version.py
@@ -54,7 +54,7 @@ class VersionState:
                     }
                 ]
             ),
-            columns_to_types=self._version_columns_to_types,
+            target_columns_to_types=self._version_columns_to_types,
         )
 
     def get_versions(self) -> Versions:

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -512,7 +512,7 @@ class TableDiff:
                     )
 
             with self.adapter.temp_table(
-                query, name=temp_table, columns_to_types=None, **temp_table_kwargs
+                query, name=temp_table, target_columns_to_types=None, **temp_table_kwargs
             ) as table:
                 summary_sums = [
                     exp.func("SUM", "s_exists").as_("s_count"),

--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -494,7 +494,7 @@ class TableDiff:
             schema = to_schema(temp_schema, dialect=self.dialect)
             temp_table = exp.table_("diff", db=schema.db, catalog=schema.catalog, quoted=True)
 
-            temp_table_kwargs = {}
+            temp_table_kwargs: t.Dict[str, t.Any] = {}
             if isinstance(self.adapter, AthenaEngineAdapter):
                 # Athena has two table formats: Hive (the default) and Iceberg. TableDiff requires that
                 # the formats be the same for the source, target, and temp tables.

--- a/sqlmesh/migrations/v0007_env_table_info_to_kind.py
+++ b/sqlmesh/migrations/v0007_env_table_info_to_kind.py
@@ -86,7 +86,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             environments_table,
             pd.DataFrame(new_environments),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "snapshots": exp.DataType.build("text"),
                 "start_at": exp.DataType.build("text"),

--- a/sqlmesh/migrations/v0009_remove_pre_post_hooks.py
+++ b/sqlmesh/migrations/v0009_remove_pre_post_hooks.py
@@ -53,7 +53,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0011_add_model_kind_name.py
+++ b/sqlmesh/migrations/v0011_add_model_kind_name.py
@@ -53,7 +53,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0012_update_jinja_expressions.py
+++ b/sqlmesh/migrations/v0012_update_jinja_expressions.py
@@ -57,7 +57,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0013_serde_using_model_dialects.py
+++ b/sqlmesh/migrations/v0013_serde_using_model_dialects.py
@@ -55,7 +55,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0016_fix_windows_path.py
+++ b/sqlmesh/migrations/v0016_fix_windows_path.py
@@ -49,7 +49,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0017_fix_windows_seed_path.py
+++ b/sqlmesh/migrations/v0017_fix_windows_seed_path.py
@@ -45,7 +45,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0018_rename_snapshot_model_to_node.py
+++ b/sqlmesh/migrations/v0018_rename_snapshot_model_to_node.py
@@ -43,7 +43,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0020_remove_redundant_attributes_from_dbt_models.py
+++ b/sqlmesh/migrations/v0020_remove_redundant_attributes_from_dbt_models.py
@@ -48,7 +48,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0021_fix_table_properties.py
+++ b/sqlmesh/migrations/v0021_fix_table_properties.py
@@ -52,7 +52,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0022_move_project_to_model.py
+++ b/sqlmesh/migrations/v0022_move_project_to_model.py
@@ -44,7 +44,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0024_replace_model_kind_name_enum_with_value.py
+++ b/sqlmesh/migrations/v0024_replace_model_kind_name_enum_with_value.py
@@ -45,7 +45,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0025_fix_intervals_and_missing_change_category.py
+++ b/sqlmesh/migrations/v0025_fix_intervals_and_missing_change_category.py
@@ -85,7 +85,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),
@@ -98,7 +98,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
             engine_adapter.insert_append(
                 intervals_table,
                 pd.DataFrame(new_intervals),
-                columns_to_types={
+                target_columns_to_types={
                     "id": exp.DataType.build(index_type),
                     "created_ts": exp.DataType.build("bigint"),
                     "name": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0026_remove_dialect_from_seed.py
+++ b/sqlmesh/migrations/v0026_remove_dialect_from_seed.py
@@ -45,7 +45,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0027_minute_interval_to_five.py
+++ b/sqlmesh/migrations/v0027_minute_interval_to_five.py
@@ -47,7 +47,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0029_generate_schema_types_using_dialect.py
+++ b/sqlmesh/migrations/v0029_generate_schema_types_using_dialect.py
@@ -46,7 +46,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0030_update_unrestorable_snapshots.py
+++ b/sqlmesh/migrations/v0030_update_unrestorable_snapshots.py
@@ -55,7 +55,7 @@ def migrate(state_sync: t.Any, **kwargs: t.Any) -> None:  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0031_remove_dbt_target_fields.py
+++ b/sqlmesh/migrations/v0031_remove_dbt_target_fields.py
@@ -55,7 +55,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0034_add_default_catalog.py
+++ b/sqlmesh/migrations/v0034_add_default_catalog.py
@@ -161,7 +161,7 @@ def migrate(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ig
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),
@@ -241,7 +241,7 @@ def migrate(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ig
         engine_adapter.insert_append(
             environments_table,
             pd.DataFrame(new_environments),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "snapshots": exp.DataType.build(blob_type),
                 "start_at": exp.DataType.build("text"),
@@ -316,7 +316,7 @@ def migrate(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ig
         engine_adapter.insert_append(
             intervals_table,
             pd.DataFrame(new_intervals),
-            columns_to_types={
+            target_columns_to_types={
                 "id": exp.DataType.build(index_type),
                 "created_ts": exp.DataType.build("bigint"),
                 "name": exp.DataType.build(index_type),
@@ -359,7 +359,7 @@ def migrate(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ig
         engine_adapter.insert_append(
             seeds_table,
             pd.DataFrame(new_seeds),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "content": exp.DataType.build("text"),

--- a/sqlmesh/migrations/v0037_remove_dbt_is_incremental_macro.py
+++ b/sqlmesh/migrations/v0037_remove_dbt_is_incremental_macro.py
@@ -51,7 +51,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0038_add_expiration_ts_to_snapshot.py
+++ b/sqlmesh/migrations/v0038_add_expiration_ts_to_snapshot.py
@@ -62,7 +62,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0039_include_environment_in_plan_dag_spec.py
+++ b/sqlmesh/migrations/v0039_include_environment_in_plan_dag_spec.py
@@ -60,7 +60,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             plan_dags_table,
             pd.DataFrame(new_specs),
-            columns_to_types={
+            target_columns_to_types={
                 "request_id": exp.DataType.build(index_type),
                 "dag_id": exp.DataType.build(index_type),
                 "dag_spec": exp.DataType.build(blob_type),

--- a/sqlmesh/migrations/v0041_remove_hash_raw_query_attribute.py
+++ b/sqlmesh/migrations/v0041_remove_hash_raw_query_attribute.py
@@ -48,7 +48,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0042_trim_indirect_versions.py
+++ b/sqlmesh/migrations/v0042_trim_indirect_versions.py
@@ -55,7 +55,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0043_fix_remove_obsolete_attributes_in_plan_dags.py
+++ b/sqlmesh/migrations/v0043_fix_remove_obsolete_attributes_in_plan_dags.py
@@ -53,7 +53,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             plan_dags_table,
             pd.DataFrame(new_dag_specs),
-            columns_to_types={
+            target_columns_to_types={
                 "request_id": exp.DataType.build(index_type),
                 "dag_id": exp.DataType.build(index_type),
                 "dag_spec": exp.DataType.build(blob_type),

--- a/sqlmesh/migrations/v0045_move_gateway_variable.py
+++ b/sqlmesh/migrations/v0045_move_gateway_variable.py
@@ -59,7 +59,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0048_drop_indirect_versions.py
+++ b/sqlmesh/migrations/v0048_drop_indirect_versions.py
@@ -48,7 +48,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0051_rename_column_descriptions.py
+++ b/sqlmesh/migrations/v0051_rename_column_descriptions.py
@@ -54,7 +54,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0055_add_updated_ts_unpaused_ts_ttl_ms_unrestorable_to_snapshot.py
+++ b/sqlmesh/migrations/v0055_add_updated_ts_unpaused_ts_ttl_ms_unrestorable_to_snapshot.py
@@ -118,7 +118,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0056_restore_table_indexes.py
+++ b/sqlmesh/migrations/v0056_restore_table_indexes.py
@@ -79,7 +79,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter.insert_append(
         new_snapshots_table,
         exp.select("*").from_(snapshots_table),
-        columns_to_types=snapshots_columns_to_types,
+        target_columns_to_types=snapshots_columns_to_types,
     )
 
     # Recreate the environments table and its indexes.
@@ -89,7 +89,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter.insert_append(
         new_environments_table,
         exp.select("*").from_(environments_table),
-        columns_to_types=environments_columns_to_types,
+        target_columns_to_types=environments_columns_to_types,
     )
 
     # Recreate the intervals table and its indexes.
@@ -105,7 +105,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter.insert_append(
         new_intervals_table,
         exp.select("*").from_(intervals_table),
-        columns_to_types=intervals_columns_to_types,
+        target_columns_to_types=intervals_columns_to_types,
     )
 
     # Drop old tables.

--- a/sqlmesh/migrations/v0060_move_audits_to_model.py
+++ b/sqlmesh/migrations/v0060_move_audits_to_model.py
@@ -72,7 +72,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0063_change_signals.py
+++ b/sqlmesh/migrations/v0063_change_signals.py
@@ -84,7 +84,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0064_join_when_matched_strings.py
+++ b/sqlmesh/migrations/v0064_join_when_matched_strings.py
@@ -71,7 +71,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0069_update_dev_table_suffix.py
+++ b/sqlmesh/migrations/v0069_update_dev_table_suffix.py
@@ -85,7 +85,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types=snapshots_columns_to_types,
+            target_columns_to_types=snapshots_columns_to_types,
         )
 
     new_environments = []
@@ -144,7 +144,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             environments_table,
             pd.DataFrame(new_environments),
-            columns_to_types=environments_columns_to_types,
+            target_columns_to_types=environments_columns_to_types,
         )
 
 

--- a/sqlmesh/migrations/v0071_add_dev_version_to_intervals.py
+++ b/sqlmesh/migrations/v0071_add_dev_version_to_intervals.py
@@ -137,7 +137,7 @@ def _migrate_intervals(
         engine_adapter.insert_append(
             intervals_table,
             pd.DataFrame(new_intervals),
-            columns_to_types=intervals_columns_to_types,
+            target_columns_to_types=intervals_columns_to_types,
         )
 
 
@@ -215,7 +215,7 @@ def _migrate_snapshots(
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types=snapshots_columns_to_types,
+            target_columns_to_types=snapshots_columns_to_types,
         )
 
 

--- a/sqlmesh/migrations/v0073_remove_symbolic_disable_restatement.py
+++ b/sqlmesh/migrations/v0073_remove_symbolic_disable_restatement.py
@@ -69,5 +69,5 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types=snapshots_columns_to_types,
+            target_columns_to_types=snapshots_columns_to_types,
         )

--- a/sqlmesh/migrations/v0075_remove_validate_query.py
+++ b/sqlmesh/migrations/v0075_remove_validate_query.py
@@ -69,7 +69,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0081_update_partitioned_by.py
+++ b/sqlmesh/migrations/v0081_update_partitioned_by.py
@@ -78,7 +78,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0085_deterministic_repr.py
+++ b/sqlmesh/migrations/v0085_deterministic_repr.py
@@ -117,7 +117,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0087_normalize_blueprint_variables.py
+++ b/sqlmesh/migrations/v0087_normalize_blueprint_variables.py
@@ -124,7 +124,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/migrations/v0090_add_forward_only_column.py
+++ b/sqlmesh/migrations/v0090_add_forward_only_column.py
@@ -85,7 +85,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         engine_adapter.insert_append(
             snapshots_table,
             pd.DataFrame(new_snapshots),
-            columns_to_types={
+            target_columns_to_types={
                 "name": exp.DataType.build(index_type),
                 "identifier": exp.DataType.build(index_type),
                 "version": exp.DataType.build(index_type),

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -409,4 +409,9 @@ def get_source_columns_to_types(
     columns_to_types: t.Dict[str, exp.DataType],
     source_columns: t.Optional[t.List[str]],
 ) -> t.Dict[str, exp.DataType]:
-    return {k: v for k, v in columns_to_types.items() if not source_columns or k in source_columns}
+    source_column_lookup = set(source_columns) if source_columns else None
+    return {
+        k: v
+        for k, v in columns_to_types.items()
+        if not source_column_lookup or k in source_column_lookup
+    }

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -403,3 +403,10 @@ class CorrelationId:
     @classmethod
     def from_plan_id(cls, plan_id: str) -> CorrelationId:
         return CorrelationId(JobType.PLAN, plan_id)
+
+
+def get_source_columns_to_types(
+    columns_to_types: t.Dict[str, exp.DataType],
+    source_columns: t.Optional[t.List[str]],
+) -> t.Dict[str, exp.DataType]:
+    return {k: v for k, v in columns_to_types.items() if not source_columns or k in source_columns}

--- a/tests/core/engine_adapter/integration/__init__.py
+++ b/tests/core/engine_adapter/integration/__init__.py
@@ -340,7 +340,7 @@ class TestContext:
                 list(data.itertuples(index=False, name=None)),
                 batch_start=0,
                 batch_end=sys.maxsize,
-                columns_to_types=columns_to_types,
+                target_columns_to_types=columns_to_types,
             )
         if self.test_type == "df":
             formatted_df = self._format_df(data, to_datetime=self.dialect != "trino")

--- a/tests/core/engine_adapter/integration/conftest.py
+++ b/tests/core/engine_adapter/integration/conftest.py
@@ -145,7 +145,7 @@ def ctx_df(
     yield from create_test_context(*request.param)
 
 
-@pytest.fixture(params=list(generate_pytest_params(ENGINES, query=True, df=True)))
+@pytest.fixture(params=list(generate_pytest_params(ENGINES, query=True, df=False)))
 def ctx_query_and_df(
     request: FixtureRequest,
     create_test_context: t.Callable[[IntegrationTestEngine, str], t.Iterable[TestContext]],

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -283,7 +283,7 @@ def test_ctas_source_columns(ctx_query_and_df: TestContext):
         table_description="test table description",
         column_descriptions={"id": "test id column description"},
         table_format=ctx.default_table_format,
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         source_columns=["id", "ds"],
     )
 
@@ -372,7 +372,7 @@ def test_create_view_source_columns(ctx_query_and_df: TestContext):
         table_description="test view description",
         column_descriptions={"id": "test id column description"},
         source_columns=["id", "ds"],
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
     )
 
     expected_data = input_data.copy()
@@ -470,7 +470,7 @@ def test_nan_roundtrip(ctx_df: TestContext):
     ctx.engine_adapter.replace_query(
         table,
         ctx.input_data(input_data),
-        columns_to_types=ctx.columns_to_types,
+        target_columns_to_types=ctx.columns_to_types,
     )
     results = ctx.get_metadata_results()
     assert not results.views
@@ -502,7 +502,9 @@ def test_replace_query(ctx_query_and_df: TestContext):
         # provided then it checks the table itself for types. This is fine within SQLMesh since we always know the tables
         # exist prior to evaluation but when running these tests that isn't the case. As a result we just pass in
         # columns_to_types for these two engines so we can still test inference on the other ones
-        columns_to_types=ctx.columns_to_types if ctx.dialect in ["spark", "databricks"] else None,
+        target_columns_to_types=ctx.columns_to_types
+        if ctx.dialect in ["spark", "databricks"]
+        else None,
         table_format=ctx.default_table_format,
     )
     results = ctx.get_metadata_results()
@@ -524,7 +526,7 @@ def test_replace_query(ctx_query_and_df: TestContext):
         ctx.engine_adapter.replace_query(
             table,
             ctx.input_data(replace_data),
-            columns_to_types=(
+            target_columns_to_types=(
                 ctx.columns_to_types if ctx.dialect in ["spark", "databricks"] else None
             ),
             table_format=ctx.default_table_format,
@@ -559,7 +561,7 @@ def test_replace_query_source_columns(ctx_query_and_df: TestContext):
         ctx.input_data(input_data),
         table_format=ctx.default_table_format,
         source_columns=["id", "ds"],
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
     )
     expected_data = input_data.copy()
     expected_data["ignored_column"] = pd.Series()
@@ -585,7 +587,7 @@ def test_replace_query_source_columns(ctx_query_and_df: TestContext):
             ctx.input_data(replace_data),
             table_format=ctx.default_table_format,
             source_columns=["id", "ds"],
-            columns_to_types=columns_to_types,
+            target_columns_to_types=columns_to_types,
         )
         expected_data = replace_data.copy()
         expected_data["ignored_column"] = pd.Series()
@@ -620,7 +622,9 @@ def test_replace_query_batched(ctx_query_and_df: TestContext):
         # provided then it checks the table itself for types. This is fine within SQLMesh since we always know the tables
         # exist prior to evaluation but when running these tests that isn't the case. As a result we just pass in
         # columns_to_types for these two engines so we can still test inference on the other ones
-        columns_to_types=ctx.columns_to_types if ctx.dialect in ["spark", "databricks"] else None,
+        target_columns_to_types=ctx.columns_to_types
+        if ctx.dialect in ["spark", "databricks"]
+        else None,
         table_format=ctx.default_table_format,
     )
     results = ctx.get_metadata_results()
@@ -642,7 +646,7 @@ def test_replace_query_batched(ctx_query_and_df: TestContext):
         ctx.engine_adapter.replace_query(
             table,
             ctx.input_data(replace_data),
-            columns_to_types=(
+            target_columns_to_types=(
                 ctx.columns_to_types if ctx.dialect in ["spark", "databricks"] else None
             ),
             table_format=ctx.default_table_format,
@@ -714,7 +718,7 @@ def test_insert_append_source_columns(ctx_query_and_df: TestContext):
         table,
         ctx.input_data(input_data),
         source_columns=["id", "ds"],
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
     )
     expected_data = input_data.copy()
     expected_data["ignored_column"] = pd.Series()
@@ -738,7 +742,7 @@ def test_insert_append_source_columns(ctx_query_and_df: TestContext):
             table,
             ctx.input_data(append_data),
             source_columns=["id", "ds"],
-            columns_to_types=columns_to_types,
+            target_columns_to_types=columns_to_types,
         )
         append_expected_data = append_data.copy()
         append_expected_data["ignored_column"] = pd.Series()
@@ -786,7 +790,7 @@ def test_insert_overwrite_by_time_partition(ctx_query_and_df: TestContext):
         end="2022-01-03",
         time_formatter=ctx.time_formatter,
         time_column=ctx.time_column,
-        columns_to_types=ctx.columns_to_types,
+        target_columns_to_types=ctx.columns_to_types,
     )
     results = ctx.get_metadata_results()
     assert len(results.views) == 0
@@ -815,7 +819,7 @@ def test_insert_overwrite_by_time_partition(ctx_query_and_df: TestContext):
             end="2022-01-05",
             time_formatter=ctx.time_formatter,
             time_column=ctx.time_column,
-            columns_to_types=ctx.columns_to_types,
+            target_columns_to_types=ctx.columns_to_types,
         )
         results = ctx.get_metadata_results()
         assert len(results.views) == 0
@@ -879,7 +883,7 @@ def test_insert_overwrite_by_time_partition_source_columns(ctx_query_and_df: Tes
         end="2022-01-03",
         time_formatter=ctx.time_formatter,
         time_column=ctx.time_column,
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         source_columns=["id", "ds"],
     )
 
@@ -913,7 +917,7 @@ def test_insert_overwrite_by_time_partition_source_columns(ctx_query_and_df: Tes
             end="2022-01-05",
             time_formatter=ctx.time_formatter,
             time_column=ctx.time_column,
-            columns_to_types=columns_to_types,
+            target_columns_to_types=columns_to_types,
             source_columns=["id", "ds"],
         )
         results = ctx.get_metadata_results()
@@ -960,7 +964,7 @@ def test_merge(ctx_query_and_df: TestContext):
     ctx.engine_adapter.merge(
         table,
         ctx.input_data(input_data),
-        columns_to_types=None,
+        target_columns_to_types=None,
         unique_key=[exp.to_identifier("id")],
     )
     results = ctx.get_metadata_results()
@@ -982,7 +986,7 @@ def test_merge(ctx_query_and_df: TestContext):
         ctx.engine_adapter.merge(
             table,
             ctx.input_data(merge_data),
-            columns_to_types=None,
+            target_columns_to_types=None,
             unique_key=[exp.to_identifier("id")],
         )
         results = ctx.get_metadata_results()
@@ -1030,7 +1034,7 @@ def test_merge_source_columns(ctx_query_and_df: TestContext):
         table,
         ctx.input_data(input_data),
         unique_key=[exp.to_identifier("id")],
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         source_columns=["id", "ds"],
     )
 
@@ -1057,7 +1061,7 @@ def test_merge_source_columns(ctx_query_and_df: TestContext):
             table,
             ctx.input_data(merge_data),
             unique_key=[exp.to_identifier("id")],
-            columns_to_types=columns_to_types,
+            target_columns_to_types=columns_to_types,
             source_columns=["id", "ds"],
         )
 
@@ -1119,7 +1123,7 @@ def test_scd_type_2_by_time(ctx_query_and_df: TestContext):
         updated_at_col=exp.column("updated_at", quoted=True),
         execution_time="2023-01-01 00:00:00",
         updated_at_as_valid_from=False,
-        columns_to_types=input_schema,
+        target_columns_to_types=input_schema,
         table_format=ctx.default_table_format,
         truncate=True,
     )
@@ -1182,7 +1186,7 @@ def test_scd_type_2_by_time(ctx_query_and_df: TestContext):
         updated_at_col=exp.column("updated_at", quoted=True),
         execution_time="2023-01-05 00:00:00",
         updated_at_as_valid_from=False,
-        columns_to_types=input_schema,
+        target_columns_to_types=input_schema,
         table_format=ctx.default_table_format,
         truncate=False,
     )
@@ -1278,7 +1282,7 @@ def test_scd_type_2_by_time_source_columns(ctx_query_and_df: TestContext):
         table_format=ctx.default_table_format,
         truncate=True,
         start="2022-01-01 00:00:00",
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         source_columns=["id", "name", "updated_at"],
     )
     results = ctx.get_metadata_results()
@@ -1346,7 +1350,7 @@ def test_scd_type_2_by_time_source_columns(ctx_query_and_df: TestContext):
         table_format=ctx.default_table_format,
         truncate=False,
         start="2022-01-01 00:00:00",
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         source_columns=["id", "name", "updated_at"],
     )
     results = ctx.get_metadata_results()
@@ -1443,7 +1447,7 @@ def test_scd_type_2_by_column(ctx_query_and_df: TestContext):
         valid_to_col=exp.column("valid_to", quoted=True),
         execution_time="2023-01-01",
         execution_time_as_valid_from=False,
-        columns_to_types=ctx.columns_to_types,
+        target_columns_to_types=ctx.columns_to_types,
         truncate=True,
     )
     results = ctx.get_metadata_results()
@@ -1514,7 +1518,7 @@ def test_scd_type_2_by_column(ctx_query_and_df: TestContext):
         valid_to_col=exp.column("valid_to", quoted=True),
         execution_time="2023-01-05 00:00:00",
         execution_time_as_valid_from=False,
-        columns_to_types=ctx.columns_to_types,
+        target_columns_to_types=ctx.columns_to_types,
         truncate=False,
     )
     results = ctx.get_metadata_results()
@@ -1623,7 +1627,7 @@ def test_scd_type_2_by_column_source_columns(ctx_query_and_df: TestContext):
         execution_time_as_valid_from=False,
         truncate=True,
         start="2023-01-01",
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         source_columns=["id", "name", "status"],
     )
     results = ctx.get_metadata_results()
@@ -1700,7 +1704,7 @@ def test_scd_type_2_by_column_source_columns(ctx_query_and_df: TestContext):
         execution_time_as_valid_from=False,
         truncate=False,
         start="2023-01-01",
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         source_columns=["id", "name", "status"],
     )
     results = ctx.get_metadata_results()
@@ -3077,13 +3081,13 @@ def test_value_normalization(
     }
 
     ctx.engine_adapter.create_table(
-        table_name=test_table, columns_to_types=columns_to_types_normalized
+        table_name=test_table, target_columns_to_types=columns_to_types_normalized
     )
     data_query = next(select_from_values(input_data_with_idx, columns_to_types_normalized))
     ctx.engine_adapter.insert_append(
         table_name=test_table,
         query_or_df=data_query,
-        columns_to_types=columns_to_types_normalized,
+        target_columns_to_types=columns_to_types_normalized,
     )
 
     query = (

--- a/tests/core/engine_adapter/integration/test_integration_athena.py
+++ b/tests/core/engine_adapter/integration/test_integration_athena.py
@@ -284,10 +284,10 @@ def test_hive_drop_table_removes_data(ctx: TestContext, engine_adapter: AthenaEn
     columns_to_types = columns_to_types_from_df(data)
 
     engine_adapter.create_table(
-        table_name=seed_table, columns_to_types=columns_to_types, exists=False
+        table_name=seed_table, target_columns_to_types=columns_to_types, exists=False
     )
     engine_adapter.insert_append(
-        table_name=seed_table, query_or_df=data, columns_to_types=columns_to_types
+        table_name=seed_table, query_or_df=data, target_columns_to_types=columns_to_types
     )
     assert engine_adapter.fetchone(f"select count(*) from {seed_table}")[0] == 1  # type: ignore
 
@@ -295,7 +295,7 @@ def test_hive_drop_table_removes_data(ctx: TestContext, engine_adapter: AthenaEn
     # This ensures that our drop table logic to delete the data from S3 is working
     engine_adapter.drop_table(seed_table, exists=False)
     engine_adapter.create_table(
-        table_name=seed_table, columns_to_types=columns_to_types, exists=False
+        table_name=seed_table, target_columns_to_types=columns_to_types, exists=False
     )
     assert engine_adapter.fetchone(f"select count(*) from {seed_table}")[0] == 0  # type: ignore
 
@@ -382,12 +382,14 @@ def test_insert_overwrite_by_time_partition_date_type(
         return exp.cast(exp.Literal.string(to_ds(time)), "date")
 
     engine_adapter.create_table(
-        table_name=table, columns_to_types=columns_to_types, partitioned_by=[exp.to_column("date")]
+        table_name=table,
+        target_columns_to_types=columns_to_types,
+        partitioned_by=[exp.to_column("date")],
     )
     engine_adapter.insert_overwrite_by_time_partition(
         table_name=table,
         query_or_df=data,
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         time_column=exp.to_identifier("date"),
         start="2023-01-01",
         end="2023-01-03",
@@ -406,7 +408,7 @@ def test_insert_overwrite_by_time_partition_date_type(
     engine_adapter.insert_overwrite_by_time_partition(
         table_name=table,
         query_or_df=new_data,
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         time_column=exp.to_identifier("date"),
         start="2023-01-03",
         end="2023-01-04",
@@ -442,12 +444,14 @@ def test_insert_overwrite_by_time_partition_datetime_type(
         return exp.cast(exp.Literal.string(to_ts(time)), "datetime")
 
     engine_adapter.create_table(
-        table_name=table, columns_to_types=columns_to_types, partitioned_by=[exp.to_column("ts")]
+        table_name=table,
+        target_columns_to_types=columns_to_types,
+        partitioned_by=[exp.to_column("ts")],
     )
     engine_adapter.insert_overwrite_by_time_partition(
         table_name=table,
         query_or_df=data,
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         time_column=exp.to_identifier("ts"),
         start="2023-01-01 00:00:00",
         end="2023-01-01 04:00:00",
@@ -469,7 +473,7 @@ def test_insert_overwrite_by_time_partition_datetime_type(
     engine_adapter.insert_overwrite_by_time_partition(
         table_name=table,
         query_or_df=new_data,
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         time_column=exp.to_identifier("ts"),
         start="2023-01-01 03:00:00",
         end="2023-01-01 05:00:00",

--- a/tests/core/engine_adapter/test_athena.py
+++ b/tests/core/engine_adapter/test_athena.py
@@ -133,7 +133,7 @@ def test_create_table_hive(adapter: AthenaEngineAdapter) -> None:
 
     adapter.create_table(
         model.name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_properties=model.physical_properties,
         partitioned_by=model.partitioned_by,
         storage_format=model.storage_format,
@@ -165,7 +165,7 @@ def test_create_table_iceberg(adapter: AthenaEngineAdapter) -> None:
 
     adapter.create_table(
         model.name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_properties=model.physical_properties,
         partitioned_by=model.partitioned_by,
         table_format=model.table_format,
@@ -193,14 +193,14 @@ def test_create_table_no_location(adapter: AthenaEngineAdapter) -> None:
     with pytest.raises(SQLMeshError, match=r"Cannot figure out location.*"):
         adapter.create_table(
             model.name,
-            columns_to_types=model.columns_to_types_or_raise,
+            target_columns_to_types=model.columns_to_types_or_raise,
             table_properties=model.physical_properties,
         )
 
     adapter.s3_warehouse_location = "s3://bucket/prefix"
     adapter.create_table(
         model.name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_properties=model.physical_properties,
     )
 
@@ -214,7 +214,7 @@ def test_ctas_hive(adapter: AthenaEngineAdapter):
 
     adapter.ctas(
         table_name="foo.bar",
-        columns_to_types={"a": exp.DataType.build("int")},
+        target_columns_to_types={"a": exp.DataType.build("int")},
         query_or_df=parse_one("select 1", into=exp.Select),
     )
 
@@ -228,7 +228,7 @@ def test_ctas_iceberg(adapter: AthenaEngineAdapter):
 
     adapter.ctas(
         table_name="foo.bar",
-        columns_to_types={"a": exp.DataType.build("int")},
+        target_columns_to_types={"a": exp.DataType.build("int")},
         query_or_df=parse_one("select 1", into=exp.Select),
         table_format="iceberg",
     )
@@ -242,7 +242,7 @@ def test_ctas_iceberg_no_specific_location(adapter: AthenaEngineAdapter):
     with pytest.raises(SQLMeshError, match=r"Cannot figure out location.*"):
         adapter.ctas(
             table_name="foo.bar",
-            columns_to_types={"a": exp.DataType.build("int")},
+            target_columns_to_types={"a": exp.DataType.build("int")},
             query_or_df=parse_one("select 1", into=exp.Select),
             table_properties={"table_type": exp.Literal.string("iceberg")},
         )
@@ -270,7 +270,7 @@ def test_ctas_iceberg_partitioned(adapter: AthenaEngineAdapter):
     adapter.s3_warehouse_location = "s3://bucket/prefix/"
     adapter.ctas(
         table_name=model.name,
-        columns_to_types=model.columns_to_types,
+        target_columns_to_types=model.columns_to_types,
         partitioned_by=model.partitioned_by,
         query_or_df=model.ctas_query(),
         table_format=model.table_format,
@@ -298,7 +298,7 @@ def test_replace_query(adapter: AthenaEngineAdapter, mocker: MockerFixture):
     adapter.replace_query(
         table_name="test",
         query_or_df=parse_one("select 1 as a", into=exp.Select),
-        columns_to_types={"a": exp.DataType.build("int")},
+        target_columns_to_types={"a": exp.DataType.build("int")},
         table_properties={},
     )
 
@@ -317,7 +317,7 @@ def test_replace_query(adapter: AthenaEngineAdapter, mocker: MockerFixture):
     adapter.replace_query(
         table_name="test",
         query_or_df=parse_one("select 1 as a", into=exp.Select),
-        columns_to_types={"a": exp.DataType.build("int")},
+        target_columns_to_types={"a": exp.DataType.build("int")},
         table_properties={},
     )
 
@@ -482,14 +482,14 @@ def test_iceberg_partition_transforms(adapter: AthenaEngineAdapter):
 
     adapter.create_table(
         table_name=model.name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         partitioned_by=model.partitioned_by,
         table_format=model.table_format,
     )
 
     adapter.ctas(
         table_name=model.name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         partitioned_by=model.partitioned_by,
         query_or_df=model.ctas_query(),
         table_format=model.table_format,

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -82,7 +82,7 @@ def test_create_view_pandas_source_columns(make_mocked_engine_adapter: t.Callabl
     adapter.create_view(
         "test_view",
         pd.DataFrame({"a": [1, 2, 3]}),
-        columns_to_types={"a": bigint_dtype, "b": bigint_dtype},
+        target_columns_to_types={"a": bigint_dtype, "b": bigint_dtype},
         replace=False,
         source_columns=["a"],
     )
@@ -97,7 +97,10 @@ def test_create_view_query_source_columns(make_mocked_engine_adapter: t.Callable
     adapter.create_view(
         "test_view",
         parse_one("SELECT a FROM tbl"),
-        columns_to_types={"a": exp.DataType.build("BIGINT"), "b": exp.DataType.build("BIGINT")},
+        target_columns_to_types={
+            "a": exp.DataType.build("BIGINT"),
+            "b": exp.DataType.build("BIGINT"),
+        },
         replace=False,
         source_columns=["a"],
     )
@@ -113,14 +116,14 @@ def test_create_materialized_view(make_mocked_engine_adapter: t.Callable):
         "test_view",
         parse_one("SELECT a FROM tbl"),
         materialized=True,
-        columns_to_types={"a": exp.DataType.build("INT")},
+        target_columns_to_types={"a": exp.DataType.build("INT")},
     )
     adapter.create_view(
         "test_view",
         parse_one("SELECT a FROM tbl"),
         replace=False,
         materialized=True,
-        columns_to_types={"a": exp.DataType.build("INT")},
+        target_columns_to_types={"a": exp.DataType.build("INT")},
     )
 
     adapter.cursor.execute.assert_has_calls(
@@ -136,7 +139,7 @@ def test_create_materialized_view(make_mocked_engine_adapter: t.Callable):
         parse_one("SELECT a, b FROM tbl"),
         replace=False,
         materialized=True,
-        columns_to_types={"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
+        target_columns_to_types={"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
     )
     adapter.create_view(
         "test_view", parse_one("SELECT a, b FROM tbl"), replace=False, materialized=True
@@ -220,7 +223,7 @@ def test_insert_overwrite_by_time_partition(make_mocked_engine_adapter: t.Callab
         end="2022-01-02",
         time_column="b",
         time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
-        columns_to_types={"a": exp.DataType.build("INT"), "b": exp.DataType.build("STRING")},
+        target_columns_to_types={"a": exp.DataType.build("INT"), "b": exp.DataType.build("STRING")},
     )
 
     adapter.cursor.begin.assert_called_once()
@@ -247,7 +250,10 @@ def test_insert_overwrite_by_time_partition_missing_time_column_type(
         end="2022-01-02",
         time_column="b",
         time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
-        columns_to_types={"a": exp.DataType.build("INT"), "b": exp.DataType.build("UNKNOWN")},
+        target_columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "b": exp.DataType.build("UNKNOWN"),
+        },
     )
 
     columns_mock.assert_called_once_with("test_table")
@@ -274,7 +280,7 @@ def test_insert_overwrite_by_time_partition_supports_insert_overwrite(
         end="2022-01-02",
         time_column="b",
         time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
-        columns_to_types={"a": exp.DataType.build("INT"), "b": exp.DataType.build("STRING")},
+        target_columns_to_types={"a": exp.DataType.build("INT"), "b": exp.DataType.build("STRING")},
     )
 
     adapter.cursor.execute.assert_called_once_with(
@@ -296,7 +302,10 @@ def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas(
         end="2022-01-02",
         time_column="ds",
         time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
-        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+        target_columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "ds": exp.DataType.build("STRING"),
+        },
     )
 
     assert to_sql_calls(adapter) == [
@@ -317,7 +326,10 @@ def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas_sou
         end="2022-01-02",
         time_column="ds",
         time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
-        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+        target_columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "ds": exp.DataType.build("STRING"),
+        },
         source_columns=["a"],
     )
     assert to_sql_calls(adapter) == [
@@ -337,7 +349,10 @@ def test_insert_overwrite_by_time_partition_supports_insert_overwrite_query_sour
         end="2022-01-02",
         time_column="ds",
         time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
-        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+        target_columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "ds": exp.DataType.build("STRING"),
+        },
         source_columns=["a"],
     )
     assert to_sql_calls(adapter) == [
@@ -356,7 +371,7 @@ def test_insert_overwrite_by_time_partition_replace_where(make_mocked_engine_ada
         end="2022-01-02",
         time_column="b",
         time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
-        columns_to_types={"a": exp.DataType.build("INT"), "b": exp.DataType.build("STRING")},
+        target_columns_to_types={"a": exp.DataType.build("INT"), "b": exp.DataType.build("STRING")},
     )
 
     assert to_sql_calls(adapter) == [
@@ -379,7 +394,10 @@ def test_insert_overwrite_by_time_partition_replace_where_pandas(
         end="2022-01-02",
         time_column="ds",
         time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
-        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+        target_columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "ds": exp.DataType.build("STRING"),
+        },
     )
 
     assert to_sql_calls(adapter) == [
@@ -400,7 +418,10 @@ def test_insert_overwrite_by_time_partition_replace_where_pandas_source_columns(
         end="2022-01-02",
         time_column="ds",
         time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
-        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+        target_columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "ds": exp.DataType.build("STRING"),
+        },
         source_columns=["a"],
     )
     assert to_sql_calls(adapter) == [
@@ -420,7 +441,10 @@ def test_insert_overwrite_by_time_partition_replace_where_query_source_columns(
         end="2022-01-02",
         time_column="ds",
         time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
-        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+        target_columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "ds": exp.DataType.build("STRING"),
+        },
         source_columns=["a"],
     )
     assert to_sql_calls(adapter) == [
@@ -440,7 +464,7 @@ def test_insert_overwrite_no_where(make_mocked_engine_adapter: t.Callable):
     adapter._insert_overwrite_by_condition(
         "test_table",
         source_queries,
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
     )
 
     adapter.cursor.begin.assert_called_once()
@@ -467,7 +491,7 @@ def test_insert_overwrite_by_condition_column_contains_unsafe_characters(
     adapter._insert_overwrite_by_condition(
         "test_table",
         source_queries,
-        columns_to_types=None,
+        target_columns_to_types=None,
     )
 
     # The goal here is to assert that we don't parse `foo.bar.baz` into a qualified column
@@ -482,7 +506,7 @@ def test_insert_append_query(make_mocked_engine_adapter: t.Callable):
     adapter.insert_append(
         "test_table",
         parse_one("SELECT a FROM tbl"),
-        columns_to_types={"a": exp.DataType.build("INT")},
+        target_columns_to_types={"a": exp.DataType.build("INT")},
     )
 
     assert to_sql_calls(adapter) == [
@@ -496,7 +520,7 @@ def test_insert_append_query_select_star(make_mocked_engine_adapter: t.Callable)
     adapter.insert_append(
         "test_table",
         parse_one("SELECT 1 AS a, * FROM tbl"),
-        columns_to_types={"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
+        target_columns_to_types={"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")},
     )
 
     assert to_sql_calls(adapter) == [
@@ -511,7 +535,7 @@ def test_insert_append_pandas(make_mocked_engine_adapter: t.Callable):
     adapter.insert_append(
         "test_table",
         df,
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("INT"),
             "b": exp.DataType.build("INT"),
         },
@@ -530,7 +554,7 @@ def test_insert_append_pandas_batches(make_mocked_engine_adapter: t.Callable):
     adapter.insert_append(
         "test_table",
         df,
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("INT"),
             "b": exp.DataType.build("INT"),
         },
@@ -552,7 +576,7 @@ def test_insert_append_pandas_source_columns(make_mocked_engine_adapter: t.Calla
     adapter.insert_append(
         "test_table",
         df,
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("INT"),
             "b": exp.DataType.build("INT"),
         },
@@ -568,7 +592,7 @@ def test_insert_append_query_source_columns(make_mocked_engine_adapter: t.Callab
     adapter.insert_append(
         "test_table",
         parse_one("SELECT a FROM tbl"),
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("INT"),
             "b": exp.DataType.build("INT"),
         },
@@ -1082,7 +1106,7 @@ def test_merge_upsert(make_mocked_engine_adapter: t.Callable, assert_exp_eq):
     adapter.merge(
         target_table="target",
         source_table=t.cast(exp.Select, parse_one('SELECT "ID", ts, val FROM source')),
-        columns_to_types={
+        target_columns_to_types={
             "ID": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
             "val": exp.DataType.build("int"),
@@ -1113,7 +1137,7 @@ MERGE INTO "target" AS "__MERGE_TARGET__" USING (
     adapter.merge(
         target_table="target",
         source_table=parse_one("SELECT id, ts, val FROM source"),
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
             "val": exp.DataType.build("int"),
@@ -1134,7 +1158,7 @@ def test_merge_upsert_pandas(make_mocked_engine_adapter: t.Callable):
     adapter.merge(
         target_table="target",
         source_table=df,
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
             "val": exp.DataType.build("int"),
@@ -1151,7 +1175,7 @@ def test_merge_upsert_pandas(make_mocked_engine_adapter: t.Callable):
     adapter.merge(
         target_table="target",
         source_table=df,
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
             "val": exp.DataType.build("int"),
@@ -1171,7 +1195,7 @@ def test_merge_upsert_pandas_source_columns(make_mocked_engine_adapter: t.Callab
     adapter.merge(
         target_table="target",
         source_table=df,
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
             "val": exp.DataType.build("int"),
@@ -1191,7 +1215,7 @@ def test_merge_upsert_query_source_columns(make_mocked_engine_adapter: t.Callabl
     adapter.merge(
         target_table="target",
         source_table=parse_one("SELECT id, ts FROM source"),
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
             "val": exp.DataType.build("int"),
@@ -1212,7 +1236,7 @@ def test_merge_when_matched(make_mocked_engine_adapter: t.Callable, assert_exp_e
     adapter.merge(
         target_table="target",
         source_table=t.cast(exp.Select, parse_one('SELECT "ID", ts, val FROM source')),
-        columns_to_types={
+        target_columns_to_types={
             "ID": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
             "val": exp.DataType.build("int"),
@@ -1265,7 +1289,7 @@ def test_merge_when_matched_multiple(make_mocked_engine_adapter: t.Callable, ass
     adapter.merge(
         target_table="target",
         source_table=t.cast(exp.Select, parse_one('SELECT "ID", ts, val FROM source')),
-        columns_to_types={
+        target_columns_to_types={
             "ID": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
             "val": exp.DataType.build("int"),
@@ -1336,7 +1360,7 @@ def test_merge_filter(make_mocked_engine_adapter: t.Callable, assert_exp_eq):
     adapter.merge(
         target_table="target",
         source_table=t.cast(exp.Select, parse_one('SELECT "ID", ts, val FROM source')),
-        columns_to_types={
+        target_columns_to_types={
             "ID": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
             "val": exp.DataType.build("int"),
@@ -1418,7 +1442,7 @@ def test_scd_type_2_by_time(make_mocked_engine_adapter: t.Callable):
         valid_from_col=exp.column("test_valid_from", quoted=True),
         valid_to_col=exp.column("test_valid_to", quoted=True),
         updated_at_col=exp.column("test_UPDATED_at", quoted=True),
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("VARCHAR"),
             "price": exp.DataType.build("DOUBLE"),
@@ -1624,7 +1648,7 @@ def test_scd_type_2_by_time_source_columns(make_mocked_engine_adapter: t.Callabl
         valid_from_col=exp.column("test_valid_from", quoted=True),
         valid_to_col=exp.column("test_valid_to", quoted=True),
         updated_at_col=exp.column("test_UPDATED_at", quoted=True),
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("VARCHAR"),
             "price": exp.DataType.build("DOUBLE"),
@@ -1830,7 +1854,7 @@ def test_scd_type_2_by_time_no_invalidate_hard_deletes(make_mocked_engine_adapte
         valid_to_col=exp.column("test_valid_to", quoted=True),
         updated_at_col=exp.column("test_updated_at", quoted=True),
         invalidate_hard_deletes=False,
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("VARCHAR"),
             "price": exp.DataType.build("DOUBLE"),
@@ -2017,7 +2041,7 @@ def test_merge_scd_type_2_pandas(make_mocked_engine_adapter: t.Callable):
         valid_from_col=exp.column("test_valid_from", quoted=True),
         valid_to_col=exp.column("test_valid_to", quoted=True),
         updated_at_col=exp.column("test_updated_at", quoted=True),
-        columns_to_types={
+        target_columns_to_types={
             "id1": exp.DataType.build("INT"),
             "id2": exp.DataType.build("INT"),
             "name": exp.DataType.build("VARCHAR"),
@@ -2200,7 +2224,7 @@ def test_scd_type_2_by_column(make_mocked_engine_adapter: t.Callable):
         valid_from_col=exp.column("test_VALID_from", quoted=True),
         valid_to_col=exp.column("test_valid_to", quoted=True),
         check_columns=[exp.column("name"), exp.column("price")],
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("VARCHAR"),
             "price": exp.DataType.build("DOUBLE"),
@@ -2381,7 +2405,7 @@ def test_scd_type_2_by_column_composite_key(make_mocked_engine_adapter: t.Callab
         valid_from_col=exp.column("test_VALID_from", quoted=True),
         valid_to_col=exp.column("test_valid_to", quoted=True),
         check_columns=[exp.column("name"), exp.column("price")],
-        columns_to_types={
+        target_columns_to_types={
             "id_a": exp.DataType.build("VARCHAR"),
             "id_b": exp.DataType.build("VARCHAR"),
             "name": exp.DataType.build("VARCHAR"),
@@ -2573,7 +2597,7 @@ def test_scd_type_2_truncate(make_mocked_engine_adapter: t.Callable):
         valid_from_col=exp.column("test_valid_from", quoted=True),
         valid_to_col=exp.column("test_valid_to", quoted=True),
         check_columns=[exp.column("name"), exp.column("price")],
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("VARCHAR"),
             "price": exp.DataType.build("DOUBLE"),
@@ -2756,7 +2780,7 @@ def test_scd_type_2_by_column_star_check(make_mocked_engine_adapter: t.Callable)
         valid_from_col=exp.column("test_valid_from", quoted=True),
         valid_to_col=exp.column("test_valid_to", quoted=True),
         check_columns=exp.Star(),
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("VARCHAR"),
             "price": exp.DataType.build("DOUBLE"),
@@ -2951,7 +2975,7 @@ def test_scd_type_2_by_column_no_invalidate_hard_deletes(make_mocked_engine_adap
         valid_to_col=exp.column("test_valid_to", quoted=True),
         invalidate_hard_deletes=False,
         check_columns=[exp.column("name"), exp.column("price")],
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("VARCHAR"),
             "price": exp.DataType.build("DOUBLE"),
@@ -3181,7 +3205,7 @@ def test_replace_query_pandas_source_columns(make_mocked_engine_adapter: t.Calla
     adapter.replace_query(
         "test_table",
         df,
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("INT"),
             "b": exp.DataType.build("INT"),
         },
@@ -3197,7 +3221,7 @@ def test_replace_query_query_source_columns(make_mocked_engine_adapter: t.Callab
     adapter.replace_query(
         "test_table",
         parse_one("SELECT a FROM tbl"),
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("INT"),
             "b": exp.DataType.build("INT"),
         },
@@ -3225,7 +3249,7 @@ def test_replace_query_self_referencing_not_exists_unknown(
         adapter.replace_query(
             "test",
             parse_one("SELECT a FROM test"),
-            columns_to_types={"a": exp.DataType.build("UNKNOWN")},
+            target_columns_to_types={"a": exp.DataType.build("UNKNOWN")},
         )
 
 
@@ -3242,7 +3266,7 @@ def test_replace_query_self_referencing_exists(
     adapter.replace_query(
         "test",
         parse_one("SELECT a FROM test"),
-        columns_to_types={"a": exp.DataType.build("UNKNOWN")},
+        target_columns_to_types={"a": exp.DataType.build("UNKNOWN")},
     )
 
     assert to_sql_calls(adapter) == [
@@ -3263,7 +3287,7 @@ def test_replace_query_self_referencing_not_exists_known(
     adapter.replace_query(
         "test",
         parse_one("SELECT a FROM test"),
-        columns_to_types={"a": exp.DataType.build("INT")},
+        target_columns_to_types={"a": exp.DataType.build("INT")},
     )
 
     assert to_sql_calls(adapter) == [
@@ -3362,7 +3386,7 @@ def test_ctas_pandas_source_columns(make_mocked_engine_adapter: t.Callable):
     adapter.ctas(
         "test_table",
         df,
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("INT"),
             "b": exp.DataType.build("INT"),
         },
@@ -3378,7 +3402,7 @@ def test_ctas_query_source_columns(make_mocked_engine_adapter: t.Callable):
     adapter.ctas(
         "test_table",
         parse_one("SELECT a FROM tbl"),
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("INT"),
             "b": exp.DataType.build("INT"),
         },
@@ -3528,7 +3552,7 @@ def test_insert_overwrite_by_partition_query(
         table_name,
         parse_one("SELECT a, ds, b FROM tbl"),
         partitioned_by=[d.parse_one(k) for k in partitioned_by],
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("int"),
             "ds": exp.DataType.build("DATETIME"),
             "b": exp.DataType.build("boolean"),
@@ -3568,7 +3592,7 @@ def test_insert_overwrite_by_partition_query_insert_overwrite_strategy(
             d.parse_one("DATETIME_TRUNC(ds, MONTH)"),
             d.parse_one("b"),
         ],
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("int"),
             "ds": exp.DataType.build("DATETIME"),
             "b": exp.DataType.build("boolean"),

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -76,6 +76,36 @@ def test_create_view_pandas(make_mocked_engine_adapter: t.Callable):
     ]
 
 
+def test_create_view_pandas_source_columns(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    bigint_dtype = exp.DataType.build("BIGINT")
+    adapter.create_view(
+        "test_view",
+        pd.DataFrame({"a": [1, 2, 3]}),
+        columns_to_types={"a": bigint_dtype, "b": bigint_dtype},
+        replace=False,
+        source_columns=["a"],
+    )
+
+    assert to_sql_calls(adapter) == [
+        'CREATE VIEW "test_view" ("a", "b") AS SELECT "a", CAST(NULL AS BIGINT) AS "b" FROM (SELECT CAST("a" AS BIGINT) AS "a" FROM (VALUES (1), (2), (3)) AS "t"("a")) AS "select_source_columns"',
+    ]
+
+
+def test_create_view_query_source_columns(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    adapter.create_view(
+        "test_view",
+        parse_one("SELECT a FROM tbl"),
+        columns_to_types={"a": exp.DataType.build("BIGINT"), "b": exp.DataType.build("BIGINT")},
+        replace=False,
+        source_columns=["a"],
+    )
+    assert to_sql_calls(adapter) == [
+        'CREATE VIEW "test_view" ("a", "b") AS SELECT "a", CAST(NULL AS BIGINT) AS "b" FROM (SELECT "a" FROM "tbl") AS "select_source_columns"',
+    ]
+
+
 def test_create_materialized_view(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(EngineAdapter)
     adapter.SUPPORTS_MATERIALIZED_VIEWS = True
@@ -274,6 +304,47 @@ def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas(
     ]
 
 
+def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas_source_columns(
+    make_mocked_engine_adapter: t.Callable,
+):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    adapter.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
+    df = pd.DataFrame({"a": [1, 2]})
+    adapter.insert_overwrite_by_time_partition(
+        "test_table",
+        df,
+        start="2022-01-01",
+        end="2022-01-02",
+        time_column="ds",
+        time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
+        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+        source_columns=["a"],
+    )
+    assert to_sql_calls(adapter) == [
+        """INSERT OVERWRITE TABLE "test_table" ("a", "ds") SELECT "a", "ds" FROM (SELECT CAST("a" AS INT) AS "a", CAST(NULL AS TEXT) AS "ds" FROM (VALUES (1), (2)) AS "t"("a")) AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02'"""
+    ]
+
+
+def test_insert_overwrite_by_time_partition_supports_insert_overwrite_query_source_columns(
+    make_mocked_engine_adapter: t.Callable,
+):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    adapter.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.INSERT_OVERWRITE
+    adapter.insert_overwrite_by_time_partition(
+        "test_table",
+        parse_one("SELECT a FROM tbl"),
+        start="2022-01-01",
+        end="2022-01-02",
+        time_column="ds",
+        time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
+        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+        source_columns=["a"],
+    )
+    assert to_sql_calls(adapter) == [
+        """INSERT OVERWRITE TABLE "test_table" ("a", "ds") SELECT "a", "ds" FROM (SELECT "a", CAST(NULL AS TEXT) AS "ds" FROM (SELECT "a" FROM "tbl") AS "select_source_columns") AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02'"""
+    ]
+
+
 def test_insert_overwrite_by_time_partition_replace_where(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(EngineAdapter)
     adapter.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.REPLACE_WHERE
@@ -313,6 +384,47 @@ def test_insert_overwrite_by_time_partition_replace_where_pandas(
 
     assert to_sql_calls(adapter) == [
         """INSERT INTO "test_table" REPLACE WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02' SELECT "a", "ds" FROM (SELECT CAST("a" AS INT) AS "a", CAST("ds" AS TEXT) AS "ds" FROM (VALUES (1, '2022-01-01'), (2, '2022-01-02')) AS "t"("a", "ds")) AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02'"""
+    ]
+
+
+def test_insert_overwrite_by_time_partition_replace_where_pandas_source_columns(
+    make_mocked_engine_adapter: t.Callable,
+):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    adapter.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.REPLACE_WHERE
+    df = pd.DataFrame({"a": [1, 2]})
+    adapter.insert_overwrite_by_time_partition(
+        "test_table",
+        df,
+        start="2022-01-01",
+        end="2022-01-02",
+        time_column="ds",
+        time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
+        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+        source_columns=["a"],
+    )
+    assert to_sql_calls(adapter) == [
+        """INSERT INTO "test_table" REPLACE WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02' SELECT "a", "ds" FROM (SELECT CAST("a" AS INT) AS "a", CAST(NULL AS TEXT) AS "ds" FROM (VALUES (1), (2)) AS "t"("a")) AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02'"""
+    ]
+
+
+def test_insert_overwrite_by_time_partition_replace_where_query_source_columns(
+    make_mocked_engine_adapter: t.Callable,
+):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    adapter.INSERT_OVERWRITE_STRATEGY = InsertOverwriteStrategy.REPLACE_WHERE
+    adapter.insert_overwrite_by_time_partition(
+        "test_table",
+        parse_one("SELECT a FROM tbl"),
+        start="2022-01-01",
+        end="2022-01-02",
+        time_column="ds",
+        time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
+        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+        source_columns=["a"],
+    )
+    assert to_sql_calls(adapter) == [
+        """INSERT INTO "test_table" REPLACE WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02' SELECT "a", "ds" FROM (SELECT "a", CAST(NULL AS TEXT) AS "ds" FROM (SELECT "a" FROM "tbl") AS "select_source_columns") AS "_subquery" WHERE "ds" BETWEEN '2022-01-01' AND '2022-01-02'"""
     ]
 
 
@@ -431,6 +543,39 @@ def test_insert_append_pandas_batches(make_mocked_engine_adapter: t.Callable):
         'INSERT INTO "test_table" ("a", "b") SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (VALUES (1, 4)) AS "t"("a", "b")',
         'INSERT INTO "test_table" ("a", "b") SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (VALUES (2, 5)) AS "t"("a", "b")',
         'INSERT INTO "test_table" ("a", "b") SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (VALUES (3, 6)) AS "t"("a", "b")',
+    ]
+
+
+def test_insert_append_pandas_source_columns(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    adapter.insert_append(
+        "test_table",
+        df,
+        columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "b": exp.DataType.build("INT"),
+        },
+        source_columns=["a"],
+    )
+    assert to_sql_calls(adapter) == [
+        'INSERT INTO "test_table" ("a", "b") SELECT CAST("a" AS INT) AS "a", CAST(NULL AS INT) AS "b" FROM (VALUES (1), (2), (3)) AS "t"("a")',
+    ]
+
+
+def test_insert_append_query_source_columns(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    adapter.insert_append(
+        "test_table",
+        parse_one("SELECT a FROM tbl"),
+        columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "b": exp.DataType.build("INT"),
+        },
+        source_columns=["a"],
+    )
+    assert to_sql_calls(adapter) == [
+        'INSERT INTO "test_table" ("a", "b") SELECT "a", CAST(NULL AS INT) AS "b" FROM (SELECT "a" FROM "tbl") AS "select_source_columns"',
     ]
 
 
@@ -899,9 +1044,11 @@ def test_alter_table(
     original_from_structs = adapter.SCHEMA_DIFFER._from_structs
 
     def _from_structs(
-        current_struct: exp.DataType, new_struct: exp.DataType
+        current_struct: exp.DataType, new_struct: exp.DataType, *, ignore_destructive: bool = False
     ) -> t.List[TableAlterOperation]:
-        operations = original_from_structs(current_struct, new_struct)
+        operations = original_from_structs(
+            current_struct, new_struct, ignore_destructive=ignore_destructive
+        )
         if not operations:
             return operations
         assert (
@@ -1013,6 +1160,47 @@ def test_merge_upsert_pandas(make_mocked_engine_adapter: t.Callable):
     )
     adapter.cursor.execute.assert_called_once_with(
         'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT CAST("id" AS INT) AS "id", CAST("ts" AS TIMESTAMP) AS "ts", CAST("val" AS INT) AS "val" FROM (VALUES (1, 4, 1), (2, 5, 2), (3, 6, 3)) AS "t"("id", "ts", "val")) AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" AND "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts" '
+        'WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" '
+        'WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val")'
+    )
+
+
+def test_merge_upsert_pandas_source_columns(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    df = pd.DataFrame({"id": [1, 2, 3], "ts": [4, 5, 6]})
+    adapter.merge(
+        target_table="target",
+        source_table=df,
+        columns_to_types={
+            "id": exp.DataType.build("int"),
+            "ts": exp.DataType.build("timestamp"),
+            "val": exp.DataType.build("int"),
+        },
+        unique_key=[exp.to_identifier("id")],
+        source_columns=["id", "ts"],
+    )
+    adapter.cursor.execute.assert_called_once_with(
+        'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT CAST("id" AS INT) AS "id", CAST("ts" AS TIMESTAMP) AS "ts", CAST(NULL AS INT) AS "val" FROM (VALUES (1, 4), (2, 5), (3, 6)) AS "t"("id", "ts")) AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" '
+        'WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" '
+        'WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val")'
+    )
+
+
+def test_merge_upsert_query_source_columns(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    adapter.merge(
+        target_table="target",
+        source_table=parse_one("SELECT id, ts FROM source"),
+        columns_to_types={
+            "id": exp.DataType.build("int"),
+            "ts": exp.DataType.build("timestamp"),
+            "val": exp.DataType.build("int"),
+        },
+        unique_key=[exp.to_identifier("id")],
+        source_columns=["id", "ts"],
+    )
+    adapter.cursor.execute.assert_called_once_with(
+        'MERGE INTO "target" AS "__MERGE_TARGET__" USING (SELECT "id", "ts", CAST(NULL AS INT) AS "val" FROM (SELECT "id", "ts" FROM "source") AS "select_source_columns") AS "__MERGE_SOURCE__" ON "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id" '
         'WHEN MATCHED THEN UPDATE SET "__MERGE_TARGET__"."id" = "__MERGE_SOURCE__"."id", "__MERGE_TARGET__"."ts" = "__MERGE_SOURCE__"."ts", "__MERGE_TARGET__"."val" = "__MERGE_SOURCE__"."val" '
         'WHEN NOT MATCHED THEN INSERT ("id", "ts", "val") VALUES ("__MERGE_SOURCE__"."id", "__MERGE_SOURCE__"."ts", "__MERGE_SOURCE__"."val")'
     )
@@ -1413,6 +1601,219 @@ FROM (
 ) AS "_subquery"
     """
         ).sql()
+    )
+
+
+def test_scd_type_2_by_time_source_columns(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "name": ["a", "b", "c"],
+            "test_UPDATED_at": [
+                "2020-01-01 10:00:00",
+                "2020-01-02 15:00:00",
+                "2020-01-03 12:00:00",
+            ],
+        }
+    )
+    adapter.scd_type_2_by_time(
+        target_table="target",
+        source_table=df,
+        unique_key=[exp.column("id")],
+        valid_from_col=exp.column("test_valid_from", quoted=True),
+        valid_to_col=exp.column("test_valid_to", quoted=True),
+        updated_at_col=exp.column("test_UPDATED_at", quoted=True),
+        columns_to_types={
+            "id": exp.DataType.build("INT"),
+            "name": exp.DataType.build("VARCHAR"),
+            "price": exp.DataType.build("DOUBLE"),
+            "test_UPDATED_at": exp.DataType.build("TIMESTAMP"),
+            "test_valid_from": exp.DataType.build("TIMESTAMP"),
+            "test_valid_to": exp.DataType.build("TIMESTAMP"),
+        },
+        source_columns=["id", "name", "test_UPDATED_at"],
+        execution_time=datetime(2020, 1, 1, 0, 0, 0),
+        start=datetime(2020, 1, 1, 0, 0, 0),
+        is_restatement=True,
+    )
+    sql_calls = to_sql_calls(adapter)
+    assert (
+        parse_one(sql_calls[1]).sql()
+        == parse_one("""
+CREATE OR REPLACE TABLE "target" AS
+WITH "source" AS (
+  SELECT DISTINCT ON ("id")
+    TRUE AS "_exists",
+    "id",
+    "name",
+    "price",
+    CAST("test_UPDATED_at" AS TIMESTAMP) AS "test_UPDATED_at"
+  FROM (
+    SELECT
+      CAST("id" AS INT) AS "id",
+      CAST("name" AS VARCHAR) AS "name",
+      CAST(NULL AS DOUBLE) AS "price",
+      CAST("test_UPDATED_at" AS TIMESTAMP) AS "test_UPDATED_at"
+    FROM (VALUES
+      (1, 'a', '2020-01-01 10:00:00'),
+      (2, 'b', '2020-01-02 15:00:00'),
+      (3, 'c', '2020-01-03 12:00:00')) AS "t"("id", "name", "test_UPDATED_at")
+  ) AS "raw_source"
+), "static" AS (
+  SELECT
+    "id",
+    "name",
+    "price",
+    "test_UPDATED_at",
+    "test_valid_from",
+    "test_valid_to",
+    TRUE AS "_exists"
+  FROM "target"
+  WHERE
+    NOT "test_valid_to" IS NULL
+), "latest" AS (
+  SELECT
+    "id",
+    "name",
+    "price",
+    "test_UPDATED_at",
+    "test_valid_from",
+    "test_valid_to",
+    TRUE AS "_exists"
+  FROM "target"
+  WHERE
+    "test_valid_to" IS NULL
+), "deleted" AS (
+  SELECT
+    "static"."id",
+    "static"."name",
+    "static"."price",
+    "static"."test_UPDATED_at",
+    "static"."test_valid_from",
+    "static"."test_valid_to"
+  FROM "static"
+  LEFT JOIN "latest"
+    ON "static"."id" = "latest"."id"
+  WHERE
+    "latest"."test_valid_to" IS NULL
+), "latest_deleted" AS (
+  SELECT
+    TRUE AS "_exists",
+    "id" AS "_key0",
+    MAX("test_valid_to") AS "test_valid_to"
+  FROM "deleted"
+  GROUP BY
+    "id"
+), "joined" AS (
+  SELECT
+    "source"."_exists" AS "_exists",
+    "latest"."id" AS "t_id",
+    "latest"."name" AS "t_name",
+    "latest"."price" AS "t_price",
+    "latest"."test_UPDATED_at" AS "t_test_UPDATED_at",
+    "latest"."test_valid_from" AS "t_test_valid_from",
+    "latest"."test_valid_to" AS "t_test_valid_to",
+    "source"."id" AS "id",
+    "source"."name" AS "name",
+    "source"."price" AS "price",
+    "source"."test_UPDATED_at" AS "test_UPDATED_at"
+  FROM "latest"
+  LEFT JOIN "source"
+    ON "latest"."id" = "source"."id"
+  UNION ALL
+  SELECT
+    "source"."_exists" AS "_exists",
+    "latest"."id" AS "t_id",
+    "latest"."name" AS "t_name",
+    "latest"."price" AS "t_price",
+    "latest"."test_UPDATED_at" AS "t_test_UPDATED_at",
+    "latest"."test_valid_from" AS "t_test_valid_from",
+    "latest"."test_valid_to" AS "t_test_valid_to",
+    "source"."id" AS "id",
+    "source"."name" AS "name",
+    "source"."price" AS "price",
+    "source"."test_UPDATED_at" AS "test_UPDATED_at"
+  FROM "latest"
+  RIGHT JOIN "source"
+    ON "latest"."id" = "source"."id"
+  WHERE
+    "latest"."_exists" IS NULL
+), "updated_rows" AS (
+  SELECT
+    COALESCE("joined"."t_id", "joined"."id") AS "id",
+    COALESCE("joined"."t_name", "joined"."name") AS "name",
+    COALESCE("joined"."t_price", "joined"."price") AS "price",
+    COALESCE("joined"."t_test_UPDATED_at", "joined"."test_UPDATED_at") AS "test_UPDATED_at",
+    CASE
+      WHEN "t_test_valid_from" IS NULL AND NOT "latest_deleted"."_exists" IS NULL
+      THEN CASE
+        WHEN "latest_deleted"."test_valid_to" > "test_UPDATED_at"
+        THEN "latest_deleted"."test_valid_to"
+        ELSE "test_UPDATED_at"
+      END
+      WHEN "t_test_valid_from" IS NULL
+      THEN CAST('1970-01-01 00:00:00' AS TIMESTAMP)
+      ELSE "t_test_valid_from"
+    END AS "test_valid_from",
+    CASE
+      WHEN "joined"."test_UPDATED_at" > "joined"."t_test_UPDATED_at"
+      THEN "joined"."test_UPDATED_at"
+      WHEN "joined"."_exists" IS NULL
+      THEN CAST('2020-01-01 00:00:00' AS TIMESTAMP)
+      ELSE "t_test_valid_to"
+    END AS "test_valid_to"
+  FROM "joined"
+  LEFT JOIN "latest_deleted"
+    ON "joined"."id" = "latest_deleted"."_key0"
+), "inserted_rows" AS (
+  SELECT
+    "id",
+    "name",
+    "price",
+    "test_UPDATED_at",
+    "test_UPDATED_at" AS "test_valid_from",
+    CAST(NULL AS TIMESTAMP) AS "test_valid_to"
+  FROM "joined"
+  WHERE
+    "joined"."test_UPDATED_at" > "joined"."t_test_UPDATED_at"
+)
+SELECT
+  CAST("id" AS INT) AS "id",
+  CAST("name" AS VARCHAR) AS "name",
+  CAST("price" AS DOUBLE) AS "price",
+  CAST("test_UPDATED_at" AS TIMESTAMP) AS "test_UPDATED_at",
+  CAST("test_valid_from" AS TIMESTAMP) AS "test_valid_from",
+  CAST("test_valid_to" AS TIMESTAMP) AS "test_valid_to"
+FROM (
+  SELECT
+    "id",
+    "name",
+    "price",
+    "test_UPDATED_at",
+    "test_valid_from",
+    "test_valid_to"
+  FROM "static"
+  UNION ALL
+  SELECT
+    "id",
+    "name",
+    "price",
+    "test_UPDATED_at",
+    "test_valid_from",
+    "test_valid_to"
+  FROM "updated_rows"
+  UNION ALL
+  SELECT
+    "id",
+    "name",
+    "price",
+    "test_UPDATED_at",
+    "test_valid_from",
+    "test_valid_to"
+  FROM "inserted_rows"
+) AS "_subquery"
+    """).sql()
     )
 
 
@@ -2774,6 +3175,39 @@ def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable):
     ]
 
 
+def test_replace_query_pandas_source_columns(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    adapter.replace_query(
+        "test_table",
+        df,
+        columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "b": exp.DataType.build("INT"),
+        },
+        source_columns=["a"],
+    )
+    assert to_sql_calls(adapter) == [
+        'CREATE OR REPLACE TABLE "test_table" AS SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (SELECT CAST("a" AS INT) AS "a", CAST(NULL AS INT) AS "b" FROM (VALUES (1), (2), (3)) AS "t"("a")) AS "_subquery"',
+    ]
+
+
+def test_replace_query_query_source_columns(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    adapter.replace_query(
+        "test_table",
+        parse_one("SELECT a FROM tbl"),
+        columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "b": exp.DataType.build("INT"),
+        },
+        source_columns=["a"],
+    )
+    assert to_sql_calls(adapter) == [
+        'CREATE OR REPLACE TABLE "test_table" AS SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (SELECT "a", CAST(NULL AS INT) AS "b" FROM (SELECT "a" FROM "tbl") AS "select_source_columns") AS "_subquery"',
+    ]
+
+
 def test_replace_query_self_referencing_not_exists_unknown(
     make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
 ):
@@ -2919,6 +3353,39 @@ def test_ctas_pandas(make_mocked_engine_adapter: t.Callable):
 
     assert to_sql_calls(adapter) == [
         'CREATE TABLE IF NOT EXISTS "new_table" AS SELECT CAST("a" AS BIGINT) AS "a", CAST("b" AS BIGINT) AS "b" FROM (SELECT CAST("a" AS BIGINT) AS "a", CAST("b" AS BIGINT) AS "b" FROM (VALUES (1, 4), (2, 5), (3, 6)) AS "t"("a", "b")) AS "_subquery"'
+    ]
+
+
+def test_ctas_pandas_source_columns(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    adapter.ctas(
+        "test_table",
+        df,
+        columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "b": exp.DataType.build("INT"),
+        },
+        source_columns=["a"],
+    )
+    assert to_sql_calls(adapter) == [
+        'CREATE TABLE IF NOT EXISTS "test_table" AS SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (SELECT CAST("a" AS INT) AS "a", CAST(NULL AS INT) AS "b" FROM (VALUES (1), (2), (3)) AS "t"("a")) AS "_subquery"',
+    ]
+
+
+def test_ctas_query_source_columns(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    adapter.ctas(
+        "test_table",
+        parse_one("SELECT a FROM tbl"),
+        columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "b": exp.DataType.build("INT"),
+        },
+        source_columns=["a"],
+    )
+    assert to_sql_calls(adapter) == [
+        'CREATE TABLE IF NOT EXISTS "test_table" AS SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (SELECT "a", CAST(NULL AS INT) AS "b" FROM (SELECT "a" FROM "tbl") AS "select_source_columns") AS "_subquery"',
     ]
 
 
@@ -3142,3 +3609,71 @@ def test_log_sql(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
         mock_logger.log.call_args_list[4][0][2]
         == 'CREATE OR REPLACE TABLE "test" AS SELECT CAST("id" AS BIGINT) AS "id", CAST("value" AS TEXT) AS "value" FROM (SELECT CAST("id" AS BIGINT) AS "id", CAST("value" AS TEXT) AS "value" FROM (VALUES "<REDACTED VALUES>") AS "t"("id", "value")) AS "_subquery"'
     )
+
+
+@pytest.mark.parametrize(
+    "columns, source_columns, expected",
+    [
+        (["a", "b"], None, 'SELECT "a", "b"'),
+        (["a", "b"], ["a"], 'SELECT "a", NULL AS "b"'),
+        (["a", "b"], ["a", "b"], 'SELECT "a", "b"'),
+        (["a", "b"], ["c", "d"], 'SELECT NULL AS "a", NULL AS "b"'),
+        (["a", "b"], [], 'SELECT "a", "b"'),
+    ],
+)
+def test_select_columns(
+    columns: t.List[str], source_columns: t.Optional[t.List[str]], expected: str
+) -> None:
+    assert (
+        EngineAdapter._select_columns(
+            columns,
+            source_columns,
+        ).sql()
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "columns_to_types, source_columns, expected",
+    [
+        (
+            {
+                "a": exp.DataType.build("INT"),
+                "b": exp.DataType.build("TEXT"),
+            },
+            None,
+            [
+                'CAST("a" AS INT) AS "a"',
+                'CAST("b" AS TEXT) AS "b"',
+            ],
+        ),
+        (
+            {
+                "a": exp.DataType.build("INT"),
+                "b": exp.DataType.build("TEXT"),
+            },
+            ["a"],
+            [
+                'CAST("a" AS INT) AS "a"',
+                'CAST(NULL AS TEXT) AS "b"',
+            ],
+        ),
+        (
+            {
+                "a": exp.DataType.build("INT"),
+                "b": exp.DataType.build("TEXT"),
+            },
+            ["b", "c"],
+            [
+                'CAST(NULL AS INT) AS "a"',
+                'CAST("b" AS TEXT) AS "b"',
+            ],
+        ),
+    ],
+)
+def test_casted_columns(
+    columns_to_types: t.Dict[str, exp.DataType], source_columns: t.List[str], expected: t.List[str]
+) -> None:
+    assert [
+        x.sql() for x in EngineAdapter._casted_columns(columns_to_types, source_columns)
+    ] == expected

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -38,7 +38,7 @@ def test_insert_overwrite_by_time_partition_query(
         end="2022-01-05",
         time_formatter=lambda x, _: exp.Literal.string(x.strftime("%Y-%m-%d")),
         time_column="ds",
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("int"),
             "ds": exp.DataType.build("string"),
         },
@@ -68,7 +68,7 @@ def test_insert_overwrite_by_partition_query(
         partitioned_by=[
             d.parse_one("DATETIME_TRUNC(ds, MONTH)"),
         ],
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("int"),
             "ds": exp.DataType.build("DATETIME"),
         },
@@ -111,7 +111,7 @@ def test_insert_overwrite_by_partition_query_unknown_column_types(
         partitioned_by=[
             d.parse_one("DATETIME_TRUNC(ds, MONTH)"),
         ],
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("unknown"),
             "ds": exp.DataType.build("UNKNOWN"),
         },
@@ -176,7 +176,7 @@ def test_insert_overwrite_by_time_partition_pandas(
         end="2022-01-05",
         time_formatter=lambda x, _: exp.Literal.string(x.strftime("%Y-%m-%d")),
         time_column="ds",
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("int"),
             "ds": exp.DataType.build("string"),
         },
@@ -431,7 +431,7 @@ def test_merge(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter.merge(
         target_table="target",
         source_table=parse_one("SELECT id, ts, val FROM source"),
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.Type.INT,
             "ts": exp.DataType.Type.TIMESTAMP,
             "val": exp.DataType.Type.INT,
@@ -488,7 +488,7 @@ def test_merge_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixt
     adapter.merge(
         target_table="target",
         source_table=df,
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "ts": exp.DataType.build("TIMESTAMP"),
             "val": exp.DataType.build("INT"),
@@ -733,14 +733,14 @@ def test_nested_comments(make_mocked_engine_adapter: t.Callable, mocker: MockerF
 
     adapter.create_table(
         "test_table",
-        columns_to_types=nested_columns_to_types,
+        target_columns_to_types=nested_columns_to_types,
         column_descriptions=long_column_descriptions,
     )
 
     adapter.ctas(
         "test_table",
         parse_one("SELECT * FROM source_table"),
-        columns_to_types=nested_columns_to_types,
+        target_columns_to_types=nested_columns_to_types,
         column_descriptions=long_column_descriptions,
     )
 

--- a/tests/core/engine_adapter/test_bigquery.py
+++ b/tests/core/engine_adapter/test_bigquery.py
@@ -205,7 +205,7 @@ def test_insert_overwrite_by_time_partition_pandas(
     assert load_temp_table.kwargs["job_config"].write_disposition is None
     assert (
         merge_sql.sql(dialect="bigquery")
-        == "MERGE INTO test_table AS __MERGE_TARGET__ USING (SELECT `a`, `ds` FROM (SELECT `a`, `ds` FROM project.dataset.temp_table) AS _subquery WHERE ds BETWEEN '2022-01-01' AND '2022-01-05') AS __MERGE_SOURCE__ ON FALSE WHEN NOT MATCHED BY SOURCE AND ds BETWEEN '2022-01-01' AND '2022-01-05' THEN DELETE WHEN NOT MATCHED THEN INSERT (a, ds) VALUES (a, ds)"
+        == "MERGE INTO test_table AS __MERGE_TARGET__ USING (SELECT `a`, `ds` FROM (SELECT CAST(`a` AS INT64) AS `a`, CAST(`ds` AS STRING) AS `ds` FROM project.dataset.temp_table) AS _subquery WHERE ds BETWEEN '2022-01-01' AND '2022-01-05') AS __MERGE_SOURCE__ ON FALSE WHEN NOT MATCHED BY SOURCE AND ds BETWEEN '2022-01-01' AND '2022-01-05' THEN DELETE WHEN NOT MATCHED THEN INSERT (a, ds) VALUES (a, ds)"
     )
     assert (
         drop_temp_table_sql.sql(dialect="bigquery")
@@ -295,7 +295,7 @@ def test_replace_query_pandas(make_mocked_engine_adapter: t.Callable, mocker: Mo
     ]
     sql_calls = _to_sql_calls(execute_mock)
     assert sql_calls == [
-        "CREATE OR REPLACE TABLE `test_table` AS SELECT CAST(`a` AS INT64) AS `a`, CAST(`b` AS INT64) AS `b` FROM (SELECT `a`, `b` FROM `project`.`dataset`.`temp_table`) AS `_subquery`",
+        "CREATE OR REPLACE TABLE `test_table` AS SELECT CAST(`a` AS INT64) AS `a`, CAST(`b` AS INT64) AS `b` FROM (SELECT CAST(`a` AS INT64) AS `a`, CAST(`b` AS INT64) AS `b` FROM `project`.`dataset`.`temp_table`) AS `_subquery`",
         "DROP TABLE IF EXISTS `project`.`dataset`.`temp_table`",
     ]
 
@@ -498,7 +498,7 @@ def test_merge_pandas(make_mocked_engine_adapter: t.Callable, mocker: MockerFixt
 
     sql_calls = _to_sql_calls(execute_mock, identify=False)
     assert sql_calls == [
-        "MERGE INTO target AS __MERGE_TARGET__ USING (SELECT `id`, `ts`, `val` FROM project.dataset.temp_table) AS __MERGE_SOURCE__ ON __MERGE_TARGET__.id = __MERGE_SOURCE__.id "
+        "MERGE INTO target AS __MERGE_TARGET__ USING (SELECT CAST(`id` AS INT64) AS `id`, CAST(`ts` AS DATETIME) AS `ts`, CAST(`val` AS INT64) AS `val` FROM project.dataset.temp_table) AS __MERGE_SOURCE__ ON __MERGE_TARGET__.id = __MERGE_SOURCE__.id "
         "WHEN MATCHED THEN UPDATE SET __MERGE_TARGET__.id = __MERGE_SOURCE__.id, __MERGE_TARGET__.ts = __MERGE_SOURCE__.ts, __MERGE_TARGET__.val = __MERGE_SOURCE__.val "
         "WHEN NOT MATCHED THEN INSERT (id, ts, val) VALUES (__MERGE_SOURCE__.id, __MERGE_SOURCE__.ts, __MERGE_SOURCE__.val)",
         "DROP TABLE IF EXISTS project.dataset.temp_table",

--- a/tests/core/engine_adapter/test_clickhouse.py
+++ b/tests/core/engine_adapter/test_clickhouse.py
@@ -603,7 +603,7 @@ def test_scd_type_2_by_time(
         valid_from_col=exp.column("test_valid_from", quoted=True),
         valid_to_col=exp.column("test_valid_to", quoted=True),
         updated_at_col=exp.column("test_UPDATED_at", quoted=True),
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("VARCHAR"),
             "price": exp.DataType.build("DOUBLE"),
@@ -815,7 +815,7 @@ def test_scd_type_2_by_column(
         valid_from_col=exp.column("test_VALID_from", quoted=True),
         valid_to_col=exp.column("test_valid_to", quoted=True),
         check_columns=[exp.column("name"), exp.column("price")],
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("VARCHAR"),
             "price": exp.DataType.build("DOUBLE"),

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -159,7 +159,7 @@ def test_insert_overwrite_by_partition_query(
             d.parse_one("DATETIME_TRUNC(ds, MONTH)"),
             d.parse_one("b"),
         ],
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("int"),
             "ds": exp.DataType.build("DATETIME"),
             "b": exp.DataType.build("boolean"),

--- a/tests/core/engine_adapter/test_mixins.py
+++ b/tests/core/engine_adapter/test_mixins.py
@@ -23,7 +23,7 @@ def test_logical_merge(make_mocked_engine_adapter: t.Callable, mocker: MockerFix
     adapter.merge(
         target_table="target",
         source_table=t.cast(exp.Select, parse_one("SELECT id, ts, val FROM source")),
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType(this=exp.DataType.Type.INT),
             "ts": exp.DataType(this=exp.DataType.Type.TIMESTAMP),
             "val": exp.DataType(this=exp.DataType.Type.INT),
@@ -48,7 +48,7 @@ def test_logical_merge(make_mocked_engine_adapter: t.Callable, mocker: MockerFix
     adapter.merge(
         target_table="target",
         source_table=t.cast(exp.Select, parse_one("SELECT id, ts, val FROM source")),
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType(this=exp.DataType.Type.INT),
             "ts": exp.DataType(this=exp.DataType.Type.TIMESTAMP),
             "val": exp.DataType(this=exp.DataType.Type.INT),

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -290,7 +290,10 @@ def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas_not
         end="2022-01-02",
         time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
         time_column="ds",
-        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+        target_columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "ds": exp.DataType.build("STRING"),
+        },
     )
     adapter._connection_pool.get().bulk_copy.assert_called_with(
         f"__temp_test_table_{temp_table_id}", [(1, "2022-01-01"), (2, "2022-01-02")]
@@ -327,7 +330,10 @@ def test_insert_overwrite_by_time_partition_supports_insert_overwrite_pandas_exi
         end="2022-01-02",
         time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
         time_column="ds",
-        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+        target_columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "ds": exp.DataType.build("STRING"),
+        },
     )
     assert to_sql_calls(adapter) == [
         f"""MERGE INTO [test_table] AS [__MERGE_TARGET__] USING (SELECT [a] AS [a], [ds] AS [ds] FROM (SELECT CAST([a] AS INTEGER) AS [a], CAST([ds] AS VARCHAR(MAX)) AS [ds] FROM [__temp_test_table_{temp_table_id}]) AS [_subquery] WHERE [ds] BETWEEN '2022-01-01' AND '2022-01-02') AS [__MERGE_SOURCE__] ON (1 = 0) WHEN NOT MATCHED BY SOURCE AND [ds] BETWEEN '2022-01-01' AND '2022-01-02' THEN DELETE WHEN NOT MATCHED THEN INSERT ([a], [ds]) VALUES ([a], [ds]);""",
@@ -359,7 +365,10 @@ def test_insert_overwrite_by_time_partition_replace_where_pandas(
         end="2022-01-02",
         time_formatter=lambda x, _: exp.Literal.string(to_ds(x)),
         time_column="ds",
-        columns_to_types={"a": exp.DataType.build("INT"), "ds": exp.DataType.build("STRING")},
+        target_columns_to_types={
+            "a": exp.DataType.build("INT"),
+            "ds": exp.DataType.build("STRING"),
+        },
     )
     adapter._connection_pool.get().bulk_copy.assert_called_with(
         f"__temp_test_table_{temp_table_id}", [(1, "2022-01-01"), (2, "2022-01-02")]
@@ -391,7 +400,7 @@ def test_insert_append_pandas(
     adapter.insert_append(
         table_name,
         df,
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("INT"),
             "b": exp.DataType.build("INT"),
         },
@@ -461,7 +470,7 @@ def test_merge_pandas(
     adapter.merge(
         target_table=table_name,
         source_table=df,
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("int"),
             "ts": exp.DataType.build("TIMESTAMP"),
             "val": exp.DataType.build("int"),
@@ -485,7 +494,7 @@ def test_merge_pandas(
     adapter.merge(
         target_table=table_name,
         source_table=df,
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("int"),
             "ts": exp.DataType.build("TIMESTAMP"),
             "val": exp.DataType.build("int"),
@@ -524,7 +533,7 @@ def test_merge_exists(
     adapter.merge(
         target_table=table_name,
         source_table=df,
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("int"),
             "ts": exp.DataType.build("TIMESTAMP"),
             "val": exp.DataType.build("int"),
@@ -545,7 +554,7 @@ def test_merge_exists(
     adapter.merge(
         target_table=table_name,
         source_table=df,
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("int"),
             "ts": exp.DataType.build("TIMESTAMP"),
             "val": exp.DataType.build("int"),
@@ -567,7 +576,7 @@ def test_merge_exists(
     adapter.merge(
         target_table=table_name,
         source_table=df,
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("int"),
             "ts": exp.DataType.build("TIMESTAMP"),
         },
@@ -913,7 +922,7 @@ def test_replace_query_strategy(adapter: MSSQLEngineAdapter, mocker: MockerFixtu
         table_properties=model.physical_properties,
         table_description=model.description,
         column_descriptions=model.column_descriptions,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
     )
 
     # subsequent - table exists
@@ -937,7 +946,7 @@ def test_replace_query_strategy(adapter: MSSQLEngineAdapter, mocker: MockerFixtu
         table_properties=model.physical_properties,
         table_description=model.description,
         column_descriptions=model.column_descriptions,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
     )
 
     assert to_sql_calls(adapter) == [

--- a/tests/core/engine_adapter/test_postgres.py
+++ b/tests/core/engine_adapter/test_postgres.py
@@ -99,7 +99,7 @@ def test_merge_version_gte_15(make_mocked_engine_adapter: t.Callable):
     adapter.merge(
         target_table="target",
         source_table=t.cast(exp.Select, parse_one('SELECT "ID", ts, val FROM source')),
-        columns_to_types={
+        target_columns_to_types={
             "ID": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
             "val": exp.DataType.build("int"),
@@ -127,7 +127,7 @@ def test_merge_version_lt_15(
     adapter.merge(
         target_table="target",
         source_table=t.cast(exp.Select, parse_one('SELECT "ID", ts, val FROM source')),
-        columns_to_types={
+        target_columns_to_types={
             "ID": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
             "val": exp.DataType.build("int"),

--- a/tests/core/engine_adapter/test_redshift.py
+++ b/tests/core/engine_adapter/test_redshift.py
@@ -220,7 +220,7 @@ def test_values_to_sql(adapter: t.Callable, mocker: MockerFixture):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     result = adapter._values_to_sql(
         values=list(df.itertuples(index=False, name=None)),
-        columns_to_types={"a": exp.DataType.build("int"), "b": exp.DataType.build("int")},
+        target_columns_to_types={"a": exp.DataType.build("int"), "b": exp.DataType.build("int")},
         batch_start=0,
         batch_end=2,
     )
@@ -272,7 +272,7 @@ def test_replace_query_with_df_table_exists(adapter: t.Callable, mocker: MockerF
     adapter.replace_query(
         table_name="test_table",
         query_or_df=df,
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("int"),
             "b": exp.DataType.build("int"),
         },
@@ -299,7 +299,7 @@ def test_replace_query_with_df_table_not_exists(adapter: t.Callable, mocker: Moc
     adapter.replace_query(
         table_name="test_table",
         query_or_df=df,
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("int"),
             "b": exp.DataType.build("int"),
         },
@@ -342,7 +342,7 @@ def test_create_view(adapter: t.Callable):
     adapter.create_view(
         view_name="test_view",
         query_or_df=parse_one("SELECT cola FROM table"),
-        columns_to_types={
+        target_columns_to_types={
             "a": exp.DataType.build("int"),
             "b": exp.DataType.build("int"),
         },
@@ -428,7 +428,7 @@ def test_merge(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter.merge(
         target_table=exp.to_table("target_table_name"),
         source_table=t.cast(exp.Select, parse_one('SELECT "ID", ts, val FROM source')),
-        columns_to_types={
+        target_columns_to_types={
             "ID": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
             "val": exp.DataType.build("int"),
@@ -440,7 +440,7 @@ def test_merge(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter.merge(
         target_table=exp.to_table("target_table_name"),
         source_table=t.cast(exp.Select, parse_one('SELECT "ID", ts, val FROM source')),
-        columns_to_types={
+        target_columns_to_types={
             "ID": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
             "val": exp.DataType.build("int"),
@@ -473,7 +473,7 @@ def test_merge_when_matched_error(make_mocked_engine_adapter: t.Callable, mocker
         adapter.merge(
             target_table=exp.to_table("target_table_name"),
             source_table=t.cast(exp.Select, parse_one('SELECT "ID", val FROM source')),
-            columns_to_types={
+            target_columns_to_types={
                 "ID": exp.DataType.build("int"),
                 "val": exp.DataType.build("int"),
             },
@@ -521,7 +521,7 @@ def test_merge_logical_filter_error(make_mocked_engine_adapter: t.Callable, mock
         adapter.merge(
             target_table=exp.to_table("target_table_name_2"),
             source_table=t.cast(exp.Select, parse_one('SELECT "ID", ts FROM source')),
-            columns_to_types={
+            target_columns_to_types={
                 "ID": exp.DataType.build("int"),
                 "ts": exp.DataType.build("timestamp"),
             },
@@ -546,7 +546,7 @@ def test_merge_logical(
     adapter.merge(
         target_table=exp.to_table("target"),
         source_table=t.cast(exp.Select, parse_one('SELECT "ID", ts FROM source')),
-        columns_to_types={
+        target_columns_to_types={
             "ID": exp.DataType.build("int"),
             "ts": exp.DataType.build("timestamp"),
         },

--- a/tests/core/engine_adapter/test_snowflake.py
+++ b/tests/core/engine_adapter/test_snowflake.py
@@ -254,14 +254,14 @@ def test_create_managed_table(make_mocked_engine_adapter: t.Callable, mocker: Mo
         adapter.create_managed_table(
             table_name="test_table",
             query=query,
-            columns_to_types=columns_to_types,
+            target_columns_to_types=columns_to_types,
         )
 
     # warehouse not specified, should default to current_warehouse()
     adapter.create_managed_table(
         table_name="test_table",
         query=query,
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         table_properties={"target_lag": exp.Literal.string("20 minutes")},
     )
 
@@ -269,7 +269,7 @@ def test_create_managed_table(make_mocked_engine_adapter: t.Callable, mocker: Mo
     adapter.create_managed_table(
         table_name="test_table",
         query=query,
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         table_properties={
             "target_lag": exp.Literal.string("20 minutes"),
             "warehouse": exp.to_identifier("foo"),
@@ -280,7 +280,7 @@ def test_create_managed_table(make_mocked_engine_adapter: t.Callable, mocker: Mo
     adapter.create_managed_table(
         table_name="test_table",
         query=query,
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         table_properties={
             "target_lag": exp.Literal.string("20 minutes"),
         },
@@ -292,7 +292,7 @@ def test_create_managed_table(make_mocked_engine_adapter: t.Callable, mocker: Mo
     adapter.create_managed_table(
         table_name="test_table",
         query=query,
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         table_properties={
             "target_lag": exp.Literal.string("20 minutes"),
             "refresh_mode": exp.Literal.string("auto"),
@@ -304,7 +304,7 @@ def test_create_managed_table(make_mocked_engine_adapter: t.Callable, mocker: Mo
     adapter.create_managed_table(
         table_name="test_table",
         query=query,
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         table_properties={
             "target_lag": exp.Literal.string("20 minutes"),
             "catalog": exp.Literal.string("snowflake"),
@@ -343,7 +343,7 @@ def test_ctas_skips_dynamic_table_properties(make_mocked_engine_adapter: t.Calla
     adapter.ctas(
         table_name="test_table",
         query_or_df=query,
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         table_properties={
             "warehouse": exp.to_identifier("foo"),
             "target_lag": exp.Literal.string("20 minutes"),
@@ -463,7 +463,10 @@ def test_replace_query_snowpark_dataframe(
     adapter.replace_query(
         table_name="foo",
         query_or_df=df,
-        columns_to_types={"ID": exp.DataType.build("INT"), "NAME": exp.DataType.build("VARCHAR")},
+        target_columns_to_types={
+            "ID": exp.DataType.build("INT"),
+            "NAME": exp.DataType.build("VARCHAR"),
+        },
     )
 
     # verify that DROP VIEW is called instead of DROP TABLE
@@ -622,7 +625,7 @@ SELECT a::INT;
     )
     adapter.create_table(
         model.name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_properties=model.physical_properties,
     )
 
@@ -657,7 +660,7 @@ SELECT a::INT;
     )
     adapter.create_table(
         model.name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_properties=model.physical_properties,
     )
 
@@ -733,7 +736,7 @@ def test_table_format_iceberg(snowflake_mocked_engine_adapter: SnowflakeEngineAd
 
     adapter.create_table(
         table_name=model.name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_format=model.table_format,
         table_properties=model.physical_properties,
     )
@@ -741,7 +744,7 @@ def test_table_format_iceberg(snowflake_mocked_engine_adapter: SnowflakeEngineAd
     adapter.ctas(
         table_name=model.name,
         query_or_df=model.render_query_or_raise(),
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_format=model.table_format,
         table_properties=model.physical_properties,
     )

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -83,7 +83,7 @@ def test_replace_query_table_properties_not_exists(
     adapter.replace_query(
         "test_table",
         parse_one("SELECT 1 AS cola, '2' AS colb, '3' AS colc"),
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         partitioned_by=[exp.to_column("colb")],
         storage_format="ICEBERG",
         table_properties={"a": exp.convert(1)},
@@ -117,7 +117,7 @@ def test_replace_query_table_properties_exists(
     adapter.replace_query(
         "test_table",
         parse_one("SELECT 1 AS cola, '2' AS colb, '3' AS colc"),
-        columns_to_types=columns_to_types,
+        target_columns_to_types=columns_to_types,
         partitioned_by=[exp.to_column("colb")],
         storage_format="ICEBERG",
         table_properties={"a": exp.convert(1)},
@@ -582,7 +582,7 @@ def test_scd_type_2_by_time(
         valid_from_col=exp.column("test_valid_from", quoted=True),
         valid_to_col=exp.column("test_valid_to", quoted=True),
         updated_at_col=exp.column("test_updated_at", quoted=True),
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("VARCHAR"),
             "price": exp.DataType.build("DOUBLE"),
@@ -1010,7 +1010,7 @@ def test_replace_query_with_wap_self_reference(
     adapter.replace_query(
         "catalog.schema.table.branch_wap_12345",
         parse_one("SELECT 1 as a FROM catalog.schema.table.branch_wap_12345"),
-        columns_to_types={"a": exp.DataType.build("INT")},
+        target_columns_to_types={"a": exp.DataType.build("INT")},
         storage_format="ICEBERG",
     )
 
@@ -1047,7 +1047,7 @@ def test_table_format(adapter: SparkEngineAdapter, mocker: MockerFixture):
     # both table_format and storage_format
     adapter.create_table(
         table_name=model.name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_format=model.table_format,
         storage_format=model.storage_format,
     )
@@ -1055,21 +1055,21 @@ def test_table_format(adapter: SparkEngineAdapter, mocker: MockerFixture):
     # just table_format
     adapter.create_table(
         table_name=model.name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_format=model.table_format,
     )
 
     # just storage_format set to a table format (test for backwards compatibility)
     adapter.create_table(
         table_name=model.name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         storage_format=model.table_format,
     )
 
     adapter.ctas(
         table_name=model.name,
         query_or_df=model.query,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_format=model.table_format,
         storage_format=model.storage_format,
     )

--- a/tests/core/engine_adapter/test_trino.py
+++ b/tests/core/engine_adapter/test_trino.py
@@ -183,7 +183,7 @@ def test_partitioned_by_iceberg_transforms(
 
     adapter.create_table(
         table_name=model.view_name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         partitioned_by=model.partitioned_by,
     )
 
@@ -426,7 +426,7 @@ def test_table_format(trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: M
 
     adapter.create_table(
         table_name=model.name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_format=model.table_format,
         storage_format=model.storage_format,
     )
@@ -434,7 +434,7 @@ def test_table_format(trino_mocked_engine_adapter: TrinoEngineAdapter, mocker: M
     adapter.ctas(
         table_name=model.name,
         query_or_df=t.cast(exp.Query, model.query),
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_format=model.table_format,
         storage_format=model.storage_format,
     )
@@ -472,14 +472,14 @@ def test_table_location(trino_mocked_engine_adapter: TrinoEngineAdapter, mocker:
 
     adapter.create_table(
         table_name=model.name,
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_properties=model.physical_properties,
     )
 
     adapter.ctas(
         table_name=model.name,
         query_or_df=t.cast(exp.Query, model.query),
-        columns_to_types=model.columns_to_types_or_raise,
+        target_columns_to_types=model.columns_to_types_or_raise,
         table_properties=model.physical_properties,
     )
 

--- a/tests/core/state_sync/test_state_sync.py
+++ b/tests/core/state_sync/test_state_sync.py
@@ -2205,7 +2205,7 @@ def test_migrate_rows(state_sync: EngineAdapterStateSync, mocker: MockerFixture)
     state_sync.engine_adapter.replace_query(
         "sqlmesh._snapshots",
         pd.read_json("tests/fixtures/migrations/snapshots.json"),
-        columns_to_types={
+        target_columns_to_types={
             "name": exp.DataType.build("text"),
             "identifier": exp.DataType.build("text"),
             "version": exp.DataType.build("text"),
@@ -2216,7 +2216,7 @@ def test_migrate_rows(state_sync: EngineAdapterStateSync, mocker: MockerFixture)
     state_sync.engine_adapter.replace_query(
         "sqlmesh._environments",
         pd.read_json("tests/fixtures/migrations/environments.json"),
-        columns_to_types={
+        target_columns_to_types={
             "name": exp.DataType.build("text"),
             "snapshots": exp.DataType.build("text"),
             "start_at": exp.DataType.build("text"),
@@ -2285,7 +2285,7 @@ def test_backup_state(state_sync: EngineAdapterStateSync, mocker: MockerFixture)
     state_sync.engine_adapter.replace_query(
         "sqlmesh._snapshots",
         pd.read_json("tests/fixtures/migrations/snapshots.json"),
-        columns_to_types={
+        target_columns_to_types={
             "name": exp.DataType.build("text"),
             "identifier": exp.DataType.build("text"),
             "version": exp.DataType.build("text"),
@@ -2310,7 +2310,7 @@ def test_restore_snapshots_table(state_sync: EngineAdapterStateSync) -> None:
     state_sync.engine_adapter.replace_query(
         "sqlmesh._snapshots",
         pd.read_json("tests/fixtures/migrations/snapshots.json"),
-        columns_to_types=snapshot_columns_to_types,
+        target_columns_to_types=snapshot_columns_to_types,
     )
 
     old_snapshots = state_sync.engine_adapter.fetchdf("select * from sqlmesh._snapshots")

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -16,7 +16,7 @@ from sqlglot.errors import SchemaError
 
 import sqlmesh.core.constants
 from sqlmesh.cli.project_init import init_example_project
-from sqlmesh.core.console import get_console, TerminalConsole
+from sqlmesh.core.console import TerminalConsole
 from sqlmesh.core import dialect as d, constants as c
 from sqlmesh.core.config import (
     load_configs,

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -2886,9 +2886,9 @@ def test_restatement_plan_hourly_with_downstream_daily_restates_correct_interval
         "ts": exp.DataType.build("timestamp"),
     }
     external_table = exp.table_(table="external_table", db="test", quoted=True)
-    engine_adapter.create_table(table_name=external_table, columns_to_types=columns_to_types)
+    engine_adapter.create_table(table_name=external_table, target_columns_to_types=columns_to_types)
     engine_adapter.insert_append(
-        table_name=external_table, query_or_df=df, columns_to_types=columns_to_types
+        table_name=external_table, query_or_df=df, target_columns_to_types=columns_to_types
     )
 
     # plan + apply
@@ -2939,7 +2939,7 @@ def test_restatement_plan_hourly_with_downstream_daily_restates_correct_interval
         }
     )
     engine_adapter.replace_query(
-        table_name=external_table, query_or_df=df, columns_to_types=columns_to_types
+        table_name=external_table, query_or_df=df, target_columns_to_types=columns_to_types
     )
 
     # Restate A across a day boundary with the expectation that two day intervals in B are affected
@@ -3018,9 +3018,9 @@ def test_restatement_plan_respects_disable_restatements(tmp_path: Path):
         "ts": exp.DataType.build("timestamp"),
     }
     external_table = exp.table_(table="external_table", db="test", quoted=True)
-    engine_adapter.create_table(table_name=external_table, columns_to_types=columns_to_types)
+    engine_adapter.create_table(table_name=external_table, target_columns_to_types=columns_to_types)
     engine_adapter.insert_append(
-        table_name=external_table, query_or_df=df, columns_to_types=columns_to_types
+        table_name=external_table, query_or_df=df, target_columns_to_types=columns_to_types
     )
 
     # plan + apply
@@ -3124,9 +3124,9 @@ def test_restatement_plan_clears_correct_intervals_across_environments(tmp_path:
         "date": exp.DataType.build("date"),
     }
     external_table = exp.table_(table="external_table", db="test", quoted=True)
-    engine_adapter.create_table(table_name=external_table, columns_to_types=columns_to_types)
+    engine_adapter.create_table(table_name=external_table, target_columns_to_types=columns_to_types)
     engine_adapter.insert_append(
-        table_name=external_table, query_or_df=df, columns_to_types=columns_to_types
+        table_name=external_table, query_or_df=df, target_columns_to_types=columns_to_types
     )
 
     # first, create the prod models
@@ -3319,9 +3319,9 @@ def test_prod_restatement_plan_clears_correct_intervals_in_derived_dev_tables(tm
         "ts": exp.DataType.build("timestamp"),
     }
     external_table = exp.table_(table="external_table", db="test", quoted=True)
-    engine_adapter.create_table(table_name=external_table, columns_to_types=columns_to_types)
+    engine_adapter.create_table(table_name=external_table, target_columns_to_types=columns_to_types)
     engine_adapter.insert_append(
-        table_name=external_table, query_or_df=df, columns_to_types=columns_to_types
+        table_name=external_table, query_or_df=df, target_columns_to_types=columns_to_types
     )
 
     # plan + apply A, B, C in prod
@@ -3469,9 +3469,9 @@ def test_prod_restatement_plan_clears_unaligned_intervals_in_derived_dev_tables(
         "ts": exp.DataType.build("timestamp"),
     }
     external_table = exp.table_(table="external_table", db="test", quoted=True)
-    engine_adapter.create_table(table_name=external_table, columns_to_types=columns_to_types)
+    engine_adapter.create_table(table_name=external_table, target_columns_to_types=columns_to_types)
     engine_adapter.insert_append(
-        table_name=external_table, query_or_df=df, columns_to_types=columns_to_types
+        table_name=external_table, query_or_df=df, target_columns_to_types=columns_to_types
     )
 
     # plan + apply A[hourly] in prod
@@ -3611,9 +3611,9 @@ def test_prod_restatement_plan_causes_dev_intervals_to_be_processed_in_next_dev_
         "ts": exp.DataType.build("timestamp"),
     }
     external_table = exp.table_(table="external_table", db="test", quoted=True)
-    engine_adapter.create_table(table_name=external_table, columns_to_types=columns_to_types)
+    engine_adapter.create_table(table_name=external_table, target_columns_to_types=columns_to_types)
     engine_adapter.insert_append(
-        table_name=external_table, query_or_df=df, columns_to_types=columns_to_types
+        table_name=external_table, query_or_df=df, target_columns_to_types=columns_to_types
     )
 
     # plan + apply A[hourly] in prod
@@ -3746,9 +3746,9 @@ def test_prod_restatement_plan_causes_dev_intervals_to_be_widened_on_full_restat
         "ts": exp.DataType.build("timestamp"),
     }
     external_table = exp.table_(table="external_table", db="test", quoted=True)
-    engine_adapter.create_table(table_name=external_table, columns_to_types=columns_to_types)
+    engine_adapter.create_table(table_name=external_table, target_columns_to_types=columns_to_types)
     engine_adapter.insert_append(
-        table_name=external_table, query_or_df=df, columns_to_types=columns_to_types
+        table_name=external_table, query_or_df=df, target_columns_to_types=columns_to_types
     )
 
     # plan + apply A[daily] in prod
@@ -3881,9 +3881,9 @@ def test_prod_restatement_plan_missing_model_in_dev(
         "ts": exp.DataType.build("timestamp"),
     }
     external_table = exp.table_(table="external_table", db="test", quoted=True)
-    engine_adapter.create_table(table_name=external_table, columns_to_types=columns_to_types)
+    engine_adapter.create_table(table_name=external_table, target_columns_to_types=columns_to_types)
     engine_adapter.insert_append(
-        table_name=external_table, query_or_df=df, columns_to_types=columns_to_types
+        table_name=external_table, query_or_df=df, target_columns_to_types=columns_to_types
     )
 
     # plan + apply A[hourly] in dev

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -7948,7 +7948,6 @@ def test_incremental_unmanaged_model_ignore_destructive_change(tmp_path: Path):
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     data_filepath = data_dir / "test.duckdb"
-    set_console(TerminalConsole())
 
     config = Config(
         model_defaults=ModelDefaultsConfig(dialect="duckdb"),
@@ -8058,7 +8057,6 @@ def test_scd_type_2_by_time_ignore_destructive_change(tmp_path: Path):
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     data_filepath = data_dir / "test.duckdb"
-    set_console(TerminalConsole())
 
     config = Config(
         model_defaults=ModelDefaultsConfig(dialect="duckdb"),

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -204,7 +204,7 @@ def test_evaluate(mocker: MockerFixture, adapter_mock, make_snapshot):
     )
 
     common_kwargs = dict(
-        columns_to_types={"a": exp.DataType.build("int")},
+        target_columns_to_types={"a": exp.DataType.build("int")},
         table_format=None,
         storage_format="parquet",
         partitioned_by=[exp.to_column("a", quoted=True)],
@@ -693,14 +693,14 @@ def test_evaluate_incremental_unmanaged_with_intervals(
             snapshot.table_name(),
             model.render_query(),
             [exp.to_column("ds", quoted=True)],
-            columns_to_types=model.columns_to_types,
+            target_columns_to_types=model.columns_to_types,
             source_columns=None,
         )
     else:
         adapter_mock.insert_append.assert_called_once_with(
             snapshot.table_name(),
             model.render_query(),
-            columns_to_types=model.columns_to_types,
+            target_columns_to_types=model.columns_to_types,
             source_columns=None,
         )
 
@@ -735,7 +735,7 @@ def test_evaluate_incremental_unmanaged_no_intervals(
         model.render_query(),
         clustered_by=[],
         column_descriptions={},
-        columns_to_types=table_columns,
+        target_columns_to_types=table_columns,
         partition_interval_unit=model.partition_interval_unit,
         partitioned_by=model.partitioned_by,
         table_format=None,
@@ -851,7 +851,10 @@ def test_create_new_forward_only_model(mocker: MockerFixture, adapter_mock, make
     # Only non-deployable table should be created
     adapter_mock.create_table.assert_called_once_with(
         f"sqlmesh__test_schema.test_schema__test_model__{snapshot.dev_version}__dev",
-        columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("varchar")},
+        target_columns_to_types={
+            "a": exp.DataType.build("int"),
+            "ds": exp.DataType.build("varchar"),
+        },
         table_format=None,
         storage_format=None,
         partitioned_by=model.partitioned_by,
@@ -1010,7 +1013,7 @@ def test_create_prod_table_exists_forward_only(mocker: MockerFixture, adapter_mo
     adapter_mock.create_schema.assert_called_once_with(to_schema("sqlmesh__test_schema"))
     adapter_mock.create_table.assert_called_once_with(
         f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev",
-        columns_to_types={"a": exp.DataType.build("int")},
+        target_columns_to_types={"a": exp.DataType.build("int")},
         table_format=None,
         storage_format=None,
         partitioned_by=[],
@@ -1611,7 +1614,7 @@ def test_create_clone_in_dev(mocker: MockerFixture, adapter_mock, make_snapshot)
 
     adapter_mock.create_table.assert_called_once_with(
         f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev__schema_migration_source",
-        columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("date")},
+        target_columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("date")},
         table_format=None,
         storage_format=None,
         partitioned_by=[exp.to_column("ds", quoted=True)],
@@ -1671,7 +1674,7 @@ def test_create_clone_in_dev_missing_table(mocker: MockerFixture, adapter_mock, 
 
     adapter_mock.create_table.assert_called_once_with(
         f"sqlmesh__test_schema.test_schema__test_model__{snapshot.dev_version}__dev",
-        columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("date")},
+        target_columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("date")},
         table_format=None,
         storage_format=None,
         partitioned_by=[exp.to_column("ds", quoted=True)],
@@ -1788,7 +1791,7 @@ def test_create_clone_in_dev_self_referencing(
 
     adapter_mock.create_table.assert_called_once_with(
         f"sqlmesh__test_schema.test_schema__test_model__{snapshot.version}__dev__schema_migration_source",
-        columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("date")},
+        target_columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("date")},
         table_format=None,
         storage_format=None,
         partitioned_by=[exp.to_column("ds", quoted=True)],
@@ -1919,7 +1922,7 @@ def test_forward_only_snapshot_for_added_model(mocker: MockerFixture, adapter_mo
     evaluator.create([snapshot], {})
 
     common_create_args = dict(
-        columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("date")},
+        target_columns_to_types={"a": exp.DataType.build("int"), "ds": exp.DataType.build("date")},
         table_format=None,
         storage_format=None,
         partitioned_by=[exp.to_column("ds", quoted=True)],
@@ -1963,7 +1966,7 @@ def test_create_scd_type_2_by_time(adapter_mock, make_snapshot):
     evaluator.create([snapshot], {})
 
     common_kwargs = dict(
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("STRING"),
             "updated_at": exp.DataType.build("TIMESTAMPTZ"),
@@ -2100,7 +2103,7 @@ def test_insert_into_scd_type_2_by_time(
     adapter_mock.scd_type_2_by_time.assert_called_once_with(
         target_table=snapshot.table_name(),
         source_table=model.render_query(),
-        columns_to_types=table_columns,
+        target_columns_to_types=table_columns,
         table_format=None,
         unique_key=[exp.to_column("id", quoted=True)],
         valid_from_col=exp.column("valid_from", quoted=True),
@@ -2142,7 +2145,7 @@ def test_create_scd_type_2_by_column(adapter_mock, make_snapshot):
     evaluator.create([snapshot], {})
 
     common_kwargs = dict(
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("STRING"),
             # Make sure that the call includes these extra columns
@@ -2273,7 +2276,7 @@ def test_insert_into_scd_type_2_by_column(
     adapter_mock.scd_type_2_by_column.assert_called_once_with(
         target_table=snapshot.table_name(),
         source_table=model.render_query(),
-        columns_to_types=table_columns,
+        target_columns_to_types=table_columns,
         table_format=None,
         unique_key=[exp.to_column("id", quoted=True)],
         check_columns=exp.Star(),
@@ -2323,7 +2326,7 @@ def test_create_incremental_by_unique_key_updated_at_exp(adapter_mock, make_snap
     adapter_mock.merge.assert_called_once_with(
         snapshot.table_name(),
         model.render_query(),
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("STRING"),
             "updated_at": exp.DataType.build("TIMESTAMP"),
@@ -2392,7 +2395,7 @@ def test_create_incremental_by_unique_key_multiple_updated_at_exp(adapter_mock, 
     adapter_mock.merge.assert_called_once_with(
         snapshot.table_name(),
         model.render_query(),
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "name": exp.DataType.build("STRING"),
             "updated_at": exp.DataType.build("TIMESTAMP"),
@@ -2488,7 +2491,7 @@ def test_create_incremental_by_unique_no_intervals(adapter_mock, make_snapshot):
         model.render_query(),
         clustered_by=[],
         column_descriptions={},
-        columns_to_types=table_columns,
+        target_columns_to_types=table_columns,
         partition_interval_unit=model.partition_interval_unit,
         partitioned_by=model.partitioned_by,
         table_format=None,
@@ -2553,7 +2556,7 @@ def test_create_incremental_by_unique_key_merge_filter(adapter_mock, make_snapsh
     adapter_mock.merge.assert_called_once_with(
         snapshot.table_name(),
         model.render_query(),
-        columns_to_types={
+        target_columns_to_types={
             "id": exp.DataType.build("INT"),
             "updated_at": exp.DataType.build("TIMESTAMP"),
         },
@@ -2620,7 +2623,10 @@ def test_create_seed(mocker: MockerFixture, adapter_mock, make_snapshot):
     evaluator.create([snapshot], {})
 
     common_create_kwargs: t.Dict[str, t.Any] = dict(
-        columns_to_types={"id": exp.DataType.build("bigint"), "name": exp.DataType.build("text")},
+        target_columns_to_types={
+            "id": exp.DataType.build("bigint"),
+            "name": exp.DataType.build("text"),
+        },
         table_format=None,
         storage_format=None,
         partitioned_by=[],
@@ -2698,7 +2704,10 @@ def test_create_seed_on_error(mocker: MockerFixture, adapter_mock, make_snapshot
         f"sqlmesh__db.db__seed__{snapshot.version}",
         mocker.ANY,
         column_descriptions={},
-        columns_to_types={"id": exp.DataType.build("bigint"), "name": exp.DataType.build("text")},
+        target_columns_to_types={
+            "id": exp.DataType.build("bigint"),
+            "name": exp.DataType.build("text"),
+        },
         table_format=None,
         storage_format=None,
         partitioned_by=[],
@@ -2755,7 +2764,10 @@ def test_create_seed_no_intervals(mocker: MockerFixture, adapter_mock, make_snap
         f"sqlmesh__db.db__seed__{snapshot.version}",
         mocker.ANY,
         column_descriptions={},
-        columns_to_types={"id": exp.DataType.build("bigint"), "name": exp.DataType.build("text")},
+        target_columns_to_types={
+            "id": exp.DataType.build("bigint"),
+            "name": exp.DataType.build("text"),
+        },
         table_format=None,
         storage_format=None,
         partitioned_by=[],
@@ -3261,7 +3273,7 @@ def test_evaluate_incremental_by_partition(mocker: MockerFixture, make_snapshot,
             exp.to_column("ds", quoted=True),
             exp.to_column("b", quoted=True),
         ],
-        columns_to_types=model.columns_to_types,
+        target_columns_to_types=model.columns_to_types,
         clustered_by=[],
         table_properties={},
         column_descriptions={},
@@ -3291,7 +3303,7 @@ def test_evaluate_incremental_by_partition(mocker: MockerFixture, make_snapshot,
             exp.to_column("ds", quoted=True),
             exp.to_column("b", quoted=True),
         ],
-        columns_to_types=model.columns_to_types,
+        target_columns_to_types=model.columns_to_types,
         source_columns=None,
     )
 
@@ -3522,7 +3534,7 @@ def test_create_managed(adapter_mock, make_snapshot, mocker: MockerFixture):
     adapter_mock.create_managed_table.assert_called_with(
         table_name=snapshot.table_name(),
         query=mocker.ANY,
-        columns_to_types=model.columns_to_types,
+        target_columns_to_types=model.columns_to_types,
         partitioned_by=model.partitioned_by,
         clustered_by=model.clustered_by,
         table_properties=model.physical_properties,
@@ -3594,7 +3606,7 @@ def test_evaluate_managed(adapter_mock, make_snapshot, mocker: MockerFixture):
     adapter_mock.replace_query.assert_called_with(
         snapshot.table_name(is_deployable=False),
         mocker.ANY,
-        columns_to_types=table_colmns,
+        target_columns_to_types=table_colmns,
         table_format=model.table_format,
         storage_format=model.storage_format,
         partitioned_by=model.partitioned_by,
@@ -3776,7 +3788,7 @@ def test_create_snapshot(
     )
 
     common_kwargs: t.Dict[str, t.Any] = dict(
-        columns_to_types={"a": exp.DataType.build("int")},
+        target_columns_to_types={"a": exp.DataType.build("int")},
         table_format=None,
         storage_format=None,
         partitioned_by=[],
@@ -3843,13 +3855,16 @@ def test_migrate_snapshot(snapshot: Snapshot, mocker: MockerFixture, adapter_moc
         [
             call(
                 new_snapshot.table_name(),
-                columns_to_types={"a": exp.DataType.build("int")},
+                target_columns_to_types={"a": exp.DataType.build("int")},
                 column_descriptions={},
                 **common_kwargs,
             ),
             call(
                 new_snapshot.table_name(is_deployable=False),
-                columns_to_types={"a": exp.DataType.build("int"), "b": exp.DataType.build("int")},
+                target_columns_to_types={
+                    "a": exp.DataType.build("int"),
+                    "b": exp.DataType.build("int"),
+                },
                 column_descriptions=None,
                 **common_kwargs,
             ),

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -31,16 +31,16 @@ def test_adapter_relation(sushi_test_project: Project, runtime_renderer: t.Calla
     engine_adapter.create_schema("foo")
     engine_adapter.create_schema("ignored")
     engine_adapter.create_table(
-        table_name="foo.bar", columns_to_types={"baz": exp.DataType.build("int")}
+        table_name="foo.bar", target_columns_to_types={"baz": exp.DataType.build("int")}
     )
     engine_adapter.create_table(
-        table_name="foo.another", columns_to_types={"col": exp.DataType.build("int")}
+        table_name="foo.another", target_columns_to_types={"col": exp.DataType.build("int")}
     )
     engine_adapter.create_view(
         view_name="foo.bar_view", query_or_df=parse_one("select * from foo.bar")
     )
     engine_adapter.create_table(
-        table_name="ignored.ignore", columns_to_types={"col": exp.DataType.build("int")}
+        table_name="ignored.ignore", target_columns_to_types={"col": exp.DataType.build("int")}
     )
 
     assert (
@@ -262,10 +262,10 @@ def test_adapter_map_snapshot_tables(
     engine_adapter.create_schema("sqlmesh")
     engine_adapter.create_table(
         table_name='"memory"."sqlmesh"."test_db__test_model"',
-        columns_to_types={"baz": exp.DataType.build("int")},
+        target_columns_to_types={"baz": exp.DataType.build("int")},
     )
     engine_adapter.create_table(
-        table_name="foo.bar", columns_to_types={"col": exp.DataType.build("int")}
+        table_name="foo.bar", target_columns_to_types={"col": exp.DataType.build("int")}
     )
 
     expected_test_model_table_name = parse_one('"memory"."sqlmesh"."test_db__test_model"').sql(
@@ -324,7 +324,7 @@ def test_adapter_get_relation_normalization(
 
         engine_adapter.create_schema('"FOO"')
         engine_adapter.create_table(
-            table_name='"FOO"."BAR"', columns_to_types={"baz": exp.DataType.build("int")}
+            table_name='"FOO"."BAR"', target_columns_to_types={"baz": exp.DataType.build("int")}
         )
 
         assert (

--- a/tests/dbt/test_integration.py
+++ b/tests/dbt/test_integration.py
@@ -194,9 +194,11 @@ test_config = config"""
         columns_to_types = columns_to_types_from_df(df)
 
         if values:
-            adapter.replace_query("sushi.raw_marketing", df, columns_to_types=columns_to_types)
+            adapter.replace_query(
+                "sushi.raw_marketing", df, target_columns_to_types=columns_to_types
+            )
         else:
-            adapter.create_table("sushi.raw_marketing", columns_to_types=columns_to_types)
+            adapter.create_table("sushi.raw_marketing", target_columns_to_types=columns_to_types)
 
     def _normalize_dbt_dataframe(
         self,


### PR DESCRIPTION
BREAKING: `columns_to_types` has been renamed to `target_columns_to_types` for engine adapter methods. 

This PR adds support for "ignoring" a destructive change using the `on_destructive_change` property. As documentation says, this property should not be used in most cases and is really just being added for dbt support. It could be useful though for an "escape-hatch" situation.

The concept of ignoring a destructive change is pushed down to the SchemaDiffer class level because the SchemaDiffer needs to be aware of this property is being used due to positional changes. If the engine supports positional changes and the SchemaDiffer wasn't aware then it could generate alter commands that involve changing columns assuming a column order that wouldn't really happen.

Prior to this PR, the engine adapter class assumed that the Query or DataFrame had the same columns as `columns_to_types`. `columns_to_types` has been renamed to `target_columns_to_types` and now represents the target table columns and can now drift out of sync of the "source" query or DataFrame. To account for this, engine adapter methods which take a `QueryOrDF` now also take a `source_columns` which tells the adapter what columns are in that source. If needed, it will pad out the columns in the source to match the target. 

Note: I am intentionally not changing dbt adapter implementation since I plan on updating it once `on_additive_change` support is added in follow up PR. That will isolate the breaking changes related to `on_schema_change` support to a single PR and it is just breaking for dbt adapter. 