### PR TITLE
Se/improve athena get data objs

### DIFF
--- a/sqlmesh/core/engine_adapter/athena.py
+++ b/sqlmesh/core/engine_adapter/athena.py
@@ -129,13 +129,16 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
                 .where(exp.column("table_schema", table="t").eq(schema))
                 .with_(
                     "object_names",
-                    exp.select(exp.Literal("name")).from_(
+                    exp.select(exp.column("name")).from_(
                         exp.Values(
                             expressions=[
                                 exp.Tuple(expressions=[exp.Literal.string(name)])
                                 for name in object_names
                             ],
-                        ).as_("t(name)"),
+                            alias=exp.TableAlias(
+                                this="t", columns=[exp.column("name")],
+                            )
+                        )
                     ),
                 )
             )


### PR DESCRIPTION
The current query used to get data objects in Athena becomes very slow as more models are included.

This PR uses a "CTE of VALUES with a join" strategy to speed up the query time significantly.  From ~4 mins to <10 seconds when querying for 412 objects in my case.