### PR TITLE
Feat: Improve CLI and --explain output for restatements

### DIFF
--- a/sqlmesh/core/plan/builder.py
+++ b/sqlmesh/core/plan/builder.py
@@ -338,6 +338,7 @@ class PlanBuilder:
             directly_modified=directly_modified,
             indirectly_modified=indirectly_modified,
             deployability_index=deployability_index,
+            selected_models_to_restate=self._restate_models,
             restatements=restatements,
             start_override_per_model=self._start_override_per_model,
             end_override_per_model=end_override_per_model,

--- a/sqlmesh/core/plan/definition.py
+++ b/sqlmesh/core/plan/definition.py
@@ -58,7 +58,16 @@ class Plan(PydanticModel, frozen=True):
     indirectly_modified: t.Dict[SnapshotId, t.Set[SnapshotId]]
 
     deployability_index: DeployabilityIndex
+    selected_models_to_restate: t.Optional[t.Set[str]] = None
+    """Models that have been explicitly selected for restatement by a user"""
     restatements: t.Dict[SnapshotId, Interval]
+    """
+    All models being restated, which are typically the explicitly selected ones + their downstream dependencies.
+    
+    Note that dev previews are also considered restatements, so :selected_models_to_restate can be empty
+    while :restatements is still populated with dev previews
+    """
+
     start_override_per_model: t.Optional[t.Dict[str, datetime]]
     end_override_per_model: t.Optional[t.Dict[str, datetime]]
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -247,7 +247,7 @@ def test_plan_restate_model(runner, tmp_path):
     )
     assert result.exit_code == 0
     assert_duckdb_test(result)
-    assert "Restating models" in result.output
+    assert "Models selected for restatement" in result.output
     assert "sqlmesh_example.full_model   [full refresh" in result.output
     assert_model_batches_executed(result)
     assert "Virtual layer updated" not in result.output

--- a/tests/core/test_plan_stages.py
+++ b/tests/core/test_plan_stages.py
@@ -771,9 +771,11 @@ def test_build_plan_stages_restatement_prod_identifies_dev_intervals(
     # note: we only clear the intervals from state for "a" in dev, we leave prod alone
     assert restatement_stage.snapshot_intervals_to_clear
     assert len(restatement_stage.snapshot_intervals_to_clear) == 1
-    snapshot_name, clear_request = list(restatement_stage.snapshot_intervals_to_clear.items())[0]
-    assert isinstance(clear_request, SnapshotIntervalClearRequest)
+    snapshot_name, clear_requests = list(restatement_stage.snapshot_intervals_to_clear.items())[0]
     assert snapshot_name == '"a"'
+    assert len(clear_requests) == 1
+    clear_request = clear_requests[0]
+    assert isinstance(clear_request, SnapshotIntervalClearRequest)
     assert clear_request.snapshot_id == snapshot_a_dev.snapshot_id
     assert clear_request.snapshot == snapshot_a_dev.id_and_version
     assert clear_request.interval == (to_timestamp("2023-01-01"), to_timestamp("2023-01-02"))


### PR DESCRIPTION
This PR builds on #5285 to make it easier to reason about what's going on with restatements, which are a critical part of seamless dbt compatibility.

Currently, "restatements" has some nuance:
- Many things assume a plan is a restatement plan if `plan.restatements` is set. However, `plan.restatements` gets set for dev previews, leading to confusion when SQLMesh outputs "Restating models" when no restatements were specified
- We don't show how the selector for `--restate-model` maps to the backfill item list, leading to "why do I suddenly have 100 models to backfill when I only specified 3"-type questions
- In `--explain`, we currently just say "some intervals might cleared", instead of specifically listing the affected snapshots and what environments theyre promoted in

# Current state (before this PR)
## Dev previews
- notice that it says "Restating models" even though `--restate-model` was not specified
<img width="400" alt="Screenshot From 2025-09-11 10-41-47" src="https://github.com/user-attachments/assets/58a18319-ecf1-4cac-b932-61125764fe8e" />

## Actual restatement (with `--explain`)
- We say "Restating models" without listing anything
- The backfill model list has a model that wasnt even specified - why is `erin.test` there when I just wanted to restate `sqlmesh_example.full_model`??
- We do indicate that we invalidate some intervals, but we don't go into exactly what "invalidate" means and what will be affected by that
<img width="400" alt="Screenshot From 2025-09-11 10-48-40" src="https://github.com/user-attachments/assets/38d0743b-f1c2-4b67-aa43-e5e5729e2aba" />

# After this PR

## Dev previews
 - we simply dont output the "Restating models" indicator, because we arent actually restating any models
<img width="400" alt="Screenshot From 2025-09-11 10-46-01" src="https://github.com/user-attachments/assets/8b399c4c-1c09-4cfe-bcac-3970f4b8af72" />

## Actual restatement (no `--explain`)
- We list which models matched the selector separately from the models to backfill
- We include an explanation as to why the backfill list may be larger than expected
<img width="400"  alt="Screenshot From 2025-09-11 10-50-28" src="https://github.com/user-attachments/assets/7d3237da-60f2-4866-9eb0-2fe7af52e3c7" />

## Actual restatement (with `--explain`)
- The `--explain` output makes it clear that only state is affected by this plan
- It explains that only tables in development environments are affected
- It then exactly lists which tables are affected and which environments they're in
<img width="952" height="490" alt="Screenshot From 2025-09-11 13-30-40" src="https://github.com/user-attachments/assets/fea00d35-a7ec-4852-bf66-82d887027bdb" />
