### PR TITLE
Fix: ensure root package is treated top-level in dbt

### DIFF
--- a/sqlmesh/utils/jinja.py
+++ b/sqlmesh/utils/jinja.py
@@ -330,13 +330,16 @@ class JinjaMacroRegistry(PydanticModel):
                 if macro.is_top_level and macro_name not in root_macros:
                     root_macros[macro_name] = macro_wrapper
 
+        top_level_packages = self.top_level_packages.copy()
+
         if self.root_package_name is not None:
             package_macros[self.root_package_name].update(root_macros)
+            top_level_packages.append(self.root_package_name)
 
         env = environment()
 
         builtin_globals = self._create_builtin_globals(kwargs)
-        for top_level_package_name in self.top_level_packages:
+        for top_level_package_name in top_level_packages:
             # Make sure that the top-level package doesn't fully override the same builtin package.
             package_macros[top_level_package_name] = AttributeDict(
                 {

--- a/tests/fixtures/dbt/sushi_test/dbt_packages/my_macros/dbt_project.yml
+++ b/tests/fixtures/dbt/sushi_test/dbt_packages/my_macros/dbt_project.yml
@@ -1,0 +1,17 @@
+name: 'my_macros'
+version: '1.0.0'
+config-version: 2
+
+profile: 'my_macros'
+
+model-paths: ["models"]
+analysis-paths: ["analyses"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"
+clean-targets:
+  - "target"
+  - "dbt_packages"

--- a/tests/fixtures/dbt/sushi_test/dbt_packages/my_macros/macros/log_value_alt.sql
+++ b/tests/fixtures/dbt/sushi_test/dbt_packages/my_macros/macros/log_value_alt.sql
@@ -1,0 +1,3 @@
+{% macro log_value_alt(v) %}
+    {{ log("Entered value is: " ~ v) }}
+{% endmacro %}

--- a/tests/fixtures/dbt/sushi_test/dbt_packages/my_package/dbt_project.yml
+++ b/tests/fixtures/dbt/sushi_test/dbt_packages/my_package/dbt_project.yml
@@ -1,0 +1,17 @@
+name: 'my_project'
+version: '1.0.0'
+config-version: 2
+
+profile: 'my_project'
+
+model-paths: ["models"]
+analysis-paths: ["analyses"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"
+clean-targets:
+  - "target"
+  - "dbt_packages"

--- a/tests/fixtures/dbt/sushi_test/dbt_packages/my_package/models/dummy_model.sql
+++ b/tests/fixtures/dbt/sushi_test/dbt_packages/my_package/models/dummy_model.sql
@@ -1,0 +1,4 @@
+{{ log_value_alt(1) }}
+
+SELECT
+  1 AS c

--- a/tests/fixtures/dbt/sushi_test/dbt_project.yml
+++ b/tests/fixtures/dbt/sushi_test/dbt_project.yml
@@ -8,7 +8,10 @@ model-paths: ["models"]
 analysis-paths: ["analyses"]
 test-paths: ["tests"]
 seed-paths: ["seeds"]
-macro-paths: ["macros"]
+macro-paths: [
+  "macros",
+  "dbt_packages/my_macros/macros",
+]
 snapshot-paths: ["snapshots"]
 
 target-path: "target"  # directory which will store compiled SQL files


### PR DESCRIPTION
The added test demonstrates what this PR aims to support. Basically:

- The root project specifies a `macros` directory in `dbt_project.yml` that lives within `dbt_packages/`
- Another package in that directory references said macro without qualifying it with its package name

The above works in dbt, but SQLMesh didn't support it until now because an assumption was made that each package could only see the contents defined within it, not outside of it. So, the package in the 2nd bullet above would fail to see the aforementioned macro and fail at render time, since the symbol wasn't present in `jinja_env.globals`.
