### PR TITLE
Chore: Address more integration test flakiness

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -310,10 +310,10 @@ workflows:
                 - athena
                 - fabric
                 - gcp-postgres
-          filters:
-            branches:
-              only:
-                - main
+          #filters:
+          #  branches:
+          #    only:
+          #      - main
       - ui_style
       - ui_test
       - vscode_test

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -310,10 +310,10 @@ workflows:
                 - athena
                 - fabric
                 - gcp-postgres
-          #filters:
-          #  branches:
-          #    only:
-          #      - main
+          filters:
+            branches:
+              only:
+                - main
       - ui_style
       - ui_test
       - vscode_test

--- a/.circleci/manage-test-db.sh
+++ b/.circleci/manage-test-db.sh
@@ -80,7 +80,11 @@ redshift_down() {
     EXIT_CODE=1
     ATTEMPTS=0
     while [ $EXIT_CODE -ne 0 ] && [ $ATTEMPTS -lt 5 ]; do
-        redshift_exec "select pg_terminate_backend(procpid) from pg_stat_activity where datname = '$1'"
+        # note: sometimes this pg_terminate_backend() call can randomly fail with: ERROR:  Insufficient privileges 
+        # if it does, let's proceed with the drop anyway rather than aborting and never attempting the drop
+        redshift_exec "select pg_terminate_backend(procpid) from pg_stat_activity where datname = '$1'" || true
+        
+        # perform drop
         redshift_exec "drop database $1;" && EXIT_CODE=$? || EXIT_CODE=$?
         if [ $EXIT_CODE -ne 0 ]; then
             echo "Unable to drop database; retrying..."

--- a/sqlmesh/core/engine_adapter/fabric.py
+++ b/sqlmesh/core/engine_adapter/fabric.py
@@ -153,6 +153,12 @@ class FabricEngineAdapter(LogicalMergeMixin, MSSQLEngineAdapter):
 
         logger.info(f"Switching from catalog '{current_catalog}' to '{catalog_name}'")
 
+        # commit the transaction before closing the connection to help prevent errors like:
+        # > Snapshot isolation transaction failed in database because the object accessed by the statement has been modified by a
+        # > DDL statement in another concurrent transaction since the start of this transaction
+        # on subsequent queries in the new connection
+        self._connection_pool.commit()
+
         # note: we call close() on the connection pool instead of self.close() because self.close() calls close_all()
         # on the connection pool but we just want to close the connection for this thread
         self._connection_pool.close()


### PR DESCRIPTION
This addresses:

 - An oversight in tearing down the database for Redshift that caused [this failure](https://app.circleci.com/pipelines/github/TobikoData/sqlmesh/23761/workflows/3630bb10-cb60-4a40-8a46-ceac25108e44/jobs/270112)
 - The failures caused by `teardown failed on attempt N! Exiting immediately!` when there is a `StashKey` error
    - eg [here for trino](https://app.circleci.com/pipelines/github/TobikoData/sqlmesh/23774/workflows/da3cc0fb-02fc-41d7-8bcd-0d89309731bf/jobs/270410)
    - and [here for fabric](https://app.circleci.com/pipelines/github/TobikoData/sqlmesh/23756/workflows/541b8d2c-da3d-4f18-94db-43871d1dec05/jobs/270034)

I had a handler for capturing the `StashKey` errors and it worked - if `pytest-retry` wasnt in the mix. So it was working for `style_and_cicd_tests` but not the engine adapter integration tests.

`pytest-retry` registers its own handler, which runs before ours and bombs out before we even have a chance to handle the error.

So this PR adjusts the hook call order at runtime to call ours first before the one from `pytest-retry`
