### PR TITLE
Revert: Partial restatements for SCD type 2 models

### DIFF
--- a/docs/concepts/models/model_kinds.md
+++ b/docs/concepts/models/model_kinds.md
@@ -935,13 +935,7 @@ SQLMesh achieves this by adding a `valid_from` and `valid_to` column to your mod
 
 Therefore, you can use these models to not only tell you what the latest value is for a given record but also what the values were anytime in the past. Note that maintaining this history does come at a cost of increased storage and compute and this may not be a good fit for sources that change frequently since the history could get very large.
 
-**Note**: SCD Type 2 models support [restatements](../plans.md#restatement-plans) with specific limitations:
-
-- **Full restatements**: The entire table will be recreated from scratch when no start date is specified
-- **Partial restatements**: You can specify a start date to restate data from a certain point onwards to the latest interval. The end date will always be set to the latest interval's end date, regardless of what end date you specify
-- **Partial sections**: Restatements of specific sections (discontinued ranges) of the table are not supported
-
-Data restatement is disabled for models of this kind by default (`disable_restatement true`). To enable restatements, set `disable_restatement false` in your model configuration.
+**Note**: Partial data [restatement](../plans.md#restatement-plans) is not supported for this model kind, which means that the entire table will be recreated from scratch if restated. This may lead to data loss, so data restatement is disabled for models of this kind by default.
 
 There are two ways to tracking changes: By Time (Recommended) or By Column.
 
@@ -1289,11 +1283,11 @@ This is the most accurate representation of the menu based on the source data pr
 
 ### Processing Source Table with Historical Data
 
-The most common case for SCD Type 2 is creating history for a table that it doesn't have it already.
+The most common case for SCD Type 2 is creating history for a table that it doesn't have it already. 
 In the example of the restaurant menu, the menu just tells you what is offered right now, but you want to know what was offered over time.
 In this case, the default setting of `None` for `batch_size` is the best option.
 
-Another use case though is processing a source table that already has history in it.
+Another use case though is processing a source table that already has history in it. 
 A common example of this is a "daily snapshot" table that is created by a source system that takes a snapshot of the data at the end of each day.
 If your source table has historical records, like a "daily snapshot" table, then set `batch_size` to `1` to process each interval (each day if a `@daily` cron) in sequential order.
 That way the historical records will be properly captured in the SCD Type 2 table.
@@ -1439,14 +1433,11 @@ GROUP BY
   id
 ```
 
-### SCD Type 2 Restatements
+### Reset SCD Type 2 Model (clearing history)
 
 SCD Type 2 models are designed by default to protect the data that has been captured because it is not possible to recreate the history once it has been lost.
 However, there are cases where you may want to clear the history and start fresh.
-
-#### Enabling Restatements
-
-To enable restatements for an SCD Type 2 model, set `disable_restatement` to `false` in the model definition:
+For this use use case you will want to start by setting `disable_restatement` to `false` in the model definition.
 
 ```sql linenums="1" hl_lines="5"
 MODEL (
@@ -1458,9 +1449,8 @@ MODEL (
 );
 ```
 
-#### Full Restatements (Clearing All History)
-
-To clear all history and recreate the entire table from scratch:
+Plan/apply this change to production.
+Then you will want to [restate the model](../plans.md#restatement-plans).
 
 ```bash
 sqlmesh plan --restate-model db.menu_items
@@ -1468,29 +1458,7 @@ sqlmesh plan --restate-model db.menu_items
 
 !!! warning
 
-    This will remove **all** historical data on the model which in most situations cannot be recovered.
-
-#### Partial Restatements (From a Specific Date)
-
-You can restate data from a specific start date onwards. This will:
-- Delete all records with `valid_from >= start_date`
-- Reprocess the data from the start date to the latest interval
-
-```bash
-sqlmesh plan --restate-model db.menu_items --start "2023-01-15"
-```
-
-!!! note
-
-    If you specify an end date for SCD Type 2 restatements, it will be ignored and automatically set to the latest interval's end date.
-
-```bash
-# This end date will be ignored and set to the latest interval
-sqlmesh plan --restate-model db.menu_items --start "2023-01-15" --end "2023-01-20"
-```
-
-
-#### Re-enabling Protection
+    This will remove the historical data on the model which in most situations cannot be recovered.
 
 Once complete you will want to remove `disable_restatement` on the model definition which will set it back to `true` and prevent accidental data loss.
 

--- a/sqlmesh/core/engine_adapter/trino.py
+++ b/sqlmesh/core/engine_adapter/trino.py
@@ -256,7 +256,6 @@ class TrinoEngineAdapter(
         unique_key: t.Sequence[exp.Expression],
         valid_from_col: exp.Column,
         valid_to_col: exp.Column,
-        start: TimeLike,
         execution_time: t.Union[TimeLike, exp.Column],
         invalidate_hard_deletes: bool = True,
         updated_at_col: t.Optional[exp.Column] = None,
@@ -267,7 +266,6 @@ class TrinoEngineAdapter(
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         truncate: bool = False,
-        is_restatement: bool = False,
         **kwargs: t.Any,
     ) -> None:
         if columns_to_types and self.current_catalog_type == "delta_lake":
@@ -279,7 +277,6 @@ class TrinoEngineAdapter(
             unique_key,
             valid_from_col,
             valid_to_col,
-            start,
             execution_time,
             invalidate_hard_deletes,
             updated_at_col,
@@ -290,7 +287,6 @@ class TrinoEngineAdapter(
             table_description,
             column_descriptions,
             truncate,
-            is_restatement,
             **kwargs,
         )
 

--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -141,6 +141,7 @@ class ModelKindMixin:
             self.is_incremental_unmanaged
             or self.is_incremental_by_unique_key
             or self.is_incremental_by_partition
+            or self.is_scd_type_2
             or self.is_managed
             or self.is_full
             or self.is_view

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -235,11 +235,6 @@ class BuiltInPlanEvaluator(PlanEvaluator):
             return
 
         scheduler = self.create_scheduler(stage.all_snapshots.values(), self.snapshot_evaluator)
-        # Convert model name restatements to snapshot ID restatements
-        restatements_by_snapshot_id = {
-            stage.all_snapshots[name].snapshot_id: interval
-            for name, interval in plan.restatements.items()
-        }
         errors, _ = scheduler.run_merged_intervals(
             merged_intervals=stage.snapshot_to_intervals,
             deployability_index=stage.deployability_index,
@@ -248,7 +243,6 @@ class BuiltInPlanEvaluator(PlanEvaluator):
             circuit_breaker=self._circuit_breaker,
             start=plan.start,
             end=plan.end,
-            restatements=restatements_by_snapshot_id,
         )
         if errors:
             raise PlanError("Plan application failed.")

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -161,7 +161,6 @@ class Scheduler:
         deployability_index: DeployabilityIndex,
         batch_index: int,
         environment_naming_info: t.Optional[EnvironmentNamingInfo] = None,
-        is_restatement: bool = False,
         **kwargs: t.Any,
     ) -> t.List[AuditResult]:
         """Evaluate a snapshot and add the processed interval to the state sync.
@@ -193,7 +192,6 @@ class Scheduler:
             snapshots=snapshots,
             deployability_index=deployability_index,
             batch_index=batch_index,
-            is_restatement=is_restatement,
             **kwargs,
         )
         audit_results = self._audit_snapshot(
@@ -373,7 +371,6 @@ class Scheduler:
         end: t.Optional[TimeLike] = None,
         run_environment_statements: bool = False,
         audit_only: bool = False,
-        restatements: t.Optional[t.Dict[SnapshotId, Interval]] = None,
     ) -> t.Tuple[t.List[NodeExecutionFailedError[SchedulingUnit]], t.List[SchedulingUnit]]:
         """Runs precomputed batches of missing intervals.
 
@@ -450,10 +447,6 @@ class Scheduler:
                         execution_time=execution_time,
                     )
                 else:
-                    # Determine if this snapshot and interval is a restatement (for SCD type 2)
-                    is_restatement = (
-                        restatements is not None and snapshot.snapshot_id in restatements
-                    )
                     audit_results = self.evaluate(
                         snapshot=snapshot,
                         environment_naming_info=environment_naming_info,
@@ -462,7 +455,6 @@ class Scheduler:
                         execution_time=execution_time,
                         deployability_index=deployability_index,
                         batch_index=batch_idx,
-                        is_restatement=is_restatement,
                     )
 
                 evaluation_duration_ms = now_timestamp() - execution_start_ts
@@ -671,7 +663,6 @@ class Scheduler:
             end=end,
             run_environment_statements=run_environment_statements,
             audit_only=audit_only,
-            restatements=remove_intervals,
         )
 
         return CompletionStatus.FAILURE if errors else CompletionStatus.SUCCESS

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -837,21 +837,6 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
 
             removal_interval = expanded_removal_interval
 
-        # SCD Type 2 validation that end date is the latest interval if it was provided
-        if not is_preview and self.is_scd_type_2 and self.intervals:
-            requested_start, requested_end = removal_interval
-            latest_end = self.intervals[-1][1]
-            if requested_end < latest_end:
-                from sqlmesh.core.console import get_console
-
-                get_console().log_warning(
-                    f"SCD Type 2 model '{self.model.name}' does not support end date in restatements.\n"
-                    f"Requested end date [{to_ts(requested_end)}] is less than the latest interval end date.\n"
-                    f"The requested end date will be ignored. Using the latest interval end instead: [{to_ts(latest_end)}]"
-                )
-
-                removal_interval = self.inclusive_exclusive(requested_start, latest_end, strict)
-
         return removal_interval
 
     @property

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -140,7 +140,6 @@ class SnapshotEvaluator:
         snapshots: t.Dict[str, Snapshot],
         deployability_index: t.Optional[DeployabilityIndex] = None,
         batch_index: int = 0,
-        is_restatement: bool = False,
         **kwargs: t.Any,
     ) -> t.Optional[str]:
         """Renders the snapshot's model, executes it and stores the result in the snapshot's physical table.
@@ -166,7 +165,6 @@ class SnapshotEvaluator:
             snapshots,
             deployability_index=deployability_index,
             batch_index=batch_index,
-            is_restatement=is_restatement,
             **kwargs,
         )
         if result is None or isinstance(result, str):
@@ -624,7 +622,6 @@ class SnapshotEvaluator:
         limit: t.Optional[int] = None,
         deployability_index: t.Optional[DeployabilityIndex] = None,
         batch_index: int = 0,
-        is_restatement: bool = False,
         **kwargs: t.Any,
     ) -> DF | str | None:
         """Renders the snapshot's model and executes it. The return value depends on whether the limit was specified.
@@ -697,7 +694,6 @@ class SnapshotEvaluator:
                     end=end,
                     execution_time=execution_time,
                     physical_properties=rendered_physical_properties,
-                    is_restatement=is_restatement,
                 )
             else:
                 logger.info(
@@ -719,7 +715,6 @@ class SnapshotEvaluator:
                     end=end,
                     execution_time=execution_time,
                     physical_properties=rendered_physical_properties,
-                    is_restatement=is_restatement,
                 )
 
         with (
@@ -1840,8 +1835,6 @@ class SCDType2Strategy(MaterializableStrategy):
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
                 truncate=is_first_insert,
-                start=kwargs["start"],
-                is_restatement=kwargs.get("is_restatement", False),
             )
         elif isinstance(model.kind, SCDType2ByColumnKind):
             self.adapter.scd_type_2_by_column(
@@ -1859,8 +1852,6 @@ class SCDType2Strategy(MaterializableStrategy):
                 table_description=model.description,
                 column_descriptions=model.column_descriptions,
                 truncate=is_first_insert,
-                start=kwargs["start"],
-                is_restatement=kwargs.get("is_restatement", False),
             )
         else:
             raise SQLMeshError(

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -744,7 +744,6 @@ def test_scd_type_2_by_time(ctx_query_and_df: TestContext):
         columns_to_types=input_schema,
         table_format=ctx.default_table_format,
         truncate=True,
-        start="2022-01-01 00:00:00",
     )
     results = ctx.get_metadata_results()
     assert len(results.views) == 0
