### PR TITLE
Fix!: Avoid using rendered query when computing the data hash

### DIFF
--- a/sqlmesh/core/context_diff.py
+++ b/sqlmesh/core/context_diff.py
@@ -435,7 +435,7 @@ class ContextDiff(PydanticModel):
             return False
 
         current, previous = self.modified_snapshots[name]
-        return current.fingerprint.data_hash != previous.fingerprint.data_hash
+        return current.is_directly_modified(previous)
 
     def indirectly_modified(self, name: str) -> bool:
         """Returns whether or not a node was indirectly modified in this context.
@@ -451,10 +451,7 @@ class ContextDiff(PydanticModel):
             return False
 
         current, previous = self.modified_snapshots[name]
-        return (
-            current.fingerprint.data_hash == previous.fingerprint.data_hash
-            and current.fingerprint.parent_data_hash != previous.fingerprint.parent_data_hash
-        )
+        return current.is_indirectly_modified(previous)
 
     def metadata_updated(self, name: str) -> bool:
         """Returns whether or not the given node's metadata has been updated.
@@ -470,7 +467,7 @@ class ContextDiff(PydanticModel):
             return False
 
         current, previous = self.modified_snapshots[name]
-        return current.fingerprint.metadata_hash != previous.fingerprint.metadata_hash
+        return current.is_metadata_updated(previous)
 
     def text_diff(self, name: str) -> str:
         """Finds the difference of a node between the current and remote environment.

--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -21,7 +21,7 @@ from sqlmesh.utils.metaprogramming import (
     prepare_env,
     serialize_env,
 )
-from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator
+from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator, get_dialect
 
 if t.TYPE_CHECKING:
     from sqlglot.dialects.dialect import DialectType
@@ -663,3 +663,51 @@ depends_on_validator: t.Callable = field_validator(
     mode="before",
     check_fields=False,
 )(depends_on)
+
+
+class ParsableSql(PydanticModel):
+    sql: str
+
+    _parsed: t.Optional[exp.Expression] = None
+    _parsed_dialect: t.Optional[str] = None
+
+    def parse(self, dialect: str) -> exp.Expression:
+        if self._parsed is None or self._parsed_dialect != dialect:
+            self._parsed = d.parse_one(self.sql, dialect=dialect)
+            self._parsed_dialect = dialect
+        return self._parsed
+
+    @classmethod
+    def from_parsed_expression(
+        cls, parsed_expression: exp.Expression, dialect: str, use_meta_sql: bool = False
+    ) -> ParsableSql:
+        sql = (
+            parsed_expression.meta.get("sql") or parsed_expression.sql(dialect=dialect)
+            if use_meta_sql
+            else parsed_expression.sql(dialect=dialect)
+        )
+        result = cls(sql=sql)
+        result._parsed = parsed_expression
+        result._parsed_dialect = dialect
+        return result
+
+    @classmethod
+    def validator(cls) -> classmethod:
+        def _validate_parsable_sql(v: t.Any, info: ValidationInfo) -> ParsableSql:
+            if isinstance(v, str):
+                return ParsableSql(sql=v)
+            if isinstance(v, exp.Expression):
+                return ParsableSql.from_parsed_expression(
+                    v, get_dialect(info.data), use_meta_sql=False
+                )
+            return ParsableSql.parse_obj(v)
+
+        return field_validator(
+            "query_",
+            # "expressions_",
+            # "pre_statements_",
+            # "post_statements_",
+            # "on_virtual_update_",
+            mode="before",
+            check_fields=False,
+        )(_validate_parsable_sql)

--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -616,11 +616,6 @@ def parse_strings_with_macro_refs(value: t.Any, dialect: DialectType) -> t.Any:
 
 
 expression_validator: t.Callable = field_validator(
-    # "query",
-    # "expressions_",
-    "pre_statements_",
-    "post_statements_",
-    "on_virtual_update_",
     "unique_key",
     mode="before",
     check_fields=False,
@@ -719,9 +714,9 @@ class ParsableSql(PydanticModel):
         return field_validator(
             "query_",
             "expressions_",
-            # "pre_statements_",
-            # "post_statements_",
-            # "on_virtual_update_",
+            "pre_statements_",
+            "post_statements_",
+            "on_virtual_update_",
             mode="before",
             check_fields=False,
         )(_validate_parsable_sql)

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -540,15 +540,15 @@ class _Model(ModelMeta, frozen=True):
 
     @property
     def pre_statements(self) -> t.List[exp.Expression]:
-        return self._get_statements("pre_statements_")
+        return self._get_parsed_statements("pre_statements_")
 
     @property
     def post_statements(self) -> t.List[exp.Expression]:
-        return self._get_statements("post_statements_")
+        return self._get_parsed_statements("post_statements_")
 
     @property
     def on_virtual_update(self) -> t.List[exp.Expression]:
-        return self._get_statements("on_virtual_update_")
+        return self._get_parsed_statements("on_virtual_update_")
 
     @property
     def macro_definitions(self) -> t.List[d.MacroDef]:
@@ -559,7 +559,7 @@ class _Model(ModelMeta, frozen=True):
             if isinstance(s, d.MacroDef)
         ]
 
-    def _get_statements(self, attr_name: str) -> t.List[exp.Expression]:
+    def _get_parsed_statements(self, attr_name: str) -> t.List[exp.Expression]:
         value = getattr(self, attr_name)
         if not value:
             return []
@@ -1060,10 +1060,10 @@ class _Model(ModelMeta, frozen=True):
             else:
                 for this_statement, other_statement in zip(this_statements, other_statements):
                     this_rendered = (
-                        self._statement_renderer(this_statement).render() or this_statement.sql
+                        self._statement_renderer(this_statement).render() or this_statement
                     )
                     other_rendered = (
-                        other._statement_renderer(other_statement).render() or other_statement.sql
+                        other._statement_renderer(other_statement).render() or other_statement
                     )
                     if this_rendered != other_rendered:
                         is_metadata_change = False
@@ -1092,8 +1092,9 @@ class _Model(ModelMeta, frozen=True):
     def _data_hash_values_sql(self) -> t.List[str]:
         data = []
 
-        for statement in [*(self.pre_statements_ or []), *(self.post_statements_ or [])]:
-            data.append(statement.sql)
+        for statements in [self.pre_statements_, self.post_statements_]:
+            for statement in statements or []:
+                data.append(statement.sql)
 
         return data
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2297,6 +2297,7 @@ Learn more at https://sqlmesh.readthedocs.io/en/stable/concepts/models/overview
         variables=variables,
         inline_audits=inline_audits,
         blueprint_variables=blueprint_variables,
+        use_original_sql=True,
         **meta_fields,
     )
 
@@ -2519,6 +2520,7 @@ def _create_model(
     signal_definitions: t.Optional[SignalRegistry] = None,
     variables: t.Optional[t.Dict[str, t.Any]] = None,
     blueprint_variables: t.Optional[t.Dict[str, t.Any]] = None,
+    use_original_sql: bool = False,
     **kwargs: t.Any,
 ) -> Model:
     validate_extra_and_required_fields(
@@ -2555,7 +2557,7 @@ def _create_model(
     if "query" in kwargs:
         statements.append(kwargs["query"])
         kwargs["query"] = ParsableSql.from_parsed_expression(
-            kwargs["query"], dialect, use_meta_sql=True
+            kwargs["query"], dialect, use_meta_sql=use_original_sql
         )
 
     # Merge default statements with model-specific statements
@@ -2569,7 +2571,7 @@ def _create_model(
             is_metadata = statement_field == "on_virtual_update"
             statements.extend((stmt, is_metadata) for stmt in kwargs[statement_field])
             kwargs[statement_field] = [
-                ParsableSql.from_parsed_expression(stmt, dialect, use_meta_sql=True)
+                ParsableSql.from_parsed_expression(stmt, dialect, use_meta_sql=use_original_sql)
                 for stmt in kwargs[statement_field]
             ]
 

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -25,7 +25,6 @@ from sqlmesh.core.node import IntervalUnit
 from sqlmesh.core.macros import MacroRegistry, macro
 from sqlmesh.core.model.common import (
     ParsableSql,
-    expression_validator,
     make_python_env,
     parse_dependencies,
     parse_strings_with_macro_refs,
@@ -152,21 +151,17 @@ class _Model(ModelMeta, frozen=True):
     audit_definitions: t.Dict[str, ModelAudit] = {}
     mapping_schema: t.Dict[str, t.Any] = {}
     extract_dependencies_from_query: bool = True
-
-    _full_depends_on: t.Optional[t.Set[str]] = None
-    _statement_renderer_cache: t.Dict[int, ExpressionRenderer] = {}
-
-    pre_statements_: t.Optional[t.List[exp.Expression]] = Field(
-        default=None, alias="pre_statements"
-    )
-    post_statements_: t.Optional[t.List[exp.Expression]] = Field(
-        default=None, alias="post_statements"
-    )
-    on_virtual_update_: t.Optional[t.List[exp.Expression]] = Field(
+    pre_statements_: t.Optional[t.List[ParsableSql]] = Field(default=None, alias="pre_statements")
+    post_statements_: t.Optional[t.List[ParsableSql]] = Field(default=None, alias="post_statements")
+    on_virtual_update_: t.Optional[t.List[ParsableSql]] = Field(
         default=None, alias="on_virtual_update"
     )
 
-    _expressions_validator = expression_validator
+    _full_depends_on: t.Optional[t.Set[str]] = None
+    _statement_renderer_cache: t.Dict[int, ExpressionRenderer] = {}
+    _is_metadata_only_change_cache: t.Dict[int, bool] = {}
+
+    _expressions_validator = ParsableSql.validator()
 
     def __getstate__(self) -> t.Dict[t.Any, t.Any]:
         state = super().__getstate__()
@@ -545,15 +540,15 @@ class _Model(ModelMeta, frozen=True):
 
     @property
     def pre_statements(self) -> t.List[exp.Expression]:
-        return self.pre_statements_ or []
+        return self._get_statements("pre_statements_")
 
     @property
     def post_statements(self) -> t.List[exp.Expression]:
-        return self.post_statements_ or []
+        return self._get_statements("post_statements_")
 
     @property
     def on_virtual_update(self) -> t.List[exp.Expression]:
-        return self.on_virtual_update_ or []
+        return self._get_statements("on_virtual_update_")
 
     @property
     def macro_definitions(self) -> t.List[d.MacroDef]:
@@ -563,6 +558,17 @@ class _Model(ModelMeta, frozen=True):
             for s in self.pre_statements + self.post_statements + self.on_virtual_update
             if isinstance(s, d.MacroDef)
         ]
+
+    def _get_statements(self, attr_name: str) -> t.List[exp.Expression]:
+        value = getattr(self, attr_name)
+        if not value:
+            return []
+        result = []
+        for v in value:
+            parsed = v.parse(self.dialect)
+            if not isinstance(parsed, exp.Semicolon):
+                result.append(parsed)
+        return result
 
     def _render_statements(
         self,
@@ -1027,6 +1033,45 @@ class _Model(ModelMeta, frozen=True):
         """
         raise NotImplementedError
 
