### PR TITLE
feat: support batching of janitor cleanup

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -309,6 +309,15 @@ Usage: sqlmesh janitor [OPTIONS]
 Options:
   --ignore-ttl  Cleanup snapshots that are not referenced in any environment,
                 regardless of when they're set to expire
+  --batch-start TEXT
+                Optional datetime (for example, "2024-12-01" or "2 days ago")
+                to begin evaluating expired snapshots. When omitted the
+                janitor starts at the current time.
+  --batch-seconds INTEGER
+                When provided alongside --batch-start, reruns the janitor in
+                batches by advancing the evaluation time in the given number
+                of seconds until it catches up to "now". Use this to throttle
+                large cleanup jobs.
   --help        Show this message and exit.
 ```
 

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -631,16 +631,35 @@ def invalidate(ctx: click.Context, environment: str, **kwargs: t.Any) -> None:
     is_flag=True,
     help="Cleanup snapshots that are not referenced in any environment, regardless of when they're set to expire",
 )
+@click.option(
+    "--batch-start",
+    help="The batch start datetime to start processing expired snapshots to avoid large requests.",
+)
+@click.option(
+    "--batch-seconds",
+    "batch_size_seconds",
+    type=int,
+    help="When provided with --batch-start, runs the janitor in batches by incrementing the timestamp by this many seconds until reaching the current time.",
+)
 @click.pass_context
 @error_handler
 @cli_analytics
-def janitor(ctx: click.Context, ignore_ttl: bool, **kwargs: t.Any) -> None:
+def janitor(
+    ctx: click.Context,
+    ignore_ttl: bool,
+    batch_start: t.Optional[TimeLike],
+    batch_size_seconds: t.Optional[int],
+) -> None:
     """
     Run the janitor process on-demand.
 
     The janitor cleans up old environments and expired snapshots.
     """
-    ctx.obj.run_janitor(ignore_ttl, **kwargs)
+    ctx.obj.run_janitor(
+        ignore_ttl,
+        batch_start=batch_start,
+        batch_size_seconds=batch_size_seconds,
+    )
 
 
 @cli.command("destroy")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -14,7 +14,7 @@ from click import ClickException
 from click.testing import CliRunner
 from sqlmesh import RuntimeEnv
 from sqlmesh.cli.project_init import ProjectTemplate, init_example_project
-from sqlmesh.cli.main import cli
+from sqlmesh.cli.main import cli, janitor
 from sqlmesh.core.context import Context
 from sqlmesh.integrations.dlt import generate_dlt_models
 from sqlmesh.utils.date import now_ds, time_like_to_str, timedelta, to_datetime, yesterday_ds
@@ -125,6 +125,40 @@ def init_prod_and_backfill(runner, temp_dir) -> None:
     )
     assert_plan_success(result)
     assert path.exists(temp_dir / "db.db")
+
+
+def test_cli_janitor_batch_string(runner: CliRunner, mocker) -> None:
+    context_mock = mocker.MagicMock()
+
+    result = runner.invoke(
+        janitor,
+        ["--ignore-ttl", "--batch-start", "2025-01-01", "--batch-seconds", "60"],
+        obj=context_mock,
+    )
+
+    assert result.exit_code == 0
+    context_mock.run_janitor.assert_called_once_with(
+        True,
+        batch_start="2025-01-01",
+        batch_size_seconds=60,
+    )
+
+
+def test_cli_janitor_batch_int(runner: CliRunner, mocker) -> None:
+    context_mock = mocker.MagicMock()
+
+    result = runner.invoke(
+        janitor,
+        ["--ignore-ttl", "--batch-start", "1735862400000", "--batch-seconds", "60"],
+        obj=context_mock,
+    )
+
+    assert result.exit_code == 0
+    context_mock.run_janitor.assert_called_once_with(
+        True,
+        batch_start="1735862400000",
+        batch_size_seconds=60,
+    )
 
 
 def assert_duckdb_test(result) -> None:


### PR DESCRIPTION
Prior to this PR, janitor would always read all expired snapshots into memory. This is fine during normal operations but if for some reason janitor has not run for a while this can result in a lot of snapshots being read into memory. 

This PR allows users to configure the janitor to batch up what is being processed. It does this by adjusting the "current_ts" (`batch_start`) and then incrementing this by the provided `batch_size_seconds`. So for example a user could provide the following to process the last 7 days of expired snapshots 1 day at a time:

```
sqlmesh janitor --batch-start "7 days ago" --batch-seconds 86400
```

