### PR TITLE
fix: use provided deployability index

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -916,7 +916,6 @@ class SnapshotEvaluator:
         if not snapshot.requires_schema_migration_in_prod:
             return
 
-        deployability_index = DeployabilityIndex.all_deployable()
         render_kwargs: t.Dict[str, t.Any] = dict(
             engine_adapter=adapter,
             snapshots=parent_snapshots_by_name(snapshot, snapshots),

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -1383,9 +1383,6 @@ def test_migrate_snapshot_data_object_type_mismatch(
     adapter.cursor.execute.assert_has_calls(
         [
             call('DROP TABLE IF EXISTS "sqlmesh__test_schema"."test_schema__test_model__1"'),
-            call(
-                'CREATE VIEW "sqlmesh__test_schema"."test_schema__test_model__1" AS SELECT "c" AS "c", "a" AS "a" FROM "tbl" AS "tbl"'
-            ),
         ]
     )
 


### PR DESCRIPTION
The behavior in main means the passed in `deployability_index` was ignored. So the options were to either do the change in this PR or remove `deployability_index` from the function args. 