### PR TITLE
fix: pydantic v1 issues with dbt 1.6 semantic models

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -92,6 +92,44 @@ jobs:
         # of DuckDB require a version of DuckDB we no longer support
         run: |
           source .venv/bin/activate
+
+          # Remove semantic_models and metrics sections for DBT versions < 1.6.0
+          # Using explicit list to avoid version comparison issues
+          if [[ "${{ matrix.dbt-version }}" == "1.3" ]] || \
+             [[ "${{ matrix.dbt-version }}" == "1.4" ]] || \
+             [[ "${{ matrix.dbt-version }}" == "1.5" ]]; then
+            
+            echo "DBT version is ${{ matrix.dbt-version }} (< 1.6.0), removing semantic_models and metrics sections..."
+            
+            schema_file="tests/fixtures/dbt/sushi_test/models/schema.yml"
+            if [[ -f "$schema_file" ]]; then
+              echo "Modifying $schema_file..."
+              
+              # Create a temporary file
+              temp_file=$(mktemp)
+              
+              # Use awk to remove semantic_models and metrics sections
+              awk '
+                /^semantic_models:/ { in_semantic=1; next }
+                /^metrics:/ { in_metrics=1; next }
+                /^[^ ]/ && (in_semantic || in_metrics) { 
+                  in_semantic=0; 
+                  in_metrics=0 
+                }
+                !in_semantic && !in_metrics { print }
+              ' "$schema_file" > "$temp_file"
+              
+              # Move the temp file back
+              mv "$temp_file" "$schema_file"
+              
+              echo "Successfully removed semantic_models and metrics sections"
+            else
+              echo "Schema file not found at $schema_file, skipping..."
+            fi
+          else
+            echo "DBT version is ${{ matrix.dbt-version }} (>= 1.6.0), keeping semantic_models and metrics sections"
+          fi
+
           make dbt-fast-test
       - name: Test SQLMesh info in sushi_dbt
         working-directory: ./examples/sushi_dbt
@@ -104,4 +142,5 @@ jobs:
           else
             echo "DBT version is ${{ matrix.dbt-version }} (>= 1.5.0), keeping version parameters"
           fi
+
           sqlmesh info --skip-connection

--- a/tests/fixtures/dbt/sushi_test/models/schema.yml
+++ b/tests/fixtures/dbt/sushi_test/models/schema.yml
@@ -52,3 +52,23 @@ sources:
     tables:
       - name: items
       - name: orders
+
+semantic_models:
+  - name: top_waiters
+    description: Some description
+    model: ref('top_waiters')
+    measures:
+      - name: total_waiters
+        agg: sum
+        expr: waiter
+    dimensions:
+      - name: waiter
+        type: categorical
+
+metrics:
+  - name: some_waiter_thing
+    description: Something
+    type: simple
+    label: testing
+    type_params:
+      measure: total_waiters


### PR DESCRIPTION
dbt 1.6 requires Pydantic v1 but this is just to support semantic models. Prior to this change, if a user is on 1.6 and has a semantic model they will get a Pydantic error trying to validate their semantic models since it expects v1 but we forced v2. 

This PR disables Semantic Models for 1.6+. It does this by disabling the validation that happens on manifest load and then removes any loaded semantic models from the manifest. This ensures we don't interact with these objects going forward. 

This PR could be adjusted to just remove semantic models for 1.6 and leave them for 1.7+ but I don't see why the SQLMesh adapter would care about semantic models so it seems better to remove them entirely. 