### PR TITLE
Chore: Split migration script implementations into DDL and DML

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -587,6 +587,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             self._state_sync = self._new_state_sync()
 
             if self._state_sync.get_versions(validate=False).schema_version == 0:
+                self.console.log_status_update("Initializing new project state...")
                 self._state_sync.migrate(default_catalog=self.default_catalog)
             self._state_sync.get_versions()
             self._state_sync = CachingStateSync(self._state_sync)  # type: ignore

--- a/sqlmesh/core/state_sync/db/environment.py
+++ b/sqlmesh/core/state_sync/db/environment.py
@@ -285,11 +285,13 @@ class EnvironmentState:
         return []
 
     def _environment_from_row(self, row: t.Tuple[str, ...]) -> Environment:
-        return Environment(**{field: row[i] for i, field in enumerate(Environment.all_fields())})
+        return Environment(
+            **{field: row[i] for i, field in enumerate(sorted(Environment.all_fields()))}
+        )
 
     def _environment_summmary_from_row(self, row: t.Tuple[str, ...]) -> EnvironmentSummary:
         return EnvironmentSummary(
-            **{field: row[i] for i, field in enumerate(EnvironmentSummary.all_fields())}
+            **{field: row[i] for i, field in enumerate(sorted(EnvironmentSummary.all_fields()))}
         )
 
     def _environments_query(
@@ -298,7 +300,7 @@ class EnvironmentState:
         lock_for_update: bool = False,
         required_fields: t.Optional[t.List[str]] = None,
     ) -> exp.Select:
-        query_fields = required_fields if required_fields else Environment.all_fields()
+        query_fields = required_fields if required_fields else sorted(Environment.all_fields())
         query = (
             exp.select(*(exp.to_identifier(field) for field in query_fields))
             .from_(self.environments_table)
@@ -328,7 +330,7 @@ class EnvironmentState:
                 self.engine_adapter,
                 self._environments_query(
                     where=where,
-                    required_fields=list(EnvironmentSummary.all_fields()),
+                    required_fields=sorted(EnvironmentSummary.all_fields()),
                 ),
             )
         ]

--- a/sqlmesh/core/state_sync/db/migrator.py
+++ b/sqlmesh/core/state_sync/db/migrator.py
@@ -177,10 +177,10 @@ class StateMigrator:
 
         for migration in migrations:
             logger.info(f"Applying migration {migration}")
-            migration.migrate_ddl(state_sync, default_catalog=default_catalog)
+            migration.migrate_schemas(state_sync, default_catalog=default_catalog)
             if state_table_exist:
                 # No need to run DML for the initial migration since all tables are empty
-                migration.migrate_dml(state_sync, default_catalog=default_catalog)
+                migration.migrate_rows(state_sync, default_catalog=default_catalog)
 
         snapshot_count_after = self.snapshot_state.count()
 

--- a/sqlmesh/core/state_sync/db/migrator.py
+++ b/sqlmesh/core/state_sync/db/migrator.py
@@ -173,9 +173,14 @@ class StateMigrator:
 
         snapshot_count_before = self.snapshot_state.count() if versions.schema_version else None
 
+        state_table_exist = any(self.engine_adapter.table_exists(t) for t in self._state_tables)
+
         for migration in migrations:
             logger.info(f"Applying migration {migration}")
-            migration.migrate(state_sync, default_catalog=default_catalog)
+            migration.migrate_ddl(state_sync, default_catalog=default_catalog)
+            if state_table_exist:
+                # No need to run DML for the initial migration since all tables are empty
+                migration.migrate_dml(state_sync, default_catalog=default_catalog)
 
         snapshot_count_after = self.snapshot_state.count()
 

--- a/sqlmesh/migrations/v0001_init.py
+++ b/sqlmesh/migrations/v0001_init.py
@@ -9,7 +9,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"
@@ -58,3 +58,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
             "sqlglot_version": exp.DataType.build("text"),
         },
     )
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0001_init.py
+++ b/sqlmesh/migrations/v0001_init.py
@@ -9,7 +9,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"
@@ -60,5 +60,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     )
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0002_remove_identify.py
+++ b/sqlmesh/migrations/v0002_remove_identify.py
@@ -1,9 +1,9 @@
 """Remove identify=True kwarg for rendering sql"""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0002_remove_identify.py
+++ b/sqlmesh/migrations/v0002_remove_identify.py
@@ -1,5 +1,9 @@
 """Remove identify=True kwarg for rendering sql"""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0003_move_batch_size.py
+++ b/sqlmesh/migrations/v0003_move_batch_size.py
@@ -5,11 +5,11 @@ import json
 from sqlglot import exp
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     snapshots_table = "_snapshots"
     if state_sync.schema:
         snapshots_table = f"{state_sync.schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0003_move_batch_size.py
+++ b/sqlmesh/migrations/v0003_move_batch_size.py
@@ -5,7 +5,11 @@ import json
 from sqlglot import exp
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     snapshots_table = "_snapshots"
     if state_sync.schema:
         snapshots_table = f"{state_sync.schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
+++ b/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
@@ -3,7 +3,7 @@
 from sqlglot import exp
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -23,5 +23,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
+++ b/sqlmesh/migrations/v0004_environmnent_add_finalized_at.py
@@ -3,7 +3,7 @@
 from sqlglot import exp
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -21,3 +21,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
     )
 
     engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0005_create_seed_table.py
+++ b/sqlmesh/migrations/v0005_create_seed_table.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     seeds_table = "_seeds"
     if state_sync.schema:
@@ -24,5 +24,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     )
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0005_create_seed_table.py
+++ b/sqlmesh/migrations/v0005_create_seed_table.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     seeds_table = "_seeds"
     if state_sync.schema:
@@ -22,3 +22,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         },
         primary_key=("name", "identifier"),
     )
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0006_change_seed_hash.py
+++ b/sqlmesh/migrations/v0006_change_seed_hash.py
@@ -1,9 +1,9 @@
 """Seed hashes moved from to_string to to_json for performance."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0006_change_seed_hash.py
+++ b/sqlmesh/migrations/v0006_change_seed_hash.py
@@ -1,5 +1,9 @@
 """Seed hashes moved from to_string to to_json for performance."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0007_env_table_info_to_kind.py
+++ b/sqlmesh/migrations/v0007_env_table_info_to_kind.py
@@ -12,7 +12,11 @@ def _hash(data):  # type: ignore
     return str(zlib.crc32(";".join("" if d is None else d for d in data).encode("utf-8")))
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0007_env_table_info_to_kind.py
+++ b/sqlmesh/migrations/v0007_env_table_info_to_kind.py
@@ -12,11 +12,11 @@ def _hash(data):  # type: ignore
     return str(zlib.crc32(";".join("" if d is None else d for d in data).encode("utf-8")))
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0008_create_intervals_table.py
+++ b/sqlmesh/migrations/v0008_create_intervals_table.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     intervals_table = "_intervals"
     if state_sync.schema:
