### PR TITLE
feat: trino support replace table iceberg and delta

### DIFF
--- a/sqlmesh/core/engine_adapter/athena.py
+++ b/sqlmesh/core/engine_adapter/athena.py
@@ -437,6 +437,7 @@ class AthenaEngineAdapter(PandasNativeFetchDFSupportMixin, RowDiffMixin):
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         source_columns: t.Optional[t.List[str]] = None,
+        supports_replace_table_override: t.Optional[bool] = None,
         **kwargs: t.Any,
     ) -> None:
         table = exp.to_table(table_name)

--- a/sqlmesh/core/engine_adapter/mixins.py
+++ b/sqlmesh/core/engine_adapter/mixins.py
@@ -228,7 +228,7 @@ class HiveMetastoreTablePropertiesMixin(EngineAdapter):
 
     def _truncate_comment(self, comment: str, length: t.Optional[int]) -> str:
         # iceberg and delta do not have a comment length limit
-        if self.current_catalog_type in ("iceberg", "delta"):
+        if self.current_catalog_type in ("iceberg", "delta_lake"):
             return comment
         return super()._truncate_comment(comment, length)
 

--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -253,6 +253,7 @@ class RedshiftEngineAdapter(
         table_description: t.Optional[str] = None,
         column_descriptions: t.Optional[t.Dict[str, str]] = None,
         source_columns: t.Optional[t.List[str]] = None,
+        supports_replace_table_override: t.Optional[bool] = None,
         **kwargs: t.Any,
     ) -> None:
         """


### PR DESCRIPTION
Prior to this PR we assumed all Trino catalogs didn't support replace table but this isn't true for Iceberg and Delta Lake. Therefore this PR updates Trino to use replace table for those catalogs.

Some other key changes:
* Users may have a forked custom connector instead of the open source connector and if they do this then it will have a new connector name. This PR updates the catalog name check to check if "iceberg" or "delta_lake" are in the name. That isn't perfect but will help cover more cases.
* The engine adapter methods did `current_catalog_type` but this just looks at the current default catalog for the connection. We should be looking at the target table of the operation and it's catalog if it exists and then fallback to the connection catalog if it does not. 
   * `current_catalog_type` still exists just to support truncating comment methods. They should also be updated to use the target table/catalog but that change was proving to be a larger refactor and determined to be out of scope of this PR. 
* Tests were using a catalog type of `delta` when it should be `delta_lake`. I base this on documentation and our own integration tests
   * https://trino.io/docs/current/connector/delta-lake.html#general-configuration
   * https://github.com/TobikoData/sqlmesh/blob/e8576e9aab71d3237a80b360d8ae1ed417849540/tests/core/engine_adapter/integration/docker/trino/catalog/datalake_delta.properties#L1

