### PR TITLE
feat!: support unicode characters

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -300,8 +300,8 @@ workflows:
           name: cloud_engine_<< matrix.engine >>
           context:
             - sqlmesh_cloud_database_integration
-          requires:
-            - engine_tests_docker
+#          requires:
+#            - engine_tests_docker
           matrix:
             parameters:
               engine:
@@ -313,10 +313,10 @@ workflows:
                 - athena
                 - fabric
                 - gcp-postgres
-          filters:
-            branches:
-              only:
-                - main
+#          filters:
+#            branches:
+#              only:
+#                - main
       - ui_style
       - ui_test
       - vscode_test

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -34,6 +34,8 @@ class DatabricksEngineAdapter(SparkEngineAdapter):
     SUPPORTS_CLONING = True
     SUPPORTS_MATERIALIZED_VIEWS = True
     SUPPORTS_MATERIALIZED_VIEW_SCHEMA = True
+    # Spark has this set to false for compatibility when mixing with Trino but that isn't a concern with Databricks
+    QUOTE_IDENTIFIERS_IN_VIEWS = True
     SCHEMA_DIFFER_KWARGS = {
         "support_positional_add": True,
         "nested_support": NestedSupport.ALL,

--- a/sqlmesh/utils/__init__.py
+++ b/sqlmesh/utils/__init__.py
@@ -13,6 +13,7 @@ import traceback
 import types
 import typing as t
 import uuid
+import unicodedata
 from dataclasses import dataclass
 from collections import defaultdict
 from contextlib import contextmanager
@@ -289,11 +290,13 @@ def sqlglot_dialects() -> str:
     return "'" + "', '".join(Dialects.__members__.values()) + "'"
 
 
-NON_ALNUM = re.compile(r"[^a-zA-Z0-9_]")
+NON_WORD = re.compile(r"\W", flags=re.UNICODE)
 
 
 def sanitize_name(name: str) -> str:
-    return NON_ALNUM.sub("_", name)
+    s = unicodedata.normalize("NFC", name)
+    s = NON_WORD.sub("_", s)
+    return s
 
 
 def groupby(

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,22 @@
+import pytest
+
+from sqlmesh.utils import sanitize_name
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("simple", "simple"),
+        ("snake_case", "snake_case"),
+        ("客户数据", "客户数据"),  # pure Chinese kept
+        ("客户-数据 v2", "客户_数据_v2"),  # dash/space -> underscore
+        ("中文，逗号", "中文_逗号"),  # full-width comma -> underscore
+        ("a/b", "a_b"),  # slash -> underscore
+        ("spaces\tand\nnewlines", "spaces_and_newlines"),
+        ("data📦2025", "data_2025"),
+        ("MiXeD123_名字", "MiXeD123_名字"),
+        ("", ""),
+    ],
+)
+def test_sanitize_known_cases(raw, expected):
+    assert sanitize_name(raw) == expected

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -39,6 +39,7 @@ def test_file_cache(tmp_path: Path, mocker: MockerFixture):
     loader.assert_called_once()
 
     assert "___test_model_" in cache._cache_entry_path('"test_model"').name
+    assert "客户数据" in cache._cache_entry_path("客户数据").name
 
 
 def test_optimized_query_cache(tmp_path: Path, mocker: MockerFixture):


### PR DESCRIPTION
BREAKING: If users currently have unicode characters then their table name will update to actually include the unicode name. Still thinking through how to migrate this. 

This PR affects `santize_name` function would before would replace unicode characters with underscores. This is used for populating the file cache and creating table names. Therefore someone could have had a SQLMesh project that would run but it would not have correct names and they could get conflicts when reading from cache or writing. 

Therefore this PR updates `sanitize_name` to maintain the unicode characters while still removing things like double quotes from the resulting name.