### PR TITLE
Chore: temporarily ignore duckdb typing bc of 1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,9 @@ module = [
     "pydantic_core.*",
     "dlt.*",
     "bigframes.*",
-    "json_stream.*"
+    "json_stream.*",
+    "duckdb",
+    "duckdb.*"
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
DuckDB 1.4 omitted the typing file

https://github.com/duckdb/duckdb-python/pull/58