### PR TITLE
chore: add dbt microbatch interface

### DIFF
--- a/sqlmesh/dbt/common.py
+++ b/sqlmesh/dbt/common.py
@@ -132,6 +132,10 @@ class GeneralConfig(DbtConfig):
     def config_attribute_dict(self) -> AttributeDict[str, t.Any]:
         return AttributeDict(self.dict(exclude=EXCLUDED_CONFIG_ATTRIBUTE_KEYS))
 
+    def _get_field_value(self, field: str) -> t.Optional[t.Any]:
+        field_val = getattr(self, field, None)
+        return field_val if field_val is not None else self.meta.get(field, None)
+
     def replace(self, other: T) -> None:
         """
         Replace the contents of this instance with the passed in instance.
@@ -152,9 +156,7 @@ class GeneralConfig(DbtConfig):
         """
         kwargs = {}
         for field in self.sqlmesh_config_fields:
-            field_val = getattr(self, field, None)
-            if field_val is None:
-                field_val = self.meta.get(field, None)
+            field_val = self._get_field_value(field)
             if field_val is not None:
                 kwargs[field] = field_val
         return kwargs

--- a/tests/dbt/test_model.py
+++ b/tests/dbt/test_model.py
@@ -1,8 +1,12 @@
+import datetime
+import typing as t
 import pytest
 
 from pathlib import Path
 
+from sqlglot import exp
 from sqlmesh import Context
+from sqlmesh.core.model import TimeColumn, IncrementalByTimeRangeKind
 from sqlmesh.dbt.common import Dependencies
 from sqlmesh.dbt.context import DbtContext
 from sqlmesh.dbt.model import ModelConfig
@@ -11,6 +15,49 @@ from sqlmesh.dbt.test import TestConfig
 from sqlmesh.utils.yaml import YAML
 
 pytestmark = pytest.mark.dbt
+
+
+@pytest.fixture
+def create_empty_project(tmp_path: Path) -> t.Callable[[], t.Tuple[Path, Path]]:
+    def _create_empty_project() -> t.Tuple[Path, Path]:
+        yaml = YAML()
+        dbt_project_dir = tmp_path / "dbt"
+        dbt_project_dir.mkdir()
+        dbt_model_dir = dbt_project_dir / "models"
+        dbt_model_dir.mkdir()
+        dbt_project_config = {
+            "name": "empty_project",
+            "version": "1.0.0",
+            "config-version": 2,
+            "profile": "test",
+            "model-paths": ["models"],
+        }
+        dbt_project_file = dbt_project_dir / "dbt_project.yml"
+        with open(dbt_project_file, "w", encoding="utf-8") as f:
+            YAML().dump(dbt_project_config, f)
+        sqlmesh_config = {
+            "model_defaults": {
+                "start": "2025-01-01",
+            }
+        }
+        sqlmesh_config_file = dbt_project_dir / "sqlmesh.yaml"
+        with open(sqlmesh_config_file, "w", encoding="utf-8") as f:
+            YAML().dump(sqlmesh_config, f)
+        dbt_data_dir = tmp_path / "dbt_data"
+        dbt_data_dir.mkdir()
+        dbt_data_file = dbt_data_dir / "local.db"
+        dbt_profile_config = {
+            "test": {
+                "outputs": {"duckdb": {"type": "duckdb", "path": str(dbt_data_file)}},
+                "target": "duckdb",
+            }
+        }
+        db_profile_file = dbt_project_dir / "profiles.yml"
+        with open(db_profile_file, "w", encoding="utf-8") as f:
+            yaml.dump(dbt_profile_config, f)
+        return dbt_project_dir, dbt_model_dir
+
+    return _create_empty_project
 
 
 def test_model_test_circular_references() -> None:
@@ -68,16 +115,13 @@ def test_model_test_circular_references() -> None:
 
 @pytest.mark.slow
 def test_load_invalid_ref_audit_constraints(
-    tmp_path: Path, caplog, dbt_dummy_postgres_config: PostgresConfig
+    tmp_path: Path, caplog, dbt_dummy_postgres_config: PostgresConfig, create_empty_project
 ) -> None:
     yaml = YAML()