@@ -36,3 +36,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter.create_index(
         intervals_table, "name_identifier_idx", ("name", "identifier", "created_ts")
     )
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0008_create_intervals_table.py
+++ b/sqlmesh/migrations/v0008_create_intervals_table.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     intervals_table = "_intervals"
     if state_sync.schema:
@@ -38,5 +38,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     )
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0009_remove_pre_post_hooks.py
+++ b/sqlmesh/migrations/v0009_remove_pre_post_hooks.py
@@ -7,11 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0009_remove_pre_post_hooks.py
+++ b/sqlmesh/migrations/v0009_remove_pre_post_hooks.py
@@ -7,7 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0010_seed_hash_batch_size.py
+++ b/sqlmesh/migrations/v0010_seed_hash_batch_size.py
@@ -1,9 +1,9 @@
 """Seed metadata hashes now correctly include the batch_size."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0010_seed_hash_batch_size.py
+++ b/sqlmesh/migrations/v0010_seed_hash_batch_size.py
@@ -1,5 +1,9 @@
 """Seed metadata hashes now correctly include the batch_size."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0011_add_model_kind_name.py
+++ b/sqlmesh/migrations/v0011_add_model_kind_name.py
@@ -7,9 +7,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
-    import pandas as pd
-
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"
@@ -29,6 +27,18 @@ def migrate(state_sync, **kwargs):  # type: ignore
         ],
     )
     engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    import pandas as pd
+
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+
+    index_type = index_text_type(engine_adapter.dialect)
 
     new_snapshots = []
 

--- a/sqlmesh/migrations/v0011_add_model_kind_name.py
+++ b/sqlmesh/migrations/v0011_add_model_kind_name.py
@@ -7,7 +7,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"
@@ -29,7 +29,7 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0012_update_jinja_expressions.py
+++ b/sqlmesh/migrations/v0012_update_jinja_expressions.py
@@ -9,11 +9,11 @@ from sqlmesh.utils.jinja import has_jinja
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0012_update_jinja_expressions.py
+++ b/sqlmesh/migrations/v0012_update_jinja_expressions.py
@@ -9,7 +9,11 @@ from sqlmesh.utils.jinja import has_jinja
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0013_serde_using_model_dialects.py
+++ b/sqlmesh/migrations/v0013_serde_using_model_dialects.py
@@ -9,11 +9,11 @@ from sqlmesh.utils.jinja import has_jinja
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0013_serde_using_model_dialects.py
+++ b/sqlmesh/migrations/v0013_serde_using_model_dialects.py
@@ -9,7 +9,11 @@ from sqlmesh.utils.jinja import has_jinja
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0014_fix_dev_intervals.py
+++ b/sqlmesh/migrations/v0014_fix_dev_intervals.py
@@ -1,11 +1,11 @@
 """Fix snapshot intervals that have been erroneously marked as dev."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     schema = state_sync.schema
     intervals_table = "_intervals"
     if schema:

--- a/sqlmesh/migrations/v0014_fix_dev_intervals.py
+++ b/sqlmesh/migrations/v0014_fix_dev_intervals.py
@@ -1,7 +1,11 @@
 """Fix snapshot intervals that have been erroneously marked as dev."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     schema = state_sync.schema
     intervals_table = "_intervals"
     if schema:

--- a/sqlmesh/migrations/v0015_environment_add_promoted_snapshot_ids.py
+++ b/sqlmesh/migrations/v0015_environment_add_promoted_snapshot_ids.py
@@ -4,7 +4,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -26,5 +26,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0015_environment_add_promoted_snapshot_ids.py
+++ b/sqlmesh/migrations/v0015_environment_add_promoted_snapshot_ids.py
@@ -4,7 +4,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -24,3 +24,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
     )
 
     engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0016_fix_windows_path.py
+++ b/sqlmesh/migrations/v0016_fix_windows_path.py
@@ -7,11 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0016_fix_windows_path.py
+++ b/sqlmesh/migrations/v0016_fix_windows_path.py
@@ -7,7 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0017_fix_windows_seed_path.py
+++ b/sqlmesh/migrations/v0017_fix_windows_seed_path.py
@@ -7,11 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0017_fix_windows_seed_path.py
+++ b/sqlmesh/migrations/v0017_fix_windows_seed_path.py
@@ -7,7 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0018_rename_snapshot_model_to_node.py
+++ b/sqlmesh/migrations/v0018_rename_snapshot_model_to_node.py
@@ -7,11 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0018_rename_snapshot_model_to_node.py
+++ b/sqlmesh/migrations/v0018_rename_snapshot_model_to_node.py
@@ -7,7 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0019_add_env_suffix_target.py
+++ b/sqlmesh/migrations/v0019_add_env_suffix_target.py
@@ -3,7 +3,7 @@
 from sqlglot import exp
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -20,6 +20,13 @@ def migrate(state_sync, **kwargs):  # type: ignore
         ],
     )
     engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    environments_table = "_environments"
