### PR TITLE
feat: dbt adapter allow invalid ref for tests

### DIFF
--- a/sqlmesh/dbt/context.py
+++ b/sqlmesh/dbt/context.py
@@ -265,8 +265,7 @@ class DbtContext:
                 else:
                     models[ref] = t.cast(ModelConfig, model)
             else:
-                exception = MissingModelError(f"Model '{ref}' was not found.")
-                exception.model_name = ref
+                exception = MissingModelError(ref)
                 raise exception
 
         for source in dependencies.sources:

--- a/sqlmesh/dbt/context.py
+++ b/sqlmesh/dbt/context.py
@@ -11,7 +11,7 @@ from sqlmesh.dbt.builtin import _relation_info_to_relation
 from sqlmesh.dbt.manifest import ManifestHelper
 from sqlmesh.dbt.target import TargetConfig
 from sqlmesh.utils import AttributeDict
-from sqlmesh.utils.errors import ConfigError, SQLMeshError
+from sqlmesh.utils.errors import ConfigError, SQLMeshError, MissingModelError
 from sqlmesh.utils.jinja import (
     JinjaGlobalAttribute,
     JinjaMacroRegistry,
@@ -265,7 +265,9 @@ class DbtContext:
                 else:
                     models[ref] = t.cast(ModelConfig, model)
             else:
-                raise ConfigError(f"Model '{ref}' was not found.")
+                exception = MissingModelError(f"Model '{ref}' was not found.")
+                exception.model_name = ref
+                raise exception
 
         for source in dependencies.sources:
             if source in self.sources:

--- a/sqlmesh/utils/errors.py
+++ b/sqlmesh/utils/errors.py
@@ -33,6 +33,12 @@ class ConfigError(SQLMeshError):
             self.location = Path(location) if isinstance(location, str) else location
 
 
+class MissingModelError(ConfigError):
+    """Raised when a model that is referenced is missing."""
+
+    model_name: str
+
+
 class MissingDependencyError(SQLMeshError):
     """Local environment is missing a required dependency for the given operation"""
 

--- a/sqlmesh/utils/errors.py
+++ b/sqlmesh/utils/errors.py
@@ -36,7 +36,9 @@ class ConfigError(SQLMeshError):
 class MissingModelError(ConfigError):
     """Raised when a model that is referenced is missing."""
 
-    model_name: str
+    def __init__(self, model_name: str) -> None:
+        self.model_name = model_name
+        super().__init__(f"Model '{model_name}' was not found.")
 
 
 class MissingDependencyError(SQLMeshError):

--- a/tests/dbt/test_model.py
+++ b/tests/dbt/test_model.py
@@ -1,10 +1,14 @@
 import pytest
 
+from pathlib import Path
+
+from sqlmesh import Context
 from sqlmesh.dbt.common import Dependencies
 from sqlmesh.dbt.context import DbtContext
 from sqlmesh.dbt.model import ModelConfig
 from sqlmesh.dbt.test import TestConfig
 from sqlmesh.utils.errors import ConfigError
+from sqlmesh.utils.yaml import YAML
 
 pytestmark = pytest.mark.dbt
 
@@ -44,3 +48,85 @@ def test_model_test_circular_references() -> None:
         upstream_model.check_for_circular_test_refs(context)
     with pytest.raises(ConfigError, match="between tests"):
         downstream_model.check_for_circular_test_refs(context)
+
+
+def test_load_invalid_ref_audit_constraints(tmp_path: Path) -> None:
+    yaml = YAML()
+    dbt_project_dir = tmp_path / "dbt"
+    dbt_project_dir.mkdir()
+    dbt_model_dir = dbt_project_dir / "models"
+    dbt_model_dir.mkdir()
+    full_model_contents = "SELECT 1 as cola"
+    full_model_file = dbt_model_dir / "full_model.sql"
+    with open(full_model_file, "w", encoding="utf-8") as f:
+        f.write(full_model_contents)
+    model_schema = {
+        "version": 2,
+        "models": [
+            {
+                "name": "full_model",
+                "description": "A full model bad ref for audit and constraints",
+                "columns": [
+                    {
+                        "name": "cola",
+                        "description": "A column that is used in a ref audit and constraints",
+                        "constraints": [
+                            {
+                                "type": "primary_key",
+                                "columns": ["cola"],
+                                "expression": "ref('not_real_model') (cola)",
+                            }
+                        ],
+                        "tests": [
+                            {
+                                "relationships": {
+                                    "to": "ref('not_real_model')",
+                                    "field": "cola",
+                                    "description": "A test that references a model that does not exist",
+                                }
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    model_schema_file = dbt_model_dir / "schema.yml"
+    with open(model_schema_file, "w", encoding="utf-8") as f:
+        yaml.dump(model_schema, f)
+    dbt_project_config = {
+        "name": "invalid_ref_audit_constraints",
+        "version": "1.0.0",
+        "config-version": 2,
+        "profile": "test",
+        "model-paths": ["models"],
+    }
+    dbt_project_file = dbt_project_dir / "dbt_project.yml"
+    with open(dbt_project_file, "w", encoding="utf-8") as f:
+        yaml.dump(dbt_project_config, f)
+    sqlmesh_config = {
+        "model_defaults": {
+            "start": "2025-01-01",
+        }
+    }
+    sqlmesh_config_file = dbt_project_dir / "sqlmesh.yaml"
+    with open(sqlmesh_config_file, "w", encoding="utf-8") as f:
+        yaml.dump(sqlmesh_config, f)
+    dbt_data_dir = tmp_path / "dbt_data"
+    dbt_data_dir.mkdir()
+    dbt_data_file = dbt_data_dir / "local.db"
+    dbt_profile_config = {
+        "test": {
+            "outputs": {"duckdb": {"type": "duckdb", "path": str(dbt_data_file)}},
+            "target": "duckdb",
+        }
+    }
+    db_profile_file = dbt_project_dir / "profiles.yml"
+    with open(db_profile_file, "w", encoding="utf-8") as f:
+        yaml.dump(dbt_profile_config, f)
+
+    context = Context(paths=dbt_project_dir)
+    fqn = '"local"."main"."full_model"'
+    assert fqn in context.snapshots
+    # The audit isn't loaded due to the invalid ref
+    assert context.snapshots[fqn].model.audits == []

--- a/tests/dbt/test_model.py
+++ b/tests/dbt/test_model.py
@@ -50,7 +50,7 @@ def test_model_test_circular_references() -> None:
         downstream_model.check_for_circular_test_refs(context)
 
 
-def test_load_invalid_ref_audit_constraints(tmp_path: Path) -> None:
+def test_load_invalid_ref_audit_constraints(tmp_path: Path, caplog) -> None:
     yaml = YAML()
     dbt_project_dir = tmp_path / "dbt"
     dbt_project_dir.mkdir()
@@ -126,6 +126,10 @@ def test_load_invalid_ref_audit_constraints(tmp_path: Path) -> None:
         yaml.dump(dbt_profile_config, f)
 
     context = Context(paths=dbt_project_dir)
+    assert (
+        "Skipping audit 'relationships_full_model_cola__cola__ref_not_real_model_' because model 'not_real_model' is not a valid ref"
+        in caplog.text
+    )
     fqn = '"local"."main"."full_model"'
     assert fqn in context.snapshots
     # The audit isn't loaded due to the invalid ref


### PR DESCRIPTION
Dbt ignores with a warning tests that have refs to models that don't exist. This mimics that behavior. 

dbt function that explicitly does not fail if test: https://github.com/dbt-labs/dbt-core/blob/0836095a572532fc22b1c0981346eebe56f7d1fb/core/dbt/parser/manifest.py#L1324-L1332

I noticed in testing that constraints that make invalid refs also do not affect execution so I included that in the test although I didn't have to make any code changes at this time to support it. 