### PR TITLE
feat: add dedicated `incremental_by_time_range` strategy

### DIFF
--- a/examples/sushi_dbt/models/customer_revenue_by_day.sql
+++ b/examples/sushi_dbt/models/customer_revenue_by_day.sql
@@ -1,7 +1,7 @@
 {{
   config(
     materialized='incremental',
-    incremental_strategy='delete+insert',
+    incremental_strategy='incremental_by_time_range',
     cluster_by=['ds'],
     time_column='ds',
   )

--- a/examples/sushi_dbt/models/waiter_as_customer_by_day.sql
+++ b/examples/sushi_dbt/models/waiter_as_customer_by_day.sql
@@ -1,7 +1,7 @@
 {{
   config(
     materialized='incremental',
-    incremental_strategy='delete+insert',
+    incremental_strategy='incremental_by_time_range',
     cluster_by=['ds'],
     time_column='ds',
   )

--- a/examples/sushi_dbt/models/waiter_revenue_by_day.sql
+++ b/examples/sushi_dbt/models/waiter_revenue_by_day.sql
@@ -1,7 +1,7 @@
 {{
   config(
     materialized='incremental',
-    incremental_strategy='delete+insert',
+    incremental_strategy='incremental_by_time_range',
     cluster_by=['ds'],
     time_column='ds',
   )

--- a/examples/sushi_dbt/models/waiter_revenue_by_day_v1.sql
+++ b/examples/sushi_dbt/models/waiter_revenue_by_day_v1.sql
@@ -1,7 +1,7 @@
 {{
   config(
     materialized='incremental',
-    incremental_strategy='delete+insert',
+    incremental_strategy='incremental_by_time_range',
     cluster_by=['ds'],
     time_column='ds',
   )

--- a/tests/dbt/test_manifest.py
+++ b/tests/dbt/test_manifest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from sqlmesh.core.config import ModelDefaultsConfig
+from sqlmesh.core.model import TimeColumn
 from sqlmesh.dbt.basemodel import Dependencies
 from sqlmesh.dbt.common import ModelAttrs
 from sqlmesh.dbt.context import DbtContext
@@ -83,7 +84,7 @@ def test_manifest_helper(caplog):
     assert waiter_as_customer_by_day_config.materialized == "incremental"
     assert waiter_as_customer_by_day_config.incremental_strategy == "delete+insert"
     assert waiter_as_customer_by_day_config.cluster_by == ["ds"]
-    assert waiter_as_customer_by_day_config.time_column == "ds"
+    assert waiter_as_customer_by_day_config.time_column == TimeColumn.create("ds", "duckdb")
 
     if DBT_VERSION >= (1, 5, 0):
         waiter_revenue_by_day_config = models["waiter_revenue_by_day_v2"]
@@ -105,7 +106,7 @@ def test_manifest_helper(caplog):
     assert waiter_revenue_by_day_config.materialized == "incremental"
     assert waiter_revenue_by_day_config.incremental_strategy == "delete+insert"
     assert waiter_revenue_by_day_config.cluster_by == ["ds"]
-    assert waiter_revenue_by_day_config.time_column == "ds"
+    assert waiter_revenue_by_day_config.time_column == TimeColumn.create("ds", "duckdb")
     assert waiter_revenue_by_day_config.dialect_ == "bigquery"
 
     assert helper.models("customers")["customers"].dependencies == Dependencies(

--- a/tests/dbt/test_model.py
+++ b/tests/dbt/test_model.py
@@ -354,7 +354,10 @@ def test_load_incremental_time_range_strategy_all_defined(
         config(
             materialized='incremental',
             incremental_strategy='incremental_by_time_range',
-            time_column='ds',
+            time_column={
+                'column': 'ds',
+                'format': '%Y%m%d'
+            },
             auto_restatement_intervals=3,
             partition_by_time_column=false,
             lookback=5,
@@ -393,7 +396,7 @@ def test_load_incremental_time_range_strategy_all_defined(
     assert model.kind.partition_by_time_column is False
     assert model.kind.lookback == 5
     assert model.kind.time_column == TimeColumn(
-        column=exp.to_column("ds", quoted=True), format="%Y-%m-%d"
+        column=exp.to_column("ds", quoted=True), format="%Y%m%d"
     )
     assert model.kind.batch_size == 3
     assert model.kind.batch_concurrency == 2


### PR DESCRIPTION
Prior to this PR, users could opt-in to using the incremental by time range SQLMesh behavior by adding a `time_column` property to their incremental config and then setting `{% if sqlmesh_incremental is defined %}` jinja block. 

This PR deprecates this behavior (but still supports it for now) and add a new incremental strategy called `incremental_by_time_range`. This gives SQLMesh it's own API for defining it's specific fields and removes the need for defining a jinja code block to activate it. 