### PR TITLE
Fix(vscode): Use url instead of endpoint for for consistent API fields

### DIFF
--- a/sqlmesh/lsp/api.py
+++ b/sqlmesh/lsp/api.py
@@ -25,7 +25,7 @@ class ApiRequest(CustomMethodRequestBaseClass):
     """
 
     requestId: str
-    endpoint: str
+    url: str
     method: t.Optional[str] = "GET"
     params: t.Optional[t.Dict[str, t.Any]] = None
     body: t.Optional[t.Dict[str, t.Any]] = None

--- a/sqlmesh/lsp/main.py
+++ b/sqlmesh/lsp/main.py
@@ -326,7 +326,7 @@ class SQLMeshLanguageServer:
         ls.log_trace(f"API request: {request}")
         context = self._context_get_or_load()
 
-        parsed_url = urllib.parse.urlparse(request.endpoint)
+        parsed_url = urllib.parse.urlparse(request.url)
         path_parts = parsed_url.path.strip("/").split("/")
 
         if request.method == "GET":
@@ -423,7 +423,7 @@ class SQLMeshLanguageServer:
                         )
                 return ApiResponseGetTableDiff(data=table_diff_result)
 
-        raise NotImplementedError(f"API request not implemented: {request.endpoint}")
+        raise NotImplementedError(f"API request not implemented: {request.url}")
 
     def _custom_supported_methods(
         self, ls: LanguageServer, params: SupportedMethodsRequest

--- a/vscode/bus/src/callbacks.ts
+++ b/vscode/bus/src/callbacks.ts
@@ -51,7 +51,7 @@ export type RPCMethods = {
   }
   api_query: {
     params: {
-      endpoint: string
+      url: string
       method: string
       params: any
       body: any

--- a/vscode/extension/src/commands/tableDiff.ts
+++ b/vscode/extension/src/commands/tableDiff.ts
@@ -206,7 +206,7 @@ export function showTableDiff(
 
         return await lspClient.call_custom_method('sqlmesh/api', {
           method: 'GET',
-          endpoint: '/api/table_diff',
+          url: '/api/table_diff',
           params: {
             source: selectedSourceEnv.label,
             target: selectedTargetEnv.label,
@@ -484,7 +484,7 @@ export function showTableDiff(
 
                     return await lspClient.call_custom_method('sqlmesh/api', {
                       method: 'GET',
-                      endpoint: '/api/table_diff',
+                      url: '/api/table_diff',
                       params: {
                         source: sourceEnvironment,
                         target: targetEnvironment,

--- a/vscode/extension/src/lsp/custom.ts
+++ b/vscode/extension/src/lsp/custom.ts
@@ -50,7 +50,7 @@ interface AllModelsResponse extends BaseResponse {
 }
 
 export interface AbstractAPICallRequest {
-  endpoint: string
+  url: string
   method: string
   params: Record<string, any>
   body: Record<string, any>

--- a/vscode/react/src/api/instance.ts
+++ b/vscode/react/src/api/instance.ts
@@ -39,7 +39,7 @@ export async function fetchAPI<T = any, B extends object = any>(
   _options?: Partial<FetchOptionsWithSignal>,
 ): Promise<T & ResponseWithDetail> {
   const request = {
-    endpoint: config.url,
+    url: config.url,
     method: config.method,
     params: config.params,
     body: config.data,

--- a/vscode/react/src/components/tablediff/RerunController.tsx
+++ b/vscode/react/src/components/tablediff/RerunController.tsx
@@ -93,7 +93,7 @@ export function RerunController({
 
         const apiPromise = callRpc('api_query', {
           method: 'GET',
-          endpoint: '/api/table_diff',
+          url: '/api/table_diff',
           params: params,
           body: {},
         })


### PR DESCRIPTION
This fixes to use the url field instead of endpoint across all lsp apis for consistency