### PR TITLE
fix: BigQueryEngineAdapter.get_table_schema() mypy error

### DIFF
--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -296,7 +296,9 @@ class BigQueryEngineAdapter(InsertOverwriteWithMergeMixin, ClusteredByMixin, Row
         table = exp.to_table(table_name)
         if len(table.parts) == 3 and "." in table.name:
             self.execute(exp.select("*").from_(table).limit(0))
-            return self._query_job._query_results.schema
+            query_job = self._query_job
+            assert query_job is not None
+            return query_job._query_results.schema
         return self._get_table(table).schema
 
     def columns(


### PR DESCRIPTION
This follows the same logic from [BigQueryEngineAdapter.columns()](https://github.com/TobikoData/sqlmesh/blob/main/sqlmesh/core/engine_adapter/bigquery.py#L351-L357) to ensure `query_job` is not None before using it.