### PR TITLE
Chore!: deprecate support for mixing Jinja & SQLMesh macros

### DIFF
--- a/docs/concepts/macros/jinja_macros.md
+++ b/docs/concepts/macros/jinja_macros.md
@@ -321,6 +321,6 @@ Some SQL dialects interpret double and single quotes differently. We could repla
 
 ## Mixing macro systems
 
-SQLMesh supports both the Jinja and [SQLMesh](./sqlmesh_macros.md) macro systems. We strongly recommend using only one system in a single model - if both are present, they may fail or behave in unintuitive ways.
+SQLMesh supports both the Jinja and [SQLMesh](./sqlmesh_macros.md) macro systems.
 
-[Predefined SQLMesh macro variables](./macro_variables.md) can be used in a query containing user-defined Jinja variables and functions. However, predefined variables passed as arguments to a user-defined Jinja macro function must use the Jinja curly brace syntax `{{ start_ds }}` instead of the SQLMesh macro `@` prefix syntax `@start_ds`. Note that curly brace syntax may require quoting to generate the equivalent of the `@` syntax.
+Mixing the two systems is not supported, i.e., a SQL model may either use Jinja syntax, or SQLMesh macro syntax, but not both.

--- a/docs/concepts/macros/sqlmesh_macros.md
+++ b/docs/concepts/macros/sqlmesh_macros.md
@@ -2119,4 +2119,6 @@ Typed macros in SQLMesh not only enhance the development experience by making ma
 
 ## Mixing macro systems
 
-SQLMesh supports both SQLMesh and [Jinja](./jinja_macros.md) macro systems. We strongly recommend using only one system in a model - if both are present, they may fail or behave in unintuitive ways.
+SQLMesh supports both the Jinja and [SQLMesh](./sqlmesh_macros.md) macro systems.
+
+Mixing the two systems is not supported, i.e., a SQL model may either use Jinja syntax, or SQLMesh macro syntax, but not both.

--- a/examples/sushi/models/waiter_as_customer_by_day.sql
+++ b/examples/sushi/models/waiter_as_customer_by_day.sql
@@ -27,6 +27,6 @@ SELECT
 FROM sushi.waiters AS w
 JOIN sushi.customers as c ON w.waiter_id = c.customer_id
 JOIN sushi.waiter_names as wn ON w.waiter_id = wn.id
-WHERE w.event_date BETWEEN @start_date AND @end_date;
+WHERE w.event_date BETWEEN CAST('{{ start_date }}' AS DATE) AND CAST('{{ end_date }}' AS DATE);
 
 JINJA_END;


### PR DESCRIPTION
Mixing jinja and sqlmesh macros is discouraged today and it probably doesn't quite work in many cases. This PR deprecates any support that existed for mixing the two systems, in favour of reducing the overhead involved in rendering jinja-based queries (e.g., that come from dbt projects). Now, sqlmesh macros are only rendered for non-jinja-based models.