### PR TITLE
Fix: Regression that caused view snapshos not to be migrated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,8 @@ module = [
     "pydantic_core.*",
     "dlt.*",
     "bigframes.*",
-    "json_stream.*"
+    "json_stream.*",
+    "duckdb.*"
 ]
 ignore_missing_imports = true
 

--- a/sqlmesh/core/plan/stages.py
+++ b/sqlmesh/core/plan/stages.py
@@ -281,9 +281,7 @@ class PlanStagesBuilder:
             snapshots_with_schema_migration = [
                 snapshots[s_id]
                 for s_id in dag.subdag(*snapshot_ids_with_schema_migration)
-                if snapshots[s_id].is_paused
-                and snapshots[s_id].is_model
-                and not snapshots[s_id].is_symbolic
+                if snapshots[s_id].supports_schema_migration_in_prod
             ]
 
         snapshots_to_intervals = self._missing_intervals(

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1483,7 +1483,7 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         return (
             self.is_paused
             and self.is_model
-            and self.is_materialized
+            and not self.is_symbolic
             and (
                 (self.previous_version and self.previous_version.version == self.version)
                 or self.model.forward_only

--- a/sqlmesh/core/snapshot/definition.py
+++ b/sqlmesh/core/snapshot/definition.py
@@ -1478,18 +1478,18 @@ class Snapshot(PydanticModel, SnapshotInfoMixin):
         )
 
     @property
+    def supports_schema_migration_in_prod(self) -> bool:
+        """Returns whether or not this snapshot supports schema migration when deployed to production."""
+        return self.is_paused and self.is_model and not self.is_symbolic
+
+    @property
     def requires_schema_migration_in_prod(self) -> bool:
         """Returns whether or not this snapshot requires a schema migration when deployed to production."""
-        return (
-            self.is_paused
-            and self.is_model
-            and not self.is_symbolic
-            and (
-                (self.previous_version and self.previous_version.version == self.version)
-                or self.model.forward_only
-                or bool(self.model.physical_version)
-                or not self.virtual_environment_mode.is_full
-            )
+        return self.supports_schema_migration_in_prod and (
+            (self.previous_version and self.previous_version.version == self.version)
+            or self.model.forward_only
+            or bool(self.model.physical_version)
+            or not self.virtual_environment_mode.is_full
         )
 
     @property

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1593,7 +1593,7 @@ def test_raw_code_handling(sushi_test_dbt_context: Context):
     hook = model.render_pre_statements()[0]
     assert (
         hook.sql()
-        == f'''CREATE TABLE "t" AS SELECT 'Length is {raw_code_length}' AS "length_col"'''
+        == f'''CREATE TABLE IF NOT EXISTS "t" AS SELECT 'Length is {raw_code_length}' AS "length_col"'''
     )
 
 

--- a/tests/core/test_plan_stages.py
+++ b/tests/core/test_plan_stages.py
@@ -1661,16 +1661,17 @@ def test_build_plan_stages_indirect_non_breaking_view_migration(
     stages = build_plan_stages(plan, state_reader, None)
 
     # Verify stages
-    assert len(stages) == 8
+    assert len(stages) == 9
 
     assert isinstance(stages[0], CreateSnapshotRecordsStage)
     assert isinstance(stages[1], PhysicalLayerSchemaCreationStage)
     assert isinstance(stages[2], BackfillStage)
     assert isinstance(stages[3], EnvironmentRecordUpdateStage)
-    assert isinstance(stages[4], UnpauseStage)
-    assert isinstance(stages[5], BackfillStage)
-    assert isinstance(stages[6], VirtualLayerUpdateStage)
-    assert isinstance(stages[7], FinalizeEnvironmentStage)
+    assert isinstance(stages[4], MigrateSchemasStage)
+    assert isinstance(stages[5], UnpauseStage)
+    assert isinstance(stages[6], BackfillStage)
+    assert isinstance(stages[7], VirtualLayerUpdateStage)
+    assert isinstance(stages[8], FinalizeEnvironmentStage)
 
 
 def test_build_plan_stages_virtual_environment_mode_filtering(

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -1402,7 +1402,13 @@ def test_migrate_view(
     evaluator = SnapshotEvaluator(adapter)
     evaluator.migrate([snapshot], {})
 
-    adapter.cursor.execute.assert_not_called()
+    adapter.cursor.execute.assert_has_calls(
+        [
+            call(
+                f'CREATE OR REPLACE VIEW "sqlmesh__test_schema"."test_schema__test_model__{snapshot.version}" ("c", "a") AS SELECT "c" AS "c", "a" AS "a" FROM "tbl" AS "tbl"'
+            ),
+        ]
+    )
 
 
 def test_migrate_snapshot_data_object_type_mismatch(

--- a/tests/fixtures/dbt/sushi_test/models/model_with_raw_code.sql
+++ b/tests/fixtures/dbt/sushi_test/models/model_with_raw_code.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    pre_hook=['CREATE TABLE t AS SELECT \'Length is {{ model.raw_code|length }}\' AS length_col']
+    pre_hook=['CREATE TABLE IF NOT EXISTS t AS SELECT \'Length is {{ model.raw_code|length }}\' AS length_col']
   )
 }}
 


### PR DESCRIPTION
Previously, we were incorrectly skipping the migration stage for view snapshots.