+    def is_metadata_only_change(self, other: _Node) -> bool:
+        if self._is_metadata_only_change_cache.get(id(other), None) is not None:
+            return self._is_metadata_only_change_cache[id(other)]
+
+        is_metadata_change = True
+        if (
+            not isinstance(other, _Model)
+            or self.metadata_hash == other.metadata_hash
+            or self._data_hash_values_no_sql != other._data_hash_values_no_sql
+        ):
+            is_metadata_change = False
+        else:
+            this_statements = [
+                s
+                for s in [*self.pre_statements, *self.post_statements]
+                if not self._is_metadata_statement(s)
+            ]
+            other_statements = [
+                s
+                for s in [*other.pre_statements, *other.post_statements]
+                if not other._is_metadata_statement(s)
+            ]
+            if len(this_statements) != len(other_statements):
+                is_metadata_change = False
+            else:
+                for this_statement, other_statement in zip(this_statements, other_statements):
+                    this_rendered = (
+                        self._statement_renderer(this_statement).render() or this_statement.sql
+                    )
+                    other_rendered = (
+                        other._statement_renderer(other_statement).render() or other_statement.sql
+                    )
+                    if this_rendered != other_rendered:
+                        is_metadata_change = False
+                        break
+
+        self._is_metadata_only_change_cache[id(other)] = is_metadata_change
+        return is_metadata_change
+
     @property
     def data_hash(self) -> str:
         """
@@ -1041,6 +1086,19 @@ class _Model(ModelMeta, frozen=True):
 
     @property
     def _data_hash_values(self) -> t.List[str]:
+        return self._data_hash_values_no_sql + self._data_hash_values_sql
+
+    @property
+    def _data_hash_values_sql(self) -> t.List[str]:
+        data = []
+
+        for statement in [*(self.pre_statements_ or []), *(self.post_statements_ or [])]:
+            data.append(statement.sql)
+
+        return data
+
+    @property
+    def _data_hash_values_no_sql(self) -> t.List[str]:
         data = [
             str(  # Exclude metadata only macro funcs
                 [(k, v) for k, v in self.sorted_python_env if not v.is_metadata]
@@ -1068,18 +1126,6 @@ class _Model(ModelMeta, frozen=True):
             data.append(key)
             data.append(gen(value))
 
-        for statement in (*self.pre_statements, *self.post_statements):
-            statement_exprs: t.List[exp.Expression] = []
-            if not isinstance(statement, d.MacroDef):
-                rendered = self._statement_renderer(statement).render()
-                if self._is_metadata_statement(statement):
-                    continue
-                if rendered:
-                    statement_exprs = rendered
-                else:
-                    statement_exprs = [statement]
-            data.extend(gen(e) for e in statement_exprs)
-
         return data  # type: ignore
 
     def _audit_metadata_hash_values(self) -> t.List[str]:
@@ -1095,13 +1141,9 @@ class _Model(ModelMeta, frozen=True):
                     metadata.append(gen(arg_value))
             else:
                 audit = self.audit_definitions[audit_name]
-                query = (
-                    self.render_audit_query(audit, **t.cast(t.Dict[str, t.Any], audit_args))
-                    or audit.query
-                )
                 metadata.extend(
                     [
-                        gen(query),
+                        audit.query_.sql,
                         audit.dialect,
                         str(audit.skip),
                         str(audit.blocking),
@@ -1172,12 +1214,9 @@ class _Model(ModelMeta, frozen=True):
         if metadata_only_macros:
             additional_metadata.append(str(metadata_only_macros))
 
-        for statement in (*self.pre_statements, *self.post_statements):
-            if self._is_metadata_statement(statement):
-                additional_metadata.append(gen(statement))
-
-        for statement in self.on_virtual_update:
-            additional_metadata.append(gen(statement))
+        for statements in [self.pre_statements_, self.post_statements_, self.on_virtual_update_]:
+            for statement in statements or []:
+                additional_metadata.append(statement.sql)
 
         return additional_metadata
 
@@ -1279,9 +1318,7 @@ class SqlModel(_Model):
     query_: ParsableSql = Field(alias="query")
     source_type: t.Literal["sql"] = "sql"
 
-    _query_validator = ParsableSql.validator()
     _columns_to_types: t.Optional[t.Dict[str, exp.DataType]] = None
-    _is_metadata_only_change_cache: t.Dict[int, bool] = {}
 
     def __getstate__(self) -> t.Dict[t.Any, t.Any]:
         state = super().__getstate__()
@@ -1513,19 +1550,16 @@ class SqlModel(_Model):
         if self._is_metadata_only_change_cache.get(id(previous), None) is not None:
             return self._is_metadata_only_change_cache[id(previous)]
 
-        if (
-            not isinstance(previous, SqlModel)
-            or self.metadata_hash == previous.metadata_hash
-            or self._data_hash_values_no_query != previous._data_hash_values_no_query
-        ):
-            is_metadata_change = False
-        else:
-            # If the rendered queries are the same, then this is a metadata only change
-            this_rendered_query = self.render_query()
-            previous_rendered_query = previous.render_query()
-            is_metadata_change = (
-                this_rendered_query is not None and this_rendered_query == previous_rendered_query
-            )
+        if not super().is_metadata_only_change(previous):
+            return False
+
+        if not isinstance(previous, SqlModel):
+            self._is_metadata_only_change_cache[id(previous)] = False
+            return False
+
+        this_rendered_query = self.render_query() or self.query
+        previous_rendered_query = previous.render_query() or previous.query
+        is_metadata_change = this_rendered_query == previous_rendered_query
 
         self._is_metadata_only_change_cache[id(previous)] = is_metadata_change
         return is_metadata_change
@@ -1549,22 +1583,22 @@ class SqlModel(_Model):
         )
 
     @property
-    def _data_hash_values_no_query(self) -> t.List[str]:
+    def _data_hash_values_no_sql(self) -> t.List[str]:
         return [
-            *super()._data_hash_values,
+            *super()._data_hash_values_no_sql,
             *self.jinja_macros.data_hash_values,
         ]
 
     @property
-    def _data_hash_values(self) -> t.List[str]:
+    def _data_hash_values_sql(self) -> t.List[str]:
         return [
-            *self._data_hash_values_no_query,
-            gen(self.query, comments=False),
+            *super()._data_hash_values_sql,
+            self.query_.sql,
         ]
 
     @property
     def _additional_metadata(self) -> t.List[str]:
-        return [*super()._additional_metadata, gen(self.query, comments=True)]
+        return [*super()._additional_metadata, self.query_.sql]
 
     @property
     def violated_rules_for_query(self) -> t.Dict[type[Rule], t.Any]:
@@ -1788,8 +1822,8 @@ class SeedModel(_Model):
         return self.seed.reader(dialect=self.dialect, settings=self.kind.csv_settings)
 
     @property
-    def _data_hash_values(self) -> t.List[str]:
-        data = super()._data_hash_values
+    def _data_hash_values_no_sql(self) -> t.List[str]:
+        data = super()._data_hash_values_no_sql
         for column_name, column_hash in self.column_hashes.items():
             data.append(column_name)
             data.append(column_hash)
@@ -1882,8 +1916,8 @@ class PythonModel(_Model):
         return None
 
     @property
-    def _data_hash_values(self) -> t.List[str]:
-        data = super()._data_hash_values
+    def _data_hash_values_no_sql(self) -> t.List[str]:
+        data = super()._data_hash_values_no_sql
         data.append(self.entrypoint)
         return data
 
@@ -2287,7 +2321,6 @@ Learn more at https://sqlmesh.readthedocs.io/en/stable/concepts/models/overview
 def create_sql_model(
     name: TableName,
     query: t.Optional[exp.Expression],
-    dialect: t.Optional[str] = None,
     **kwargs: t.Any,
 ) -> Model:
     """Creates a SQL model.
