### PR TITLE
Fix(databricks): Materialized view drop failure due to incorrect type

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -302,18 +302,18 @@ workflows:
           matrix:
             parameters:
               engine:
-                # - snowflake
+                - snowflake
                 - databricks
-                # - redshift
-                # - bigquery
-                # - clickhouse-cloud
-                # - athena
-                # - fabric
-                # - gcp-postgres
-          # filters:
-          #   branches:
-          #     only:
-          #       - main
+                - redshift
+                - bigquery
+                - clickhouse-cloud
+                - athena
+                - fabric
+                - gcp-postgres
+          filters:
+            branches:
+              only:
+                - main
       - ui_style
       - ui_test
       - vscode_test

--- a/tests/core/engine_adapter/integration/test_integration.py
+++ b/tests/core/engine_adapter/integration/test_integration.py
@@ -403,10 +403,10 @@ def test_materialized_view(ctx_query_and_df: TestContext):
     ctx = ctx_query_and_df
     if not ctx.engine_adapter.SUPPORTS_MATERIALIZED_VIEWS:
         pytest.skip(f"Engine adapter {ctx.engine_adapter} doesn't support materialized views")
-    # if ctx.engine_adapter.dialect == "databricks":
-    #     pytest.skip(
-    #         "Databricks requires DBSQL Serverless or Pro warehouse to test materialized views which we do not have setup"
-    #     )
+    if ctx.engine_adapter.dialect == "databricks":
+        pytest.skip(
+            "Databricks requires DBSQL Serverless or Pro warehouse to test materialized views which we do not have setup"
+        )
     if ctx.engine_adapter.dialect == "snowflake":
         pytest.skip("Snowflake requires enterprise edition which we do not have setup")
     input_data = pd.DataFrame(


### PR DESCRIPTION
This fixes #5249 and correctly maps `MATERIALIZED_VIEW` to `materialized_view` instead of `view` in the case statement of `_get_data_objects`.

Previously the Databricks adapter was incorrectly identifying materialized views as regular views. This caused `DROP VIEW` to be issued instead of `DROP MATERIALIZED VIEW` resulting in the error:

`  Cannot drop a materialized view with DROP VIEW. Please use DROP MATERIALIZED VIEW instead
`

---

#### failure scenatio

So this wasn't exercised before #5087 but now since `drop_data_object_on_type_mismatch` is called like this inside `create_view`:
```
self.drop_data_object_on_type_mismatch(
      self.get_data_object(view_name),
      DataObjectType.VIEW if not materialized else DataObjectType.MATERIALIZED_VIEW,
)
```
- `get_data_object` internally would return a materialised view's type as view while the conditional would correctly map as materialised view
- this incorrect mismatch would result in the `drop_data_object` operation inside `drop_data_object_on_type_mismatch` 
- the drop would use the type returned from the query which would be `view` thus resulting in the error