+    if state_sync.schema:
+        environments_table = f"{state_sync.schema}.{environments_table}"
 
     state_sync.engine_adapter.update_table(
         environments_table,

--- a/sqlmesh/migrations/v0019_add_env_suffix_target.py
+++ b/sqlmesh/migrations/v0019_add_env_suffix_target.py
@@ -3,7 +3,7 @@
 from sqlglot import exp
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -22,7 +22,7 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:

--- a/sqlmesh/migrations/v0020_remove_redundant_attributes_from_dbt_models.py
+++ b/sqlmesh/migrations/v0020_remove_redundant_attributes_from_dbt_models.py
@@ -7,11 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0020_remove_redundant_attributes_from_dbt_models.py
+++ b/sqlmesh/migrations/v0020_remove_redundant_attributes_from_dbt_models.py
@@ -7,7 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0021_fix_table_properties.py
+++ b/sqlmesh/migrations/v0021_fix_table_properties.py
@@ -8,7 +8,11 @@ from sqlmesh.core import dialect as d
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0021_fix_table_properties.py
+++ b/sqlmesh/migrations/v0021_fix_table_properties.py
@@ -8,11 +8,11 @@ from sqlmesh.core import dialect as d
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0022_move_project_to_model.py
+++ b/sqlmesh/migrations/v0022_move_project_to_model.py
@@ -7,11 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0022_move_project_to_model.py
+++ b/sqlmesh/migrations/v0022_move_project_to_model.py
@@ -7,7 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0023_fix_added_models_with_forward_only_parents.py
+++ b/sqlmesh/migrations/v0023_fix_added_models_with_forward_only_parents.py
@@ -8,11 +8,11 @@ from sqlglot import exp
 from sqlmesh.utils.dag import DAG
 
 
-def migrate_ddl(state_sync: t.Any, **kwargs) -> None:  # type: ignore
+def migrate_schemas(state_sync: t.Any, **kwargs) -> None:  # type: ignore
     pass
 
 
-def migrate_dml(state_sync: t.Any, **kwargs) -> None:  # type: ignore
+def migrate_rows(state_sync: t.Any, **kwargs) -> None:  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0023_fix_added_models_with_forward_only_parents.py
+++ b/sqlmesh/migrations/v0023_fix_added_models_with_forward_only_parents.py
@@ -8,7 +8,11 @@ from sqlglot import exp
 from sqlmesh.utils.dag import DAG
 
 
-def migrate(state_sync: t.Any, **kwargs) -> None:  # type: ignore
+def migrate_ddl(state_sync: t.Any, **kwargs) -> None:  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync: t.Any, **kwargs) -> None:  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0024_replace_model_kind_name_enum_with_value.py
+++ b/sqlmesh/migrations/v0024_replace_model_kind_name_enum_with_value.py
@@ -7,11 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0024_replace_model_kind_name_enum_with_value.py
+++ b/sqlmesh/migrations/v0024_replace_model_kind_name_enum_with_value.py
@@ -7,7 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0025_fix_intervals_and_missing_change_category.py
+++ b/sqlmesh/migrations/v0025_fix_intervals_and_missing_change_category.py
@@ -10,7 +10,11 @@ from sqlmesh.utils.date import now_timestamp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0025_fix_intervals_and_missing_change_category.py
+++ b/sqlmesh/migrations/v0025_fix_intervals_and_missing_change_category.py
@@ -10,11 +10,11 @@ from sqlmesh.utils.date import now_timestamp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0026_remove_dialect_from_seed.py
+++ b/sqlmesh/migrations/v0026_remove_dialect_from_seed.py
@@ -7,11 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0026_remove_dialect_from_seed.py
+++ b/sqlmesh/migrations/v0026_remove_dialect_from_seed.py
@@ -7,7 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0027_minute_interval_to_five.py
+++ b/sqlmesh/migrations/v0027_minute_interval_to_five.py
@@ -7,11 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0027_minute_interval_to_five.py
+++ b/sqlmesh/migrations/v0027_minute_interval_to_five.py
@@ -7,7 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0028_add_plan_dags_table.py
+++ b/sqlmesh/migrations/v0028_add_plan_dags_table.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     plan_dags_table = "_plan_dags"
@@ -27,3 +27,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
     )
 
     engine_adapter.create_index(plan_dags_table, "dag_id_idx", ("dag_id",))
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0028_add_plan_dags_table.py
+++ b/sqlmesh/migrations/v0028_add_plan_dags_table.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     plan_dags_table = "_plan_dags"
@@ -29,5 +29,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.create_index(plan_dags_table, "dag_id_idx", ("dag_id",))
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0029_generate_schema_types_using_dialect.py
+++ b/sqlmesh/migrations/v0029_generate_schema_types_using_dialect.py
@@ -7,7 +7,11 @@ from sqlglot import exp, parse_one
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0029_generate_schema_types_using_dialect.py
+++ b/sqlmesh/migrations/v0029_generate_schema_types_using_dialect.py
@@ -7,11 +7,11 @@ from sqlglot import exp, parse_one
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0030_update_unrestorable_snapshots.py
+++ b/sqlmesh/migrations/v0030_update_unrestorable_snapshots.py
@@ -9,7 +9,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync: t.Any, **kwargs: t.Any) -> None:  # type: ignore
+def migrate_ddl(state_sync: t.Any, **kwargs: t.Any) -> None:  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync: t.Any, **kwargs: t.Any) -> None:  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0030_update_unrestorable_snapshots.py
+++ b/sqlmesh/migrations/v0030_update_unrestorable_snapshots.py
@@ -9,11 +9,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync: t.Any, **kwargs: t.Any) -> None:  # type: ignore
+def migrate_schemas(state_sync: t.Any, **kwargs: t.Any) -> None:  # type: ignore
     pass
 
 
-def migrate_dml(state_sync: t.Any, **kwargs: t.Any) -> None:  # type: ignore
+def migrate_rows(state_sync: t.Any, **kwargs: t.Any) -> None:  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0031_remove_dbt_target_fields.py
+++ b/sqlmesh/migrations/v0031_remove_dbt_target_fields.py
@@ -7,11 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0031_remove_dbt_target_fields.py
+++ b/sqlmesh/migrations/v0031_remove_dbt_target_fields.py
@@ -7,7 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0032_add_sqlmesh_version.py
+++ b/sqlmesh/migrations/v0032_add_sqlmesh_version.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     versions_table = "_versions"
     if state_sync.schema:
@@ -25,5 +25,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0032_add_sqlmesh_version.py
+++ b/sqlmesh/migrations/v0032_add_sqlmesh_version.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     versions_table = "_versions"
     if state_sync.schema:
@@ -23,3 +23,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
     )
 
     engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0033_mysql_fix_blob_text_type.py
+++ b/sqlmesh/migrations/v0033_mysql_fix_blob_text_type.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     if engine_adapter.dialect != "mysql":
         return
@@ -43,3 +43,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         )
 
         engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0033_mysql_fix_blob_text_type.py
+++ b/sqlmesh/migrations/v0033_mysql_fix_blob_text_type.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     if engine_adapter.dialect != "mysql":
         return
@@ -45,5 +45,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
         engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0034_add_default_catalog.py