@@ -2304,14 +2337,7 @@ def create_sql_model(
         )
         assert isinstance(query, (exp.Query, d.JinjaQuery, d.MacroFunc))
 
-    dialect = dialect or ""
-    return _create_model(
-        SqlModel,
-        name,
-        query=ParsableSql.from_parsed_expression(query, dialect, use_meta_sql=True),
-        dialect=dialect,
-        **kwargs,
-    )
+    return _create_model(SqlModel, name, query=query, **kwargs)
 
 
 def create_seed_model(
@@ -2525,34 +2551,26 @@ def _create_model(
 
     statements: t.List[t.Union[exp.Expression, t.Tuple[exp.Expression, bool]]] = []
 
-    # Merge default pre_statements with model-specific pre_statements
-    if "pre_statements" in defaults:
-        kwargs["pre_statements"] = [
-            exp.maybe_parse(stmt, dialect=dialect) for stmt in defaults["pre_statements"]
-        ] + kwargs.get("pre_statements", [])
-
-    # Merge default post_statements with model-specific post_statements
-    if "post_statements" in defaults:
-        kwargs["post_statements"] = [
-            exp.maybe_parse(stmt, dialect=dialect) for stmt in defaults["post_statements"]
-        ] + kwargs.get("post_statements", [])
-
-    # Merge default on_virtual_update with model-specific on_virtual_update
-    if "on_virtual_update" in defaults:
-        kwargs["on_virtual_update"] = [
-            exp.maybe_parse(stmt, dialect=dialect) for stmt in defaults["on_virtual_update"]
-        ] + kwargs.get("on_virtual_update", [])
-
-    if "pre_statements" in kwargs:
-        statements.extend(kwargs["pre_statements"])
     if "query" in kwargs:
-        statements.append(kwargs["query"].parse(dialect))
-    if "post_statements" in kwargs:
-        statements.extend(kwargs["post_statements"])
+        statements.append(kwargs["query"])
+        kwargs["query"] = ParsableSql.from_parsed_expression(
+            kwargs["query"], dialect, use_meta_sql=True
+        )
 
-    # Macros extracted from these statements need to be treated as metadata only
-    if "on_virtual_update" in kwargs:
-        statements.extend((stmt, True) for stmt in kwargs["on_virtual_update"])
+    # Merge default statements with model-specific statements
+    for statement_field in ["pre_statements", "post_statements", "on_virtual_update"]:
+        if statement_field in defaults:
+            kwargs[statement_field] = [
+                exp.maybe_parse(stmt, dialect=dialect) for stmt in defaults[statement_field]
+            ] + kwargs.get(statement_field, [])
+        if statement_field in kwargs:
+            # Macros extracted from these statements need to be treated as metadata only
+            is_metadata = statement_field == "on_virtual_update"
+            statements.extend((stmt, is_metadata) for stmt in kwargs[statement_field])
+            kwargs[statement_field] = [
+                ParsableSql.from_parsed_expression(stmt, dialect, use_meta_sql=True)
+                for stmt in kwargs[statement_field]
+            ]
 
     # This is done to allow variables like @gateway to be used in these properties
     # since rendering shifted from load time to run time.

--- a/sqlmesh/core/node.py
+++ b/sqlmesh/core/node.py
@@ -308,16 +308,6 @@ class _Node(PydanticModel):
         return None
 
     @property
-    def data_hash(self) -> str:
-        """
-        Computes the data hash for the node.
-
-        Returns:
-            The data hash for the node.
-        """
-        raise NotImplementedError
-
-    @property
     def interval_unit(self) -> IntervalUnit:
         """Returns the interval unit using which data intervals are computed for this node."""
         if self.interval_unit_ is not None:
@@ -333,6 +323,16 @@ class _Node(PydanticModel):
         return self.name
 
     @property
+    def data_hash(self) -> str:
+        """
+        Computes the data hash for the node.
+
+        Returns:
+            The data hash for the node.
+        """
+        raise NotImplementedError
+
+    @property
     def metadata_hash(self) -> str:
         """
         Computes the metadata hash for the node.
@@ -341,6 +341,30 @@ class _Node(PydanticModel):
             The metadata hash for the node.
         """
         raise NotImplementedError
+
+    def is_metadata_only_change(self, previous: _Node) -> bool:
+        """Determines if this node is a metadata only change in relation to the `previous` node.
+
+        Args:
+            previous: The previous node to compare against.
+
+        Returns:
+            True if this node is a metadata only change, False otherwise.
+        """
+        return self.data_hash == previous.data_hash and self.metadata_hash != previous.metadata_hash
+
+    def is_data_change(self, previous: _Node) -> bool:
+        """Determines if this node is a data change in relation to the `previous` node.
+
+        Args:
+            previous: The previous node to compare against.
+
+        Returns:
+            True if this node is a data change, False otherwise.
+        """
+        return (
+            self.data_hash != previous.data_hash or self.metadata_hash != previous.metadata_hash
+        ) and not self.is_metadata_only_change(previous)
 
     def croniter(self, value: TimeLike) -> CroniterCache:
         if self._croniter is None:

--- a/sqlmesh/core/snapshot/categorizer.py
+++ b/sqlmesh/core/snapshot/categorizer.py
@@ -47,11 +47,12 @@ def categorize_change(
     if type(new_model) != type(old_model):
         return default_category
 
-    if new.fingerprint.data_hash == old.fingerprint.data_hash:
-        if new.fingerprint.metadata_hash == old.fingerprint.metadata_hash:
-            raise SQLMeshError(
-                f"{new} is unmodified or indirectly modified and should not be categorized"
-            )
+    if new.fingerprint == old.fingerprint:
+        raise SQLMeshError(
+            f"{new} is unmodified or indirectly modified and should not be categorized"
+        )
+
+    if not new.is_directly_modified(old):
         if new.fingerprint.parent_data_hash == old.fingerprint.parent_data_hash:
             return SnapshotChangeCategory.NON_BREAKING
         return None

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1230,6 +1230,21 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
             )
             self.intervals = remove_interval(self.intervals, *pending_restatement_interval)
 
+    def is_directly_modified(self, other: Snapshot) -> bool:
+        """Returns whether or not this snapshot is directly modified in relation to the other snapshot."""
+        return self.node.is_data_change(other.node)
+
+    def is_indirectly_modified(self, other: Snapshot) -> bool:
+        """Returns whether or not this snapshot is indirectly modified in relation to the other snapshot."""
+        return (
+            self.fingerprint.parent_data_hash != other.fingerprint.parent_data_hash
+            and not self.node.is_data_change(other.node)
+        )
+
+    def is_metadata_updated(self, other: Snapshot) -> bool:
+        """Returns whether or not this snapshot contains metadata changes in relation to the other snapshot."""
+        return self.fingerprint.metadata_hash != other.fingerprint.metadata_hash
+
     @property
     def physical_schema(self) -> str:
         if self.physical_schema_ is not None:

--- a/sqlmesh/migrations/v0093_use_raw_sql_in_fingerprint.py
+++ b/sqlmesh/migrations/v0093_use_raw_sql_in_fingerprint.py
@@ -1,0 +1,5 @@
+"""Use the raw SQL when computing the model fingerprint."""
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0093_use_unrendered_query_in_fingerprint.py
+++ b/sqlmesh/migrations/v0093_use_unrendered_query_in_fingerprint.py
@@ -1,0 +1,5 @@
+"""Use the unrendered query when computing the model fingerprint."""
+
+
+def migrate(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0093_use_unrendered_query_in_fingerprint.py
+++ b/sqlmesh/migrations/v0093_use_unrendered_query_in_fingerprint.py
@@ -1,5 +1,0 @@
-"""Use the unrendered query when computing the model fingerprint."""
-
-
-def migrate(state_sync, **kwargs):  # type: ignore
-    pass

--- a/tests/core/state_sync/test_export_import.py
+++ b/tests/core/state_sync/test_export_import.py
@@ -289,8 +289,8 @@ def test_export_local_state(
     full_model = next(s for s in snapshots if "full_model" in s["name"])
     new_model = next(s for s in snapshots if "new_model" in s["name"])
 
-    assert "'1' as modified" in full_model["node"]["query"]
-    assert "SELECT 1 as id" in new_model["node"]["query"]
+    assert "'1' as modified" in full_model["node"]["query"]["sql"]
+    assert "SELECT 1 as id" in new_model["node"]["query"]["sql"]
 
 
 def test_import_invalid_file(tmp_path: Path, state_sync: StateSync) -> None:

--- a/tests/core/test_audit.py
+++ b/tests/core/test_audit.py
@@ -80,6 +80,8 @@ def test_load(assert_exp_eq):
         col IS NULL
     """,
     )
+    assert audit.query_._parsed is not None
+    assert audit.query_._parsed_dialect == "spark"
 
 
 def test_load_standalone(assert_exp_eq):
@@ -121,6 +123,8 @@ def test_load_standalone(assert_exp_eq):
         col IS NULL
     """,
     )
+    assert audit.query_._parsed is not None
+    assert audit.query_._parsed_dialect == "spark"
 
 
 def test_load_standalone_default_catalog(assert_exp_eq):

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -39,6 +39,7 @@ from sqlmesh.core.environment import Environment, EnvironmentNamingInfo, Environ
 from sqlmesh.core.plan.definition import Plan
 from sqlmesh.core.macros import MacroEvaluator, RuntimeStage
 from sqlmesh.core.model import load_sql_based_model, model, SqlModel, Model
+from sqlmesh.core.model.common import ParsableSql
 from sqlmesh.core.model.cache import OptimizedQueryCache
 from sqlmesh.core.renderer import render_statements
 from sqlmesh.core.model.kind import ModelKindName
@@ -2303,7 +2304,10 @@ def test_prompt_if_uncategorized_snapshot(mocker: MockerFixture, tmp_path: Path)
     incremental_model = context.get_model("sqlmesh_example.incremental_model")
     incremental_model_query = incremental_model.render_query()
     new_incremental_model_query = t.cast(exp.Select, incremental_model_query).select("1 AS z")
-    context.upsert_model("sqlmesh_example.incremental_model", query=new_incremental_model_query)
+    context.upsert_model(
+        "sqlmesh_example.incremental_model",
+        query_=ParsableSql(sql=new_incremental_model_query.sql(dialect=incremental_model.dialect)),
+    )
 
     mock_console = mocker.Mock()
     spy_plan = mocker.spy(mock_console, "plan")

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -6670,11 +6670,12 @@ def change_data_type(
     assert model is not None
 
     if isinstance(model, SqlModel):
-        data_types = model.query.find_all(DataType)
+        query = model.query.copy()
+        data_types = query.find_all(DataType)
         for data_type in data_types:
             if data_type.this == old_type:
                 data_type.set("this", new_type)
-        context.upsert_model(model_name, query_=model.query_)
+        context.upsert_model(model_name, query_=ParsableSql(sql=query.sql(dialect=model.dialect)))
     elif model.columns_to_types_ is not None:
         for k, v in model.columns_to_types_.items():
             if v.this == old_type:

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -6961,7 +6961,15 @@ def test_destroy(copy_to_temp_path):
 
     model = context.get_model("db_1.first_schema.model_one")
 
-    context.upsert_model(model.copy(update={"query": model.query.select("'c' AS extra")}))
+    context.upsert_model(
+        model.copy(
+            update={
+                "query_": ParsableSql(
+                    sql=model.query.select("'c' AS extra").sql(dialect=model.dialect)
+                )
+            }
+        )
+    )
     plan = context.plan_builder().build()
     context.apply(plan)
 
@@ -6972,9 +6980,25 @@ def test_destroy(copy_to_temp_path):
 
     # Create dev environment with changed models
     model = context.get_model("db_2.second_schema.model_one")
-    context.upsert_model(model.copy(update={"query": model.query.select("'d' AS extra")}))
+    context.upsert_model(
+        model.copy(
+            update={
+                "query_": ParsableSql(
+                    sql=model.query.select("'d' AS extra").sql(dialect=model.dialect)
+                )
+            }
+        )
+    )
     model = context.get_model("first_schema.model_two")
-    context.upsert_model(model.copy(update={"query": model.query.select("'d2' AS col")}))
+    context.upsert_model(
+        model.copy(
+            update={
+                "query_": ParsableSql(
+                    sql=model.query.select("'d2' AS col").sql(dialect=model.dialect)
+                )
+            }
+        )
+    )
     plan = context.plan_builder("dev").build()
     context.apply(plan)
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -5732,7 +5732,7 @@ def test_default_catalog_sql(assert_exp_eq):
     The system is not designed to actually support having an engine that doesn't support default catalog
     to start supporting it or the reverse of that. If that did happen then bugs would occur.
     """
-    HASH_WITH_CATALOG = "1269513823"
+    HASH_WITH_CATALOG = "3443912775"
 
     # Test setting default catalog doesn't change hash if it matches existing logic
     expressions = d.parse(

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -22,6 +22,7 @@ from sqlmesh.core import constants as c
 from sqlmesh.core import dialect as d
 from sqlmesh.core.console import get_console
 from sqlmesh.core.audit import ModelAudit, load_audit
+from sqlmesh.core.model.common import ParsableSql
 from sqlmesh.core.config import (
     Config,
     DuckDBConnectionConfig,
@@ -8874,7 +8875,9 @@ def test_column_description_metadata_change():
     context.upsert_model(model)
     context.plan(no_prompts=True, auto_apply=True)
 
-    context.upsert_model("db.test_model", query=parse_one("SELECT 1 AS id /* description 2 */"))
+    context.upsert_model(
+        "db.test_model", query_=ParsableSql(sql="SELECT 1 AS id /* description 2 */")
+    )
     plan = context.plan(no_prompts=True, auto_apply=True)
 
     snapshots = list(plan.snapshots.values())

--- a/tests/core/test_selector.py
+++ b/tests/core/test_selector.py
@@ -301,7 +301,7 @@ def test_select_change_schema(mocker: MockerFixture, make_snapshot):
     selector = Selector(state_reader_mock, local_models)
 
     selected = selector.select_models(["db.parent"], env_name)
-    assert selected[local_child.fqn].data_hash != child.data_hash
+    assert selected[local_child.fqn].render_query() != child.render_query()
 
     _assert_models_equal(
         selected,

--- a/tests/core/test_selector.py
+++ b/tests/core/test_selector.py
@@ -11,6 +11,7 @@ from sqlmesh.core import dialect as d
 from sqlmesh.core.audit import StandaloneAudit
 from sqlmesh.core.environment import Environment
 from sqlmesh.core.model import Model, SqlModel
+from sqlmesh.core.model.common import ParsableSql
 from sqlmesh.core.selector import Selector
 from sqlmesh.core.snapshot import SnapshotChangeCategory
 from sqlmesh.utils import UniqueKeyDict
@@ -293,7 +294,13 @@ def test_select_change_schema(mocker: MockerFixture, make_snapshot):
     }
 
     local_models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")
-    local_parent = parent.copy(update={"query": parent.query.select("2 as b", append=False)})  # type: ignore
+    local_parent = parent.copy(
+        update={
+            "query_": ParsableSql(
+                sql=parent.query.select("2 as b", append=False).sql(dialect=parent.dialect)  # type: ignore
+            )
+        }
+    )
     local_models[local_parent.fqn] = local_parent
     local_child = child.copy(update={"mapping_schema": {'"db"': {'"parent"': {"b": "INT"}}}})
     local_models[local_child.fqn] = local_child

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -79,7 +79,7 @@ def parent_model():
         name="parent.tbl",
         kind=dict(time_column="ds", name=ModelKindName.INCREMENTAL_BY_TIME_RANGE),
         dialect="spark",
-        query=parse_one("SELECT 1, ds"),
+        query="SELECT 1, ds",
     )
 
 
@@ -92,7 +92,7 @@ def model():
         dialect="spark",
         cron="1 0 * * *",
         start="2020-01-01",
-        query=parse_one("SELECT @EACH([1, 2], x -> x), ds FROM parent.tbl"),
+        query="SELECT @EACH([1, 2], x -> x), ds FROM parent.tbl",
     )
 
 
@@ -148,7 +148,9 @@ def test_json(snapshot: Snapshot):
             "project": "",
             "python_env": {},
             "owner": "owner",
-            "query": "SELECT @EACH([1, 2], x -> x), ds FROM parent.tbl",
+            "query": {
+                "sql": "SELECT @EACH([1, 2], x -> x), ds FROM parent.tbl",
+            },
             "jinja_macros": {
                 "create_builtins_module": "sqlmesh.utils.jinja",
                 "global_objs": {},
@@ -186,7 +188,7 @@ def test_json_custom_materialization(make_snapshot: t.Callable):
         dialect="spark",
         cron="1 0 * * *",
         start="2020-01-01",
-        query=parse_one("SELECT @EACH([1, 2], x -> x), ds FROM parent.tbl"),
+        query="SELECT @EACH([1, 2], x -> x), ds FROM parent.tbl",
     )
 
     snapshot = make_snapshot(

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -913,7 +913,7 @@ def test_fingerprint(model: Model, parent_model: Model):
     fingerprint = fingerprint_from_node(model, nodes={})
 
     original_fingerprint = SnapshotFingerprint(
-        data_hash="3301649319",
+        data_hash="1698409777",
         metadata_hash="3575333731",
     )
 
@@ -1013,7 +1013,7 @@ def test_fingerprint_jinja_macros(model: Model):
         }
     )
     original_fingerprint = SnapshotFingerprint(
-        data_hash="2908339239",
+        data_hash="343517722",
         metadata_hash="3575333731",
     )
 

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -915,8 +915,8 @@ def test_fingerprint(model: Model, parent_model: Model):
     fingerprint = fingerprint_from_node(model, nodes={})
 
     original_fingerprint = SnapshotFingerprint(
-        data_hash="1698409777",
-        metadata_hash="3575333731",
+        data_hash="2406542604",
+        metadata_hash="3341445192",
     )
 
     assert fingerprint == original_fingerprint
@@ -943,7 +943,7 @@ def test_fingerprint(model: Model, parent_model: Model):
     model = SqlModel(**{**model.dict(), "query": parse_one("select 1, ds -- annotation")})
     fingerprint = fingerprint_from_node(model, nodes={})
     assert new_fingerprint != fingerprint
-    assert new_fingerprint.data_hash == fingerprint.data_hash
+    assert new_fingerprint.data_hash != fingerprint.data_hash
     assert new_fingerprint.metadata_hash != fingerprint.metadata_hash
 
     model = SqlModel(
@@ -953,14 +953,14 @@ def test_fingerprint(model: Model, parent_model: Model):
     assert new_fingerprint != fingerprint
     assert new_fingerprint.data_hash != fingerprint.data_hash
     assert new_fingerprint.metadata_hash != fingerprint.metadata_hash
-    assert fingerprint.metadata_hash == original_fingerprint.metadata_hash
+    assert fingerprint.metadata_hash != original_fingerprint.metadata_hash
 
     model = SqlModel(**{**original_model.dict(), "post_statements": [parse_one("DROP TABLE test")]})
     fingerprint = fingerprint_from_node(model, nodes={})
     assert new_fingerprint != fingerprint
     assert new_fingerprint.data_hash != fingerprint.data_hash
     assert new_fingerprint.metadata_hash != fingerprint.metadata_hash
-    assert fingerprint.metadata_hash == original_fingerprint.metadata_hash
+    assert fingerprint.metadata_hash != original_fingerprint.metadata_hash
 
 
 def test_fingerprint_seed_model():
@@ -1015,8 +1015,8 @@ def test_fingerprint_jinja_macros(model: Model):
         }
     )
     original_fingerprint = SnapshotFingerprint(
-        data_hash="343517722",
-        metadata_hash="3575333731",
+        data_hash="93332825",
+        metadata_hash="3341445192",
     )
 
     fingerprint = fingerprint_from_node(model, nodes={})

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -252,6 +252,9 @@ def test_runtime_stages(capsys, mocker, adapter_mock, make_snapshot):
 
     snapshot = make_snapshot(model)
     snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    snapshot.model.render_pre_statements()
+
     assert f"RuntimeStage value: {RuntimeStage.LOADING.value}" in capsys.readouterr().out
 
     evaluator.create([snapshot], {})

--- a/tests/core/test_table_diff.py
+++ b/tests/core/test_table_diff.py
@@ -10,6 +10,7 @@ from sqlmesh.core.console import TerminalConsole
 from sqlmesh.core.context import Context
 from sqlmesh.core.config import AutoCategorizationMode, CategorizerConfig, DuckDBConnectionConfig
 from sqlmesh.core.model import SqlModel, load_sql_based_model
+from sqlmesh.core.model.common import ParsableSql
 from sqlmesh.core.table_diff import TableDiff, SchemaDiff
 import numpy as np  # noqa: TID253
 from sqlmesh.utils.errors import SQLMeshError
@@ -48,8 +49,14 @@ def capture_console_output(method_name: str, **kwargs) -> str:
 def test_data_diff(sushi_context_fixed_date, capsys, caplog):
     model = sushi_context_fixed_date.models['"memory"."sushi"."customer_revenue_by_day"']
 
-    model.query.select(exp.cast("'1'", "VARCHAR").as_("modified_col"), "1 AS y", copy=False)
-    sushi_context_fixed_date.upsert_model(model)
+    sushi_context_fixed_date.upsert_model(
+        model,
+        query_=ParsableSql(
+            sql=model.query.select(exp.cast("'1'", "VARCHAR").as_("modified_col"), "1 AS y").sql(
+                model.dialect
+            )
+        ),
+    )
 
     sushi_context_fixed_date.plan(
         "source_dev",

--- a/tests/integrations/github/cicd/test_integration.py
+++ b/tests/integrations/github/cicd/test_integration.py
@@ -16,6 +16,7 @@ from sqlglot import exp
 from sqlmesh.core.config import CategorizerConfig, Config, ModelDefaultsConfig, LinterConfig
 from sqlmesh.core.engine_adapter.shared import DataObject
 from sqlmesh.core.user import User, UserRole
+from sqlmesh.core.model.common import ParsableSql
 from sqlmesh.integrations.github.cicd import command
 from sqlmesh.integrations.github.cicd.config import GithubCICDBotConfig, MergeMethod
 from sqlmesh.integrations.github.cicd.controller import (
@@ -249,8 +250,10 @@ def test_merge_pr_has_non_breaking_change(
     ]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.select(exp.alias_("1", "new_col"), copy=False)
-    controller._context.upsert_model(model)
+    controller._context.upsert_model(
+        model,
+        query_=ParsableSql(sql=model.query.select(exp.alias_("1", "new_col")).sql(model.dialect)),
+    )
 
     github_output_file = tmp_path / "github_output.txt"
 
@@ -458,8 +461,10 @@ def test_merge_pr_has_non_breaking_change_diff_start(
     ]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.select(exp.alias_("1", "new_col"), copy=False)
-    controller._context.upsert_model(model)
+    controller._context.upsert_model(
+        model,
+        query_=ParsableSql(sql=model.query.select(exp.alias_("1", "new_col")).sql(model.dialect)),
+    )
 
     github_output_file = tmp_path / "github_output.txt"
 
@@ -666,8 +671,10 @@ def test_merge_pr_has_non_breaking_change_no_categorization(
     ]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.select(exp.alias_("1", "new_col"), copy=False)
-    controller._context.upsert_model(model)
+    controller._context.upsert_model(
+        model,
+        query_=ParsableSql(sql=model.query.select(exp.alias_("1", "new_col")).sql(model.dialect)),
+    )
 
     github_output_file = tmp_path / "github_output.txt"
 
@@ -983,8 +990,10 @@ def test_no_merge_since_no_deploy_signal(
     ]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.select(exp.alias_("1", "new_col"), copy=False)
-    controller._context.upsert_model(model)
+    controller._context.upsert_model(
+        model,
+        query_=ParsableSql(sql=model.query.select(exp.alias_("1", "new_col")).sql(model.dialect)),
+    )
 
     github_output_file = tmp_path / "github_output.txt"
 
@@ -1183,8 +1192,10 @@ def test_no_merge_since_no_deploy_signal_no_approvers_defined(
     controller._context.users = [User(username="test", github_username="test_github", roles=[])]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.select(exp.alias_("1", "new_col"), copy=False)
-    controller._context.upsert_model(model)
+    controller._context.upsert_model(
+        model,
+        query_=ParsableSql(sql=model.query.select(exp.alias_("1", "new_col")).sql(model.dialect)),
+    )
 
     github_output_file = tmp_path / "github_output.txt"
 
@@ -1357,8 +1368,10 @@ def test_deploy_comment_pre_categorized(
     controller._context.users = [User(username="test", github_username="test_github", roles=[])]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.select(exp.alias_("1", "new_col"), copy=False)
-    controller._context.upsert_model(model)
+    controller._context.upsert_model(
+        model,
+        query_=ParsableSql(sql=model.query.select(exp.alias_("1", "new_col")).sql(model.dialect)),
+    )
 
     # Manually categorize the change as non-breaking and don't backfill anything
     controller._context.plan(
@@ -1557,8 +1570,12 @@ def test_error_msg_when_applying_plan_with_bug(
     ]
     # Make an error by adding a column that doesn't exist
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.select(exp.alias_("non_existing_col", "new_col"), copy=False)
-    controller._context.upsert_model(model)
+    controller._context.upsert_model(
+        model,
+        query_=ParsableSql(
+            sql=model.query.select(exp.alias_("non_existing_col", "new_col")).sql(model.dialect)
+        ),
+    )
 
     github_output_file = tmp_path / "github_output.txt"
 
@@ -1716,8 +1733,10 @@ def test_overlapping_changes_models(
     # These changes have shared children and this ensures we don't repeat the children in the output
     # Make a non-breaking change
     model = controller._context.get_model("sushi.customers").copy()
-    model.query.select(exp.alias_("1", "new_col"), copy=False)
-    controller._context.upsert_model(model)
+    controller._context.upsert_model(
+        model,
+        query_=ParsableSql(sql=model.query.select(exp.alias_("1", "new_col")).sql(model.dialect)),
+    )
 
     # Make a breaking change
     model = controller._context.get_model("sushi.waiter_names").copy()
@@ -2283,8 +2302,10 @@ def test_has_required_approval_but_not_base_branch(
     ]
     # Make a non-breaking change
     model = controller._context.get_model("sushi.waiter_revenue_by_day").copy()
-    model.query.select(exp.alias_("1", "new_col"), copy=False)
-    controller._context.upsert_model(model)
+    controller._context.upsert_model(
+        model,
+        query_=ParsableSql(sql=model.query.select(exp.alias_("1", "new_col")).sql(model.dialect)),
+    )
 
     github_output_file = tmp_path / "github_output.txt"
 


### PR DESCRIPTION
This update eliminates the need for a rendered query when computing the model’s data hash. This means that the categorizer can now decide that the snapshot represents a metadata change even though the data hash has changed.

Doing this has the following benefits:
- Faster fingerprint calculation
- Eliminates the dependency on SQLGlot optimizer when calculating fingerprints which brings us one step closer to eliminating snapshot record migration as a result of the product upgrade 