-    dbt_project_dir = tmp_path / "dbt"
-    dbt_project_dir.mkdir()
-    dbt_model_dir = dbt_project_dir / "models"
-    dbt_model_dir.mkdir()
+    project_dir, model_dir = create_empty_project()
     # add `tests` to model config since this is loaded by dbt and ignored and we shouldn't error when loading it
     full_model_contents = """{{ config(tags=["blah"], tests=[{"blah": {"to": "ref('completely_ignored')", "field": "blah2"} }]) }} SELECT 1 as cola"""
-    full_model_file = dbt_model_dir / "full_model.sql"
+    full_model_file = model_dir / "full_model.sql"
     with open(full_model_file, "w", encoding="utf-8") as f:
         f.write(full_model_contents)
     model_schema = {
@@ -118,41 +162,11 @@ def test_load_invalid_ref_audit_constraints(
             }
         ],
     }
-    model_schema_file = dbt_model_dir / "schema.yml"
+    model_schema_file = model_dir / "schema.yml"
     with open(model_schema_file, "w", encoding="utf-8") as f:
         yaml.dump(model_schema, f)
-    dbt_project_config = {
-        "name": "invalid_ref_audit_constraints",
-        "version": "1.0.0",
-        "config-version": 2,
-        "profile": "test",
-        "model-paths": ["models"],
-    }
-    dbt_project_file = dbt_project_dir / "dbt_project.yml"
-    with open(dbt_project_file, "w", encoding="utf-8") as f:
-        yaml.dump(dbt_project_config, f)
-    sqlmesh_config = {
-        "model_defaults": {
-            "start": "2025-01-01",
-        }
-    }
-    sqlmesh_config_file = dbt_project_dir / "sqlmesh.yaml"
-    with open(sqlmesh_config_file, "w", encoding="utf-8") as f:
-        yaml.dump(sqlmesh_config, f)
-    dbt_data_dir = tmp_path / "dbt_data"
-    dbt_data_dir.mkdir()
-    dbt_data_file = dbt_data_dir / "local.db"
-    dbt_profile_config = {
-        "test": {
-            "outputs": {"duckdb": {"type": "duckdb", "path": str(dbt_data_file)}},
-            "target": "duckdb",
-        }
-    }
-    db_profile_file = dbt_project_dir / "profiles.yml"
-    with open(db_profile_file, "w", encoding="utf-8") as f:
-        yaml.dump(dbt_profile_config, f)
 
