### PR TITLE
Fix: Regression in WAP support

### DIFF
--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -402,6 +402,15 @@ class SparkEngineAdapter(
             return self.spark.catalog.currentDatabase()
         return self.fetchone(exp.select(exp.func("current_database")))[0]  # type: ignore
 
+    def get_data_object(self, target_name: TableName) -> t.Optional[DataObject]:
+        target_table = exp.to_table(target_name)
+        if isinstance(target_table.this, exp.Dot) and target_table.this.expression.name.startswith(
+            f"{self.BRANCH_PREFIX}{self.WAP_PREFIX}"
+        ):
+            # Exclude the branch name
+            target_table.set("this", target_table.this.this)
+        return super().get_data_object(target_table)
+
     def create_state_table(
         self,
         table_name: str,

--- a/tests/core/engine_adapter/test_spark.py
+++ b/tests/core/engine_adapter/test_spark.py
@@ -1080,3 +1080,19 @@ def test_table_format(adapter: SparkEngineAdapter, mocker: MockerFixture):
         "CREATE TABLE IF NOT EXISTS `test_table` (`cola` TIMESTAMP, `colb` STRING, `colc` STRING) USING ICEBERG",
         "CREATE TABLE IF NOT EXISTS `test_table` USING ICEBERG TBLPROPERTIES ('write.format.default'='orc') AS SELECT CAST(`cola` AS TIMESTAMP) AS `cola`, CAST(`colb` AS STRING) AS `colb`, CAST(`colc` AS STRING) AS `colc` FROM (SELECT CAST(1 AS TIMESTAMP) AS `cola`, CAST(2 AS STRING) AS `colb`, 'foo' AS `colc`) AS `_subquery`",
     ]
+
+
+def test_get_data_object_wap_branch(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
+    adapter = make_mocked_engine_adapter(SparkEngineAdapter, patch_get_data_objects=False)
+    mocker.patch.object(adapter, "_get_data_objects", return_value=[])
+
+    table = exp.to_table(
+        "`catalog`.`sqlmesh__test`.`test__test_view__630979748`.`branch_wap_472234d7`",
+        dialect="spark",
+    )
+    adapter.get_data_object(table)
+
+    adapter._get_data_objects.assert_called_once_with(
+        d.schema_("sqlmesh__test", "catalog"),
+        {"test__test_view__630979748"},
+    )


### PR DESCRIPTION
A regression has been introduced to WAP support in #5189. The updated table name returned by the WAP prepare step wasn't being used for actual insert.

This update mitigates the issue and address the gaps in our test coverage to prevent this issue from happening in future.