### PR TITLE
Fix: Ignore bigquery partition_by config when the target isn't bigquery

### DIFF
--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -529,7 +529,9 @@ class ModelConfig(BaseModelConfig):
                     partitioned_by.append(self._big_query_partition_by_expr(context))
                 else:
                     logger.warning(
-                        "Ignoring partition_by config for model '%s' targeting %s; it is only supported for BigQuery.", self.name, context.target.dialect
+                        "Ignoring partition_by config for model '%s' targeting %s. The format of the config field is only supported for BigQuery.",
+                        self.name,
+                        context.target.dialect,
                     )
 
             if partitioned_by:
@@ -538,7 +540,8 @@ class ModelConfig(BaseModelConfig):
         if self.cluster_by:
             if isinstance(kind, ViewKind):
                 logger.warning(
-                    f"Ignoring cluster_by config for model '{self.name}'; cluster_by is not supported for views."
+                    "Ignoring cluster_by config for model '%s'; cluster_by is not supported for views.",
+                    self.name,
                 )
             else:
                 clustered_by = []

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -38,6 +38,9 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+logger = logging.getLogger(__name__)
+
+
 INCREMENTAL_BY_TIME_STRATEGIES = set(["delete+insert", "insert_overwrite", "microbatch"])
 INCREMENTAL_BY_UNIQUE_KEY_STRATEGIES = set(["merge"])
 
@@ -521,8 +524,13 @@ class ModelConfig(BaseModelConfig):
                         raise ConfigError(
                             f"Failed to parse model '{self.canonical_name(context)}' partition_by field '{p}' in '{self.path}': {e}"
                         ) from e
-            elif isinstance(self.partition_by, dict) and context.target.dialect == "bigquery":
-                partitioned_by.append(self._big_query_partition_by_expr(context))
+            elif isinstance(self.partition_by, dict):
+                if context.target.dialect == "bigquery":
+                    partitioned_by.append(self._big_query_partition_by_expr(context))
+                else:
+                    logger.warning(
+                        f"Ignoring partition_by config for model '{self.name}' targeting {context.target.dialect}; it is only supported for bigquery."
+                    )
 
             if partitioned_by:
                 optional_kwargs["partitioned_by"] = partitioned_by

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -521,9 +521,11 @@ class ModelConfig(BaseModelConfig):
                         raise ConfigError(
                             f"Failed to parse model '{self.canonical_name(context)}' partition_by field '{p}' in '{self.path}': {e}"
                         ) from e
-            else:
+            elif isinstance(self.partition_by, dict) and context.target.dialect == "bigquery":
                 partitioned_by.append(self._big_query_partition_by_expr(context))
-            optional_kwargs["partitioned_by"] = partitioned_by
+
+            if partitioned_by:
+                optional_kwargs["partitioned_by"] = partitioned_by
 
         if self.cluster_by:
             if isinstance(kind, ViewKind):

--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -529,7 +529,7 @@ class ModelConfig(BaseModelConfig):
                     partitioned_by.append(self._big_query_partition_by_expr(context))
                 else:
                     logger.warning(
-                        f"Ignoring partition_by config for model '{self.name}' targeting {context.target.dialect}; it is only supported for bigquery."
+                        "Ignoring partition_by config for model '%s' targeting %s; it is only supported for BigQuery.", self.name, context.target.dialect
                     )
 
             if partitioned_by:

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -1469,6 +1469,9 @@ def test_partition_by(sushi_test_project: Project):
     model_config.partition_by = {"field": "ds", "data_type": "date", "granularity": "day"}
     assert model_config.to_sqlmesh(context).partitioned_by == [exp.to_column("ds", quoted=True)]
 
+    context.target = DuckDbConfig(name="target", schema="foo")
+    assert model_config.to_sqlmesh(context).partitioned_by == []
+
 
 @pytest.mark.xdist_group("dbt_manifest")
 def test_partition_by_none(sushi_test_project: Project):


### PR DESCRIPTION
dbt ignores bigquery partition_by config when not using the bigquery plugin. Have sqlmesh mimic this behavior.