### PR TITLE
feat: support custom macros in dbt vars

### DIFF
--- a/sqlmesh/dbt/context.py
+++ b/sqlmesh/dbt/context.py
@@ -101,7 +101,10 @@ class DbtContext:
         self._jinja_environment = None
 
     def set_and_render_variables(self, variables: t.Dict[str, t.Any], package: str) -> None:
-        jinja_environment = self.jinja_macros.build_environment(**self.jinja_globals)
+        package_macros = self.jinja_macros.copy(
+            update={"top_level_packages": [*self.jinja_macros.top_level_packages, package]}
+        )
+        jinja_environment = package_macros.build_environment(**self.jinja_globals)
 
         def _render_var(value: t.Any) -> t.Any:
             if isinstance(value, str):

--- a/tests/dbt/test_manifest.py
+++ b/tests/dbt/test_manifest.py
@@ -34,7 +34,11 @@ def test_manifest_helper(caplog):
         refs={"sushi.waiter_revenue_by_day", "waiter_revenue_by_day"},
         variables={"top_waiters:revenue", "top_waiters:limit"},
         model_attrs={"columns", "config"},
-        macros=[MacroReference(name="ref"), MacroReference(name="var")],
+        macros=[
+            MacroReference(name="get_top_waiters_limit"),
+            MacroReference(name="ref"),
+            MacroReference(name="var"),
+        ],
     )
     assert models["top_waiters"].materialized == "view"
     assert models["top_waiters"].dialect_ == "postgres"
@@ -181,7 +185,7 @@ def test_variable_override():
         profile.target,
         model_defaults=ModelDefaultsConfig(start="2020-01-01"),
     )
-    assert helper.models()["top_waiters"].limit_value == 10
+    assert helper.models()["top_waiters"].limit_value.strip() == "10"
 
     helper = ManifestHelper(
         project_path,

--- a/tests/fixtures/dbt/sushi_test/dbt_project.yml
+++ b/tests/fixtures/dbt/sushi_test/dbt_project.yml
@@ -39,7 +39,7 @@ sources:
     identifier: false
 
 vars:
-  top_waiters:limit: 10
+  top_waiters:limit: "{{ get_top_waiters_limit() }}"
   'top_waiters:revenue': "revenue"
 
   # The following are only used for testing purposes

--- a/tests/fixtures/dbt/sushi_test/macros/top_waiters_limit.sql
+++ b/tests/fixtures/dbt/sushi_test/macros/top_waiters_limit.sql
@@ -1,0 +1,3 @@
+{% macro get_top_waiters_limit() %}
+10
+{% endmacro %}


### PR DESCRIPTION
Prior to this PR, the dbt adapter didn't support references to custom macros in the project variables. This adds that support. 