+++ b/sqlmesh/migrations/v0034_add_default_catalog.py
@@ -63,11 +63,11 @@ def update_dbt_relations(
                     relation["database"] = default_catalog
 
 
-def migrate_ddl(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ignore
+def migrate_schemas(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ignore
+def migrate_rows(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0034_add_default_catalog.py
+++ b/sqlmesh/migrations/v0034_add_default_catalog.py
@@ -63,7 +63,11 @@ def update_dbt_relations(
                     relation["database"] = default_catalog
 
 
-def migrate(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ignore
+def migrate_ddl(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, default_catalog: t.Optional[str], **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0035_add_catalog_name_override.py
+++ b/sqlmesh/migrations/v0035_add_catalog_name_override.py
@@ -3,7 +3,7 @@
 from sqlglot import exp
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -22,5 +22,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0035_add_catalog_name_override.py
+++ b/sqlmesh/migrations/v0035_add_catalog_name_override.py
@@ -3,7 +3,7 @@
 from sqlglot import exp
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -20,3 +20,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         ],
     )
     engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0036_delete_plan_dags_bug_fix.py
+++ b/sqlmesh/migrations/v0036_delete_plan_dags_bug_fix.py
@@ -1,7 +1,11 @@
 """Add missing delete from migration #34."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     plan_dags_table = "_plan_dags"

--- a/sqlmesh/migrations/v0036_delete_plan_dags_bug_fix.py
+++ b/sqlmesh/migrations/v0036_delete_plan_dags_bug_fix.py
@@ -1,11 +1,11 @@
 """Add missing delete from migration #34."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     plan_dags_table = "_plan_dags"

--- a/sqlmesh/migrations/v0037_remove_dbt_is_incremental_macro.py
+++ b/sqlmesh/migrations/v0037_remove_dbt_is_incremental_macro.py
@@ -8,11 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0037_remove_dbt_is_incremental_macro.py
+++ b/sqlmesh/migrations/v0037_remove_dbt_is_incremental_macro.py
@@ -8,7 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0038_add_expiration_ts_to_snapshot.py
+++ b/sqlmesh/migrations/v0038_add_expiration_ts_to_snapshot.py
@@ -9,17 +9,12 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
-    import pandas as pd
-
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
-
-    index_type = index_text_type(engine_adapter.dialect)
-    blob_type = blob_text_type(engine_adapter.dialect)
 
     alter_table_exp = exp.Alter(
         this=exp.to_table(snapshots_table),
@@ -33,8 +28,20 @@ def migrate(state_sync, **kwargs):  # type: ignore
     )
     engine_adapter.execute(alter_table_exp)
 
-    new_snapshots = []
 
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    import pandas as pd
+
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+
+    index_type = index_text_type(engine_adapter.dialect)
+    blob_type = blob_text_type(engine_adapter.dialect)
+
+    new_snapshots = []
     for name, identifier, version, snapshot, kind_name in engine_adapter.fetchall(
         exp.select("name", "identifier", "version", "snapshot", "kind_name").from_(snapshots_table),
         quote_identifiers=True,

--- a/sqlmesh/migrations/v0038_add_expiration_ts_to_snapshot.py
+++ b/sqlmesh/migrations/v0038_add_expiration_ts_to_snapshot.py
@@ -9,7 +9,7 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"
@@ -29,7 +29,7 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0039_include_environment_in_plan_dag_spec.py
+++ b/sqlmesh/migrations/v0039_include_environment_in_plan_dag_spec.py
@@ -8,11 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0039_include_environment_in_plan_dag_spec.py
+++ b/sqlmesh/migrations/v0039_include_environment_in_plan_dag_spec.py
@@ -8,7 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0040_add_previous_finalized_snapshots.py
+++ b/sqlmesh/migrations/v0040_add_previous_finalized_snapshots.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -26,5 +26,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0040_add_previous_finalized_snapshots.py
+++ b/sqlmesh/migrations/v0040_add_previous_finalized_snapshots.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -24,3 +24,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         ],
     )
     engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0041_remove_hash_raw_query_attribute.py
+++ b/sqlmesh/migrations/v0041_remove_hash_raw_query_attribute.py
@@ -8,11 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0041_remove_hash_raw_query_attribute.py
+++ b/sqlmesh/migrations/v0041_remove_hash_raw_query_attribute.py
@@ -8,7 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0042_trim_indirect_versions.py
+++ b/sqlmesh/migrations/v0042_trim_indirect_versions.py
@@ -8,11 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0042_trim_indirect_versions.py
+++ b/sqlmesh/migrations/v0042_trim_indirect_versions.py
@@ -8,7 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0043_fix_remove_obsolete_attributes_in_plan_dags.py
+++ b/sqlmesh/migrations/v0043_fix_remove_obsolete_attributes_in_plan_dags.py
@@ -8,11 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0043_fix_remove_obsolete_attributes_in_plan_dags.py
+++ b/sqlmesh/migrations/v0043_fix_remove_obsolete_attributes_in_plan_dags.py
@@ -8,7 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0044_quote_identifiers_in_model_attributes.py
+++ b/sqlmesh/migrations/v0044_quote_identifiers_in_model_attributes.py
@@ -1,5 +1,9 @@
 """Quoted identifiers in model SQL attributes."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0044_quote_identifiers_in_model_attributes.py
+++ b/sqlmesh/migrations/v0044_quote_identifiers_in_model_attributes.py
@@ -1,9 +1,9 @@
 """Quoted identifiers in model SQL attributes."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0045_move_gateway_variable.py
+++ b/sqlmesh/migrations/v0045_move_gateway_variable.py
@@ -9,7 +9,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0045_move_gateway_variable.py
+++ b/sqlmesh/migrations/v0045_move_gateway_variable.py
@@ -9,11 +9,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0046_add_batch_concurrency.py
+++ b/sqlmesh/migrations/v0046_add_batch_concurrency.py
@@ -4,5 +4,9 @@ This results in a change to the metadata hash.
 """
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0046_add_batch_concurrency.py
+++ b/sqlmesh/migrations/v0046_add_batch_concurrency.py
@@ -4,9 +4,9 @@ This results in a change to the metadata hash.
 """
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0047_change_scd_string_to_column.py
+++ b/sqlmesh/migrations/v0047_change_scd_string_to_column.py
@@ -1,9 +1,9 @@
 """Changes the SCD Type 2 columns from strings to columns."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0047_change_scd_string_to_column.py
+++ b/sqlmesh/migrations/v0047_change_scd_string_to_column.py
@@ -1,5 +1,9 @@
 """Changes the SCD Type 2 columns from strings to columns."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0048_drop_indirect_versions.py
+++ b/sqlmesh/migrations/v0048_drop_indirect_versions.py
@@ -8,11 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0048_drop_indirect_versions.py
+++ b/sqlmesh/migrations/v0048_drop_indirect_versions.py
@@ -8,7 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0049_replace_identifier_with_version_in_seeds_table.py
+++ b/sqlmesh/migrations/v0049_replace_identifier_with_version_in_seeds_table.py
@@ -5,7 +5,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
 
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0049_replace_identifier_with_version_in_seeds_table.py
+++ b/sqlmesh/migrations/v0049_replace_identifier_with_version_in_seeds_table.py
@@ -5,11 +5,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
 
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0050_drop_seeds_table.py
+++ b/sqlmesh/migrations/v0050_drop_seeds_table.py
@@ -1,7 +1,7 @@
 """Drop the seeds table."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
 
     seeds_table = "_seeds"
@@ -11,5 +11,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.drop_table(seeds_table)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0050_drop_seeds_table.py
+++ b/sqlmesh/migrations/v0050_drop_seeds_table.py
@@ -1,7 +1,7 @@
 """Drop the seeds table."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
 
     seeds_table = "_seeds"
@@ -9,3 +9,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         seeds_table = f"{state_sync.schema}.{seeds_table}"
 
     engine_adapter.drop_table(seeds_table)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0051_rename_column_descriptions.py
+++ b/sqlmesh/migrations/v0051_rename_column_descriptions.py
@@ -8,11 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0051_rename_column_descriptions.py
+++ b/sqlmesh/migrations/v0051_rename_column_descriptions.py
@@ -8,7 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0052_add_normalize_name_in_environment_naming_info.py
+++ b/sqlmesh/migrations/v0052_add_normalize_name_in_environment_naming_info.py
@@ -3,7 +3,7 @@
 from sqlglot import exp
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -20,6 +20,13 @@ def migrate(state_sync, **kwargs):  # type: ignore
         ],
     )
     engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    environments_table = "_environments"
+    if state_sync.schema:
+        environments_table = f"{state_sync.schema}.{environments_table}"
 
     state_sync.engine_adapter.update_table(
         environments_table,

--- a/sqlmesh/migrations/v0052_add_normalize_name_in_environment_naming_info.py
+++ b/sqlmesh/migrations/v0052_add_normalize_name_in_environment_naming_info.py
@@ -3,7 +3,7 @@
 from sqlglot import exp
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -22,7 +22,7 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:

--- a/sqlmesh/migrations/v0053_custom_model_kind_extra_attributes.py
+++ b/sqlmesh/migrations/v0053_custom_model_kind_extra_attributes.py
@@ -1,9 +1,9 @@
 """Add batch_size, batch_concurrency, and batch_interval to the CUSTOM model kind."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0053_custom_model_kind_extra_attributes.py
+++ b/sqlmesh/migrations/v0053_custom_model_kind_extra_attributes.py
@@ -1,5 +1,9 @@
 """Add batch_size, batch_concurrency, and batch_interval to the CUSTOM model kind."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0054_fix_trailing_comments.py
+++ b/sqlmesh/migrations/v0054_fix_trailing_comments.py
@@ -1,9 +1,9 @@
 """Fix support for trailing comments in SQL model definitions."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0054_fix_trailing_comments.py
+++ b/sqlmesh/migrations/v0054_fix_trailing_comments.py
@@ -1,5 +1,9 @@
 """Fix support for trailing comments in SQL model definitions."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0055_add_updated_ts_unpaused_ts_ttl_ms_unrestorable_to_snapshot.py
+++ b/sqlmesh/migrations/v0055_add_updated_ts_unpaused_ts_ttl_ms_unrestorable_to_snapshot.py
@@ -9,17 +9,12 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
-    import pandas as pd
-
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
-
-    index_type = index_text_type(engine_adapter.dialect)
-    blob_type = blob_text_type(engine_adapter.dialect)
 
     add_column_exps = [
         exp.Alter(
@@ -77,6 +72,19 @@ def migrate(state_sync, **kwargs):  # type: ignore
         actions=[exp.Drop(this=exp.to_column("expiration_ts"), kind="COLUMN")],
     )
     engine_adapter.execute(drop_column_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    import pandas as pd
+
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+
+    index_type = index_text_type(engine_adapter.dialect)
+    blob_type = blob_text_type(engine_adapter.dialect)
 
     new_snapshots = []
 

--- a/sqlmesh/migrations/v0055_add_updated_ts_unpaused_ts_ttl_ms_unrestorable_to_snapshot.py
+++ b/sqlmesh/migrations/v0055_add_updated_ts_unpaused_ts_ttl_ms_unrestorable_to_snapshot.py
@@ -9,7 +9,7 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"
@@ -74,7 +74,7 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(drop_column_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0056_restore_table_indexes.py
+++ b/sqlmesh/migrations/v0056_restore_table_indexes.py
@@ -6,7 +6,7 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     schema = state_sync.schema
     engine_adapter = state_sync.engine_adapter
     if not engine_adapter.SUPPORTS_INDEXES:
@@ -118,5 +118,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.rename_table(new_intervals_table, intervals_table)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0056_restore_table_indexes.py
+++ b/sqlmesh/migrations/v0056_restore_table_indexes.py
@@ -6,8 +6,7 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
-    schema = state_sync.schema
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     if not engine_adapter.SUPPORTS_INDEXES:
         return
@@ -116,3 +115,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
     engine_adapter.rename_table(new_snapshots_table, snapshots_table)
     engine_adapter.rename_table(new_environments_table, environments_table)
     engine_adapter.rename_table(new_intervals_table, intervals_table)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0056_restore_table_indexes.py
+++ b/sqlmesh/migrations/v0056_restore_table_indexes.py
@@ -7,6 +7,7 @@ from sqlmesh.utils.migration import blob_text_type
 
 
 def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    schema = state_sync.schema
     engine_adapter = state_sync.engine_adapter
     if not engine_adapter.SUPPORTS_INDEXES:
         return

--- a/sqlmesh/migrations/v0057_add_table_format.py
+++ b/sqlmesh/migrations/v0057_add_table_format.py
@@ -1,5 +1,9 @@
 """Add table_format to the model top-level properties"""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0057_add_table_format.py
+++ b/sqlmesh/migrations/v0057_add_table_format.py
@@ -1,9 +1,9 @@
 """Add table_format to the model top-level properties"""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0058_add_requirements.py
+++ b/sqlmesh/migrations/v0058_add_requirements.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -26,5 +26,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0058_add_requirements.py
+++ b/sqlmesh/migrations/v0058_add_requirements.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -24,3 +24,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
     )
 
     engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0059_add_physical_version.py
+++ b/sqlmesh/migrations/v0059_add_physical_version.py
@@ -1,5 +1,9 @@
 """Add the physical_version model attribute."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0059_add_physical_version.py
+++ b/sqlmesh/migrations/v0059_add_physical_version.py
@@ -1,9 +1,9 @@
 """Add the physical_version model attribute."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0060_move_audits_to_model.py
+++ b/sqlmesh/migrations/v0060_move_audits_to_model.py
@@ -7,11 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0060_move_audits_to_model.py
+++ b/sqlmesh/migrations/v0060_move_audits_to_model.py
@@ -7,7 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0061_mysql_fix_blob_text_type.py
+++ b/sqlmesh/migrations/v0061_mysql_fix_blob_text_type.py
@@ -9,7 +9,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     if engine_adapter.dialect != "mysql":
         return
@@ -49,5 +49,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
         engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0061_mysql_fix_blob_text_type.py
+++ b/sqlmesh/migrations/v0061_mysql_fix_blob_text_type.py
@@ -9,7 +9,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     if engine_adapter.dialect != "mysql":
         return
@@ -47,3 +47,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         )
 
         engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0062_add_model_gateway.py
+++ b/sqlmesh/migrations/v0062_add_model_gateway.py
@@ -1,9 +1,9 @@
 """Add the gateway model attribute."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0062_add_model_gateway.py
+++ b/sqlmesh/migrations/v0062_add_model_gateway.py
@@ -1,5 +1,9 @@
 """Add the gateway model attribute."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0063_change_signals.py
+++ b/sqlmesh/migrations/v0063_change_signals.py
@@ -7,11 +7,11 @@ from sqlglot import exp, parse_one
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0063_change_signals.py
+++ b/sqlmesh/migrations/v0063_change_signals.py
@@ -7,7 +7,11 @@ from sqlglot import exp, parse_one
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0064_join_when_matched_strings.py
+++ b/sqlmesh/migrations/v0064_join_when_matched_strings.py
@@ -7,11 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0064_join_when_matched_strings.py
+++ b/sqlmesh/migrations/v0064_join_when_matched_strings.py
@@ -7,7 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0065_add_model_optimize.py
+++ b/sqlmesh/migrations/v0065_add_model_optimize.py
@@ -1,9 +1,9 @@
 """Add the optimize_query model attribute."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0065_add_model_optimize.py
+++ b/sqlmesh/migrations/v0065_add_model_optimize.py
@@ -1,5 +1,9 @@
 """Add the optimize_query model attribute."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0066_add_auto_restatements.py
+++ b/sqlmesh/migrations/v0066_add_auto_restatements.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     auto_restatements_table = "_auto_restatements"
@@ -38,6 +38,15 @@ def migrate(state_sync, **kwargs):  # type: ignore
         ],
     )
     engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    intervals_table = "_intervals"
+
+    if schema:
+        intervals_table = f"{schema}.{intervals_table}"
 
     engine_adapter.update_table(
         intervals_table,

--- a/sqlmesh/migrations/v0066_add_auto_restatements.py
+++ b/sqlmesh/migrations/v0066_add_auto_restatements.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     auto_restatements_table = "_auto_restatements"
@@ -40,7 +40,7 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     intervals_table = "_intervals"

--- a/sqlmesh/migrations/v0067_add_tsql_date_full_precision.py
+++ b/sqlmesh/migrations/v0067_add_tsql_date_full_precision.py
@@ -1,9 +1,9 @@
 """Add full precision for tsql to support nanoseconds."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0067_add_tsql_date_full_precision.py
+++ b/sqlmesh/migrations/v0067_add_tsql_date_full_precision.py
@@ -1,5 +1,9 @@
 """Add full precision for tsql to support nanoseconds."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0068_include_unrendered_query_in_metadata_hash.py
+++ b/sqlmesh/migrations/v0068_include_unrendered_query_in_metadata_hash.py
@@ -1,9 +1,9 @@
 """Include the unrendered query in the metadata hash."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0068_include_unrendered_query_in_metadata_hash.py
+++ b/sqlmesh/migrations/v0068_include_unrendered_query_in_metadata_hash.py
@@ -1,5 +1,9 @@
 """Include the unrendered query in the metadata hash."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0069_update_dev_table_suffix.py
+++ b/sqlmesh/migrations/v0069_update_dev_table_suffix.py
@@ -7,11 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0069_update_dev_table_suffix.py
+++ b/sqlmesh/migrations/v0069_update_dev_table_suffix.py
@@ -7,7 +7,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0070_include_grains_in_metadata_hash.py
+++ b/sqlmesh/migrations/v0070_include_grains_in_metadata_hash.py
@@ -1,5 +1,9 @@
 """Include grains in the metadata hash."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0070_include_grains_in_metadata_hash.py
+++ b/sqlmesh/migrations/v0070_include_grains_in_metadata_hash.py
@@ -1,9 +1,9 @@
 """Include grains in the metadata hash."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0071_add_dev_version_to_intervals.py
+++ b/sqlmesh/migrations/v0071_add_dev_version_to_intervals.py
@@ -8,7 +8,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     intervals_table = "_intervals"
@@ -29,7 +29,7 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     intervals_table = "_intervals"

--- a/sqlmesh/migrations/v0071_add_dev_version_to_intervals.py
+++ b/sqlmesh/migrations/v0071_add_dev_version_to_intervals.py
@@ -8,14 +8,12 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     intervals_table = "_intervals"
-    snapshots_table = "_snapshots"
     if schema:
         intervals_table = f"{schema}.{intervals_table}"
-        snapshots_table = f"{schema}.{snapshots_table}"
 
     index_type = index_text_type(engine_adapter.dialect)
     alter_table_exp = exp.Alter(
@@ -29,6 +27,16 @@ def migrate(state_sync, **kwargs):  # type: ignore
         ],
     )
     engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    intervals_table = "_intervals"
+    snapshots_table = "_snapshots"
+    if schema:
+        intervals_table = f"{schema}.{intervals_table}"
+        snapshots_table = f"{schema}.{snapshots_table}"
 
     used_dev_versions: t.Set[t.Tuple[str, str]] = set()
     used_versions: t.Set[t.Tuple[str, str]] = set()

--- a/sqlmesh/migrations/v0072_add_environment_statements.py
+++ b/sqlmesh/migrations/v0072_add_environment_statements.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type, index_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     environment_statements_table = "_environment_statements"
@@ -27,5 +27,5 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     )
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0072_add_environment_statements.py
+++ b/sqlmesh/migrations/v0072_add_environment_statements.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type, index_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     environment_statements_table = "_environment_statements"
@@ -25,3 +25,7 @@ def migrate(state_sync, **kwargs):  # type: ignore
         },
         primary_key=("environment_name",),
     )
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    pass