-    context = Context(paths=dbt_project_dir)
+    context = Context(paths=project_dir)
     assert (
         "Skipping audit 'relationships_full_model_cola__cola__ref_not_real_model_' because model 'not_real_model' is not a valid ref"
         in caplog.text
@@ -165,3 +179,122 @@ def test_load_invalid_ref_audit_constraints(
     assert fqn in context.snapshots
     # The audit isn't loaded due to the invalid ref
     assert context.snapshots[fqn].model.audits == []
+
+
+@pytest.mark.slow
+def test_load_microbatch_all_defined(
+    tmp_path: Path, caplog, dbt_dummy_postgres_config: PostgresConfig, create_empty_project
+) -> None:
+    project_dir, model_dir = create_empty_project()
+    # add `tests` to model config since this is loaded by dbt and ignored and we shouldn't error when loading it
+    microbatch_contents = """
+    {{
+        config(
+            materialized='incremental',
+            incremental_strategy='microbatch',
+            event_time='ds',
+            begin='2020-01-01',
+            batch_size='day',
+            lookback=2,
+            concurrent_batches=true
+        )
+    }}
+    
+    SELECT 1 as cola, '2025-01-01' as ds
+    """
+    microbatch_model_file = model_dir / "microbatch.sql"
+    with open(microbatch_model_file, "w", encoding="utf-8") as f:
+        f.write(microbatch_contents)
+
+    snapshot_fqn = '"local"."main"."microbatch"'
+    context = Context(paths=project_dir)
+    model = context.snapshots[snapshot_fqn].model
+    # Validate model-level attributes
+    assert model.start == datetime.datetime(2020, 1, 1, 0, 0)
+    assert model.interval_unit.is_day
+    # Validate model kind attributes
+    assert isinstance(model.kind, IncrementalByTimeRangeKind)
+    assert model.kind.lookback == 2
+    assert model.kind.time_column == TimeColumn(
+        column=exp.to_column("ds", quoted=True), format="%Y-%m-%d"
+    )
+    assert model.kind.batch_size == 1
+
+
+@pytest.mark.slow
+def test_load_microbatch_all_defined_diff_values(
+    tmp_path: Path, caplog, dbt_dummy_postgres_config: PostgresConfig, create_empty_project
+) -> None:
+    project_dir, model_dir = create_empty_project()
+    # add `tests` to model config since this is loaded by dbt and ignored and we shouldn't error when loading it
+    microbatch_contents = """
+    {{
+        config(
+            materialized='incremental',
+            incremental_strategy='microbatch',
+            cron='@yearly',
+            event_time='blah',
+            begin='2022-01-01',
+            batch_size='year',
+            lookback=20,
+            concurrent_batches=false
+        )
+    }}
+
+    SELECT 1 as cola, '2022-01-01' as blah
+    """
+    microbatch_model_file = model_dir / "microbatch.sql"
+    with open(microbatch_model_file, "w", encoding="utf-8") as f:
+        f.write(microbatch_contents)
+
+    snapshot_fqn = '"local"."main"."microbatch"'
+    context = Context(paths=project_dir)
+    model = context.snapshots[snapshot_fqn].model
+    # Validate model-level attributes
+    assert model.start == datetime.datetime(2022, 1, 1, 0, 0)
+    assert model.interval_unit.is_year
+    # Validate model kind attributes
+    assert isinstance(model.kind, IncrementalByTimeRangeKind)
+    assert model.kind.lookback == 20
+    assert model.kind.time_column == TimeColumn(
+        column=exp.to_column("blah", quoted=True), format="%Y-%m-%d"
+    )
+    assert model.kind.batch_size is None
+
+
+@pytest.mark.slow
+def test_load_microbatch_required_only(
+    tmp_path: Path, caplog, dbt_dummy_postgres_config: PostgresConfig, create_empty_project
+) -> None:
+    project_dir, model_dir = create_empty_project()
+    # add `tests` to model config since this is loaded by dbt and ignored and we shouldn't error when loading it
+    microbatch_contents = """
+    {{
+        config(
+            materialized='incremental',
+            incremental_strategy='microbatch',
+            begin='2021-01-01',
+            event_time='ds',
+            batch_size='hour',
+        )
+    }}
+
+    SELECT 1 as cola, '2021-01-01' as ds
+    """
+    microbatch_model_file = model_dir / "microbatch.sql"
+    with open(microbatch_model_file, "w", encoding="utf-8") as f:
+        f.write(microbatch_contents)
+
+    snapshot_fqn = '"local"."main"."microbatch"'
+    context = Context(paths=project_dir)
+    model = context.snapshots[snapshot_fqn].model
+    # Validate model-level attributes
+    assert model.start == datetime.datetime(2021, 1, 1, 0, 0)
+    assert model.interval_unit.is_hour
+    # Validate model kind attributes
+    assert isinstance(model.kind, IncrementalByTimeRangeKind)
+    assert model.kind.lookback == 1
+    assert model.kind.time_column == TimeColumn(
+        column=exp.to_column("ds", quoted=True), format="%Y-%m-%d"
+    )
+    assert model.kind.batch_size is None


### PR DESCRIPTION
This PR does not add runtime support for microbatch - it just allows the dbt adapter to load microbatch models. Follow up PR(s) will be adding runtime support so it matches dbt behavior.