### PR TITLE
feat: widen dbt-core compatibility range

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,8 @@ on:
 concurrency:
   group: 'pr-${{ github.event.pull_request.number }}'
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   test-vscode:
     env:
@@ -66,3 +68,61 @@ jobs:
           name: playwright-report
           path: vscode/extension/playwright-report/
           retention-days: 30
+  test-dbt-versions:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dbt-version:
+          [
+            '1.3.0',
+            '1.4.0',
+            '1.5.0',
+            '1.6.0',
+            '1.7.0',
+            '1.8.0',
+            '1.9.0',
+            '1.10.0',
+          ]
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Install SQLMesh dev dependencies
+        run: |
+          uv venv .venv
+          source .venv/bin/activate
+          sed -i 's/"pydantic>=2.0.0"/"pydantic"/g' pyproject.toml
+          if [[ "${{ matrix.dbt-version }}" == "1.10.0" ]]; then
+            # For 1.10.0: only add version to dbt-core, remove versions from all adapter packages
+            sed -i -E 's/"(dbt-core)[^"]*"/"\1~=${{ matrix.dbt-version }}"/g' pyproject.toml
+            # Remove version constraints from all dbt adapter packages
+            sed -i -E 's/"(dbt-(bigquery|duckdb|snowflake|athena-community|clickhouse|databricks|redshift|trino))[^"]*"/"\1"/g' pyproject.toml
+          else
+            # For other versions: apply version to all dbt packages
+            sed -i -E 's/"(dbt-[^">=<~!]+)[^"]*"/"\1~=${{ matrix.dbt-version }}"/g' pyproject.toml
+          fi
+          UV=1 make install-dev
+          uv pip install pydantic>=2.0.0 --reinstall
+      - name: Run dbt tests
+        # We can't run slow tests across all engines due to tests requiring DuckDB and old versions
+        # of DuckDB require a version of DuckDB we no longer support
+        run: |
+          source .venv/bin/activate
+          make dbt-fast-test
+      - name: Test SQLMesh info in sushi_dbt
+        working-directory: ./examples/sushi_dbt
+        run: |
+          source ../../.venv/bin/activate
+          sed -i 's/target: in_memory/target: postgres/g' profiles.yml
+          if [[ $(echo -e "${{ matrix.dbt-version }}\n1.5.0" | sort -V | head -n1) == "${{ matrix.dbt-version }}" ]] && [[ "${{ matrix.dbt-version }}" != "1.5.0" ]]; then
+            echo "DBT version is ${{ matrix.dbt-version }} (< 1.5.0), removing version parameters..."
+            sed -i -e 's/, version=1) }}/) }}/g' -e 's/, v=1) }}/) }}/g' models/top_waiters.sql
+          else
+            echo "DBT version is ${{ matrix.dbt-version }} (>= 1.5.0), keeping version parameters"
+          fi
+          sqlmesh info --skip-connection

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 .PHONY: docs
 
+ifdef UV
+    PIP := uv pip
+else
+    PIP := pip3
+endif
+
 install-dev:
-	pip3 install -e ".[dev,web,slack,dlt,lsp]" ./examples/custom_materializations
+	$(PIP) install -e ".[dev,web,slack,dlt,lsp]" ./examples/custom_materializations
 
 install-doc:
-	pip3 install -r ./docs/requirements.txt
+	$(PIP) install -r ./docs/requirements.txt
 
 install-pre-commit:
 	pre-commit install
@@ -22,16 +28,16 @@ doc-test:
 	python -m pytest --doctest-modules sqlmesh/core sqlmesh/utils
 
 package:
-	pip3 install build && python3 -m build
+	$(PIP) install build && python3 -m build
 
 publish: package