--- a/sqlmesh/migrations/v0073_remove_symbolic_disable_restatement.py
+++ b/sqlmesh/migrations/v0073_remove_symbolic_disable_restatement.py
@@ -6,7 +6,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0073_remove_symbolic_disable_restatement.py
+++ b/sqlmesh/migrations/v0073_remove_symbolic_disable_restatement.py
@@ -6,11 +6,11 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0074_add_partition_by_time_column_property.py
+++ b/sqlmesh/migrations/v0074_add_partition_by_time_column_property.py
@@ -2,5 +2,9 @@
 (default: True to keep the original behaviour)"""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0074_add_partition_by_time_column_property.py
+++ b/sqlmesh/migrations/v0074_add_partition_by_time_column_property.py
@@ -2,9 +2,9 @@
 (default: True to keep the original behaviour)"""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0075_remove_validate_query.py
+++ b/sqlmesh/migrations/v0075_remove_validate_query.py
@@ -8,11 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0075_remove_validate_query.py
+++ b/sqlmesh/migrations/v0075_remove_validate_query.py
@@ -8,7 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0076_add_cron_tz.py
+++ b/sqlmesh/migrations/v0076_add_cron_tz.py
@@ -1,5 +1,9 @@
 """Add 'cron_tz' property to node definition."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0076_add_cron_tz.py
+++ b/sqlmesh/migrations/v0076_add_cron_tz.py
@@ -1,9 +1,9 @@
 """Add 'cron_tz' property to node definition."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0077_fix_column_type_hash_calculation.py
