### PR TITLE
Chore: attempt to fix flakey dbt test

### DIFF
--- a/tests/dbt/test_model.py
+++ b/tests/dbt/test_model.py
@@ -734,6 +734,7 @@ def test_load_microbatch_with_ref_no_filter(
 
 
 @pytest.mark.slow
+@pytest.mark.isolated
 def test_load_multiple_snapshots_defined_in_same_file(sushi_test_dbt_context: Context) -> None:
     context = sushi_test_dbt_context
     assert context.get_model("snapshots.items_snapshot")


### PR DESCRIPTION
Simple approach attempting to fix the following issue [observed in CI/CD](https://app.circleci.com/pipelines/github/TobikoData/sqlmesh/24288/workflows/a7316a15-3224-4677-a127-890cb39f8dd5/jobs/281579):

```
ERROR tests/dbt/test_model.py::test_load_multiple_snapshots_defined_in_same_file - sqlmesh.utils.errors.SQLMeshError: Failed to load dbt manifest: Compilation Error in model waiter_revenue_by_day (models/waiter_revenue_by_day.sql)
  In dispatch: No macro named 'current_engine' found within namespace: 'customers'
      Searched for: 'duckdb__current_engine', 'default__current_engine'
```

