### PR TITLE
Fix: Variable overrides for dbt packages

### DIFF
--- a/sqlmesh/dbt/project.py
+++ b/sqlmesh/dbt/project.py
@@ -113,6 +113,8 @@ class Project:
                 package.variables.update(package_scoped_vars)
             else:
                 package.variables.update(all_project_variables)
+            if variable_overrides:
+                package.variables.update(variable_overrides)
 
         return Project(context, profile, packages)
 

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -368,6 +368,16 @@ def test_variables(assert_exp_eq, sushi_test_project):
 
 
 @pytest.mark.slow
+def test_variables_override(init_and_plan_context: t.Callable):
+    context, _ = init_and_plan_context(
+        "tests/fixtures/dbt/sushi_test", config="test_config_with_var_override"
+    )
+    dbt_project = context._loaders[0]._load_projects()[0]  # type: ignore
+    assert dbt_project.packages["sushi"].variables["some_var"] == "overridden_from_config_py"
+    assert dbt_project.packages["customers"].variables["some_var"] == "overridden_from_config_py"
+
+
+@pytest.mark.slow
 def test_jinja_in_dbt_variables(sushi_test_dbt_context: Context):
     assert sushi_test_dbt_context.render("sushi.top_waiters").sql().endswith("LIMIT 10")
 

--- a/tests/fixtures/dbt/sushi_test/config.py
+++ b/tests/fixtures/dbt/sushi_test/config.py
@@ -11,6 +11,16 @@ config = sqlmesh_config(
 
 test_config = config
 
+
+test_config_with_var_override = sqlmesh_config(
+    Path(__file__).parent,
+    model_defaults=ModelDefaultsConfig(dialect="duckdb", start="Jan 1 2022"),
+    variables={
+        "some_var": "overridden_from_config_py",
+    },
+)
+
+
 test_config_with_normalization_strategy = sqlmesh_config(
     Path(__file__).parent,
     model_defaults=ModelDefaultsConfig(


### PR DESCRIPTION
I've realized that I missed another edge case.