### PR TITLE
Fix(dbt): Update dispatch signature to match dbt method

### DIFF
--- a/tests/dbt/test_adapter.py
+++ b/tests/dbt/test_adapter.py
@@ -243,6 +243,34 @@ def test_adapter_dispatch(sushi_test_project: Project, runtime_renderer: t.Calla
     assert renderer("{{ adapter.dispatch('current_timestamp')() }}") == "now()"
     assert renderer("{{ adapter.dispatch('current_timestamp', 'dbt')() }}") == "now()"
 
+    # test with keyword arguments
+    assert (
+        renderer(
+            "{{ adapter.dispatch(macro_name='current_engine', macro_namespace='customers')() }}"
+        )
+        == "duckdb"
+    )
+    assert renderer("{{ adapter.dispatch(macro_name='current_timestamp')() }}") == "now()"
+    assert (
+        renderer("{{ adapter.dispatch(macro_name='current_timestamp', macro_namespace='dbt')() }}")
+        == "now()"
+    )
+
+    # mixing positional and keyword arguments
+    assert (
+        renderer("{{ adapter.dispatch('current_engine', macro_namespace='customers')() }}")
+        == "duckdb"
+    )
+    assert (
+        renderer("{{ adapter.dispatch('current_timestamp', macro_namespace=None)() }}") == "now()"
+    )
+    assert (
+        renderer("{{ adapter.dispatch('current_timestamp', macro_namespace='dbt')() }}") == "now()"
+    )
+
+    with pytest.raises(ConfigError, match=r"Macro 'current_engine'.*was not found."):
+        renderer("{{ adapter.dispatch(macro_name='current_engine')() }}")
+
     with pytest.raises(ConfigError, match=r"Macro 'current_engine'.*was not found."):
         renderer("{{ adapter.dispatch('current_engine')() }}")
 


### PR DESCRIPTION
 This aligns the parameter names to ensure compatibility when using adapter.dispatch() with keyword arguments. The dispatch method in dbt uses `macro_namespace` and `macro_name` as parameters for example:

```jinja
{% macro my_macro(arg1, arg2) -%}
  {{ return(adapter.dispatch(macro_name='my_macro', macro_namespace='package_1')(arg1, arg2)) }}
{%- endmacro %}
```


Dbt docs: https://docs.getdbt.com/reference/dbt-jinja-functions/dispatch
