### PR TITLE
fix: dbt microbatch parameter conversion

### DIFF
--- a/tests/dbt/test_model.py
+++ b/tests/dbt/test_model.py
@@ -219,6 +219,7 @@ def test_load_microbatch_all_defined(
         column=exp.to_column("ds", quoted=True), format="%Y-%m-%d"
     )
     assert model.kind.batch_size == 1
+    assert model.depends_on_self is False
 
 
 @pytest.mark.slow
@@ -259,7 +260,8 @@ def test_load_microbatch_all_defined_diff_values(
     assert model.kind.time_column == TimeColumn(
         column=exp.to_column("blah", quoted=True), format="%Y-%m-%d"
     )
-    assert model.kind.batch_size is None
+    assert model.kind.batch_size == 1
+    assert model.depends_on_self is True
 
 
 @pytest.mark.slow
@@ -297,4 +299,5 @@ def test_load_microbatch_required_only(
     assert model.kind.time_column == TimeColumn(
         column=exp.to_column("ds", quoted=True), format="%Y-%m-%d"
     )
-    assert model.kind.batch_size is None
+    assert model.kind.batch_size == 1
+    assert model.depends_on_self is False


### PR DESCRIPTION
Fixes two misunderstanding of the dbt microbatch:
* SQLMesh `batch_size` is always 1 for dbt microbatch. In other words, they never issue a query that spans multiple intervals.
* `concurrent_batches` really determines, in SQLMesh terms, if a model depends on self which ultimately determine if the snapshot depends on past. Like SQLMesh, dbt determines this automatically by looking for self-referenes but users can force this with the `concurrent_batches` flag. Therefore if we see is `False`, meaning it should run sequentially, then we add the model to the `depends_on`. 