### PR TITLE
Feat(state_sync): Add the ability to fetch all versions of a snapshot by name

### DIFF
--- a/sqlmesh/core/snapshot/__init__.py
+++ b/sqlmesh/core/snapshot/__init__.py
@@ -4,6 +4,7 @@ from sqlmesh.core.snapshot.definition import (
     Node as Node,
     QualifiedViewName as QualifiedViewName,
     Snapshot as Snapshot,
+    MinimalSnapshot as MinimalSnapshot,
     SnapshotChangeCategory as SnapshotChangeCategory,
     SnapshotDataVersion as SnapshotDataVersion,
     SnapshotFingerprint as SnapshotFingerprint,

--- a/sqlmesh/core/snapshot/__init__.py
+++ b/sqlmesh/core/snapshot/__init__.py
@@ -4,7 +4,7 @@ from sqlmesh.core.snapshot.definition import (
     Node as Node,
     QualifiedViewName as QualifiedViewName,
     Snapshot as Snapshot,
-    MinimalSnapshot as MinimalSnapshot,
+    SnapshotIdAndVersion as SnapshotIdAndVersion,
     SnapshotChangeCategory as SnapshotChangeCategory,
     SnapshotDataVersion as SnapshotDataVersion,
     SnapshotFingerprint as SnapshotFingerprint,

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1487,9 +1487,9 @@ class SnapshotTableCleanupTask(PydanticModel):
     dev_table_only: bool
 
 
-SnapshotIdLike = t.Union[SnapshotId, SnapshotTableInfo, Snapshot]
+SnapshotIdLike = t.Union[SnapshotId, SnapshotTableInfo, MinimalSnapshot, Snapshot]
 SnapshotInfoLike = t.Union[SnapshotTableInfo, Snapshot]
-SnapshotNameVersionLike = t.Union[SnapshotNameVersion, SnapshotTableInfo, Snapshot]
+SnapshotNameVersionLike = t.Union[SnapshotNameVersion, SnapshotTableInfo, MinimalSnapshot, Snapshot]
 
 
 class DeployabilityIndex(PydanticModel, frozen=True):

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -588,6 +588,30 @@ class SnapshotTableInfo(PydanticModel, SnapshotInfoMixin, frozen=True):
         return SnapshotNameVersion(name=self.name, version=self.version)
 
 
+class MinimalSnapshot(PydanticModel):
+    """A stripped down version of a snapshot that is used in situations where we want to fetch the main fields of the snapshots table
+    without the overhead of parsing the full snapshot payload and fetching intervals.
+    """
+
+    name: str
+    version: str
+    dev_version_: t.Optional[str] = Field(alias="dev_version")
+    identifier: str
+    fingerprint: SnapshotFingerprint
+
+    @property
+    def snapshot_id(self) -> SnapshotId:
+        return SnapshotId(name=self.name, identifier=self.identifier)
+
+    @property
+    def name_version(self) -> SnapshotNameVersion:
+        return SnapshotNameVersion(name=self.name, version=self.version)
+
+    @property
+    def dev_version(self) -> str:
+        return self.dev_version_ or self.fingerprint.to_version()
+
+
 class Snapshot(PydanticModel, SnapshotInfoMixin):
     """A snapshot represents a node at a certain point in time.
 

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -23,6 +23,7 @@ from sqlmesh.core.snapshot import (
     SnapshotTableCleanupTask,
     SnapshotTableInfo,
     SnapshotNameVersion,
+    MinimalSnapshot,
 )
 from sqlmesh.core.snapshot.definition import Interval, SnapshotIntervals
 from sqlmesh.utils import major_minor
@@ -98,21 +99,21 @@ class StateReader(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_snapshot_ids_by_names(
+    def get_snapshots_by_names(
         self,
         snapshot_names: t.Iterable[str],
         current_ts: t.Optional[int] = None,
         exclude_expired: bool = True,
-    ) -> t.Set[SnapshotId]:
+    ) -> t.Set[MinimalSnapshot]:
         """Return the snapshot id's for all versions of the specified snapshot names.
 
         Args:
-            snapshot_names: Iterable of snapshot names to fetch all snapshot id's for
+            snapshot_names: Iterable of snapshot names to fetch all snapshot for
             current_ts: Sets the current time for identifying which snapshots have expired so they can be excluded (only relevant if :exclude_expired=True)
             exclude_expired: Whether or not to return the snapshot id's of expired snapshots in the result
 
         Returns:
-            A dictionary mapping snapshot names to a list of relevant snapshot id's
+            A set containing all the matched snapshot records. To fetch full snapshots, pass it into StateSync.get_snapshots()
         """
 
     @abc.abstractmethod

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -23,7 +23,7 @@ from sqlmesh.core.snapshot import (
     SnapshotTableCleanupTask,
     SnapshotTableInfo,
     SnapshotNameVersion,
-    MinimalSnapshot,
+    SnapshotIdAndVersion,
 )
 from sqlmesh.core.snapshot.definition import Interval, SnapshotIntervals
 from sqlmesh.utils import major_minor
@@ -104,7 +104,7 @@ class StateReader(abc.ABC):
         snapshot_names: t.Iterable[str],
         current_ts: t.Optional[int] = None,
         exclude_expired: bool = True,
-    ) -> t.Set[MinimalSnapshot]:
+    ) -> t.Set[SnapshotIdAndVersion]:
         """Return the snapshot records for all versions of the specified snapshot names.
 
         Args:

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -105,10 +105,10 @@ class StateReader(abc.ABC):
         current_ts: t.Optional[int] = None,
         exclude_expired: bool = True,
     ) -> t.Set[MinimalSnapshot]:
-        """Return the snapshot id's for all versions of the specified snapshot names.
+        """Return the snapshot records for all versions of the specified snapshot names.
 
         Args:
-            snapshot_names: Iterable of snapshot names to fetch all snapshot for
+            snapshot_names: Iterable of snapshot names to fetch all snapshot records for
             current_ts: Sets the current time for identifying which snapshots have expired so they can be excluded (only relevant if :exclude_expired=True)
             exclude_expired: Whether or not to return the snapshot id's of expired snapshots in the result
 

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -98,6 +98,24 @@ class StateReader(abc.ABC):
         """
 
     @abc.abstractmethod
+    def get_snapshot_ids_by_names(
+        self,
+        snapshot_names: t.Iterable[str],
+        current_ts: t.Optional[int] = None,
+        exclude_expired: bool = True,
+    ) -> t.Set[SnapshotId]:
+        """Return the snapshot id's for all versions of the specified snapshot names.
+
+        Args:
+            snapshot_names: Iterable of snapshot names to fetch all snapshot id's for
+            current_ts: Sets the current time for identifying which snapshots have expired so they can be excluded (only relevant if :exclude_expired=True)
+            exclude_expired: Whether or not to return the snapshot id's of expired snapshots in the result
+
+        Returns:
+            A dictionary mapping snapshot names to a list of relevant snapshot id's
+        """
+
+    @abc.abstractmethod
     def snapshots_exist(self, snapshot_ids: t.Iterable[SnapshotIdLike]) -> t.Set[SnapshotId]:
         """Checks if multiple snapshots exist in the state sync.
 

--- a/sqlmesh/core/state_sync/db/facade.py
+++ b/sqlmesh/core/state_sync/db/facade.py
@@ -29,6 +29,7 @@ from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.environment import Environment, EnvironmentStatements, EnvironmentSummary
 from sqlmesh.core.snapshot import (
     Snapshot,
+    MinimalSnapshot,
     SnapshotId,
     SnapshotIdLike,
     SnapshotInfoLike,
@@ -366,13 +367,13 @@ class EngineAdapterStateSync(StateSync):
         Snapshot.hydrate_with_intervals_by_version(snapshots.values(), intervals)
         return snapshots
 
-    def get_snapshot_ids_by_names(
+    def get_snapshots_by_names(
         self,
         snapshot_names: t.Iterable[str],
         current_ts: t.Optional[int] = None,
         exclude_expired: bool = True,
-    ) -> t.Set[SnapshotId]:
-        return self.snapshot_state.get_snapshot_ids_by_names(
+    ) -> t.Set[MinimalSnapshot]:
+        return self.snapshot_state.get_snapshots_by_names(
             snapshot_names=snapshot_names, current_ts=current_ts, exclude_expired=exclude_expired
         )
 

--- a/sqlmesh/core/state_sync/db/facade.py
+++ b/sqlmesh/core/state_sync/db/facade.py
@@ -366,6 +366,16 @@ class EngineAdapterStateSync(StateSync):
         Snapshot.hydrate_with_intervals_by_version(snapshots.values(), intervals)
         return snapshots
 
+    def get_snapshot_ids_by_names(
+        self,
+        snapshot_names: t.Iterable[str],
+        current_ts: t.Optional[int] = None,
+        exclude_expired: bool = True,
+    ) -> t.Set[SnapshotId]:
+        return self.snapshot_state.get_snapshot_ids_by_names(
+            snapshot_names=snapshot_names, current_ts=current_ts, exclude_expired=exclude_expired
+        )
+
     @transactional()
     def add_interval(
         self,

--- a/sqlmesh/core/state_sync/db/facade.py
+++ b/sqlmesh/core/state_sync/db/facade.py
@@ -29,7 +29,7 @@ from sqlmesh.core.engine_adapter import EngineAdapter
 from sqlmesh.core.environment import Environment, EnvironmentStatements, EnvironmentSummary
 from sqlmesh.core.snapshot import (
     Snapshot,
-    MinimalSnapshot,
+    SnapshotIdAndVersion,
     SnapshotId,
     SnapshotIdLike,
     SnapshotInfoLike,
@@ -372,7 +372,7 @@ class EngineAdapterStateSync(StateSync):
         snapshot_names: t.Iterable[str],
         current_ts: t.Optional[int] = None,
         exclude_expired: bool = True,
-    ) -> t.Set[MinimalSnapshot]:
+    ) -> t.Set[SnapshotIdAndVersion]:
         return self.snapshot_state.get_snapshots_by_names(
             snapshot_names=snapshot_names, current_ts=current_ts, exclude_expired=exclude_expired
         )

--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -26,7 +26,7 @@ from sqlmesh.core.snapshot import (
     SnapshotNameVersion,
     SnapshotInfoLike,
     Snapshot,
-    MinimalSnapshot,
+    SnapshotIdAndVersion,
     SnapshotId,
     SnapshotFingerprint,
 )
@@ -214,7 +214,7 @@ class SnapshotState:
             for snapshot in environment.snapshots
         }
 
-        def _is_snapshot_used(snapshot: MinimalSnapshot) -> bool:
+        def _is_snapshot_used(snapshot: SnapshotIdAndVersion) -> bool:
             return (
                 snapshot.snapshot_id in promoted_snapshot_ids
                 or snapshot.snapshot_id not in expired_candidates
@@ -312,7 +312,7 @@ class SnapshotState:
         snapshot_names: t.Iterable[str],
         current_ts: t.Optional[int] = None,
         exclude_expired: bool = True,
-    ) -> t.Set[MinimalSnapshot]:
+    ) -> t.Set[SnapshotIdAndVersion]:
         """Return the snapshot records for all versions of the specified snapshot names.
 
         Args:
@@ -333,12 +333,12 @@ class SnapshotState:
             unexpired_expr = None
 
         return {
-            MinimalSnapshot(
+            SnapshotIdAndVersion(
                 name=name,
                 identifier=identifier,
                 version=version,
                 dev_version=dev_version,
-                fingerprint=SnapshotFingerprint.parse_raw(fingerprint),
+                fingerprint=fingerprint,
             )
             for where in snapshot_name_filter(
                 snapshot_names=snapshot_names,
@@ -636,7 +636,7 @@ class SnapshotState:
         self,
         snapshots: t.Collection[SnapshotNameVersionLike],
         lock_for_update: bool = False,
-    ) -> t.List[MinimalSnapshot]:
+    ) -> t.List[SnapshotIdAndVersion]:
         """Fetches all snapshots that share the same version as the snapshots.
 
         The output includes the snapshots with the specified identifiers.
@@ -673,7 +673,7 @@ class SnapshotState:
             snapshot_rows.extend(fetchall(self.engine_adapter, query))
 
         return [
-            MinimalSnapshot(
+            SnapshotIdAndVersion(
                 name=name,
                 identifier=identifier,
                 version=version,

--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -313,15 +313,15 @@ class SnapshotState:
         current_ts: t.Optional[int] = None,
         exclude_expired: bool = True,
     ) -> t.Set[MinimalSnapshot]:
-        """Return the snapshot id's for all versions of the specified snapshot names.
+        """Return the snapshot records for all versions of the specified snapshot names.
 
         Args:
-            snapshot_names: Iterable of snapshot names to fetch all snapshot id's for
+            snapshot_names: Iterable of snapshot names to fetch all snapshot records for
             current_ts: Sets the current time for identifying which snapshots have expired so they can be excluded (only relevant if :exclude_expired=True)
             exclude_expired: Whether or not to return the snapshot id's of expired snapshots in the result
 
         Returns:
-            A dictionary mapping snapshot names to a list of relevant snapshot id's
+            A set containing all the matched snapshot records. To fetch full snapshots, pass it into StateSync.get_snapshots()
         """
         if not snapshot_names:
             return set()

--- a/tests/core/state_sync/test_state_sync.py
+++ b/tests/core/state_sync/test_state_sync.py
@@ -3569,3 +3569,81 @@ def test_update_environment_statements(state_sync: EngineAdapterStateSync):
         "@grant_schema_usage()",
         "@grant_select_privileges()",
     ]
+
+
+def test_get_snapshot_ids_by_names(
+    state_sync: EngineAdapterStateSync, make_snapshot: t.Callable[..., Snapshot]
+):
+    assert state_sync.get_snapshot_ids_by_names(snapshot_names=[]) == set()
+
+    snap_a_v1, snap_a_v2 = (
+        make_snapshot(
+            SqlModel(
+                name="a",
+                query=parse_one(f"select {i}, ds"),
+            ),
+            version="a",
+        )
+        for i in range(2)
+    )
+
+    snap_b = make_snapshot(
+        SqlModel(
+            name="b",
+            query=parse_one(f"select 'b' as b, ds"),
+        ),
+        version="b",
+    )
+
+    state_sync.push_snapshots([snap_a_v1, snap_a_v2, snap_b])
+
+    assert state_sync.get_snapshot_ids_by_names(snapshot_names=['"a"']) == {
+        snap_a_v1.snapshot_id,
+        snap_a_v2.snapshot_id,
+    }
+    assert state_sync.get_snapshot_ids_by_names(snapshot_names=['"a"', '"b"']) == {
+        snap_a_v1.snapshot_id,
+        snap_a_v2.snapshot_id,
+        snap_b.snapshot_id,
+    }
+
+
+def test_get_snapshot_ids_by_names_include_expired(
+    state_sync: EngineAdapterStateSync, make_snapshot: t.Callable[..., Snapshot]
+):
+    now_ts = now_timestamp()
+
+    normal_a = make_snapshot(
+        SqlModel(
+            name="a",
+            query=parse_one(f"select 1, ds"),
+        ),
+        version="a",
+    )
+
+    expired_a = make_snapshot(
+        SqlModel(
+            name="a",
+            query=parse_one(f"select 2, ds"),
+        ),
+        version="a",
+        ttl="in 10 seconds",
+    )
+    expired_a.updated_ts = now_ts - (
+        1000 * 15
+    )  # last updated 15 seconds ago, expired 10 seconds from last updated = expired 5 seconds ago
+
+    state_sync.push_snapshots([normal_a, expired_a])
+
+    assert state_sync.get_snapshot_ids_by_names(snapshot_names=['"a"'], current_ts=now_ts) == {
+        normal_a.snapshot_id
+    }
+    assert state_sync.get_snapshot_ids_by_names(snapshot_names=['"a"'], exclude_expired=False) == {
+        normal_a.snapshot_id,
+        expired_a.snapshot_id,
+    }
+
+    # wind back time to 10 seconds ago (before the expired snapshot is expired - it expired 5 seconds ago) to test it stil shows in a normal query
+    assert state_sync.get_snapshot_ids_by_names(
+        snapshot_names=['"a"'], current_ts=(now_ts - (10 * 1000))
+    ) == {normal_a.snapshot_id, expired_a.snapshot_id}


### PR DESCRIPTION
This is the first in a series of PR's looking at adjusting and clarifying how **restatements** work.

Currently, when a model is restated in `prod`, the following occurs:
 1. Intervals are cleared from state for that model
 2. Intervals are cleared from state for all versions of that model present in dev environments

The purpose of that last step is to prevent stale / old data from getting promoted to `prod` if someone decides to deploy a dev environment containing a version of the model that got built before the prod restatement occurred.

However, the current implementation has a gap. It only clears intervals for snapshots that are *promoted* in dev environments, because it's limited by what `StateSync` methods are available and it currently iterates over all environments from `StateSync.get_environments_summary()`.

What about snapshots that arent currently promoted in any environment? There is still a risk that someone makes a change in dev that matches one of these snapshots, and it becomes promoted in dev, and then gets deployed to prod.

So, this PR adds a method to `StateSync` that allows fetching all versions of a snapshot (based on name) regardless of if it's currently being used in an environment or not.

This will allow the `prod` restatement "clear intervals" code to properly clear all relevant intervals across all snapshots of the model, rather than skipping intervals for snapshots that don't currently belong to any environment like it does today.