### PR TITLE
Chore: make console width deterministic in tests

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -32,7 +32,7 @@ def mock_runtime_env(monkeypatch):
 
 @pytest.fixture(scope="session")
 def runner() -> CliRunner:
-    return CliRunner()
+    return CliRunner(env={"COLUMNS": "80"})
 
 
 @contextmanager
@@ -1887,7 +1887,9 @@ def test_init_interactive_cli_mode_simple(runner: CliRunner, tmp_path: Path):
     assert "no_diff: true" in config_path.read_text()
 
 
-def test_init_interactive_engine_install_msg(runner: CliRunner, tmp_path: Path):
+def test_init_interactive_engine_install_msg(runner: CliRunner, tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("sqlmesh.utils.rich.console.width", 80)
+
     # Engine install text should not appear for built-in engines like DuckDB
     # Input: 1 (DEFAULT template), 1 (duckdb engine), 1 (DEFAULT CLI mode)
     result = runner.invoke(

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -83,6 +83,7 @@ def use_terminal_console(func):
         orig_console = get_console()
         try:
             new_console = TerminalConsole()
+            new_console.console.width = 80
             new_console.console.no_color = True
             set_console(new_console)
             func(*args, **kwargs)


### PR DESCRIPTION
I tried running `pytest -n auto tests/cli/test_cli.py` from a different system, locally, and started seeing assertion errors related to line break positioning:

```
FAILED tests/cli/test_cli.py::test_plan_dev_longnames - AssertionError: assert 'sqlmesh_example__dev_butamuchlongerenvironmentname.seed_cccccccccccccccccccccccc\ncccccccccccccccccccccccccccccccccccccccccccccccccccccccc_model          [ins...
FAILED tests/cli/test_cli.py::test_plan_nonbreaking_noautocategorization - AssertionError: assert '[1] [Breaking] Backfill sqlmesh_example.incremental_model and indirectly \nmodified children' in '.\n=========================================================...
FAILED tests/cli/test_cli.py::test_run_cron_not_elapsed - AssertionError: assert 'No models are ready to run. Please wait until a model `cron` interval has \nelapsed.\n\nNext run will be ready at ' in 'No models are ready to run. Please wai...
FAILED tests/cli/test_cli.py::test_init_interactive_engine_install_msg - assert 'Run command in CLI to install your SQL engine\'s Python dependencies: pip \ninstall "sqlmesh[gcppostgres]"' in '──────────────────────────────\nWelcome to SQLMesh!\n─────────...
```

Similarly, some other tests failed in the suite. Ultimately, it appears that the rich console inherited my environment's `$COLUMNS` which wasn't 80 and that resulted in said behavior. 
