### PR TITLE
Chore: Add heplful error message when drop operation fails

### DIFF
--- a/sqlmesh/core/schema_diff.py
+++ b/sqlmesh/core/schema_diff.py
@@ -498,8 +498,11 @@ class SchemaDiffer(PydanticModel):
         columns = ensure_list(columns)
         operations: t.List[TableAlterColumnOperation] = []
         column_pos, column_kwarg = self._get_matching_kwarg(columns[-1].name, struct, pos)
-        assert column_pos is not None
-        assert column_kwarg
+        if column_pos is None or not column_kwarg:
+            raise SQLMeshError(
+                f"Cannot drop column '{columns[-1].name}' from table '{table_name}' - column not found. "
+                f"This may indicate a mismatch between the expected and actual table schemas."
+            )
         struct.expressions.pop(column_pos)
         operations.append(
             TableAlterDropColumnOperation(


### PR DESCRIPTION
While migrating a `dbt` project to `sqlmesh` noticed there is no error when drop operation assertion fails since we simply assert:

<img width="688" height="101" alt="Screenshot 2025-08-29 at 12 53 28" src="https://github.com/user-attachments/assets/8d555e89-243d-4a00-b53b-cbe1da94c09b" />

this adds a message to at least provide some info:

<img width="1046" height="112" alt="Screenshot 2025-08-29 at 12 55 01" src="https://github.com/user-attachments/assets/459b458b-4233-43a8-a9ab-859e28e01813" />
