### PR TITLE
Fix: handle whitespace trimming in dbt test-to-macro jinja normalization

### DIFF
--- a/examples/sushi_dbt/models/schema.yml
+++ b/examples/sushi_dbt/models/schema.yml
@@ -21,6 +21,8 @@ models:
         tests:
           - less_than_amount:
               amount: 1000
+          - greater_than_amount:
+              amount: 0
       - name: ds
         description: Date
   - name: top_waiters

--- a/examples/sushi_dbt/tests/generic/greater_than_amount.sql
+++ b/examples/sushi_dbt/tests/generic/greater_than_amount.sql
@@ -1,0 +1,5 @@
+{%- test greater_than_amount(model, column_name, amount) -%}
+	select *
+	from {{ model }}
+	where {{ column_name }} < {{ amount }}
+{%- endtest -%}

--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -673,12 +673,17 @@ def _node_base_config(node: ManifestNode) -> t.Dict[str, t.Any]:
 
 
 def _convert_jinja_test_to_macro(test_jinja: str) -> str:
-    TEST_TAG_REGEX = r"\s*{%\s*test\s+"
-    ENDTEST_REGEX = r"{%\s*endtest\s*%}"
+    TEST_TAG_REGEX = r"\s*{%-?\s*test\s+"
+    ENDTEST_REGEX = r"{%-?\s*endtest\s*-?%}"
+
     match = re.match(TEST_TAG_REGEX, test_jinja)
     if not match:
         # already a macro
         return test_jinja
 
-    macro = "{% macro test_" + test_jinja[match.span()[-1] :]
-    return re.sub(ENDTEST_REGEX, "{% endmacro %}", macro)
+    test_tag = test_jinja[: match.span()[-1]]
+
+    macro_tag = re.sub(r"({%-?\s*)test\s+", r"\1macro test_", test_tag)
+    macro = macro_tag + test_jinja[match.span()[-1] :]
+
+    return re.sub(ENDTEST_REGEX, lambda m: m.group(0).replace("endtest", "endmacro"), macro)


### PR DESCRIPTION
We don't handle **whitespace trimming** in the `{% test foo %} -> {% macro test_foo %}` conversion today, which results in this error: `Encountered unknown tag 'test'`. This PR address this. An example of such a test in the wild can be found [here](https://github.com/metaplane/dbt-expectations/blob/77d385655ce3318685cf6930b46d077f61de5f55/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql).
