### PR TITLE
Fix: Handle case where partition_by is explicitly passed in as None to dbt ModelConfig

### DIFF
--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -154,7 +154,11 @@ class ModelConfig(BaseModelConfig):
 
     @field_validator("partition_by", mode="before")
     @classmethod
-    def _validate_partition_by(cls, v: t.Any) -> t.Union[t.List[str], t.Dict[str, t.Any]]:
+    def _validate_partition_by(
+        cls, v: t.Any
+    ) -> t.Optional[t.Union[t.List[str], t.Dict[str, t.Any]]]:
+        if v is None:
+            return None
         if isinstance(v, str):
             return [v]
         if isinstance(v, list):

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -1330,6 +1330,23 @@ def test_partition_by(sushi_test_project: Project):
 
 
 @pytest.mark.xdist_group("dbt_manifest")
+def test_partition_by_none(sushi_test_project: Project):
+    context = sushi_test_project.context
+    context.target = BigQueryConfig(name="production", database="main", schema="sushi")
+    model_config = ModelConfig(
+        name="model",
+        alias="model",
+        schema="test",
+        package_name="package",
+        materialized="table",
+        unique_key="ds",
+        partition_by=None,
+        sql="""SELECT 1 AS one, ds FROM foo""",
+    )
+    assert model_config.partition_by is None
+
+
+@pytest.mark.xdist_group("dbt_manifest")
 def test_relation_info_to_relation():
     assert _relation_info_to_relation(
         {"quote_policy": {}},


### PR DESCRIPTION
partition_by is an optional field in dbt ModelConfig. Add support for handling the case when the partition_by is included in dbt model config explicitly as `None`.