### PR TITLE
Fix: Include root package in search candidates when resolving dbt macros

### DIFF
--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -139,11 +139,16 @@ class BaseAdapter(abc.ABC):
             return name_score, package_score
 
         jinja_env = self.jinja_macros.build_environment(**self.jinja_globals).globals
-        packages_to_check: t.Set[t.Optional[str]] = {
-            macro_namespace,
-            # self.jinja_macros.root_package_name,
-            *(k for k in jinja_env if k.startswith("dbt")),
-        }
+
+        # Build the set of packages to check based on dispatch configuration
+        packages_to_check: t.List[t.Optional[str]] = [None]
+        if macro_namespace is not None:
+            if macro_namespace in jinja_env:
+                packages_to_check = [self.jinja_macros.root_package_name, macro_namespace]
+
+        # Add dbt packages as fallback
+        packages_to_check.extend(k for k in jinja_env if k.startswith("dbt"))
+
         candidates = {}
         for macro_package in packages_to_check:
             macros = jinja_env.get(macro_package, {}) if macro_package else jinja_env

--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -139,10 +139,11 @@ class BaseAdapter(abc.ABC):
             return name_score, package_score
 
         jinja_env = self.jinja_macros.build_environment(**self.jinja_globals).globals
-        packages_to_check: t.List[t.Optional[str]] = [
+        packages_to_check: t.Set[t.Optional[str]] = {
             macro_namespace,
+            # self.jinja_macros.root_package_name,
             *(k for k in jinja_env if k.startswith("dbt")),
-        ]
+        }
         candidates = {}
         for macro_package in packages_to_check:
             macros = jinja_env.get(macro_package, {}) if macro_package else jinja_env

--- a/sqlmesh/dbt/adapter.py
+++ b/sqlmesh/dbt/adapter.py
@@ -140,7 +140,6 @@ class BaseAdapter(abc.ABC):
 
         jinja_env = self.jinja_macros.build_environment(**self.jinja_globals).globals
 
-        # Build the set of packages to check based on dispatch configuration
         packages_to_check: t.List[t.Optional[str]] = [None]
         if macro_namespace is not None:
             if macro_namespace in jinja_env:

--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -242,6 +242,7 @@ def test_adapter_dispatch(sushi_test_project: Project, runtime_renderer: t.Calla
     assert renderer("{{ adapter.dispatch('current_engine', 'customers')() }}") == "duckdb"
     assert renderer("{{ adapter.dispatch('current_timestamp')() }}") == "now()"
     assert renderer("{{ adapter.dispatch('current_timestamp', 'dbt')() }}") == "now()"
+    assert renderer("{{ adapter.dispatch('select_distinct', 'customers')() }}") == "distinct"
 
     # test with keyword arguments
     assert (

--- a/tests/fixtures/dbt/sushi_test/macros/distinct.sql
+++ b/tests/fixtures/dbt/sushi_test/macros/distinct.sql
@@ -1,0 +1,1 @@
+{% macro default__select_distinct() %}distinct{% endmacro %}


### PR DESCRIPTION
dbt package macros can be overridden in the root package. This PR includes the root package when searching  packages during macro dispatch resolution.