### PR TITLE
Chore!: Optimize snapshot unpausing

### DIFF
--- a/sqlmesh/core/state_sync/db/facade.py
+++ b/sqlmesh/core/state_sync/db/facade.py
@@ -256,7 +256,7 @@ class EngineAdapterStateSync(StateSync):
     def unpause_snapshots(
         self, snapshots: t.Collection[SnapshotInfoLike], unpaused_dt: TimeLike
     ) -> None:
-        self.snapshot_state.unpause_snapshots(snapshots, unpaused_dt, self.interval_state)
+        self.snapshot_state.unpause_snapshots(snapshots, unpaused_dt)
 
     def invalidate_environment(self, name: str, protect_prod: bool = True) -> None:
         self.environment_state.invalidate_environment(name, protect_prod)

--- a/sqlmesh/core/state_sync/db/migrator.py
+++ b/sqlmesh/core/state_sync/db/migrator.py
@@ -396,7 +396,7 @@ class StateMigrator:
         if updated_prod_environment:
             try:
                 self.snapshot_state.unpause_snapshots(
-                    updated_prod_environment.snapshots, now_timestamp(), self.interval_state
+                    updated_prod_environment.snapshots, now_timestamp()
                 )
             except Exception:
                 logger.warning("Failed to unpause migrated snapshots", exc_info=True)

--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -118,7 +118,7 @@ class SnapshotState:
         )
 
         for snapshot in snapshots:
-            # We need to mark all other snapshots that have opposite forward only status as unrestorable
+            # We need to mark all other snapshots that have forward-only opposite to the target snapshot as unrestorable
             unrestorable_snapshots_by_forward_only[not snapshot.is_forward_only].append(
                 snapshot.name_version
             )

--- a/sqlmesh/core/state_sync/db/utils.py
+++ b/sqlmesh/core/state_sync/db/utils.py
@@ -22,6 +22,21 @@ except ImportError:
 T = t.TypeVar("T")
 
 
+def snapshot_name_filter(
+    snapshot_names: t.Iterable[str],
+    batch_size: int,
+    alias: t.Optional[str] = None,
+) -> t.Iterator[exp.Condition]:
+    names = sorted(snapshot_names)
+
+    if not names:
+        yield exp.false()
+    else:
+        batches = create_batches(names, batch_size=batch_size)
+        for names in batches:
+            yield exp.column("name", table=alias).isin(*names)
+
+
 def snapshot_id_filter(
     engine_adapter: EngineAdapter,
     snapshot_ids: t.Iterable[SnapshotIdLike],

--- a/sqlmesh/migrations/v0090_add_forward_only_column.py
+++ b/sqlmesh/migrations/v0090_add_forward_only_column.py
@@ -1,0 +1,100 @@
+"""Add forward_only column to the snapshots table."""
+
+import json
+
+from sqlglot import exp
+
+from sqlmesh.utils.migration import index_text_type, blob_text_type
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    import pandas as pd
+
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+
+    alter_table_exp = exp.Alter(
+        this=exp.to_table(snapshots_table),
+        kind="TABLE",
+        actions=[
+            exp.ColumnDef(
+                this=exp.to_column("forward_only"),
+                kind=exp.DataType.build("boolean"),
+            )
+        ],
+    )
+    engine_adapter.execute(alter_table_exp)
+
+    new_snapshots = []
+
+    for (
+        name,
+        identifier,
+        version,
+        snapshot,
+        kind_name,
+        updated_ts,
+        unpaused_ts,
+        ttl_ms,
+        unrestorable,
+        forward_only,
+    ) in engine_adapter.fetchall(
+        exp.select(
+            "name",
+            "identifier",
+            "version",
+            "snapshot",
+            "kind_name",
+            "updated_ts",
+            "unpaused_ts",
+            "ttl_ms",
+            "unrestorable",
+            "forward_only",
+        ).from_(snapshots_table),
+        quote_identifiers=True,
+    ):
+        parsed_snapshot = json.loads(snapshot)
+
+        forward_only = parsed_snapshot.get("forward_only")
+        if forward_only is None:
+            forward_only = parsed_snapshot.get("change_category") == 3
+
+        new_snapshots.append(
+            {
+                "name": name,
+                "identifier": identifier,
+                "version": version,
+                "snapshot": json.dumps(parsed_snapshot),
+                "kind_name": kind_name,
+                "updated_ts": updated_ts,
+                "unpaused_ts": unpaused_ts,
+                "ttl_ms": ttl_ms,
+                "unrestorable": unrestorable,
+                "forward_only": forward_only,
+            }
+        )
+
+    if new_snapshots:
+        engine_adapter.delete_from(snapshots_table, "TRUE")
+        index_type = index_text_type(engine_adapter.dialect)
+        blob_type = blob_text_type(engine_adapter.dialect)
+
+        engine_adapter.insert_append(
+            snapshots_table,
+            pd.DataFrame(new_snapshots),
+            columns_to_types={
+                "name": exp.DataType.build(index_type),
+                "identifier": exp.DataType.build(index_type),
+                "version": exp.DataType.build(index_type),
+                "snapshot": exp.DataType.build(blob_type),
+                "kind_name": exp.DataType.build(index_type),
+                "updated_ts": exp.DataType.build("bigint"),
+                "unpaused_ts": exp.DataType.build("bigint"),
+                "ttl_ms": exp.DataType.build("bigint"),
+                "unrestorable": exp.DataType.build("boolean"),
+                "forward_only": exp.DataType.build("boolean"),
+            },
+        )


### PR DESCRIPTION
With introduction of the dev-only VDE mode, all snapshots that share the name also share the version. This means that fetching all snapshots with the same version may no longer be feasible, as it could result in retrieving the entire state in extreme cases.

This update optimizes the snapshot unpausing operation eliminating the need to fetch snapshots with shared versions. There were a few changes in the past that allow us to simplify the current implementation substantially:

- Deprecation of the Airflow support means that we no longer need to align the unpaused timestamp by the interval unit
- Interval compaction for garbage-collected snapshots means we no longer track intervals for individual snapshots, so there is no need to accurately reflect the effective-from timestamp in the state. Please note the effective-from timestamp is still considered when merging intervals for individual snapshots.