### PR TITLE
Fix: exclude bugged version of dbt-snowflake so pip resolves compatible version of dbt-adapters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,9 @@ dev = [
     "dbt-bigquery",
     "dbt-core",
     "dbt-duckdb>=1.7.1",
-    # version 1.10.1 of dbt-snowflake has an incorrect constraint on the version of dbt-adapters it's compatible with
+    # version 1.10.1 of dbt-snowflake declares that it's compatible with dbt-adapters>=1.16 but in reality
+    # it depends on the 'InvalidCatalogIntegrationConfigError' class that only exists as of dbt-adapters==1.16.6
+    # so we exclude it to prevent failures and hope that upstream releases a new version with the correct constraint
     "dbt-snowflake!=1.10.1",
     "dbt-athena-community",
     "dbt-clickhouse",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ dev = [
     "dbt-bigquery",
     "dbt-core",
     "dbt-duckdb>=1.7.1",
-    "dbt-snowflake",
+    # version 1.10.1 of dbt-snowflake has an incorrect constraint on the version of dbt-adapters it's compatible with
+    "dbt-snowflake!=1.10.1",
     "dbt-athena-community",
     "dbt-clickhouse",
     "dbt-databricks",


### PR DESCRIPTION
- ~6hrs ago, a new version of `dbt-snowflake` (1.10.1) got released
- it declares it's compatible with `dbt-adapters>=1.16`
- pip dutifully resolves `dbt-adapters==1.16.4` because that's the one that's compatible with all the dbt packages we install (mainly, `dbt-databricks` has a constraint for `<1.16.5`)
- trying to use this combination results in `ImportError: cannot import name 'InvalidCatalogIntegrationConfigError' from 'dbt.adapters.catalogs'` because that class was not introduced until `dbt-adapters==1.16.6`

so this PR excludes this specific version `1.10.1` of `dbt-snowflake` with the assumption that upstream will either yank the release or fix the issue in the next version