### PR TITLE
fix: ignore partition_by field for ephemeral models

### DIFF
--- a/sqlmesh/dbt/model.py
+++ b/sqlmesh/dbt/model.py
@@ -510,10 +510,11 @@ class ModelConfig(BaseModelConfig):
         physical_properties: t.Dict[str, t.Any] = {}
 
         if self.partition_by:
-            if isinstance(kind, ViewKind):
+            if isinstance(kind, (ViewKind, EmbeddedKind)):
                 logger.warning(
-                    "Ignoring partition_by config for model '%s'; partition_by is not supported for views.",
+                    "Ignoring partition_by config for model '%s'; partition_by is not supported for %s.",
                     self.name,
+                    "views" if isinstance(kind, ViewKind) else "ephemeral models",
                 )
             else:
                 partitioned_by = []

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -1728,6 +1728,18 @@ def test_partition_by(sushi_test_project: Project):
     )
     assert model_config.to_sqlmesh(context).partitioned_by == []
 
+    model_config = ModelConfig(
+        name="model",
+        alias="model",
+        schema="test",
+        package_name="package",
+        materialized=Materialization.EPHEMERAL.value,
+        unique_key="ds",
+        partition_by={"field": "ds", "granularity": "month"},
+        sql="""SELECT 1 AS one, ds FROM foo""",
+    )
+    assert model_config.to_sqlmesh(context).partitioned_by == []
+
 
 @pytest.mark.xdist_group("dbt_manifest")
 def test_partition_by_none(sushi_test_project: Project):


### PR DESCRIPTION
`partition_by` is not applicable for ephemeral models. dbt ignores this config if set