### PR TITLE
Chore: Pin cryptography instead of leaving it to the resolver

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -302,18 +302,18 @@ workflows:
           matrix:
             parameters:
               engine:
-                - snowflake
-                - databricks
-                - redshift
-                - bigquery
-                - clickhouse-cloud
-                - athena
-                - fabric
+                # - snowflake
+                # - databricks
+                # - redshift
+                # - bigquery
+                # - clickhouse-cloud
+                # - athena
+                # - fabric
                 - gcp-postgres
-          filters:
-            branches:
-              only:
-                - main
+          # filters:
+          #   branches:
+          #     only:
+          #       - main
       - ui_style
       - ui_test
       - vscode_test

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -302,18 +302,18 @@ workflows:
           matrix:
             parameters:
               engine:
-                # - snowflake
-                # - databricks
-                # - redshift
-                # - bigquery
-                # - clickhouse-cloud
-                # - athena
-                # - fabric
+                - snowflake
+                - databricks
+                - redshift
+                - bigquery
+                - clickhouse-cloud
+                - athena
+                - fabric
                 - gcp-postgres
-          # filters:
-          #   branches:
-          #     only:
-          #       - main
+          filters:
+            branches:
+              only:
+                - main
       - ui_style
       - ui_test
       - vscode_test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
     "agate",
     "beautifulsoup4",
     "clickhouse-connect",
-    "cryptography",
+    "cryptography<46.0.0",
     "databricks-sql-connector",
     "dbt-bigquery",
     "dbt-core",
@@ -119,7 +119,7 @@ postgres = ["psycopg2"]
 redshift = ["redshift_connector"]
 slack = ["slack_sdk"]
 snowflake = [
-    "cryptography",
+    "cryptography<46.0.0",
     "snowflake-connector-python[pandas,secure-local-storage]",
     "snowflake-snowpark-python",
 ]


### PR DESCRIPTION
Pin cryptography due to this change in 46.0.1: https://github.com/pyca/cryptography/commit/2726efdb6d67f1c90cf9c6062d9fe051965586f8 which leads to conflict on cffi since snowflake requires <2.0.0.