### PR TITLE
feat: add fix option to lint command

### DIFF
--- a/docs/examples/sqlmesh_cli_crash_course.md
+++ b/docs/examples/sqlmesh_cli_crash_course.md
@@ -675,6 +675,8 @@ This is a great way to catch SQL issues before wasting runtime in your data ware
 
     ```bash
     sqlmesh lint
+    # or apply fixes automatically
+    sqlmesh lint --fix
     ```
 
 === "Tobiko Cloud"

--- a/docs/guides/linter.md
+++ b/docs/guides/linter.md
@@ -100,7 +100,7 @@ Place a rule's code in the project's `linter/` directory. SQLMesh will load all 
 
 If the rule is specified in the project's [configuration file](#applying-linting-rules), SQLMesh will run it when:
 - A plan is created during `sqlmesh plan`
-- The command `sqlmesh lint` is ran
+- The command `sqlmesh lint` is ran. Add `--fix` to automatically apply available fixes and fail if errors remain.
 
 SQLMesh will error if a model violates the rule, informing you which model(s) violated the rule. In this example, `full_model.sql` violated the `NoMissingOwner` rule, essentially halting execution:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -636,6 +636,7 @@ Usage: sqlmesh lint [OPTIONS]
 
 Options:
   --model TEXT           A model to lint. Multiple models can be linted.  If no models are specified, every model will be linted.
+  --fix                  Apply fixes for lint errors. Fails if errors remain after fixes are applied.
   --help                 Show this message and exit.
 
 ```

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -1201,15 +1201,21 @@ def environments(obj: Context) -> None:
     multiple=True,
     help="A model to lint. Multiple models can be linted. If no models are specified, every model will be linted.",
 )
+@click.option(
+    "--fix",
+    is_flag=True,
+    help="Apply fixes for lint errors. Fails if errors remain after fixes are applied.",
+)
 @click.pass_obj
 @error_handler
 @cli_analytics
 def lint(
     obj: Context,
     models: t.Iterator[str],
+    fix: bool,
 ) -> None:
     """Run the linter for the target model(s)."""
-    obj.lint_models(models)
+    obj.lint_models(models, fix=fix)
 
 
 @cli.group(no_args_is_help=True)


### PR DESCRIPTION
## Summary
- add `--fix` flag to `sqlmesh lint` to apply automatic fixes and fail on remaining errors
- implement fix application for lint violations
- document new lint fix option and add tests

## Testing
- `pre-commit run --files docs/examples/sqlmesh_cli_crash_course.md docs/guides/linter.md docs/reference/cli.md sqlmesh/cli/main.py sqlmesh/core/context.py tests/cli/test_cli.py`
- `pytest tests/cli/test_cli.py::test_lint_fix tests/cli/test_cli.py::test_lint_fix_unfixable_error -q`

------
https://chatgpt.com/codex/tasks/task_e_6899c89c18fc8330a9329492edcfeaff