### PR TITLE
chore(web,vscode): adding npm publish shared package

### DIFF
--- a/.github/workflows/release_shared_js.yaml
+++ b/.github/workflows/release_shared_js.yaml
@@ -1,0 +1,54 @@
+name: Release shared js code
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.0.0)'
+        required: true
+        type: string
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Check branch is main
+        run: |
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            echo "Error: This workflow can only be run from the main branch"
+            exit 1
+          fi
+          echo "Branch check passed: running from main branch"
+      - name: Validate version format
+        run: |
+          version="${{ github.event.inputs.version }}"
+          if ! [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "Error: Version must be a valid semantic version (e.g., 1.0.0, 1.0.0-beta.1, 1.0.0+build.1)"
+            exit 1
+          fi
+          echo "Version format is valid: $version"
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Update package.json version
+        working-directory: web/shared_ui
+        run: |
+          npm version ${{ github.event.inputs.version }} --no-git-tag-version
+      - name: Build package
+        working-directory: web/shared_ui
+        run: pnpm run build
+      - name: Publish to npm
+        working-directory: web/shared_ui
+        run: |
+          npm publish


### PR DESCRIPTION
- publishes shared package with a custom manual trigger like vscode extension
- there is no need for the npm token because it is set up for https://docs.npmjs.com/trusted-publishers#step-1-add-a-trusted-publisher-on-npmjscom