### PR TITLE
Fix: Evaluation of metadata snapshots with audit changes

### DIFF
--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -626,6 +626,9 @@ class Scheduler:
         dag = DAG[SchedulingUnit]()
 
         for snapshot_id in snapshot_dag:
+            if snapshot_id.name not in self.snapshots_by_name:
+                continue
+
             snapshot = self.snapshots_by_name[snapshot_id.name]
             intervals = intervals_per_snapshot.get(snapshot.name, [])
 


### PR DESCRIPTION
#5189 introduced a regression in which a plan application would sometimes fail with an exception like:
```
KeyError: '<model fqn>'
```
when making metadata-only changes. 

This PR fixes the issue as well as addresses the gap in test coverage which ultimately allowed for this regression to take place.