### PR TITLE
Fix: Redundant creation of view models during the first evaluation

### DIFF
--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -646,7 +646,7 @@ def test_evaluate_materialized_view(
     )
 
     # Ensure that the materialized view is recreated even if it exists
-    assert adapter_mock.create_view.assert_called
+    assert adapter_mock.create_view.call_count == 1
 
 
 def test_evaluate_materialized_view_with_partitioned_by_cluster_by(


### PR DESCRIPTION
Closes #5331

The original intention was to create an empty table first if the user explicitly specified column types. However, `model.annotated` can return `True` for VIEW models as well if its types are known statically. This PR makes sure that the empty table creation only applies to materialized models.