### PR TITLE
fix: remove need for uvicorn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ lsp = [
     # Duplicate of web
     "fastapi==0.115.5",
     "watchfiles>=0.19.0",
-    "uvicorn[standard]==0.22.0",
+    # "uvicorn[standard]==0.22.0",
     "sse-starlette>=0.2.2",
     "pyarrow",
     # For lsp


### PR DESCRIPTION
- removes an old pin for uvicorn for the lsp
- was copied as depends on web but uvicorn is not an actual python dep
