### PR TITLE
Chore: Allow duplicate keys in dbt project yaml files

### DIFF
--- a/sqlmesh/dbt/common.py
+++ b/sqlmesh/dbt/common.py
@@ -36,7 +36,9 @@ JINJA_ONLY = {
 
 def load_yaml(source: str | Path) -> t.Dict:
     try:
-        return load(source, render_jinja=False)
+        return load(
+            source, render_jinja=False, allow_duplicate_keys=True, keep_last_duplicate_key=True
+        )
     except DuplicateKeyError as ex:
         raise ConfigError(f"{source}: {ex}" if isinstance(source, Path) else f"{ex}")
 

--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -45,3 +45,37 @@ def test_yaml() -> None:
 
     decimal_value = Decimal(123.45)
     assert yaml.load(yaml.dump(decimal_value)) == str(decimal_value)
+
+
+def test_load_keep_last_duplicate_key() -> None:
+    input_str = """
+name: first_name
+name: second_name
+name: third_name
+
+foo: bar
+
+mapping:
+    key: first_value
+    key: second_value
+    key: third_value
+
+sequence:
+    - one
+    - two
+"""
+    # Default behavior of ruamel is to keep the first key encountered
+    assert yaml.load(input_str, allow_duplicate_keys=True) == {
+        "name": "first_name",
+        "foo": "bar",
+        "mapping": {"key": "first_value"},
+        "sequence": ["one", "two"],
+    }
+
+    # Test keeping last key
+    assert yaml.load(input_str, allow_duplicate_keys=True, keep_last_duplicate_key=True) == {
+        "name": "third_name",
+        "foo": "bar",
+        "mapping": {"key": "third_value"},
+        "sequence": ["one", "two"],
+    }


### PR DESCRIPTION
dbt allows duplicate keys, although newer versions emit a deprecation warning. This PR updates yaml loading of dbt projects to also allow duplicate keys and to keep the last value of duplicate keys, matching pyyaml's behavior.