### PR TITLE
Fix: Move before all statements execution before snapshot creation logic

### DIFF
--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -457,17 +457,6 @@ class Scheduler:
             audit_only=audit_only,
         )
 
-        snapshots_to_create = {
-            s.snapshot_id
-            for s in self.snapshot_evaluator.get_snapshots_to_create(
-                selected_snapshots, deployability_index
-            )
-        }
-
-        dag = self._dag(
-            batched_intervals, snapshot_dag=snapshot_dag, snapshots_to_create=snapshots_to_create
-        )
-
         if run_environment_statements:
             environment_statements = self.state_sync.get_environment_statements(
                 environment_naming_info.name
@@ -483,6 +472,17 @@ class Scheduler:
                 end=end,
                 execution_time=execution_time,
             )
+
+        snapshots_to_create = {
+            s.snapshot_id
+            for s in self.snapshot_evaluator.get_snapshots_to_create(
+                selected_snapshots, deployability_index
+            )
+        }
+
+        dag = self._dag(
+            batched_intervals, snapshot_dag=snapshot_dag, snapshots_to_create=snapshots_to_create
+        )
 
         def run_node(node: SchedulingUnit) -> None:
             if circuit_breaker and circuit_breaker():


### PR DESCRIPTION
This fix for scheduled runs moves the before_all statements so that they are executed first before any queries are made against the engine. The added test verifies the execution order, which should currently fail in main where the logic that determines which snapshots need to be created (added here: https://github.com/TobikoData/sqlmesh/pull/5189/) is before.