### PR TITLE
Fix(dbt_cli): Add global error handling group for dbt subcommands

### DIFF
--- a/sqlmesh_dbt/cli.py
+++ b/sqlmesh_dbt/cli.py
@@ -2,7 +2,7 @@ import typing as t
 import sys
 import click
 from sqlmesh_dbt.operations import DbtOperations, create
-from sqlmesh_dbt.error import cli_global_error_handler
+from sqlmesh_dbt.error import cli_global_error_handler, ErrorHandlingGroup
 from pathlib import Path
 from sqlmesh_dbt.options import YamlParamType
 import functools
@@ -43,7 +43,7 @@ select_option = click.option(
 exclude_option = click.option("--exclude", multiple=True, help="Specify the nodes to exclude.")
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=ErrorHandlingGroup, invoke_without_command=True)
 @click.option("--profile", help="Which existing profile to load. Overrides output.profile")
 @click.option("-t", "--target", help="Which target to load for the given profile")
 @click.option(

--- a/sqlmesh_dbt/error.py
+++ b/sqlmesh_dbt/error.py
@@ -30,7 +30,7 @@ def cli_global_error_handler(
 
 
 class ErrorHandlingGroup(click.Group):
-    def add_command(self, cmd: click.Command, name: str | None = None) -> None:
+    def add_command(self, cmd: click.Command, name: t.Optional[str] = None) -> None:
         if cmd.callback:
             cmd.callback = cli_global_error_handler(cmd.callback)
         super().add_command(cmd, name=name)

--- a/sqlmesh_dbt/error.py
+++ b/sqlmesh_dbt/error.py
@@ -27,3 +27,10 @@ def cli_global_error_handler(
                 raise
 
     return wrapper
+
+
+class ErrorHandlingGroup(click.Group):
+    def add_command(self, cmd: click.Command, name: str | None = None) -> None:
+        if cmd.callback:
+            cmd.callback = cli_global_error_handler(cmd.callback)
+        super().add_command(cmd, name=name)

--- a/tests/dbt/cli/test_global_flags.py
+++ b/tests/dbt/cli/test_global_flags.py
@@ -74,7 +74,7 @@ def test_run_error_handler(
     assert "Error: List command error" in result.output
     assert "Traceback" not in result.output
 
-    # test SQLMeshError in main command wuthout subcommand
+    # test SQLMeshError in main command without subcommand
     mock_create = mocker.patch("sqlmesh_dbt.cli.create")
     mock_create.side_effect = SQLMeshError("Failed to load project")
     result = invoke_cli(["--profile", "jaffle_shop"])

--- a/tests/dbt/cli/test_global_flags.py
+++ b/tests/dbt/cli/test_global_flags.py
@@ -2,6 +2,9 @@ import typing as t
 from pathlib import Path
 import pytest
 from click.testing import Result
+from unittest.mock import patch
+from sqlmesh.utils.errors import SQLMeshError
+from sqlglot.errors import SqlglotError
 
 pytestmark = pytest.mark.slow
 
@@ -28,3 +31,61 @@ def test_profile_and_target(jaffle_shop_duckdb: Path, invoke_cli: t.Callable[...
     result = invoke_cli(["--profile", "jaffle_shop", "--target", "dev"])
     assert result.exit_code == 0
     assert "No command specified" in result.output
+
+
+def test_run_error_handler(jaffle_shop_duckdb: Path, invoke_cli: t.Callable[..., Result]):
+    with patch("sqlmesh_dbt.operations.DbtOperations.run") as mock_run:
+        mock_run.side_effect = SQLMeshError("Test error message")
+
+        result = invoke_cli(["run"])
+
+        # tesg that SQLMeshError are handled gracefully in run command
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+
+    with patch("sqlmesh_dbt.operations.DbtOperations.run") as mock_run:
+        mock_run.side_effect = SqlglotError("Invalid SQL syntax")
+
+        result = invoke_cli(["run"])
+
+        assert result.exit_code == 1
+        assert "Error: Invalid SQL syntax" in result.output
+        assert "Traceback" not in result.output
+
+    with patch("sqlmesh_dbt.operations.DbtOperations.run") as mock_run:
+        mock_run.side_effect = ValueError("Invalid configuration value")
+
+        result = invoke_cli(["run"])
+
+        assert result.exit_code == 1
+        assert "Error: Invalid configuration value" in result.output
+        assert "Traceback" not in result.output
+
+    with patch("sqlmesh_dbt.operations.DbtOperations.list_") as mock_list:
+        mock_list.side_effect = SQLMeshError("List command error")
+
+        result = invoke_cli(["list"])
+
+        assert result.exit_code == 1
+        assert "Error: List command error" in result.output
+        assert "Traceback" not in result.output
+
+    with patch("sqlmesh_dbt.cli.create") as mock_create:
+        mock_create.side_effect = SQLMeshError("Failed to load project")
+
+        # use without subcommand
+        result = invoke_cli(["--profile", "jaffle_shop"])
+
+        assert result.exit_code == 1
+        assert "Error: Failed to load project" in result.output
+        assert "Traceback" not in result.output
+
+    with patch("sqlmesh_dbt.operations.DbtOperations.run") as mock_run:
+        mock_run.side_effect = SQLMeshError("Error with selector")
+
+        # with select option
+        result = invoke_cli(["run", "--select", "model1"])
+
+        assert result.exit_code == 1
+        assert "Error: Error with selector" in result.output
+        assert "Traceback" not in result.output


### PR DESCRIPTION
Currently the traceback is printed for the sqlmesh_dbt subcommands, this introduces a custom click group subclass that automatically wraps all subcommand callbacks with `cli_global_error_handler` ensuring error handling across the cli commands like `run`, `list` and in case more are added in the future.