### PR TITLE
Fix: Sort nested AttributeDict's to prevent visual diff

### DIFF
--- a/sqlmesh/utils/jinja.py
+++ b/sqlmesh/utils/jinja.py
@@ -206,6 +206,20 @@ def extract_macro_references_and_variables(
     return macro_references, variables
 
 
+def sort_dict_recursive(
+    item: t.Dict[str, t.Any],
+) -> t.Dict[str, t.Any]:
+    sorted_dict: t.Dict[str, t.Any] = {}
+    for k, v in sorted(item.items()):
+        if isinstance(v, list):
+            sorted_dict[k] = sorted(v)
+        elif isinstance(v, dict):
+            sorted_dict[k] = sort_dict_recursive(v)
+        else:
+            sorted_dict[k] = v
+    return sorted_dict
+
+
 JinjaGlobalAttribute = t.Union[str, int, float, bool, AttributeDict]
 
 
@@ -440,7 +454,7 @@ class JinjaMacroRegistry(PydanticModel):
                 d.PythonCode(
                     expressions=[
                         f"{k} = '{v}'" if isinstance(v, str) else f"{k} = {v}"
-                        for k, v in sorted(filtered_objs.items())
+                        for k, v in sort_dict_recursive(filtered_objs).items()
                     ]
                 )
             )


### PR DESCRIPTION
Prior to this, on dbt projects, if a model had a change, often the text diff would show a diff for `refs` even though those didn't change at all. In this example, all I did was add a `stamp`, but the text diff shows a diff for `refs`:

<img width="500" height="441" alt="Screenshot From 2025-09-18 09-58-54" src="https://github.com/user-attachments/assets/e8a6cc63-a646-4149-b026-663342db69ed" />

The cause is that while the _keys_ ("refs", "sources", "vars") were sorted - the values weren't. So calling `model.render_definition()` on the Snapshot in state, calling `model.render_definition()` the local Snapshot and comparing the output could result in a text diff, even though nothing had actually changed, because the values are output in a non-deterministic order.

After this PR, we no longer see the extra "change" and the text diff focuses on what actually got changed:

<img width="500" height="464" alt="Screenshot From 2025-09-18 10-03-06" src="https://github.com/user-attachments/assets/6c55ce6e-fab6-45a1-80a1-a33884211bc1" />


