### PR TITLE
Fix: Set dbt execute variable for parse time and run time accordingly

### DIFF
--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -533,7 +533,7 @@ def create_builtin_globals(
     builtin_globals.update(
         {
             "adapter": adapter,
-            "execute": True,
+            "execute": isinstance(adapter, RuntimeAdapter),
             "load_relation": adapter.load_relation,
             "store_result": sql_execution.store_result,
             "load_result": sql_execution.load_result,

--- a/tests/core/test_integration.py
+++ b/tests/core/test_integration.py
@@ -2068,6 +2068,7 @@ def test_dbt_is_incremental_table_is_missing(sushi_test_dbt_context: Context):
     assert context.engine_adapter.table_exists(snapshot.table_name())
 
 
+@pytest.mark.xdist_group("dbt_manifest")
 def test_model_attr(sushi_test_dbt_context: Context, assert_exp_eq):
     context = sushi_test_dbt_context
     model = context.get_model("sushi.top_waiters")
@@ -2075,14 +2076,14 @@ def test_model_attr(sushi_test_dbt_context: Context, assert_exp_eq):
         model.render_query(),
         """
         SELECT
-          CAST("waiter_id" AS INT) AS "waiter_id",
-          CAST("revenue" AS DOUBLE) AS "revenue",
+          CAST("waiter_revenue_by_day_v2"."waiter_id" AS INT) AS "waiter_id",
+          CAST("waiter_revenue_by_day_v2"."revenue" AS DOUBLE) AS "revenue",
           3 AS "model_columns"
         FROM "memory"."sushi"."waiter_revenue_by_day_v2" AS "waiter_revenue_by_day_v2"
         WHERE
-          "ds" = (
+          "waiter_revenue_by_day_v2"."ds" = (
              SELECT
-               MAX("ds")
+               MAX("waiter_revenue_by_day_v2"."ds")  AS "_col_0"
              FROM "memory"."sushi"."waiter_revenue_by_day_v2" AS "waiter_revenue_by_day_v2"
            )
         ORDER BY

--- a/tests/fixtures/dbt/sushi_test/macros/execute_test.sql
+++ b/tests/fixtures/dbt/sushi_test/macros/execute_test.sql
@@ -1,0 +1,9 @@
+{% macro runtime_sql() %}
+    {% if execute %}
+        {% set result = run_query("SELECT 1 as test_col") %}
+        {% set test_value = result.columns[0][0] %}
+        {{ return(test_value) }}
+    {% else %}
+        {{ return("parse_time_placeholder") }}
+    {% endif %}
+{% endmacro %}

--- a/tests/fixtures/dbt/sushi_test/models/execute_test_model.sql
+++ b/tests/fixtures/dbt/sushi_test/models/execute_test_model.sql
@@ -1,0 +1,2 @@
+SELECT
+    '{{ runtime_sql() }}' as runtime_result


### PR DESCRIPTION
This update sets the dbt variable `execute` to False during parse-time and true for run time. Dbt models and macros have conditional logic which is guarded with this flag for runtime execution:

```jinja
{% if execute %}
  {% set result = run_query("SELECT COUNT(*) FROM my_table") %}
  SELECT {{ result.columns[0][0] }} as count
{% endif %}
```

These jinja expressions might depend on the data warehouse or to objects (like `graph`) not available at parse time, so the `execute` ensure these only should run at the runtime stage. 

dbt docs: https://docs.getdbt.com/reference/dbt-jinja-functions/execute