### PR TITLE
Chore: Cache results of get_data_objects

### DIFF
--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -164,11 +164,11 @@ class MySQLEngineAdapter(
                         exc_info=True,
                     )
 
-    def create_table_like(
+    def _create_table_like(
         self,
         target_table_name: TableName,
         source_table_name: TableName,
-        exists: bool = True,
+        exists: bool,
         **kwargs: t.Any,
     ) -> None:
         self.execute(

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -34,7 +34,7 @@ class PostgresEngineAdapter(
     HAS_VIEW_BINDING = True
     CURRENT_CATALOG_EXPRESSION = exp.column("current_catalog")
     SUPPORTS_REPLACE_TABLE = False
-    MAX_IDENTIFIER_LENGTH = 63
+    MAX_IDENTIFIER_LENGTH: t.Optional[int] = 63
     SUPPORTS_QUERY_EXECUTION_TRACKING = True
     SCHEMA_DIFFER_KWARGS = {
         "parameterized_type_defaults": {

--- a/sqlmesh/core/engine_adapter/postgres.py
+++ b/sqlmesh/core/engine_adapter/postgres.py
@@ -79,11 +79,11 @@ class PostgresEngineAdapter(
             self._connection_pool.commit()
         return df
 
-    def create_table_like(
+    def _create_table_like(
         self,
         target_table_name: TableName,
         source_table_name: TableName,
-        exists: bool = True,
+        exists: bool,
         **kwargs: t.Any,
     ) -> None:
         self.execute(

--- a/sqlmesh/core/engine_adapter/spark.py
+++ b/sqlmesh/core/engine_adapter/spark.py
@@ -402,14 +402,16 @@ class SparkEngineAdapter(
             return self.spark.catalog.currentDatabase()
         return self.fetchone(exp.select(exp.func("current_database")))[0]  # type: ignore
 
-    def get_data_object(self, target_name: TableName) -> t.Optional[DataObject]:
+    def get_data_object(
+        self, target_name: TableName, safe_to_cache: bool = False
+    ) -> t.Optional[DataObject]:
         target_table = exp.to_table(target_name)
         if isinstance(target_table.this, exp.Dot) and target_table.this.expression.name.startswith(
             f"{self.BRANCH_PREFIX}{self.WAP_PREFIX}"
         ):
             # Exclude the branch name
             target_table.set("this", target_table.this.this)
-        return super().get_data_object(target_table)
+        return super().get_data_object(target_table, safe_to_cache=safe_to_cache)
 
     def create_state_table(
         self,

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -307,6 +307,9 @@ class SnapshotEvaluator:
         ]
         self._create_schemas(gateway_table_pairs=gateway_table_pairs)
 
+        # Fetch the view data objects for the promoted snapshots to get them cached
+        self._get_virtual_data_objects(target_snapshots, environment_naming_info)
+
         deployability_index = deployability_index or DeployabilityIndex.all_deployable()
         with self.concurrent_context():
             concurrent_apply_to_snapshots(
@@ -425,7 +428,9 @@ class SnapshotEvaluator:
             target_snapshots: Target snapshots.
             deployability_index: Determines snapshots that are deployable / representative in the context of this creation.
         """
-        existing_data_objects = self._get_data_objects(target_snapshots, deployability_index)
+        existing_data_objects = self._get_physical_data_objects(
+            target_snapshots, deployability_index
+        )
         snapshots_to_create = []
         for snapshot in target_snapshots:
             if not snapshot.is_model or snapshot.is_symbolic:
@@ -482,7 +487,7 @@ class SnapshotEvaluator:
             deployability_index: Determines snapshots that are deployable in the context of this evaluation.
         """
         deployability_index = deployability_index or DeployabilityIndex.all_deployable()
-        target_data_objects = self._get_data_objects(target_snapshots, deployability_index)
+        target_data_objects = self._get_physical_data_objects(target_snapshots, deployability_index)
         if not target_data_objects:
             return
 
@@ -1472,7 +1477,7 @@ class SnapshotEvaluator:
             and adapter.table_exists(snapshot.table_name())
         )
 
-    def _get_data_objects(
+    def _get_physical_data_objects(
         self,
         target_snapshots: t.Iterable[Snapshot],
         deployability_index: DeployabilityIndex,
@@ -1488,6 +1493,59 @@ class SnapshotEvaluator:
             A dictionary of snapshot IDs to existing data objects of their physical tables. If the data object
             for a snapshot is not found, it will not be included in the dictionary.
         """
+        return self._get_data_objects(
+            target_snapshots,
+            lambda s: exp.to_table(
+                s.table_name(deployability_index.is_deployable(s)), dialect=s.model.dialect
+            ),
+        )
+
+    def _get_virtual_data_objects(
+        self,
+        target_snapshots: t.Iterable[Snapshot],
+        environment_naming_info: EnvironmentNamingInfo,
+    ) -> t.Dict[SnapshotId, DataObject]:
+        """Returns a dictionary of snapshot IDs to existing data objects of their virtual views.
+
+        Args:
+            target_snapshots: Target snapshots.
+             environment_naming_info: The environment naming info of the target virtual environment.
+
+        Returns:
+            A dictionary of snapshot IDs to existing data objects of their virtual views. If the data object
+            for a snapshot is not found, it will not be included in the dictionary.
+        """
+
+        def _get_view_name(s: Snapshot) -> exp.Table:
+            adapter = (
+                self.get_adapter(s.model_gateway)
+                if environment_naming_info.gateway_managed
+                else self.adapter
+            )
+            return exp.to_table(
+                s.qualified_view_name.for_environment(
+                    environment_naming_info, dialect=adapter.dialect
+                ),
+                dialect=adapter.dialect,
+            )
+
+        return self._get_data_objects(target_snapshots, _get_view_name)
+
+    def _get_data_objects(
+        self,
+        target_snapshots: t.Iterable[Snapshot],
+        table_name_callable: t.Callable[[Snapshot], exp.Table],
+    ) -> t.Dict[SnapshotId, DataObject]:
+        """Returns a dictionary of snapshot IDs to existing data objects.
+
+        Args:
+            target_snapshots: Target snapshots.
+            table_name_callable: A function that takes a snapshot and returns the table to look for.
+
+        Returns:
+            A dictionary of snapshot IDs to existing data objects. If the data object for a snapshot is not found,
+            it will not be included in the dictionary.
+        """
         tables_by_gateway_and_schema: t.Dict[t.Union[str, None], t.Dict[exp.Table, set[str]]] = (
             defaultdict(lambda: defaultdict(set))
         )
@@ -1495,8 +1553,7 @@ class SnapshotEvaluator:
         for snapshot in target_snapshots:
             if not snapshot.is_model or snapshot.is_symbolic:
                 continue
-            is_deployable = deployability_index.is_deployable(snapshot)
-            table = exp.to_table(snapshot.table_name(is_deployable), dialect=snapshot.model.dialect)
+            table = table_name_callable(snapshot)
             table_schema = d.schema_(table.db, catalog=table.catalog)
             tables_by_gateway_and_schema[snapshot.model_gateway][table_schema].add(table.name)
             snapshots_by_table_name[table.name] = snapshot

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -1564,7 +1564,9 @@ class SnapshotEvaluator:
             gateway: t.Optional[str] = None,
         ) -> t.List[DataObject]:
             logger.info("Listing data objects in schema %s", schema.sql())
-            return self.get_adapter(gateway).get_data_objects(schema, object_names)
+            return self.get_adapter(gateway).get_data_objects(
+                schema, object_names, safe_to_cache=True
+            )
 
         with self.concurrent_context():
             existing_objects: t.List[DataObject] = []

--- a/tests/core/engine_adapter/test_athena.py
+++ b/tests/core/engine_adapter/test_athena.py
@@ -312,6 +312,7 @@ def test_replace_query(adapter: AthenaEngineAdapter, mocker: MockerFixture):
     )
     mocker.patch.object(adapter, "_get_data_objects", return_value=[])
     adapter.cursor.execute.reset_mock()
+    adapter._clear_data_object_cache()
 
     adapter.s3_warehouse_location = "s3://foo"
     adapter.replace_query(

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -3723,6 +3723,27 @@ def test_data_object_cache_get_data_objects(
     assert mock_get_data_objects.call_count == 1  # Should not increase
 
 
+def test_data_object_cache_get_data_objects_no_object_names(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+):
+    adapter = make_mocked_engine_adapter(EngineAdapter, patch_get_data_objects=False)
+
+    table1 = DataObject(catalog=None, schema="test_schema", name="table1", type="table")
+    table2 = DataObject(catalog=None, schema="test_schema", name="table2", type="table")
+
+    mock_get_data_objects = mocker.patch.object(
+        adapter, "_get_data_objects", return_value=[table1, table2]
+    )
+
+    result1 = adapter.get_data_objects("test_schema")
+    assert len(result1) == 2
+    assert mock_get_data_objects.call_count == 1
+
+    result2 = adapter.get_data_objects("test_schema", {"table1", "table2"})
+    assert len(result2) == 2
+    assert mock_get_data_objects.call_count == 1  # Should not increase
+
+
 def test_data_object_cache_get_data_object(
     make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
 ):

--- a/tests/core/engine_adapter/test_snowflake.py
+++ b/tests/core/engine_adapter/test_snowflake.py
@@ -358,12 +358,12 @@ def test_create_managed_table(make_mocked_engine_adapter: t.Callable, mocker: Mo
 def test_drop_managed_table(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(SnowflakeEngineAdapter)
 
-    adapter.drop_managed_table(table_name=exp.parse_identifier("foo"), exists=False)
-    adapter.drop_managed_table(table_name=exp.parse_identifier("foo"), exists=True)
+    adapter.drop_managed_table(table_name="foo.bar", exists=False)
+    adapter.drop_managed_table(table_name="foo.bar", exists=True)
 
     assert to_sql_calls(adapter) == [
-        'DROP DYNAMIC TABLE "foo"',
-        'DROP DYNAMIC TABLE IF EXISTS "foo"',
+        'DROP DYNAMIC TABLE "foo"."bar"',
+        'DROP DYNAMIC TABLE IF EXISTS "foo"."bar"',
     ]
 
 

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -1344,6 +1344,7 @@ def test_promote_deployable(mocker: MockerFixture, make_snapshot):
     )
     adapter_mock.create_table.assert_not_called()
 
+    adapter_mock.get_data_objects.return_value = []
     evaluator.promote([snapshot], EnvironmentNamingInfo(name="test_env"))
 
     adapter_mock.create_schema.assert_called_once_with(to_schema("test_schema__test_env"))
@@ -4188,6 +4189,7 @@ def test_multiple_engine_promotion(mocker: MockerFixture, adapter_mock, make_sna
     connection_mock.cursor.return_value = cursor_mock
     adapter = EngineAdapter(lambda: connection_mock, "")
     adapter.with_settings = lambda **kwargs: adapter  # type: ignore
+    adapter._get_data_objects = lambda *args, **kwargs: []  # type: ignore
     engine_adapters = {"default": adapter_mock, "secondary": adapter}
 
     def columns(table_name):

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -888,6 +888,7 @@ def test_create_prod_table_exists(mocker: MockerFixture, adapter_mock, make_snap
         {
             f"test_schema__test_model__{snapshot.version}",
         },
+        safe_to_cache=True,
     )
 
 
@@ -974,6 +975,7 @@ def test_create_only_dev_table_exists(mocker: MockerFixture, adapter_mock, make_
         {
             f"test_schema__test_model__{snapshot.version}__dev",
         },
+        safe_to_cache=True,
     )
 
 
@@ -1023,6 +1025,7 @@ def test_create_new_forward_only_model(mocker: MockerFixture, adapter_mock, make
         {
             f"test_schema__test_model__{snapshot.dev_version}__dev",
         },
+        safe_to_cache=True,
     )
 
 
@@ -1113,6 +1116,7 @@ def test_create_tables_exist(
     adapter_mock.get_data_objects.assert_called_once_with(
         schema_("sqlmesh__db"),
         {table_name},
+        safe_to_cache=True,
     )
     adapter_mock.create_schema.assert_not_called()
     adapter_mock.create_table.assert_not_called()
@@ -1150,6 +1154,7 @@ def test_create_prod_table_exists_forward_only(mocker: MockerFixture, adapter_mo
         {
             f"test_schema__test_model__{snapshot.version}",
         },
+        safe_to_cache=True,
     )
 
     adapter_mock.create_table.assert_not_called()
@@ -1341,6 +1346,7 @@ def test_promote_deployable(mocker: MockerFixture, make_snapshot):
         {
             f"test_schema__test_model__{snapshot.version}",
         },
+        safe_to_cache=True,
     )
     adapter_mock.create_table.assert_not_called()
 

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -122,10 +122,10 @@ def test_dbt_custom_materialization():
     selected_model = list(plan.selected_models)[0]
     assert selected_model == "model.sushi.custom_incremental_model"
 
-    qoery = "SELECT * FROM sushi.custom_incremental_model ORDER BY created_at"
+    query = "SELECT * FROM sushi.custom_incremental_model ORDER BY created_at"
     hook_table = "SELECT * FROM hook_table ORDER BY id"
     sushi_context.apply(plan)
-    result = sushi_context.engine_adapter.fetchdf(qoery)
+    result = sushi_context.engine_adapter.fetchdf(query)
     assert len(result) == 1
     assert {"created_at", "id"}.issubset(result.columns)
 
@@ -140,7 +140,7 @@ def test_dbt_custom_materialization():
     tomorrow = datetime.now() + timedelta(days=1)
     sushi_context.run(select_models=["sushi.custom_incremental_model"], execution_time=tomorrow)
 
-    result_after_run = sushi_context.engine_adapter.fetchdf(qoery)
+    result_after_run = sushi_context.engine_adapter.fetchdf(query)
     assert {"created_at", "id"}.issubset(result_after_run.columns)
 
     # this should have added new unique values for the new row


### PR DESCRIPTION
This reduces the number of INFORMATION_SCHEMA queries from 28 down to 6 on the fresh `sushi` project. I anticipate equally dramatic improvements in other scenarios.