@@ -808,7 +807,6 @@ def test_scd_type_2_by_time(ctx_query_and_df: TestContext):
         columns_to_types=input_schema,
         table_format=ctx.default_table_format,
         truncate=False,
-        start="2022-01-01 00:00:00",
     )
     results = ctx.get_metadata_results()
     assert len(results.views) == 0
@@ -901,7 +899,6 @@ def test_scd_type_2_by_column(ctx_query_and_df: TestContext):
         execution_time_as_valid_from=False,
         columns_to_types=ctx.columns_to_types,
         truncate=True,
-        start="2023-01-01",
     )
     results = ctx.get_metadata_results()
     assert len(results.views) == 0
@@ -973,7 +970,6 @@ def test_scd_type_2_by_column(ctx_query_and_df: TestContext):
         execution_time_as_valid_from=False,
         columns_to_types=ctx.columns_to_types,
         truncate=False,
-        start="2023-01-01",
     )
     results = ctx.get_metadata_results()
     assert len(results.views) == 0

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -1239,12 +1239,10 @@ def test_scd_type_2_by_time(make_mocked_engine_adapter: t.Callable):
             "test_valid_to": exp.DataType.build("TIMESTAMP"),
         },
         execution_time=datetime(2020, 1, 1, 0, 0, 0),