+++ b/sqlmesh/migrations/v0077_fix_column_type_hash_calculation.py
@@ -1,9 +1,9 @@
 """Use the model's dialect when calculating the hash for the column types."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0077_fix_column_type_hash_calculation.py
+++ b/sqlmesh/migrations/v0077_fix_column_type_hash_calculation.py
@@ -1,5 +1,9 @@
 """Use the model's dialect when calculating the hash for the column types."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0078_warn_if_non_migratable_python_env.py
+++ b/sqlmesh/migrations/v0078_warn_if_non_migratable_python_env.py
@@ -24,7 +24,11 @@ import sqlmesh.core.dialect as d
 from sqlmesh.core.console import get_console
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0078_warn_if_non_migratable_python_env.py
+++ b/sqlmesh/migrations/v0078_warn_if_non_migratable_python_env.py
@@ -24,11 +24,11 @@ import sqlmesh.core.dialect as d
 from sqlmesh.core.console import get_console
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0079_add_gateway_managed_property.py
+++ b/sqlmesh/migrations/v0079_add_gateway_managed_property.py
@@ -3,7 +3,7 @@
 from sqlglot import exp
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -20,6 +20,13 @@ def migrate(state_sync, **kwargs):  # type: ignore
         ],
     )
     engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    engine_adapter = state_sync.engine_adapter
