### PR TITLE
Feat(dbt): Add dbt debug macro

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,3 +301,4 @@ banned-module-level-imports = [
 "sqlmesh/lsp/**/*.py" = ["TID251"]
 "tests/lsp/**/*.py" = ["TID251"]
 "benchmarks/lsp*.py" = ["TID251"]
+"sqlmesh/dbt/builtin.py" = ["T100"]

--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -21,7 +21,7 @@ from sqlmesh.dbt.adapter import BaseAdapter, ParsetimeAdapter, RuntimeAdapter
 from sqlmesh.dbt.relation import Policy
 from sqlmesh.dbt.target import TARGET_TYPE_TO_CONFIG_CLASS
 from sqlmesh.dbt.util import DBT_VERSION
-from sqlmesh.utils import AttributeDict, yaml
+from sqlmesh.utils import AttributeDict, debug_mode_enabled, yaml
 from sqlmesh.utils.date import now
 from sqlmesh.utils.errors import ConfigError, MacroEvalError
 from sqlmesh.utils.jinja import JinjaMacroRegistry, MacroReference, MacroReturnVal
@@ -316,6 +316,15 @@ def _try_literal_eval(value: str) -> t.Any:
         return value
 
 
+def debug() -> str:
+    import sys
+    import ipdb  # type: ignore
+
+    frame = sys._getframe(3)
+    ipdb.set_trace(frame)
+    return ""
+
+
 BUILTIN_GLOBALS = {
     "dbt_version": version.__version__,
     "env_var": env_var,
@@ -335,6 +344,10 @@ BUILTIN_GLOBALS = {
     "zip": do_zip,
     "zip_strict": lambda *args: list(zip(*args)),
 }
+
+# Add debug function conditionally both with dbt or sqlmesh equivalent flag
+if os.environ.get("DBT_MACRO_DEBUGGING") or debug_mode_enabled():
+    BUILTIN_GLOBALS["debug"] = debug
 
 BUILTIN_FILTERS = {
     "as_bool": as_bool,


### PR DESCRIPTION
This adds support for dbt's [debug macro](https://docs.getdbt.com/reference/dbt-jinja-functions/debug-method) in a dbt project which opens an iPython debugger in the context of a macro

```python
{% macro my_macro() %}
  {% set something_complex = my_complicated_macro() %}
  {{ debug() }}
{% endmacro %}
```

This is enabled both by using the dbt `DBT_MACRO_DEBUGGING` environment variable or the sqlmesh native: `SQLMESH_DEBUG` or running with `--debug` flag.