-	pip3 install twine && python3 -m twine upload dist/*
+	$(PIP) install twine && python3 -m twine upload dist/*
 
 package-tests:
-	pip3 install build && cp pyproject.toml tests/sqlmesh_pyproject.toml && python3 -m build tests/
+	$(PIP) install build && cp pyproject.toml tests/sqlmesh_pyproject.toml && python3 -m build tests/
 
 publish-tests: package-tests
-	pip3 install twine && python3 -m twine upload -r tobiko-private tests/dist/*
+	$(PIP) install twine && python3 -m twine upload -r tobiko-private tests/dist/*
 
 docs-serve:
 	mkdocs serve
@@ -93,6 +99,9 @@ engine-test:
 dbt-test:
 	pytest -n auto -m "dbt and not cicdonly"
 
+dbt-fast-test:
+	pytest -n auto -m "dbt and fast" --retries 3
+
 github-test:
 	pytest -n auto -m "github"
 
@@ -109,7 +118,7 @@ guard-%:
 	fi
 
 engine-%-install:
-	pip3 install -e ".[dev,web,slack,lsp,${*}]" ./examples/custom_materializations
+	$(PIP) install -e ".[dev,web,slack,lsp,${*}]" ./examples/custom_materializations
 
 engine-docker-%-up:
 	docker compose -f ./tests/core/engine_adapter/integration/docker/compose.${*}.yaml up -d
@@ -157,11 +166,11 @@ snowflake-test: guard-SNOWFLAKE_ACCOUNT guard-SNOWFLAKE_WAREHOUSE guard-SNOWFLAK
 	pytest -n auto -m "snowflake" --retries 3 --junitxml=test-results/junit-snowflake.xml
 
 bigquery-test: guard-BIGQUERY_KEYFILE engine-bigquery-install
-	pip install -e ".[bigframes]"
+	$(PIP) install -e ".[bigframes]"
 	pytest -n auto -m "bigquery" --retries 3 --junitxml=test-results/junit-bigquery.xml
 
 databricks-test: guard-DATABRICKS_CATALOG guard-DATABRICKS_SERVER_HOSTNAME guard-DATABRICKS_HTTP_PATH guard-DATABRICKS_ACCESS_TOKEN guard-DATABRICKS_CONNECT_VERSION engine-databricks-install
-	pip install 'databricks-connect==${DATABRICKS_CONNECT_VERSION}'
+	$(PIP) install 'databricks-connect==${DATABRICKS_CONNECT_VERSION}'
 	pytest -n auto -m "databricks" --retries 3 --junitxml=test-results/junit-databricks.xml
 
 redshift-test: guard-REDSHIFT_HOST guard-REDSHIFT_USER guard-REDSHIFT_PASSWORD guard-REDSHIFT_DATABASE engine-redshift-install

--- a/examples/sushi_dbt/profiles.yml
+++ b/examples/sushi_dbt/profiles.yml
@@ -3,6 +3,14 @@ sushi:
     in_memory:
       type: duckdb
       schema: sushi
+    postgres:
+      type: postgres
+      host: "host"
+      user: "user"
+      password: "password"
+      dbname: "dbname"
+      port: 5432
+      schema: sushi
     duckdb:
       type: duckdb
       path: 'local.duckdb'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ bigframes = ["bigframes>=1.32.0"]
 clickhouse = ["clickhouse-connect"]
 databricks = ["databricks-sql-connector[pyarrow]"]
 dev = [
-    "agate==1.7.1",
+    "agate",
     "beautifulsoup4",
     "clickhouse-connect",
     "cryptography",

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -188,8 +188,11 @@ class DbtLoader(Loader):
 
             self._projects.append(project)
 
-            if project.context.target.database != (self.context.default_catalog or ""):
-                raise ConfigError("Project default catalog does not match context default catalog")
+            context_default_catalog = self.context.default_catalog or ""
+            if project.context.target.database != context_default_catalog:
+                raise ConfigError(
+                    f"Project default catalog ('{project.context.target.database}') does not match context default catalog ('{context_default_catalog}')."
+                )
             for path in project.project_files:
                 self._track_file(path)
 

--- a/sqlmesh/dbt/relation.py
+++ b/sqlmesh/dbt/relation.py
@@ -1,7 +1,7 @@
 from sqlmesh.dbt.util import DBT_VERSION
 
 
-if DBT_VERSION < (1, 8, 0):
-    from dbt.contracts.relation import *  # type: ignore  # noqa: F403
-else:
+if DBT_VERSION >= (1, 8, 0):
     from dbt.adapters.contracts.relation import *  # type: ignore # noqa: F403
+else:
+    from dbt.contracts.relation import *  # type: ignore  # noqa: F403

--- a/sqlmesh/dbt/util.py
+++ b/sqlmesh/dbt/util.py
@@ -20,10 +20,10 @@ def _get_dbt_version() -> t.Tuple[int, int, int]:
 
 DBT_VERSION = _get_dbt_version()
 
-if DBT_VERSION < (1, 8, 0):
-    from dbt.clients.agate_helper import table_from_data_flat, empty_table, as_matrix  # type: ignore  # noqa: F401
-else:
+if DBT_VERSION >= (1, 8, 0):
     from dbt_common.clients.agate_helper import table_from_data_flat, empty_table, as_matrix  # type: ignore  # noqa: F401
+else:
+    from dbt.clients.agate_helper import table_from_data_flat, empty_table, as_matrix  # type: ignore  # noqa: F401
 
 
 def pandas_to_agate(df: pd.DataFrame) -> agate.Table:

--- a/tests/dbt/conftest.py
+++ b/tests/dbt/conftest.py
@@ -7,6 +7,7 @@ import pytest
 from sqlmesh.core.context import Context
 from sqlmesh.dbt.context import DbtContext
 from sqlmesh.dbt.project import Project
+from sqlmesh.dbt.target import PostgresConfig
 
 
 @pytest.fixture()
@@ -25,3 +26,16 @@ def runtime_renderer() -> t.Callable:
         return render
 
     return create_renderer
+
+
+@pytest.fixture()
+def dbt_dummy_postgres_config() -> PostgresConfig:
+    return PostgresConfig(  # type: ignore
+        name="postgres",
+        host="host",
+        user="user",
+        password="password",
+        dbname="dbname",
+        port=5432,
+        schema="schema",
+    )

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -23,6 +23,7 @@ from sqlmesh.core.schema_diff import SchemaDiffer, TableAlterChangeColumnTypeOpe
 pytestmark = pytest.mark.dbt
 
 
+@pytest.mark.slow
 def test_adapter_relation(sushi_test_project: Project, runtime_renderer: t.Callable):
     context = sushi_test_project.context
     assert context.target
@@ -96,6 +97,7 @@ def test_adapter_relation(sushi_test_project: Project, runtime_renderer: t.Calla
     assert engine_adapter.table_exists("foo.bar__backup")
 
 
+@pytest.mark.slow
 def test_bigquery_get_columns_in_relation(
     sushi_test_project: Project,
     runtime_renderer: t.Callable,
@@ -135,6 +137,7 @@ def test_bigquery_get_columns_in_relation(
 
 
 @pytest.mark.cicdonly
+@pytest.mark.slow
 def test_normalization(
     sushi_test_project: Project, runtime_renderer: t.Callable, mocker: MockerFixture
 ):
@@ -232,6 +235,7 @@ def test_normalization(
     adapter_mock.drop_table.assert_has_calls([call(relation_bla_bob)])
 
 
+@pytest.mark.slow
 def test_adapter_dispatch(sushi_test_project: Project, runtime_renderer: t.Callable):
     context = sushi_test_project.context
     renderer = runtime_renderer(context)
@@ -244,6 +248,7 @@ def test_adapter_dispatch(sushi_test_project: Project, runtime_renderer: t.Calla
 
 
 @pytest.mark.parametrize("project_dialect", ["duckdb", "bigquery"])
+@pytest.mark.slow
 def test_adapter_map_snapshot_tables(
     sushi_test_project: Project,
     runtime_renderer: t.Callable,
@@ -320,6 +325,7 @@ def test_quote_as_configured():
     adapter.quote_as_configured("foo", "database") == "foo"
 
 
+@pytest.mark.slow
 def test_adapter_get_relation_normalization(
     sushi_test_project: Project, runtime_renderer: t.Callable
 ):
@@ -352,6 +358,7 @@ def test_adapter_get_relation_normalization(
         )
 
 
+@pytest.mark.slow
 def test_adapter_expand_target_column_types(
     sushi_test_project: Project, runtime_renderer: t.Callable, mocker: MockerFixture
 ):

--- a/tests/dbt/test_integration.py
+++ b/tests/dbt/test_integration.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 import pandas as pd  # noqa: TID253
 import pytest
-from dbt.cli.main import dbtRunner
+
+from sqlmesh.dbt.util import DBT_VERSION
+
+if DBT_VERSION >= (1, 5, 0):
+    from dbt.cli.main import dbtRunner  # type: ignore
+
 import time_machine
 
 from sqlmesh import Context
@@ -303,6 +308,9 @@ test_config = config"""
         test_type: TestType,
         invalidate_hard_deletes: bool,
     ):
+        if test_type.is_dbt_runtime and DBT_VERSION < (1, 5, 0):
+            pytest.skip("The dbt version being tested doesn't support the dbtRunner so skipping.")
+
         run, adapter, context = self._init_test(
             create_scd_type_2_dbt_project,
             create_scd_type_2_sqlmesh_project,

--- a/tests/dbt/test_model.py
+++ b/tests/dbt/test_model.py
@@ -6,6 +6,7 @@ from sqlmesh import Context
 from sqlmesh.dbt.common import Dependencies
 from sqlmesh.dbt.context import DbtContext
 from sqlmesh.dbt.model import ModelConfig
+from sqlmesh.dbt.target import PostgresConfig
 from sqlmesh.dbt.test import TestConfig
 from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.yaml import YAML
@@ -50,7 +51,10 @@ def test_model_test_circular_references() -> None:
         downstream_model.check_for_circular_test_refs(context)
 
 
-def test_load_invalid_ref_audit_constraints(tmp_path: Path, caplog) -> None:
+@pytest.mark.slow
+def test_load_invalid_ref_audit_constraints(
+    tmp_path: Path, caplog, dbt_dummy_postgres_config: PostgresConfig
+) -> None:
     yaml = YAML()
     dbt_project_dir = tmp_path / "dbt"
     dbt_project_dir.mkdir()


### PR DESCRIPTION
Widens the core compatibility range by addresses a few gaps where we weren't currently compatible and then adding CI checks to run fast tests and load dbt-sushi across the latest bugfix release of each dbt version.

One key part of this change is making sure that any fast dbt test we have doesn't require a sushi context or more generally DuckDB adapter information. This is because the DuckDB dbt-adapter for old dbt releases changed how catalogs are determined that affects these tests. Therefore we currently just run this slow tests on later versions. In tests where we needed some adapter to do things like loading with the Manifest, I used a Postgres connection instead since that is stable across the dbt releases. 