+    environments_table = "_environments"
+    if state_sync.schema:
+        environments_table = f"{state_sync.schema}.{environments_table}"
 
     state_sync.engine_adapter.update_table(
         environments_table,

--- a/sqlmesh/migrations/v0079_add_gateway_managed_property.py
+++ b/sqlmesh/migrations/v0079_add_gateway_managed_property.py
@@ -3,7 +3,7 @@
 from sqlglot import exp
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:
@@ -22,7 +22,7 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     environments_table = "_environments"
     if state_sync.schema:

--- a/sqlmesh/migrations/v0080_add_batch_size_to_scd_type_2_models.py
+++ b/sqlmesh/migrations/v0080_add_batch_size_to_scd_type_2_models.py
@@ -1,5 +1,9 @@
 """Add batch_size to SCD Type 2 models and add updated_at_name to by time which changes their data hash."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0080_add_batch_size_to_scd_type_2_models.py
+++ b/sqlmesh/migrations/v0080_add_batch_size_to_scd_type_2_models.py
@@ -1,9 +1,9 @@
 """Add batch_size to SCD Type 2 models and add updated_at_name to by time which changes their data hash."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0081_update_partitioned_by.py
+++ b/sqlmesh/migrations/v0081_update_partitioned_by.py
@@ -8,11 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0081_update_partitioned_by.py
+++ b/sqlmesh/migrations/v0081_update_partitioned_by.py
@@ -8,7 +8,11 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0082_warn_if_incorrectly_duplicated_statements.py
+++ b/sqlmesh/migrations/v0082_warn_if_incorrectly_duplicated_statements.py
@@ -34,7 +34,11 @@ from sqlglot import exp
 from sqlmesh.core.console import get_console
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0082_warn_if_incorrectly_duplicated_statements.py
+++ b/sqlmesh/migrations/v0082_warn_if_incorrectly_duplicated_statements.py
@@ -34,11 +34,11 @@ from sqlglot import exp
 from sqlmesh.core.console import get_console
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0083_use_sql_for_scd_time_data_type_data_hash.py
+++ b/sqlmesh/migrations/v0083_use_sql_for_scd_time_data_type_data_hash.py
@@ -1,5 +1,9 @@
 """Use sql(...) instead of gen when computing the data hash of the time data type."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0083_use_sql_for_scd_time_data_type_data_hash.py
+++ b/sqlmesh/migrations/v0083_use_sql_for_scd_time_data_type_data_hash.py
@@ -1,9 +1,9 @@
 """Use sql(...) instead of gen when computing the data hash of the time data type."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0084_normalize_quote_when_matched_and_merge_filter.py
+++ b/sqlmesh/migrations/v0084_normalize_quote_when_matched_and_merge_filter.py
@@ -5,9 +5,9 @@ prevent un-normalized identifiers being quoted at the EngineAdapter level
 """
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0084_normalize_quote_when_matched_and_merge_filter.py
+++ b/sqlmesh/migrations/v0084_normalize_quote_when_matched_and_merge_filter.py
@@ -5,5 +5,9 @@ prevent un-normalized identifiers being quoted at the EngineAdapter level
 """
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0085_deterministic_repr.py
+++ b/sqlmesh/migrations/v0085_deterministic_repr.py
@@ -36,11 +36,11 @@ def _dict_sort(obj: t.Any) -> str:
     return repr(obj)
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0085_deterministic_repr.py
+++ b/sqlmesh/migrations/v0085_deterministic_repr.py
@@ -36,7 +36,11 @@ def _dict_sort(obj: t.Any) -> str:
     return repr(obj)
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0086_check_deterministic_bug.py
+++ b/sqlmesh/migrations/v0086_check_deterministic_bug.py
@@ -10,7 +10,11 @@ logger = logging.getLogger(__name__)
 KEYS_TO_MAKE_DETERMINISTIC = ["__sqlmesh__vars__", "__sqlmesh__blueprint__vars__"]
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0086_check_deterministic_bug.py
+++ b/sqlmesh/migrations/v0086_check_deterministic_bug.py
@@ -10,11 +10,11 @@ logger = logging.getLogger(__name__)
 KEYS_TO_MAKE_DETERMINISTIC = ["__sqlmesh__vars__", "__sqlmesh__blueprint__vars__"]
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0087_normalize_blueprint_variables.py
+++ b/sqlmesh/migrations/v0087_normalize_blueprint_variables.py
@@ -35,7 +35,11 @@ class SqlValue:
     sql: str
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0087_normalize_blueprint_variables.py
+++ b/sqlmesh/migrations/v0087_normalize_blueprint_variables.py
@@ -35,11 +35,11 @@ class SqlValue:
     sql: str
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0088_warn_about_variable_python_env_diffs.py
+++ b/sqlmesh/migrations/v0088_warn_about_variable_python_env_diffs.py
@@ -35,7 +35,11 @@ SQLMESH_BLUEPRINT_VARS = "__sqlmesh__blueprint__vars__"
 METADATA_HASH_EXPRESSIONS = {"on_virtual_update", "audits", "signals", "audit_definitions"}
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0088_warn_about_variable_python_env_diffs.py
+++ b/sqlmesh/migrations/v0088_warn_about_variable_python_env_diffs.py
@@ -35,11 +35,11 @@ SQLMESH_BLUEPRINT_VARS = "__sqlmesh__blueprint__vars__"
 METADATA_HASH_EXPRESSIONS = {"on_virtual_update", "audits", "signals", "audit_definitions"}
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0089_add_virtual_environment_mode.py
+++ b/sqlmesh/migrations/v0089_add_virtual_environment_mode.py
@@ -1,5 +1,9 @@
 """Add virtual_environment_mode to the model definition."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0089_add_virtual_environment_mode.py
+++ b/sqlmesh/migrations/v0089_add_virtual_environment_mode.py
@@ -1,9 +1,9 @@
 """Add virtual_environment_mode to the model definition."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0090_add_forward_only_column.py
+++ b/sqlmesh/migrations/v0090_add_forward_only_column.py
@@ -7,9 +7,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
-    import pandas as pd
-
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"
@@ -27,6 +25,16 @@ def migrate(state_sync, **kwargs):  # type: ignore
         ],
     )
     engine_adapter.execute(alter_table_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    import pandas as pd
+
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
 
     new_snapshots = []
 

--- a/sqlmesh/migrations/v0090_add_forward_only_column.py
+++ b/sqlmesh/migrations/v0090_add_forward_only_column.py
@@ -7,7 +7,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"
@@ -27,7 +27,7 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0091_on_additive_change.py
+++ b/sqlmesh/migrations/v0091_on_additive_change.py
@@ -1,5 +1,9 @@
 """Add on_additive_change to incremental model metadata hash."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0091_on_additive_change.py
+++ b/sqlmesh/migrations/v0091_on_additive_change.py
@@ -1,9 +1,9 @@
 """Add on_additive_change to incremental model metadata hash."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0092_warn_about_dbt_data_type_diff.py
+++ b/sqlmesh/migrations/v0092_warn_about_dbt_data_type_diff.py
@@ -17,7 +17,11 @@ from sqlmesh.core.console import get_console
 SQLMESH_DBT_PACKAGE = "sqlmesh.dbt"
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0092_warn_about_dbt_data_type_diff.py
+++ b/sqlmesh/migrations/v0092_warn_about_dbt_data_type_diff.py
@@ -17,11 +17,11 @@ from sqlmesh.core.console import get_console
 SQLMESH_DBT_PACKAGE = "sqlmesh.dbt"
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0093_use_raw_sql_in_fingerprint.py
+++ b/sqlmesh/migrations/v0093_use_raw_sql_in_fingerprint.py
@@ -1,9 +1,9 @@
 """Use the raw SQL when computing the model fingerprint."""
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0093_use_raw_sql_in_fingerprint.py
+++ b/sqlmesh/migrations/v0093_use_raw_sql_in_fingerprint.py
@@ -1,5 +1,9 @@
 """Use the raw SQL when computing the model fingerprint."""
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0094_add_dev_version_and_fingerprint_columns.py
+++ b/sqlmesh/migrations/v0094_add_dev_version_and_fingerprint_columns.py
@@ -7,9 +7,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
-    import pandas as pd
-
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"
@@ -42,6 +40,19 @@ def migrate(state_sync, **kwargs):  # type: ignore
         ],
     )
     engine_adapter.execute(add_fingerprint_exp)
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
+    import pandas as pd
+
+    engine_adapter = state_sync.engine_adapter
+    schema = state_sync.schema
+    snapshots_table = "_snapshots"
+    if schema:
+        snapshots_table = f"{schema}.{snapshots_table}"
+
+    index_type = index_text_type(engine_adapter.dialect)
+    blob_type = blob_text_type(engine_adapter.dialect)
 
     new_snapshots = []
 

