### PR TITLE
Chore: warn instead of error if description present for non-existent col

### DIFF
--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -249,7 +249,9 @@ class ModelMeta(_Node):
         if columns_to_types:
             for column_name in col_descriptions:
                 if column_name not in columns_to_types:
-                    raise ConfigError(
+                    from sqlmesh.core.console import get_console
+
+                    get_console().log_warning(
                         f"In model '{info.data['name']}', a description is provided for column '{column_name}' but it is not a column in the model."
                     )
 


### PR DESCRIPTION
For dbt compatibility