-        start=datetime(2020, 1, 1, 0, 0, 0),
-        is_restatement=True,
     )
 
     assert (
-        parse_one(adapter.cursor.execute.call_args[0][0]).sql()
+        adapter.cursor.execute.call_args[0][0]
         == parse_one(
             """
 CREATE OR REPLACE TABLE "target" AS
@@ -1273,7 +1271,8 @@ WITH "source" AS (
     "test_valid_to",
     TRUE AS "_exists"
   FROM "target"
-  WHERE NOT "test_valid_to" IS NULL AND "test_valid_to" < CAST('2020-01-01 00:00:00' AS TIMESTAMP)
+  WHERE
+    NOT "test_valid_to" IS NULL
 ), "latest" AS (
   SELECT
     "id",
@@ -1281,11 +1280,11 @@ WITH "source" AS (
     "price",
     "test_UPDATED_at",
     "test_valid_from",
-    CAST(NULL AS TIMESTAMP) AS "test_valid_to",
+    "test_valid_to",
     TRUE AS "_exists"
   FROM "target"
-  WHERE "test_valid_from" <= CAST('2020-01-01 00:00:00' AS TIMESTAMP)
-    AND ("test_valid_to" IS NULL OR "test_valid_to" >= CAST('2020-01-01 00:00:00' AS TIMESTAMP))
+  WHERE
+    "test_valid_to" IS NULL
 ), "deleted" AS (
   SELECT
     "static"."id",
@@ -1439,12 +1438,10 @@ def test_scd_type_2_by_time_no_invalidate_hard_deletes(make_mocked_engine_adapte
             "test_valid_to": exp.DataType.build("TIMESTAMP"),
         },
         execution_time=datetime(2020, 1, 1, 0, 0, 0),
-        start=datetime(2020, 1, 1, 0, 0, 0),
-        is_restatement=True,
     )
 
     assert (
-        parse_one(adapter.cursor.execute.call_args[0][0]).sql()
+        adapter.cursor.execute.call_args[0][0]
         == parse_one(
             """
 CREATE OR REPLACE TABLE "target" AS
@@ -1473,7 +1470,8 @@ WITH "source" AS (
     "test_valid_to",
     TRUE AS "_exists"
   FROM "target"
-  WHERE NOT "test_valid_to" IS NULL AND "test_valid_to" < CAST('2020-01-01 00:00:00' AS TIMESTAMP)
+  WHERE
+    NOT "test_valid_to" IS NULL
 ), "latest" AS (
   SELECT
     "id",
@@ -1481,11 +1479,11 @@ WITH "source" AS (
     "price",
     "test_updated_at",
     "test_valid_from",
-    CAST(NULL AS TIMESTAMP) AS "test_valid_to",
+    "test_valid_to",
     TRUE AS "_exists"
   FROM "target"
-  WHERE "test_valid_from" <= CAST('2020-01-01 00:00:00' AS TIMESTAMP)
-    AND ("test_valid_to" IS NULL OR "test_valid_to" >= CAST('2020-01-01 00:00:00' AS TIMESTAMP))
+  WHERE
+    "test_valid_to" IS NULL
 ), "deleted" AS (
   SELECT
     "static"."id",
@@ -1628,38 +1626,35 @@ def test_merge_scd_type_2_pandas(make_mocked_engine_adapter: t.Callable):
             "test_valid_to": exp.DataType.build("TIMESTAMPTZ"),
         },
         execution_time=datetime(2020, 1, 1, 0, 0, 0),
-        start=datetime(2020, 1, 1, 0, 0, 0),
-        is_restatement=True,
     )
 
     assert (
-        parse_one(adapter.cursor.execute.call_args[0][0]).sql()
+        adapter.cursor.execute.call_args[0][0]
         == parse_one(
             """
-  CREATE OR REPLACE TABLE "target" AS
-  WITH "source" AS (
-    SELECT DISTINCT ON ("id1", "id2")
+CREATE OR REPLACE TABLE "target" AS
+WITH "source" AS (
+  SELECT DISTINCT ON ("id1", "id2")
     TRUE AS "_exists",
     "id1",
     "id2",
     "name",
     "price",
     CAST("test_updated_at" AS TIMESTAMPTZ) AS "test_updated_at"
-    FROM (
+  FROM (
     SELECT
       CAST("id1" AS INT) AS "id1",
       CAST("id2" AS INT) AS "id2",
       CAST("name" AS VARCHAR) AS "name",
       CAST("price" AS DOUBLE) AS "price",
-      CAST("test_updated_at" AS TIMESTAMPTZ) AS "test_updated_at"
+      CAST("test_updated_at" AS TIMESTAMPTZ) AS "test_updated_at",
     FROM (VALUES
       (1, 4, 'muffins', 4.0, '2020-01-01 10:00:00'),
       (2, 5, 'chips', 5.0, '2020-01-02 15:00:00'),
-      (3, 6, 'soda', 6.0, '2020-01-03 12:00:00')
-    ) AS "t"("id1", "id2", "name", "price", "test_updated_at")
-    ) AS "raw_source"
-  ), "static" AS (
-    SELECT
+      (3, 6, 'soda', 6.0, '2020-01-03 12:00:00')) AS "t"("id1", "id2", "name", "price", "test_updated_at")
+  ) AS "raw_source"
+), "static" AS (
+  SELECT
     "id1",
     "id2",
     "name",
@@ -1668,23 +1663,24 @@ def test_merge_scd_type_2_pandas(make_mocked_engine_adapter: t.Callable):
     "test_valid_from",
     "test_valid_to",
     TRUE AS "_exists"
-    FROM "target"
-    WHERE NOT "test_valid_to" IS NULL AND "test_valid_to" < CAST('2020-01-01 00:00:00+00:00' AS TIMESTAMPTZ)
-  ), "latest" AS (
-    SELECT
+  FROM "target"
+  WHERE
+    NOT "test_valid_to" IS NULL
+), "latest" AS (
+  SELECT
     "id1",
     "id2",
     "name",
     "price",
     "test_updated_at",
     "test_valid_from",
-    CAST(NULL AS TIMESTAMPTZ) AS "test_valid_to",
+    "test_valid_to",
     TRUE AS "_exists"
-    FROM "target"
-    WHERE "test_valid_from" <= CAST('2020-01-01 00:00:00+00:00' AS TIMESTAMPTZ)
-    AND ("test_valid_to" IS NULL OR "test_valid_to" >= CAST('2020-01-01 00:00:00+00:00' AS TIMESTAMPTZ))
-  ), "deleted" AS (
-    SELECT
+  FROM "target"
+  WHERE
+    "test_valid_to" IS NULL
+), "deleted" AS (
+  SELECT
     "static"."id1",
     "static"."id2",
     "static"."name",
@@ -1692,20 +1688,23 @@ def test_merge_scd_type_2_pandas(make_mocked_engine_adapter: t.Callable):
     "static"."test_updated_at",
     "static"."test_valid_from",
     "static"."test_valid_to"
-    FROM "static"
-    LEFT JOIN "latest"
+  FROM "static"
+  LEFT JOIN "latest"
     ON "static"."id1" = "latest"."id1" AND "static"."id2" = "latest"."id2"
-    WHERE "latest"."test_valid_to" IS NULL
-  ), "latest_deleted" AS (
-    SELECT
+  WHERE
+    "latest"."test_valid_to" IS NULL
+), "latest_deleted" AS (
+  SELECT
     TRUE AS "_exists",
     "id1" AS "_key0",
     "id2" AS "_key1",
     MAX("test_valid_to") AS "test_valid_to"
-    FROM "deleted"
-    GROUP BY "id1", "id2"
-  ), "joined" AS (
-    SELECT
+  FROM "deleted"
+  GROUP BY
+    "id1",
+    "id2"
+), "joined" AS (
+  SELECT
     "source"."_exists" AS "_exists",
     "latest"."id1" AS "t_id1",
     "latest"."id2" AS "t_id2",
@@ -1719,11 +1718,11 @@ def test_merge_scd_type_2_pandas(make_mocked_engine_adapter: t.Callable):
     "source"."name" AS "name",
     "source"."price" AS "price",
     "source"."test_updated_at" AS "test_updated_at"
-    FROM "latest"
-    LEFT JOIN "source"
+  FROM "latest"
+  LEFT JOIN "source"
     ON "latest"."id1" = "source"."id1" AND "latest"."id2" = "source"."id2"
-    UNION ALL
-    SELECT
+  UNION ALL
+  SELECT
     "source"."_exists" AS "_exists",
     "latest"."id1" AS "t_id1",
     "latest"."id2" AS "t_id2",
@@ -1737,12 +1736,13 @@ def test_merge_scd_type_2_pandas(make_mocked_engine_adapter: t.Callable):
     "source"."name" AS "name",
     "source"."price" AS "price",
     "source"."test_updated_at" AS "test_updated_at"
-    FROM "latest"
-    RIGHT JOIN "source"
+  FROM "latest"
+  RIGHT JOIN "source"
     ON "latest"."id1" = "source"."id1" AND "latest"."id2" = "source"."id2"
-    WHERE "latest"."_exists" IS NULL
-  ), "updated_rows" AS (
-    SELECT
+  WHERE
+    "latest"."_exists" IS NULL
+), "updated_rows" AS (
+  SELECT
     COALESCE("joined"."t_id1", "joined"."id1") AS "id1",
     COALESCE("joined"."t_id2", "joined"."id2") AS "id2",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
@@ -1751,9 +1751,9 @@ def test_merge_scd_type_2_pandas(make_mocked_engine_adapter: t.Callable):
     CASE
       WHEN "t_test_valid_from" IS NULL AND NOT "latest_deleted"."_exists" IS NULL
       THEN CASE
-      WHEN "latest_deleted"."test_valid_to" > "test_updated_at"
-      THEN "latest_deleted"."test_valid_to"
-      ELSE "test_updated_at"
+        WHEN "latest_deleted"."test_valid_to" > "test_updated_at"
+        THEN "latest_deleted"."test_valid_to"
+        ELSE "test_updated_at"
       END
       WHEN "t_test_valid_from" IS NULL
       THEN CAST('1970-01-01 00:00:00+00:00' AS TIMESTAMPTZ)
@@ -1766,11 +1766,12 @@ def test_merge_scd_type_2_pandas(make_mocked_engine_adapter: t.Callable):
       THEN CAST('2020-01-01 00:00:00+00:00' AS TIMESTAMPTZ)
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
-    FROM "joined"
-    LEFT JOIN "latest_deleted"
-    ON "joined"."id1" = "latest_deleted"."_key0" AND "joined"."id2" = "latest_deleted"."_key1"
-  ), "inserted_rows" AS (
-    SELECT
+  FROM "joined"
+  LEFT JOIN "latest_deleted"
+    ON "joined"."id1" = "latest_deleted"."_key0"
+    AND "joined"."id2" = "latest_deleted"."_key1"
+), "inserted_rows" AS (
+  SELECT
     "id1",
     "id2",
     "name",
@@ -1778,23 +1779,12 @@ def test_merge_scd_type_2_pandas(make_mocked_engine_adapter: t.Callable):
     "test_updated_at",
     "test_updated_at" AS "test_valid_from",
     CAST(NULL AS TIMESTAMPTZ) AS "test_valid_to"
-    FROM "joined"
-    WHERE "joined"."test_updated_at" > "joined"."t_test_updated_at"
-  )
-  SELECT
-    CAST("id1" AS INT) AS "id1",
-    CAST("id2" AS INT) AS "id2",
-    CAST("name" AS VARCHAR) AS "name",
-    CAST("price" AS DOUBLE) AS "price",
-    CAST("test_updated_at" AS TIMESTAMPTZ) AS "test_updated_at",
-    CAST("test_valid_from" AS TIMESTAMPTZ) AS "test_valid_from",
-    CAST("test_valid_to" AS TIMESTAMPTZ) AS "test_valid_to"
-  FROM (
-    SELECT "id1", "id2", "name", "price", "test_updated_at", "test_valid_from", "test_valid_to" FROM "static"
-    UNION ALL SELECT "id1", "id2", "name", "price", "test_updated_at", "test_valid_from", "test_valid_to" FROM "updated_rows"
-    UNION ALL SELECT "id1", "id2", "name", "price", "test_updated_at", "test_valid_from", "test_valid_to" FROM "inserted_rows"
-  ) AS "_subquery"
-        """
+  FROM "joined"
+  WHERE
+    "joined"."test_updated_at" > "joined"."t_test_updated_at"
+)
+SELECT CAST("id1" AS INT) AS "id1", CAST("id2" AS INT) AS "id2", CAST("name" AS VARCHAR) AS "name", CAST("price" AS DOUBLE) AS "price", CAST("test_updated_at" AS TIMESTAMPTZ) AS "test_updated_at", CAST("test_valid_from" AS TIMESTAMPTZ) AS "test_valid_from", CAST("test_valid_to" AS TIMESTAMPTZ) AS "test_valid_to" FROM (SELECT "id1", "id2", "name", "price", "test_updated_at", "test_valid_from", "test_valid_to" FROM "static" UNION ALL SELECT "id1", "id2", "name", "price", "test_updated_at", "test_valid_from", "test_valid_to" FROM "updated_rows" UNION ALL SELECT "id1", "id2", "name", "price", "test_updated_at", "test_valid_from", "test_valid_to" FROM "inserted_rows") AS "_subquery"
+"""
         ).sql()
     )
 
@@ -1817,72 +1807,71 @@ def test_scd_type_2_by_column(make_mocked_engine_adapter: t.Callable):
             "test_valid_to": exp.DataType.build("TIMESTAMP"),
         },
         execution_time=datetime(2020, 1, 1, 0, 0, 0),
-        start=datetime(2020, 1, 1, 0, 0, 0),
         extra_col_ignore="testing",
-        is_restatement=True,
     )
 
     assert (
-        parse_one(adapter.cursor.execute.call_args[0][0]).sql()
+        adapter.cursor.execute.call_args[0][0]
         == parse_one(
             """
-  CREATE OR REPLACE TABLE "target" AS
-  WITH "source" AS (
-    SELECT DISTINCT ON ("id")
+CREATE OR REPLACE TABLE "target" AS
+WITH "source" AS (
+  SELECT DISTINCT ON ("id")
     TRUE AS "_exists",
     "id",
     "name",
     "price"
-    FROM (
+  FROM (
     SELECT
       "id",
       "name",
       "price"
     FROM "source"
-    ) AS "raw_source"
-  ), "static" AS (
-    SELECT
+  ) AS "raw_source"
+), "static" AS (
+  SELECT
     "id",
     "name",
     "price",
     "test_VALID_from",
     "test_valid_to",
     TRUE AS "_exists"
-    FROM "target"
-    WHERE NOT "test_valid_to" IS NULL AND "test_valid_to" < CAST('2020-01-01 00:00:00' AS TIMESTAMP)
-  ), "latest" AS (
-    SELECT
+  FROM "target"
+  WHERE
+    NOT "test_valid_to" IS NULL
+), "latest" AS (
+  SELECT
     "id",
     "name",
     "price",
     "test_VALID_from",
-    CAST(NULL AS TIMESTAMP) AS "test_valid_to",
+    "test_valid_to",
     TRUE AS "_exists"
-    FROM "target"
-    WHERE "test_VALID_from" <= CAST('2020-01-01 00:00:00' AS TIMESTAMP)
-    AND ("test_valid_to" IS NULL OR "test_valid_to" >= CAST('2020-01-01 00:00:00' AS TIMESTAMP))
-  ), "deleted" AS (
-    SELECT
+  FROM "target"
+  WHERE
+    "test_valid_to" IS NULL
+), "deleted" AS (
+  SELECT
     "static"."id",
     "static"."name",
     "static"."price",
     "static"."test_VALID_from",
     "static"."test_valid_to"
-    FROM "static"
-    LEFT JOIN "latest"
+  FROM "static"
+  LEFT JOIN "latest"
     ON "static"."id" = "latest"."id"
-    WHERE
+  WHERE
     "latest"."test_valid_to" IS NULL
-  ), "latest_deleted" AS (
-    SELECT
+), "latest_deleted" AS (
+  SELECT
     TRUE AS "_exists",
     "id" AS "_key0",
     MAX("test_valid_to") AS "test_valid_to"
-    FROM "deleted"
-    GROUP BY
+  FROM "deleted"
+  GROUP BY
     "id"
-  ), "joined" AS (
-    SELECT
+), "joined" AS (
+  SELECT
     "source"."_exists" AS "_exists",
     "latest"."id" AS "t_id",
     "latest"."name" AS "t_name",
@@ -1892,11 +1881,11 @@ def test_scd_type_2_by_column(make_mocked_engine_adapter: t.Callable):
     "source"."id" AS "id",
     "source"."name" AS "name",
     "source"."price" AS "price"
-    FROM "latest"
-    LEFT JOIN "source"
+  FROM "latest"
+  LEFT JOIN "source"
     ON "latest"."id" = "source"."id"
-    UNION ALL
-    SELECT
+  UNION ALL
+  SELECT
     "source"."_exists" AS "_exists",
     "latest"."id" AS "t_id",
     "latest"."name" AS "t_name",
@@ -1906,13 +1895,13 @@ def test_scd_type_2_by_column(make_mocked_engine_adapter: t.Callable):
     "source"."id" AS "id",
     "source"."name" AS "name",
     "source"."price" AS "price"
-    FROM "latest"
-    RIGHT JOIN "source"
+  FROM "latest"
+  RIGHT JOIN "source"
     ON "latest"."id" = "source"."id"
-    WHERE
+  WHERE
     "latest"."_exists" IS NULL
-  ), "updated_rows" AS (
-    SELECT
+), "updated_rows" AS (
+  SELECT
     COALESCE("joined"."t_id", "joined"."id") AS "id",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
     COALESCE("joined"."t_price", "joined"."price") AS "price",
@@ -1920,73 +1909,63 @@ def test_scd_type_2_by_column(make_mocked_engine_adapter: t.Callable):
     CASE
       WHEN "joined"."_exists" IS NULL
       OR (
-      (
-        NOT "joined"."t_id" IS NULL AND NOT "joined"."id" IS NULL
-      )
-      AND (
-        "joined"."name" <> "joined"."t_name"
-        OR (
-        "joined"."t_name" IS NULL AND NOT "joined"."name" IS NULL
+        (
+          NOT "joined"."t_id" IS NULL AND NOT "joined"."id" IS NULL
         )
-        OR (
-        NOT "joined"."t_name" IS NULL AND "joined"."name" IS NULL
+        AND (
+          "joined"."name" <> "joined"."t_name"
+          OR (
+            "joined"."t_name" IS NULL AND NOT "joined"."name" IS NULL
+          )
+          OR (
+            NOT "joined"."t_name" IS NULL AND "joined"."name" IS NULL
+          )
+          OR "joined"."price" <> "joined"."t_price"
+          OR (
+            "joined"."t_price" IS NULL AND NOT "joined"."price" IS NULL
+          )
+          OR (
+            NOT "joined"."t_price" IS NULL AND "joined"."price" IS NULL
+          )
         )
-        OR "joined"."price" <> "joined"."t_price"
-        OR (
-        "joined"."t_price" IS NULL AND NOT "joined"."price" IS NULL
-        )
-        OR (
-        NOT "joined"."t_price" IS NULL AND "joined"."price" IS NULL
-        )
-      )
       )
       THEN CAST('2020-01-01 00:00:00' AS TIMESTAMP)
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
-    FROM "joined"
-    LEFT JOIN "latest_deleted"
+  FROM "joined"
+  LEFT JOIN "latest_deleted"
     ON "joined"."id" = "latest_deleted"."_key0"
-  ), "inserted_rows" AS (
-    SELECT
+), "inserted_rows" AS (
+  SELECT
     "id",
     "name",
     "price",
     CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS "test_VALID_from",
     CAST(NULL AS TIMESTAMP) AS "test_valid_to"
-    FROM "joined"
-    WHERE
+  FROM "joined"
+  WHERE
     (
       NOT "joined"."t_id" IS NULL AND NOT "joined"."id" IS NULL
     )
     AND (
       "joined"."name" <> "joined"."t_name"
       OR (
-      "joined"."t_name" IS NULL AND NOT "joined"."name" IS NULL
+        "joined"."t_name" IS NULL AND NOT "joined"."name" IS NULL
       )
       OR (
-      NOT "joined"."t_name" IS NULL AND "joined"."name" IS NULL
+        NOT "joined"."t_name" IS NULL AND "joined"."name" IS NULL
       )
       OR "joined"."price" <> "joined"."t_price"
       OR (
-      "joined"."t_price" IS NULL AND NOT "joined"."price" IS NULL
+        "joined"."t_price" IS NULL AND NOT "joined"."price" IS NULL
       )
       OR (
-      NOT "joined"."t_price" IS NULL AND "joined"."price" IS NULL
+        NOT "joined"."t_price" IS NULL AND "joined"."price" IS NULL
       )
     )
-  )
-  SELECT
-    CAST("id" AS INT) AS "id",
-    CAST("name" AS VARCHAR) AS "name",
-    CAST("price" AS DOUBLE) AS "price",
-    CAST("test_VALID_from" AS TIMESTAMP) AS "test_VALID_from",
-    CAST("test_valid_to" AS TIMESTAMP) AS "test_valid_to"
-  FROM (
-    SELECT "id", "name", "price", "test_VALID_from", "test_valid_to" FROM "static"
-    UNION ALL SELECT "id", "name", "price", "test_VALID_from", "test_valid_to" FROM "updated_rows"
-    UNION ALL SELECT "id", "name", "price", "test_VALID_from", "test_valid_to" FROM "inserted_rows"
-  ) AS "_subquery"
-        """
+)
+SELECT CAST("id" AS INT) AS "id", CAST("name" AS VARCHAR) AS "name", CAST("price" AS DOUBLE) AS "price", CAST("test_VALID_from" AS TIMESTAMP) AS "test_VALID_from", CAST("test_valid_to" AS TIMESTAMP) AS "test_valid_to" FROM (SELECT "id", "name", "price", "test_VALID_from", "test_valid_to" FROM "static" UNION ALL SELECT "id", "name", "price", "test_VALID_from", "test_valid_to" FROM "updated_rows" UNION ALL SELECT "id", "name", "price", "test_VALID_from", "test_valid_to" FROM "inserted_rows") AS "_subquery"
+    """
         ).sql()
     )
 
@@ -2010,31 +1989,30 @@ def test_scd_type_2_by_column_composite_key(make_mocked_engine_adapter: t.Callab
             "test_valid_to": exp.DataType.build("TIMESTAMP"),
         },
         execution_time=datetime(2020, 1, 1, 0, 0, 0),
-        start=datetime(2020, 1, 1, 0, 0, 0),
-        is_restatement=True,
     )
+
     assert (
-        parse_one(adapter.cursor.execute.call_args[0][0]).sql()
+        adapter.cursor.execute.call_args[0][0]
         == parse_one(
             """
-  CREATE OR REPLACE TABLE "target" AS
-  WITH "source" AS (
-    SELECT DISTINCT ON (CONCAT("id_a", "id_b"))
+CREATE OR REPLACE TABLE "target" AS
+WITH "source" AS (
+  SELECT DISTINCT ON (CONCAT("id_a", "id_b"))
     TRUE AS "_exists",
     "id_a",
     "id_b",
     "name",
-    "price"
-    FROM (
+    "price",
+  FROM (
     SELECT
       "id_a",
       "id_b",
       "name",
       "price"
     FROM "source"
-    ) AS "raw_source"
-  ), "static" AS (
-    SELECT
+  ) AS "raw_source"
+), "static" AS (
+  SELECT
     "id_a",
     "id_b",
     "name",
@@ -2042,41 +2020,44 @@ def test_scd_type_2_by_column_composite_key(make_mocked_engine_adapter: t.Callab
     "test_VALID_from",
     "test_valid_to",
     TRUE AS "_exists"
-    FROM "target"
-    WHERE NOT "test_valid_to" IS NULL AND "test_valid_to" < CAST('2020-01-01 00:00:00' AS TIMESTAMP)
-  ), "latest" AS (
-    SELECT
+  FROM "target"
+  WHERE
+    NOT "test_valid_to" IS NULL
+), "latest" AS (
+  SELECT
     "id_a",
     "id_b",
     "name",
     "price",
     "test_VALID_from",
-    CAST(NULL AS TIMESTAMP) AS "test_valid_to",
+    "test_valid_to",
     TRUE AS "_exists"
-    FROM "target"
-    WHERE "test_VALID_from" <= CAST('2020-01-01 00:00:00' AS TIMESTAMP)
-    AND ("test_valid_to" IS NULL OR "test_valid_to" >= CAST('2020-01-01 00:00:00' AS TIMESTAMP))
-  ), "deleted" AS (
-    SELECT
+  FROM "target"
+  WHERE
+    "test_valid_to" IS NULL
+), "deleted" AS (
+  SELECT
     "static"."id_a",
     "static"."id_b",
     "static"."name",
     "static"."price",
     "static"."test_VALID_from",
     "static"."test_valid_to"
-    FROM "static"
-    LEFT JOIN "latest"
+  FROM "static"
+  LEFT JOIN "latest"
     ON CONCAT("static"."id_a", "static"."id_b") = CONCAT("latest"."id_a", "latest"."id_b")
-    WHERE "latest"."test_valid_to" IS NULL
-  ), "latest_deleted" AS (
-    SELECT
+  WHERE
+    "latest"."test_valid_to" IS NULL
+), "latest_deleted" AS (
+  SELECT
     TRUE AS "_exists",
     CONCAT("id_a", "id_b") AS "_key0",
     MAX("test_valid_to") AS "test_valid_to"
-    FROM "deleted"
-    GROUP BY CONCAT("id_a", "id_b")
-  ), "joined" AS (
-    SELECT
+  FROM "deleted"
+  GROUP BY
+    CONCAT("id_a", "id_b")
+), "joined" AS (
+  SELECT
     "source"."_exists" AS "_exists",
     "latest"."id_a" AS "t_id_a",
     "latest"."id_b" AS "t_id_b",
@@ -2088,11 +2069,11 @@ def test_scd_type_2_by_column_composite_key(make_mocked_engine_adapter: t.Callab
     "source"."id_b" AS "id_b",
     "source"."name" AS "name",
     "source"."price" AS "price"
-    FROM "latest"
-    LEFT JOIN "source"
+  FROM "latest"
+  LEFT JOIN "source"
     ON CONCAT("latest"."id_a", "latest"."id_b") = CONCAT("source"."id_a", "source"."id_b")
-    UNION ALL
-    SELECT
+  UNION ALL
+  SELECT
     "source"."_exists" AS "_exists",
     "latest"."id_a" AS "t_id_a",
     "latest"."id_b" AS "t_id_b",
@@ -2104,12 +2085,13 @@ def test_scd_type_2_by_column_composite_key(make_mocked_engine_adapter: t.Callab
     "source"."id_b" AS "id_b",
     "source"."name" AS "name",
     "source"."price" AS "price"
-    FROM "latest"
-    RIGHT JOIN "source"
+  FROM "latest"
+  RIGHT JOIN "source"
     ON CONCAT("latest"."id_a", "latest"."id_b") = CONCAT("source"."id_a", "source"."id_b")
-    WHERE "latest"."_exists" IS NULL
-  ), "updated_rows" AS (
-    SELECT
+  WHERE
+    "latest"."_exists" IS NULL
+), "updated_rows" AS (
+  SELECT
     COALESCE("joined"."t_id_a", "joined"."id_a") AS "id_a",
     COALESCE("joined"."t_id_b", "joined"."id_b") AS "id_b",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
@@ -2118,55 +2100,64 @@ def test_scd_type_2_by_column_composite_key(make_mocked_engine_adapter: t.Callab
     CASE
       WHEN "joined"."_exists" IS NULL
       OR (
-        (NOT CONCAT("t_id_a", "t_id_b") IS NULL AND NOT CONCAT("id_a", "id_b") IS NULL)
+        (
+          NOT CONCAT("t_id_a", "t_id_b") IS NULL AND NOT CONCAT("id_a", "id_b") IS NULL
+        )
         AND (
-        "joined"."name" <> "joined"."t_name"
-        OR ("joined"."t_name" IS NULL AND NOT "joined"."name" IS NULL)
-        OR (NOT "joined"."t_name" IS NULL AND "joined"."name" IS NULL)
-        OR "joined"."price" <> "joined"."t_price"
-        OR ("joined"."t_price" IS NULL AND NOT "joined"."price" IS NULL)
-        OR (NOT "joined"."t_price" IS NULL AND "joined"."price" IS NULL)
+          "joined"."name" <> "joined"."t_name"
+          OR (
+            "joined"."t_name" IS NULL AND NOT "joined"."name" IS NULL
+          )
+          OR (
+            NOT "joined"."t_name" IS NULL AND "joined"."name" IS NULL
+          )
+          OR "joined"."price" <> "joined"."t_price"
+          OR (
+            "joined"."t_price" IS NULL AND NOT "joined"."price" IS NULL
+          )
+          OR (
+            NOT "joined"."t_price" IS NULL AND "joined"."price" IS NULL
+          )
         )
       )
       THEN CAST('2020-01-01 00:00:00' AS TIMESTAMP)
       ELSE "t_test_valid_to"
     END AS "test_valid_to"
-    FROM "joined"
-    LEFT JOIN "latest_deleted"
+  FROM "joined"
+  LEFT JOIN "latest_deleted"
     ON CONCAT("joined"."id_a", "joined"."id_b") = "latest_deleted"."_key0"
-  ), "inserted_rows" AS (
-    SELECT
+), "inserted_rows" AS (
+  SELECT
     "id_a",
     "id_b",
     "name",
     "price",
     CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS "test_VALID_from",
     CAST(NULL AS TIMESTAMP) AS "test_valid_to"
-    FROM "joined"
-    WHERE
-    (NOT CONCAT("t_id_a", "t_id_b") IS NULL AND NOT CONCAT("id_a", "id_b") IS NULL)
+  FROM "joined"
+  WHERE
+    (
+      NOT CONCAT("t_id_a", "t_id_b") IS NULL AND NOT CONCAT("id_a", "id_b") IS NULL
+    )
     AND (
       "joined"."name" <> "joined"."t_name"
-      OR ("joined"."t_name" IS NULL AND NOT "joined"."name" IS NULL)
-      OR (NOT "joined"."t_name" IS NULL AND "joined"."name" IS NULL)
+      OR (
+        "joined"."t_name" IS NULL AND NOT "joined"."name" IS NULL
+      )
+      OR (
+        NOT "joined"."t_name" IS NULL AND "joined"."name" IS NULL
+      )
       OR "joined"."price" <> "joined"."t_price"
-      OR ("joined"."t_price" IS NULL AND NOT "joined"."price" IS NULL)
-      OR (NOT "joined"."t_price" IS NULL AND "joined"."price" IS NULL)
+      OR (
+        "joined"."t_price" IS NULL AND NOT "joined"."price" IS NULL
+      )
+      OR (
+        NOT "joined"."t_price" IS NULL AND "joined"."price" IS NULL
+      )
     )
-  )
-  SELECT
-    CAST("id_a" AS VARCHAR) AS "id_a",
-    CAST("id_b" AS VARCHAR) AS "id_b",
-    CAST("name" AS VARCHAR) AS "name",
-    CAST("price" AS DOUBLE) AS "price",
-    CAST("test_VALID_from" AS TIMESTAMP) AS "test_VALID_from",
-    CAST("test_valid_to" AS TIMESTAMP) AS "test_valid_to"
-  FROM (
-    SELECT "id_a", "id_b", "name", "price", "test_VALID_from", "test_valid_to" FROM "static"
-    UNION ALL SELECT "id_a", "id_b", "name", "price", "test_VALID_from", "test_valid_to" FROM "updated_rows"
-    UNION ALL SELECT "id_a", "id_b", "name", "price", "test_VALID_from", "test_valid_to" FROM "inserted_rows"
-  ) AS "_subquery"
-        """
+)
+SELECT CAST("id_a" AS VARCHAR) AS "id_a", CAST("id_b" AS VARCHAR) AS "id_b", CAST("name" AS VARCHAR) AS "name", CAST("price" AS DOUBLE) AS "price", CAST("test_VALID_from" AS TIMESTAMP) AS "test_VALID_from", CAST("test_valid_to" AS TIMESTAMP) AS "test_valid_to" FROM (SELECT "id_a", "id_b", "name", "price", "test_VALID_from", "test_valid_to" FROM "static" UNION ALL SELECT "id_a", "id_b", "name", "price", "test_VALID_from", "test_valid_to" FROM "updated_rows" UNION ALL SELECT "id_a", "id_b", "name", "price", "test_VALID_from", "test_valid_to" FROM "inserted_rows") AS "_subquery"
+    """
         ).sql()
     )
 
@@ -2190,7 +2181,6 @@ def test_scd_type_2_truncate(make_mocked_engine_adapter: t.Callable):
         },
         execution_time=datetime(2020, 1, 1, 0, 0, 0),
         truncate=True,
-        start=datetime(2020, 1, 1, 0, 0, 0),
     )
 
     assert (
@@ -2373,188 +2363,10 @@ def test_scd_type_2_by_column_star_check(make_mocked_engine_adapter: t.Callable)
             "test_valid_to": exp.DataType.build("TIMESTAMP"),
         },
         execution_time=datetime(2020, 1, 1, 0, 0, 0),
-        start=datetime(2020, 1, 1, 0, 0, 0),
-        is_restatement=True,
     )
 
     assert (
-        parse_one(adapter.cursor.execute.call_args[0][0]).sql()
-        == parse_one(
-            """
-  CREATE OR REPLACE TABLE "target" AS
-  WITH "source" AS (
-    SELECT DISTINCT ON ("id")
-    TRUE AS "_exists",
-    "id",
-    "name",
-    "price"
-    FROM (
-    SELECT
-      "id",
-      "name",
-      "price"
-    FROM "source"
-    ) AS "raw_source"
-  ), "static" AS (
-    SELECT
-    "id",
-    "name",
-    "price",
-    "test_valid_from",
-    "test_valid_to",
-    TRUE AS "_exists"
-    FROM "target"
-    WHERE NOT "test_valid_to" IS NULL AND "test_valid_to" < CAST('2020-01-01 00:00:00' AS TIMESTAMP)
-  ), "latest" AS (
-    SELECT
-    "id",
-    "name",
-    "price",
-    "test_valid_from",
-    CAST(NULL AS TIMESTAMP) AS "test_valid_to",
-    TRUE AS "_exists"
-    FROM "target"
-    WHERE "test_valid_from" <= CAST('2020-01-01 00:00:00' AS TIMESTAMP)
-    AND ("test_valid_to" IS NULL OR "test_valid_to" >= CAST('2020-01-01 00:00:00' AS TIMESTAMP))
-  ), "deleted" AS (
-    SELECT
-    "static"."id",
-    "static"."name",
-    "static"."price",
-    "static"."test_valid_from",
-    "static"."test_valid_to"
-    FROM "static"
-    LEFT JOIN "latest"
-    ON "static"."id" = "latest"."id"
-    WHERE "latest"."test_valid_to" IS NULL
-  ), "latest_deleted" AS (
-    SELECT
-    TRUE AS "_exists",
-    "id" AS "_key0",
-    MAX("test_valid_to") AS "test_valid_to"
-    FROM "deleted"
-    GROUP BY
-    "id"
-  ), "joined" AS (
-    SELECT
-    "source"."_exists" AS "_exists",
-    "latest"."id" AS "t_id",
-    "latest"."name" AS "t_name",
-    "latest"."price" AS "t_price",
-    "latest"."test_valid_from" AS "t_test_valid_from",
-    "latest"."test_valid_to" AS "t_test_valid_to",
-    "source"."id" AS "id",
-    "source"."name" AS "name",
-    "source"."price" AS "price"
-    FROM "latest"
-    LEFT JOIN "source"
-    ON "latest"."id" = "source"."id"
-    UNION ALL
-    SELECT
-    "source"."_exists" AS "_exists",
-    "latest"."id" AS "t_id",
-    "latest"."name" AS "t_name",
-    "latest"."price" AS "t_price",
-    "latest"."test_valid_from" AS "t_test_valid_from",
-    "latest"."test_valid_to" AS "t_test_valid_to",
-    "source"."id" AS "id",
-    "source"."name" AS "name",
-    "source"."price" AS "price"
-    FROM "latest"
-    RIGHT JOIN "source"
-    ON "latest"."id" = "source"."id"
-    WHERE "latest"."_exists" IS NULL
-  ), "updated_rows" AS (
-    SELECT
-    COALESCE("joined"."t_id", "joined"."id") AS "id",
-    COALESCE("joined"."t_name", "joined"."name") AS "name",
-    COALESCE("joined"."t_price", "joined"."price") AS "price",
-    COALESCE("t_test_valid_from", CAST('2020-01-01 00:00:00' AS TIMESTAMP)) AS "test_valid_from",
-    CASE
-      WHEN "joined"."_exists" IS NULL
-      OR (
-      (NOT "joined"."t_id" IS NULL AND NOT "joined"."id" IS NULL)
-      AND (
-        "joined"."id" <> "joined"."t_id"
-        OR ("joined"."t_id" IS NULL AND NOT "joined"."id" IS NULL)
-        OR (NOT "joined"."t_id" IS NULL AND "joined"."id" IS NULL)
-        OR "joined"."name" <> "joined"."t_name"
-        OR ("joined"."t_name" IS NULL AND NOT "joined"."name" IS NULL)
-        OR (NOT "joined"."t_name" IS NULL AND "joined"."name" IS NULL)
-        OR "joined"."price" <> "joined"."t_price"
-        OR ("joined"."t_price" IS NULL AND NOT "joined"."price" IS NULL)
-        OR (NOT "joined"."t_price" IS NULL AND "joined"."price" IS NULL)
-      )
-      )
-      THEN CAST('2020-01-01 00:00:00' AS TIMESTAMP)
-      ELSE "t_test_valid_to"
-    END AS "test_valid_to"
-    FROM "joined"
-    LEFT JOIN "latest_deleted"
-    ON "joined"."id" = "latest_deleted"."_key0"
-  ), "inserted_rows" AS (
-    SELECT
-    "id",
-    "name",
-    "price",
-    CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS "test_valid_from",
-    CAST(NULL AS TIMESTAMP) AS "test_valid_to"
-    FROM "joined"
-    WHERE
-    (NOT "joined"."t_id" IS NULL AND NOT "joined"."id" IS NULL)
-    AND (
-      "joined"."id" <> "joined"."t_id"
-      OR ("joined"."t_id" IS NULL AND NOT "joined"."id" IS NULL)
-      OR (NOT "joined"."t_id" IS NULL AND "joined"."id" IS NULL)
-      OR "joined"."name" <> "joined"."t_name"
-      OR ("joined"."t_name" IS NULL AND NOT "joined"."name" IS NULL)
-      OR (NOT "joined"."t_name" IS NULL AND "joined"."name" IS NULL)
-      OR "joined"."price" <> "joined"."t_price"
-      OR ("joined"."t_price" IS NULL AND NOT "joined"."price" IS NULL)
-      OR (NOT "joined"."t_price" IS NULL AND "joined"."price" IS NULL)
-    )
-  )
-  SELECT
-    CAST("id" AS INT) AS "id",
-    CAST("name" AS VARCHAR) AS "name",
-    CAST("price" AS DOUBLE) AS "price",
-    CAST("test_valid_from" AS TIMESTAMP) AS "test_valid_from",
-    CAST("test_valid_to" AS TIMESTAMP) AS "test_valid_to"
-  FROM (
-    SELECT "id", "name", "price", "test_valid_from", "test_valid_to" FROM "static"
-    UNION ALL SELECT "id", "name", "price", "test_valid_from", "test_valid_to" FROM "updated_rows"
-    UNION ALL SELECT "id", "name", "price", "test_valid_from", "test_valid_to" FROM "inserted_rows"
-  ) AS "_subquery"
-        """
-        ).sql()
-    )
-
-
-def test_scd_type_2_by_column_no_invalidate_hard_deletes(make_mocked_engine_adapter: t.Callable):
-    adapter = make_mocked_engine_adapter(EngineAdapter)
-
-    adapter.scd_type_2_by_column(
-        target_table="target",
-        source_table=t.cast(exp.Select, parse_one("SELECT id, name, price FROM source")),
-        unique_key=[exp.column("id")],
-        valid_from_col=exp.column("test_valid_from", quoted=True),
-        valid_to_col=exp.column("test_valid_to", quoted=True),
-        invalidate_hard_deletes=False,
-        check_columns=[exp.column("name"), exp.column("price")],
-        columns_to_types={
-            "id": exp.DataType.build("INT"),
-            "name": exp.DataType.build("VARCHAR"),
-            "price": exp.DataType.build("DOUBLE"),
-            "test_valid_from": exp.DataType.build("TIMESTAMP"),
-            "test_valid_to": exp.DataType.build("TIMESTAMP"),
-        },
-        execution_time=datetime(2020, 1, 1, 0, 0, 0),
-        start=datetime(2020, 1, 1, 0, 0, 0),
-        is_restatement=True,
-    )
-
-    assert (
-        parse_one(adapter.cursor.execute.call_args[0][0]).sql()
+        adapter.cursor.execute.call_args[0][0]
         == parse_one(
             """
 CREATE OR REPLACE TABLE "target" AS
@@ -2580,18 +2392,214 @@ WITH "source" AS (
     "test_valid_to",
     TRUE AS "_exists"
   FROM "target"
-  WHERE NOT "test_valid_to" IS NULL AND "test_valid_to" < CAST('2020-01-01 00:00:00' AS TIMESTAMP)
+  WHERE
+    NOT "test_valid_to" IS NULL
 ), "latest" AS (
   SELECT
     "id",
     "name",
     "price",
     "test_valid_from",
-    CAST(NULL AS TIMESTAMP) AS "test_valid_to",
+    "test_valid_to",
     TRUE AS "_exists"
   FROM "target"
-  WHERE "test_valid_from" <= CAST('2020-01-01 00:00:00' AS TIMESTAMP)
-    AND ("test_valid_to" IS NULL OR "test_valid_to" >= CAST('2020-01-01 00:00:00' AS TIMESTAMP))
+  WHERE
+    "test_valid_to" IS NULL
+), "deleted" AS (
+  SELECT
+    "static"."id",
+    "static"."name",
+    "static"."price",
+    "static"."test_valid_from",
+    "static"."test_valid_to"
+  FROM "static"
+  LEFT JOIN "latest"
+    ON "static"."id" = "latest"."id"
+  WHERE
+    "latest"."test_valid_to" IS NULL
+), "latest_deleted" AS (
+  SELECT
+    TRUE AS "_exists",
+    "id" AS "_key0",
+    MAX("test_valid_to") AS "test_valid_to"
+  FROM "deleted"
+  GROUP BY
+    "id"
+), "joined" AS (
+  SELECT
+    "source"."_exists" AS "_exists",
+    "latest"."id" AS "t_id",
+    "latest"."name" AS "t_name",
+    "latest"."price" AS "t_price",
+    "latest"."test_valid_from" AS "t_test_valid_from",
+    "latest"."test_valid_to" AS "t_test_valid_to",
+    "source"."id" AS "id",
+    "source"."name" AS "name",
+    "source"."price" AS "price"
+  FROM "latest"
+  LEFT JOIN "source"
+    ON "latest"."id" = "source"."id"
+  UNION ALL
+  SELECT
+    "source"."_exists" AS "_exists",
+    "latest"."id" AS "t_id",
+    "latest"."name" AS "t_name",
+    "latest"."price" AS "t_price",
+    "latest"."test_valid_from" AS "t_test_valid_from",
+    "latest"."test_valid_to" AS "t_test_valid_to",
+    "source"."id" AS "id",
+    "source"."name" AS "name",
+    "source"."price" AS "price"
+  FROM "latest"
+  RIGHT JOIN "source"
+    ON "latest"."id" = "source"."id"
+  WHERE
+    "latest"."_exists" IS NULL
+), "updated_rows" AS (
+  SELECT
+    COALESCE("joined"."t_id", "joined"."id") AS "id",
+    COALESCE("joined"."t_name", "joined"."name") AS "name",
+    COALESCE("joined"."t_price", "joined"."price") AS "price",
+    COALESCE("t_test_valid_from", CAST('2020-01-01 00:00:00' AS TIMESTAMP)) AS "test_valid_from",
+    CASE
+      WHEN "joined"."_exists" IS NULL
+      OR (
+        (
+          NOT "joined"."t_id" IS NULL AND NOT "joined"."id" IS NULL
+        )
+        AND (
+          "joined"."id" <> "joined"."t_id"
+          OR (
+            "joined"."t_id" IS NULL AND NOT "joined"."id" IS NULL
+          )
+          OR (
+            NOT "joined"."t_id" IS NULL AND "joined"."id" IS NULL
+          )
+          OR "joined"."name" <> "joined"."t_name"
+          OR (
+            "joined"."t_name" IS NULL AND NOT "joined"."name" IS NULL
+          )
+          OR (
+            NOT "joined"."t_name" IS NULL AND "joined"."name" IS NULL
+          )
+          OR "joined"."price" <> "joined"."t_price"
+          OR (
+            "joined"."t_price" IS NULL AND NOT "joined"."price" IS NULL
+          )
+          OR (
+            NOT "joined"."t_price" IS NULL AND "joined"."price" IS NULL
+          )
+        )
+      )
+      THEN CAST('2020-01-01 00:00:00' AS TIMESTAMP)
+      ELSE "t_test_valid_to"
+    END AS "test_valid_to"
+  FROM "joined"
+  LEFT JOIN "latest_deleted"
+    ON "joined"."id" = "latest_deleted"."_key0"
+), "inserted_rows" AS (
+  SELECT
+    "id",
+    "name",
+    "price",
+    CAST('2020-01-01 00:00:00' AS TIMESTAMP) AS "test_valid_from",
+    CAST(NULL AS TIMESTAMP) AS "test_valid_to"
+  FROM "joined"
+  WHERE
+    (
+      NOT "joined"."t_id" IS NULL AND NOT "joined"."id" IS NULL
+    )
+    AND (
+      "joined"."id" <> "joined"."t_id"
+      OR (
+        "joined"."t_id" IS NULL AND NOT "joined"."id" IS NULL
+      )
+      OR (
+        NOT "joined"."t_id" IS NULL AND "joined"."id" IS NULL
+      )
+      OR "joined"."name" <> "joined"."t_name"
+      OR (
+        "joined"."t_name" IS NULL AND NOT "joined"."name" IS NULL
+      )
+      OR (
+        NOT "joined"."t_name" IS NULL AND "joined"."name" IS NULL
+      )
+      OR "joined"."price" <> "joined"."t_price"
+      OR (
+        "joined"."t_price" IS NULL AND NOT "joined"."price" IS NULL
+      )
+      OR (
+        NOT "joined"."t_price" IS NULL AND "joined"."price" IS NULL
+      )
+    )
+)
+SELECT CAST("id" AS INT) AS "id", CAST("name" AS VARCHAR) AS "name", CAST("price" AS DOUBLE) AS "price", CAST("test_valid_from" AS TIMESTAMP) AS "test_valid_from", CAST("test_valid_to" AS TIMESTAMP) AS "test_valid_to" FROM (SELECT "id", "name", "price", "test_valid_from", "test_valid_to" FROM "static" UNION ALL SELECT "id", "name", "price", "test_valid_from", "test_valid_to" FROM "updated_rows" UNION ALL SELECT "id", "name", "price", "test_valid_from", "test_valid_to" FROM "inserted_rows") AS "_subquery"
+    """
+        ).sql()
+    )
+
+
+def test_scd_type_2_by_column_no_invalidate_hard_deletes(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+
+    adapter.scd_type_2_by_column(
+        target_table="target",
+        source_table=t.cast(exp.Select, parse_one("SELECT id, name, price FROM source")),
+        unique_key=[exp.column("id")],
+        valid_from_col=exp.column("test_valid_from", quoted=True),
+        valid_to_col=exp.column("test_valid_to", quoted=True),
+        invalidate_hard_deletes=False,
+        check_columns=[exp.column("name"), exp.column("price")],
+        columns_to_types={
+            "id": exp.DataType.build("INT"),
+            "name": exp.DataType.build("VARCHAR"),
+            "price": exp.DataType.build("DOUBLE"),
+            "test_valid_from": exp.DataType.build("TIMESTAMP"),
+            "test_valid_to": exp.DataType.build("TIMESTAMP"),
+        },
+        execution_time=datetime(2020, 1, 1, 0, 0, 0),
+    )
+
+    assert (
+        adapter.cursor.execute.call_args[0][0]
+        == parse_one(
+            """
+CREATE OR REPLACE TABLE "target" AS
+WITH "source" AS (
+  SELECT DISTINCT ON ("id")
+    TRUE AS "_exists",
+    "id",
+    "name",
+    "price"
+  FROM (
+    SELECT
+      "id",
+      "name",
+      "price"
+    FROM "source"
+  ) AS "raw_source"
+), "static" AS (
+  SELECT
+    "id",
+    "name",
+    "price",
+    "test_valid_from",
+    "test_valid_to",
+    TRUE AS "_exists"
+  FROM "target"
+  WHERE
+    NOT "test_valid_to" IS NULL
+), "latest" AS (
+  SELECT
+    "id",
+    "name",
+    "price",
+    "test_valid_from",
+    "test_valid_to",
+    TRUE AS "_exists"
+  FROM "target"
+  WHERE
+    "test_valid_to" IS NULL
 ), "deleted" AS (
   SELECT
     "static"."id",

--- a/tests/core/engine_adapter/test_clickhouse.py
+++ b/tests/core/engine_adapter/test_clickhouse.py
@@ -612,8 +612,6 @@ def test_scd_type_2_by_time(
             "test_valid_to": exp.DataType.build("TIMESTAMP"),
         },
         execution_time=datetime(2020, 1, 1, 0, 0, 0),
-        start=datetime(2020, 1, 1, 0, 0, 0),
-        truncate=True,
     )
 
     assert to_sql_calls(adapter)[3] == parse_one(
@@ -645,7 +643,7 @@ WITH "source" AS (
     TRUE AS "_exists"
   FROM ""__temp_target_efgh""
   WHERE
-    NOT "test_valid_to" IS NULL LIMIT 0
+    NOT "test_valid_to" IS NULL
 ), "latest" AS (
   SELECT
     "id",
@@ -657,7 +655,7 @@ WITH "source" AS (
     TRUE AS "_exists"
   FROM ""__temp_target_efgh""
   WHERE
-    "test_valid_to" IS NULL LIMIT 0
+    "test_valid_to" IS NULL
 ), "deleted" AS (
   SELECT
     "static"."id",
@@ -825,8 +823,6 @@ def test_scd_type_2_by_column(
             "test_valid_to": exp.DataType.build("TIMESTAMP"),
         },
         execution_time=datetime(2020, 1, 1, 0, 0, 0),
-        start=datetime(2020, 1, 1, 0, 0, 0),
-        truncate=True,
     )
 
     assert to_sql_calls(adapter)[3] == parse_one(
@@ -856,7 +852,7 @@ WITH "source" AS (
     TRUE AS "_exists"
   FROM "__temp_target_efgh"
   WHERE
-    NOT ("test_valid_to" IS NULL) LIMIT 0
+    NOT "test_valid_to" IS NULL
 ), "latest" AS (
   SELECT
     "id",
@@ -867,7 +863,7 @@ WITH "source" AS (
     TRUE AS "_exists"
   FROM "__temp_target_efgh"
   WHERE
-    "test_valid_to" IS NULL LIMIT 0
+    "test_valid_to" IS NULL
 ), "deleted" AS (
   SELECT
     "static"."id",
@@ -923,7 +919,7 @@ WITH "source" AS (
     COALESCE("joined"."t_id", "joined"."id") AS "id",
     COALESCE("joined"."t_name", "joined"."name") AS "name",
     COALESCE("joined"."t_price", "joined"."price") AS "price",
-    COALESCE("t_test_VALID_from", CAST('1970-01-01 00:00:00' AS Nullable(DateTime64(6)))) AS "test_VALID_from",
+    COALESCE("t_test_VALID_from", CAST('2020-01-01 00:00:00' AS Nullable(DateTime64(6)))) AS "test_VALID_from",
     CASE
       WHEN "joined"."_exists" IS NULL
       OR (

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -591,8 +591,6 @@ def test_scd_type_2_by_time(
             "test_valid_to": exp.DataType.build("TIMESTAMP"),
         },
         execution_time=datetime(2020, 1, 1, 0, 0, 0),
-        start=datetime(2020, 1, 1, 0, 0, 0),
-        truncate=True,
     )
 
     assert to_sql_calls(adapter) == [
@@ -637,7 +635,7 @@ def test_scd_type_2_by_time(
     TRUE AS `_exists`
   FROM `db`.`temp_target_abcdefgh`
   WHERE
-    NOT `test_valid_to` IS NULL LIMIT 0
+    NOT `test_valid_to` IS NULL
 ), `latest` AS (
   SELECT
     `id`,
@@ -649,7 +647,7 @@ def test_scd_type_2_by_time(
     TRUE AS `_exists`
   FROM `db`.`temp_target_abcdefgh`
   WHERE
-    `test_valid_to` IS NULL LIMIT 0
+    `test_valid_to` IS NULL
 ), `deleted` AS (
   SELECT
     `static`.`id`,

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -10441,9 +10441,9 @@ def test_signal_always_true(batch, arg1, arg2):
 
 
 def test_scd_type_2_full_history_restatement():
-    assert ModelKindName.SCD_TYPE_2.full_history_restatement_only is False
-    assert ModelKindName.SCD_TYPE_2_BY_TIME.full_history_restatement_only is False
-    assert ModelKindName.SCD_TYPE_2_BY_COLUMN.full_history_restatement_only is False
+    assert ModelKindName.SCD_TYPE_2.full_history_restatement_only is True
+    assert ModelKindName.SCD_TYPE_2_BY_TIME.full_history_restatement_only is True
+    assert ModelKindName.SCD_TYPE_2_BY_COLUMN.full_history_restatement_only is True
     assert ModelKindName.INCREMENTAL_BY_TIME_RANGE.full_history_restatement_only is False
 
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -2049,8 +2049,6 @@ def test_insert_into_scd_type_2_by_time(
         column_descriptions={},
         updated_at_as_valid_from=False,
         truncate=truncate,
-        is_restatement=False,
-        start="2020-01-01",
     )
     adapter_mock.columns.assert_called_once_with(snapshot.table_name())
 
@@ -2223,8 +2221,6 @@ def test_insert_into_scd_type_2_by_column(
         table_description=None,
         column_descriptions={},
         truncate=truncate,
-        is_restatement=False,
-        start="2020-01-01",
     )
     adapter_mock.columns.assert_called_once_with(snapshot.table_name())
 


### PR DESCRIPTION
Reverting the partial restatements support for SCD type 2 models and reopening: https://github.com/TobikoData/sqlmesh/issues/3642

( Leaving the `test_scd_type_2_regular_run_with_offset` test to ensure there are not future regressions with runs if we ever revisit enabling this again in the future. )