### PR TITLE
Fix: make sure builtin dbt macros can be referenced with the 'context.' prefix

### DIFF
--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -545,7 +545,7 @@ def create_builtin_globals(
 
     builtin_globals["run_started_at"] = jinja_globals.get("execution_dt") or now()
     builtin_globals["dbt"] = AttributeDict(builtin_globals)
-    builtin_globals["context"] = AttributeDict(builtin_globals)
+    builtin_globals["context"] = builtin_globals["dbt"]
 
     return {**builtin_globals, **jinja_globals}
 

--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -545,6 +545,7 @@ def create_builtin_globals(
 
     builtin_globals["run_started_at"] = jinja_globals.get("execution_dt") or now()
     builtin_globals["dbt"] = AttributeDict(builtin_globals)
+    builtin_globals["context"] = AttributeDict(builtin_globals)
 
     return {**builtin_globals, **jinja_globals}
 

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -1436,6 +1436,13 @@ def test_flags(sushi_test_project: Project):
 
 
 @pytest.mark.xdist_group("dbt_manifest")
+def test_context_namespace(sushi_test_project: Project):
+    context = sushi_test_project.context
+
+    assert context.render("{{ context.flags.FULL_REFRESH }}") == "None"
+
+
+@pytest.mark.xdist_group("dbt_manifest")
 def test_relation(sushi_test_project: Project):
     context = sushi_test_project.context
 


### PR DESCRIPTION
No explicit documentation of this usage, but seen in the wild

Ref: https://github.com/dbt-labs/dbt-core/blob/a9dae5cac16607558d318dd20e0aab383a58d1e2/core/dbt/context/base.py#L217