### PR TITLE
Fix: Reporting deletion of physical tables for snapshots of symbolic / audit models

### DIFF
--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -518,10 +518,12 @@ class SnapshotEvaluator:
             target_snapshots: Snapshots to cleanup.
             on_complete: A callback to call on each successfully deleted database object.
         """
+        target_snapshots = [
+            t for t in target_snapshots if t.snapshot.is_model and not t.snapshot.is_symbolic
+        ]
         snapshots_to_dev_table_only = {
             t.snapshot.snapshot_id: t.dev_table_only for t in target_snapshots
         }
-
         with self.concurrent_context():
             concurrent_apply_to_snapshots(
                 [t.snapshot for t in target_snapshots],

--- a/tests/integrations/jupyter/test_magics.py
+++ b/tests/integrations/jupyter/test_magics.py
@@ -906,9 +906,6 @@ def test_destroy(
         "Are you ABSOLUTELY SURE you want to proceed with deletion? [y/n]:",
         "Environment 'prod' invalidated.",
         "Deleted object memory.sushi",
-        'Deleted object "memory"."raw"."model1"',
-        'Deleted object "memory"."raw"."model2"',
-        'Deleted object "memory"."raw"."demographics"',
         "State tables removed.",
         "Destroy completed successfully.",
     ]


### PR DESCRIPTION
Seeing SQLMesh reporting deletion of external tables confuses and terrifies users, even though no actual deletion occurred. This PR fixes the reporting so that symbolic and audit snapshots are skipped entirely.