### PR TITLE
Fix: support auto_restatement_cron in python models

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2866,6 +2866,9 @@ def render_meta_fields(
             for key, value in field_value.items():
                 if key in RUNTIME_RENDERED_MODEL_FIELDS:
                     rendered_dict[key] = parse_strings_with_macro_refs(value, dialect)
+                elif key == "auto_restatement_cron":
+                    # Don't parse auto_restatement_cron="@..." kwarg (e.g. @daily) into MacroVar
+                    rendered_dict[key] = value
                 elif (rendered := render_field_value(value)) is not None:
                     rendered_dict[key] = rendered
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2866,8 +2866,12 @@ def render_meta_fields(
             for key, value in field_value.items():
                 if key in RUNTIME_RENDERED_MODEL_FIELDS:
                     rendered_dict[key] = parse_strings_with_macro_refs(value, dialect)
-                elif key == "auto_restatement_cron":
-                    # Don't parse auto_restatement_cron="@..." kwarg (e.g. @daily) into MacroVar
+                elif (
+                    # don't parse kind auto_restatement_cron="@..." kwargs (e.g. @daily) into MacroVar
+                    key == "auto_restatement_cron"
+                    and isinstance(value, str)
+                    and value.lower() in CRON_SHORTCUTS
+                ):
                     rendered_dict[key] = value
                 elif (rendered := render_field_value(value)) is not None:
                     rendered_dict[key] = rendered

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2898,7 +2898,15 @@ def test_python_model_decorator_kind() -> None:
     # no warning with valid kind dict
     with patch.object(get_console(), "log_warning") as mock_logger:
 
-        @model("kind_valid_dict", kind=dict(name=ModelKindName.FULL), columns={'"COL"': "int"})
+        @model(
+            "kind_valid_dict",
+            kind=dict(
+                name=ModelKindName.INCREMENTAL_BY_TIME_RANGE,
+                time_column="ds",
+                auto_restatement_cron="@hourly",
+            ),
+            columns={'"ds"': "date", '"COL"': "int"},
+        )
         def my_model(context):
             pass
 
@@ -2907,7 +2915,7 @@ def test_python_model_decorator_kind() -> None:
             path=Path("."),
         )
 
-        assert isinstance(python_model.kind, FullKind)
+        assert isinstance(python_model.kind, IncrementalByTimeRangeKind)
 
         assert not mock_logger.call_args
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2920,6 +2920,28 @@ def test_python_model_decorator_kind() -> None:
         assert not mock_logger.call_args
 
 
+def test_python_model_decorator_auto_restatement_cron() -> None:
+    @model(
+        "auto_restatement_model",
+        cron="@daily",
+        kind=dict(
+            name=ModelKindName.INCREMENTAL_BY_TIME_RANGE,
+            time_column="ds",
+            auto_restatement_cron="@hourly",
+        ),
+        columns={'"ds"': "date", '"COL"': "int"},
+    )
+    def my_model(context):
+        pass
+
+    python_model = model.get_registry()["auto_restatement_model"].model(
+        module_path=Path("."),
+        path=Path("."),
+    )
+
+    assert python_model.auto_restatement_cron == "@hourly"
+
+
 def test_python_model_decorator_col_descriptions() -> None:
     # `columns` and `column_descriptions` column names are different cases, but name normalization makes both lower
     @model("col_descriptions", columns={"col": "int"}, column_descriptions={"COL": "a column"})


### PR DESCRIPTION
For python models we currently attempt to render `auto_restatement_cron`, which incorrectly treats values like `@hourly` as SQLMesh macro variables.