### PR TITLE
Fix(dbt): Use the info to control logging for dbt log builtin

### DIFF
--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -170,7 +170,13 @@ def env_var(name: str, default: t.Optional[str] = None) -> t.Optional[str]:
 
 
 def log(msg: str, info: bool = False) -> str:
-    logger.debug(msg)
+    if info:
+        # Write to both log file and stdout
+        logger.info(msg)
+        print(msg)
+    else:
+        logger.debug(msg)
+
     return ""
 
 

--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -14,6 +14,7 @@ from dbt.adapters.base import BaseRelation, Column
 from ruamel.yaml import YAMLError
 from sqlglot import Dialect
 
+from sqlmesh.core.console import get_console
 from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.snapshot.definition import DeployabilityIndex
 from sqlmesh.dbt.adapter import BaseAdapter, ParsetimeAdapter, RuntimeAdapter
@@ -173,7 +174,7 @@ def log(msg: str, info: bool = False) -> str:
     if info:
         # Write to both log file and stdout
         logger.info(msg)
-        print(msg)
+        get_console().log_status_update(msg)
     else:
         logger.debug(msg)
 


### PR DESCRIPTION
Previously when using in dbt `log` the info parameter was ignored and we only logged in the logs if the debug mode was enabled. This updates the log builtin to use the info flag to control the levelling level to match dbt's handling ( https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/context/base.py#L570)