### PR TITLE
Fix: Disable WAP support by default for Spark and Iceberg

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -1755,6 +1755,7 @@ class SparkConnectionConfig(ConnectionConfig):
     config_dir: t.Optional[str] = None
     catalog: t.Optional[str] = None
     config: t.Dict[str, t.Any] = {}
+    wap_enabled: bool = False
 
     concurrent_tasks: int = 4
     register_comments: bool = True
@@ -1800,6 +1801,10 @@ class SparkConnectionConfig(ConnectionConfig):
             .enableHiveSupport()
             .getOrCreate(),
         }
+
+    @property
+    def _extra_engine_config(self) -> t.Dict[str, t.Any]:
+        return {"wap_enabled": self.wap_enabled}
 
 
 class TrinoAuthenticationMethod(str, Enum):

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -2357,6 +2357,11 @@ class EngineAdapter:
         """Fetches a PySpark DataFrame from the cursor"""
         raise NotImplementedError(f"Engine does not support PySpark DataFrames: {type(self)}")
 
+    @property
+    def wap_enabled(self) -> bool:
+        """Returns whether WAP is enabled for this engine."""
+        return self._extra_config.get("wap_enabled", False)
+
     def wap_supported(self, table_name: TableName) -> bool:
         """Returns whether WAP for the target table is supported."""
         return False

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -457,12 +457,14 @@ class SparkEngineAdapter(
             if wap_id.startswith(f"{self.BRANCH_PREFIX}{self.WAP_PREFIX}"):
                 table_name.set("this", table_name.this.this)
 
-        wap_supported = (
-            kwargs.get("storage_format") or ""
-        ).lower() == "iceberg" or self.wap_supported(table_name)
-        do_dummy_insert = (
-            False if not wap_supported or not exists else not self.table_exists(table_name)
-        )
+        do_dummy_insert = False
+        if self.wap_enabled:
+            wap_supported = (
+                kwargs.get("storage_format") or ""
+            ).lower() == "iceberg" or self.wap_supported(table_name)
+            do_dummy_insert = (
+                False if not wap_supported or not exists else not self.table_exists(table_name)
+            )
         super()._create_table(
             table_name_or_schema,
             expression,

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -793,6 +793,7 @@ class SnapshotEvaluator:
             if (
                 snapshot.is_materialized
                 and target_table_exists
+                and adapter.wap_enabled
                 and (model.wap_supported or adapter.wap_supported(target_table_name))
             ):
                 wap_id = random_id()[0:8]


### PR DESCRIPTION
After deprecate Airflow integration and removing the corresponding test suite we lost our only avenue for testing Spark + Iceberg combination. As a result, the Iceberg-specifc WAP support fell behind and deteriorated as the recent wave of Spark + Iceberg issues suggests.

This update disables WAP by default with the option to enable it in future. This should buy us time to introduce back continuous testing for the Spark + Iceberg combo and address all issues. 