### PR TITLE
Fix: route linter warnings correctly in github output

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -3641,7 +3641,10 @@ class MarkdownConsole(CaptureTerminalConsole):
         msg = f"\nLinter {severity} for `{model._path}`:\n{violations_msg}\n"
 
         self._print(msg)
-        self._errors.append(msg)
+        if is_error:
+            self._errors.append(msg)
+        else:
+            self._warnings.append(msg)
 
     @property
     def captured_warnings(self) -> str:


### PR DESCRIPTION
Linter warnings currently appear in the error output section