### PR TITLE
Fix: port sqlglot pipe syntax fix in _parse_select

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -350,6 +350,7 @@ def _parse_select(
     parse_subquery_alias: bool = True,
     parse_set_operation: bool = True,
     consume_pipe: bool = True,
+    from_: t.Optional[exp.From] = None,
 ) -> t.Optional[exp.Expression]:
     select = self.__parse_select(  # type: ignore
         nested=nested,
@@ -357,6 +358,7 @@ def _parse_select(
         parse_subquery_alias=parse_subquery_alias,
         parse_set_operation=parse_set_operation,
         consume_pipe=consume_pipe,
+        from_=from_,
     )
 
     if (

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -722,3 +722,11 @@ def test_sqlglot_extended_correctly(dialect: str) -> None:
 def test_connected_identifier():
     ast = d.parse_one("""SELECT ("x"at time zone 'utc')::timestamp as x""", "redshift")
     assert ast.sql("redshift") == """SELECT CAST(("x" AT TIME ZONE 'utc') AS TIMESTAMP) AS x"""
+
+
+def test_pipe_syntax():
+    ast = d.parse_one("SELECT * FROM (FROM t2 |> SELECT id)", "bigquery")
+    assert (
+        ast.sql("bigquery")
+        == "SELECT * FROM (WITH __tmp1 AS (SELECT id FROM t2) SELECT * FROM __tmp1)"
+    )


### PR DESCRIPTION
This [commit](https://github.com/tobymao/sqlglot/commit/ad8a408a4e3e26e32472fc55c67b44687992ae47#diff-766fd513e32cf21df380b769cdad09cc5ec2b1907bcdd86c10eb72708a498b09) made a breaking change in `_parse_select`. This PR updates SQLMesh's override to match it.
