### PR TITLE
Fix: properly handle empty `vars` mapping in dbt_project.yml

### DIFF
--- a/sqlmesh/dbt/project.py
+++ b/sqlmesh/dbt/project.py
@@ -99,7 +99,7 @@ class Project:
             package = package_loader.load(path.parent)
             packages[package.name] = package
 
-        all_project_variables = {**project_yaml.get("vars", {}), **(variable_overrides or {})}
+        all_project_variables = {**(project_yaml.get("vars") or {}), **(variable_overrides or {})}
         for name, package in packages.items():
             package_vars = all_project_variables.get(name)
 


### PR DESCRIPTION
The added test fails without this fix:

```
>       all_project_variables = {**project_yaml.get("vars", {}), **(variable_overrides or {})}
E       TypeError: 'NoneType' object is not a mapping
```
