### PR TITLE
Chore: Fix flaky test by unliking dbt msgpack for deterministic behaviour

### DIFF
--- a/tests/dbt/cli/test_run.py
+++ b/tests/dbt/cli/test_run.py
@@ -65,6 +65,12 @@ def test_run_with_changes_and_full_refresh(
         "select a, b, 'changed' as c from {{ ref('model_a') }}"
     )
 
+    # Clear dbt's partial parse cache to ensure file changes are detected
+    # Without it dbt may use stale cached model definitions, causing flakiness
+    partial_parse_file = project_path / "target" / "sqlmesh_partial_parse.msgpack"
+    if partial_parse_file.exists():
+        partial_parse_file.unlink()
+
     # run with --full-refresh. this should:
     # - fully refresh model_a (pick up the new records from external_table)
     # - deploy the local change to model_b (introducing the 'changed' column)


### PR DESCRIPTION
This aims to fix the flaky test `test_run_with_changes_and_full_refresh`. This fails intermittently because when the test modifies model_b.sql, dbt's change detection mechanism doesn't always register the update due to the limited granularity of filesystem timestamps. So dbt may rely on a stale cached model definition, which doesn't include the updated schema with the new column c. The fix is to explicitly unlink the partial parse cache file after modifying the model, which forces dbt to perform a full parse and register the changes.