--- a/sqlmesh/migrations/v0094_add_dev_version_and_fingerprint_columns.py
+++ b/sqlmesh/migrations/v0094_add_dev_version_and_fingerprint_columns.py
@@ -7,7 +7,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"
@@ -42,7 +42,7 @@ def migrate_ddl(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(add_fingerprint_exp)
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     import pandas as pd
 
     engine_adapter = state_sync.engine_adapter

--- a/sqlmesh/migrations/v0095_warn_about_dbt_raw_sql_diff.py
+++ b/sqlmesh/migrations/v0095_warn_about_dbt_raw_sql_diff.py
@@ -17,7 +17,11 @@ from sqlmesh.core.console import get_console
 SQLMESH_DBT_PACKAGE = "sqlmesh.dbt"
 
 
-def migrate(state_sync, **kwargs):  # type: ignore
+def migrate_ddl(state_sync, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_dml(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/sqlmesh/migrations/v0095_warn_about_dbt_raw_sql_diff.py
+++ b/sqlmesh/migrations/v0095_warn_about_dbt_raw_sql_diff.py
@@ -17,11 +17,11 @@ from sqlmesh.core.console import get_console
 SQLMESH_DBT_PACKAGE = "sqlmesh.dbt"
 
 
-def migrate_ddl(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(state_sync, **kwargs):  # type: ignore
     pass
 
 
-def migrate_dml(state_sync, **kwargs):  # type: ignore
+def migrate_rows(state_sync, **kwargs):  # type: ignore
     engine_adapter = state_sync.engine_adapter
     schema = state_sync.schema
     snapshots_table = "_snapshots"

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -168,9 +168,9 @@ def test_render(
 
     assert output.stdout == ""
     assert output.stderr == ""
-    assert len(output.outputs) == 1
-    assert len(convert_all_html_output_to_text(output)[0]) > 2200
-    assert len(convert_all_html_output_to_tags(output)[0]) > 150
+    assert len(output.outputs) == 2
+    assert len(convert_all_html_output_to_text(output)[1]) > 2200
+    assert len(convert_all_html_output_to_tags(output)[1]) > 150
 
 
 @pytest.mark.slow
@@ -182,9 +182,9 @@ def test_render_no_format(
 
     assert output.stdout == ""
     assert output.stderr == ""
-    assert len(output.outputs) == 1
-    assert len(convert_all_html_output_to_text(output)[0]) >= 700
-    assert len(convert_all_html_output_to_tags(output)[0]) >= 50
+    assert len(output.outputs) == 2
+    assert len(convert_all_html_output_to_text(output)[1]) >= 700
+    assert len(convert_all_html_output_to_tags(output)[1]) >= 50
 
 
 @pytest.mark.slow


### PR DESCRIPTION
The split allows us to skip unnecessary DML operations during the initial state setup, which significantly speeds up initialization when using engines like BigQuery.

In my test the init time went from ~1m30s down to ~25s