### PR TITLE
fix: ignore extra keys in node config

### DIFF
--- a/sqlmesh/dbt/manifest.py
+++ b/sqlmesh/dbt/manifest.py
@@ -360,16 +360,20 @@ class ManifestHelper:
                 )
 
                 self._models_per_package[node.package_name][node_name] = ModelConfig(
-                    sql=sql,
-                    dependencies=dependencies,
-                    tests=tests,
-                    **node_config,
+                    **dict(
+                        node_config,
+                        sql=sql,
+                        dependencies=dependencies,
+                        tests=tests,
+                    )
                 )
             else:
                 self._seeds_per_package[node.package_name][node_name] = SeedConfig(
-                    dependencies=Dependencies(macros=macro_references),
-                    tests=tests,
-                    **node_config,
+                    **dict(
+                        node_config,
+                        dependencies=Dependencies(macros=macro_references),
+                        tests=tests,
+                    )
                 )
 
     def _load_on_run_start_end(self) -> None:

--- a/tests/dbt/test_model.py
+++ b/tests/dbt/test_model.py
@@ -75,7 +75,8 @@ def test_load_invalid_ref_audit_constraints(
     dbt_project_dir.mkdir()
     dbt_model_dir = dbt_project_dir / "models"
     dbt_model_dir.mkdir()
-    full_model_contents = "SELECT 1 as cola"
+    # add `tests` to model config since this is loaded by dbt and ignored and we shouldn't error when loading it
+    full_model_contents = """{{ config(tags=["blah"], tests=[{"blah": {"to": "ref('completely_ignored')", "field": "blah2"} }]) }} SELECT 1 as cola"""
     full_model_file = dbt_model_dir / "full_model.sql"
     with open(full_model_file, "w", encoding="utf-8") as f:
         f.write(full_model_contents)


### PR DESCRIPTION
If a user incorrectly put `tests` in their model config dbt would ignore this and load/run fine. Our adapter would error. This change has our passed kwargs always override what is in the user's model config to match dbt behavior. 