### PR TITLE
Fix: normalize unit testing fixture catalog

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -100,8 +100,11 @@ class ModelTest(unittest.TestCase):
         self._validate_and_normalize_test()
 
         if self.engine_adapter.default_catalog:
-            self._fixture_catalog: t.Optional[exp.Identifier] = exp.parse_identifier(
-                self.engine_adapter.default_catalog, dialect=self._test_adapter_dialect
+            self._fixture_catalog: t.Optional[exp.Identifier] = normalize_identifiers(
+                exp.parse_identifier(
+                    self.engine_adapter.default_catalog, dialect=self._test_adapter_dialect
+                ),
+                dialect=self._test_adapter_dialect,
             )
         else:
             self._fixture_catalog = None


### PR DESCRIPTION
I came across this issue in a project that used a Snowflake test connection, so it's kinda "out of the blue" / no further context to provide.

In unit tests, we create fixture tables of the form `<engine_adapter_catalog>.<randomly_generated_testing_schema>.<fqn>`. The PR normalizes the leftmost part, because we omitted doing it and then quoted it in `_render_model_query` (see how `table_mapping` is used in the renderer), so for Snowflake we could end up with errors like `Database '"george"' does not exist or the required permissions are missing`.

I added a simple unit test for Snowflake to ensure there are no regressions in the future.