### PR TITLE
Fix: Allow partials by default for all models converted from a dbt project

### DIFF
--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -83,7 +83,7 @@ class ModelConfig(BaseModelConfig):
     batch_concurrency: t.Optional[int] = None
     forward_only: bool = True
     disable_restatement: t.Optional[bool] = None
-    allow_partials: t.Optional[bool] = None
+    allow_partials: bool = True
     physical_version: t.Optional[str] = None
     auto_restatement_cron: t.Optional[str] = None
     auto_restatement_intervals: t.Optional[int] = None
@@ -620,11 +620,7 @@ class ModelConfig(BaseModelConfig):
                 model_kwargs["physical_properties"] = physical_properties
 
         allow_partials = model_kwargs.pop("allow_partials", None)
-        if (
-            allow_partials is None
-            and kind.is_materialized
-            and not kind.is_incremental_by_time_range
-        ):
+        if allow_partials is None:
             # Set allow_partials to True for dbt models to preserve the original semantics.
             allow_partials = True
 

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -137,6 +137,7 @@ def test_model_to_sqlmesh_fields(dbt_dummy_postgres_config: PostgresConfig):
     assert model.dialect == "postgres"
     assert model.owner == "Sally"
     assert model.tags == ["test", "incremental"]
+    assert model.allow_partials
     kind = t.cast(IncrementalByUniqueKeyKind, model.kind)
     assert kind.batch_size == 5
     assert kind.lookback == 3

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -2110,11 +2110,11 @@ def test_allow_partials_by_default():
         sql="SELECT * FROM baz",
         materialized=Materialization.TABLE.value,
     )
-    assert model.allow_partials is None
+    assert model.allow_partials
     assert model.to_sqlmesh(context).allow_partials
 
     model.materialized = Materialization.INCREMENTAL.value
-    assert model.allow_partials is None
+    assert model.allow_partials
     assert model.to_sqlmesh(context).allow_partials
 
     model.allow_partials = True


### PR DESCRIPTION
There's no point in omitting view and incremental by time range models.