### PR TITLE
Feat(dbt): Add support for transaction in dbt pre and post hooks

### DIFF
--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -663,6 +663,7 @@ depends_on_validator: t.Callable = field_validator(
 
 class ParsableSql(PydanticModel):
     sql: str
+    transaction: t.Optional[bool] = None
 
     _parsed: t.Optional[exp.Expression] = None
     _parsed_dialect: t.Optional[str] = None

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -3232,11 +3232,11 @@ def test_create_post_statements_use_non_deployable_table(
     evaluator.create([snapshot], {}, DeployabilityIndex.none_deployable())
 
     call_args = adapter_mock.execute.call_args_list
-    pre_calls = call_args[0][0][0]
+    pre_calls = call_args[1][0][0]
     assert len(pre_calls) == 1
     assert pre_calls[0].sql(dialect="postgres") == expected_call
 
-    post_calls = call_args[1][0][0]
+    post_calls = call_args[2][0][0]
     assert len(post_calls) == 1
     assert post_calls[0].sql(dialect="postgres") == expected_call
 
@@ -3294,11 +3294,11 @@ def test_create_pre_post_statements_python_model(
     expected_call = f'CREATE INDEX IF NOT EXISTS "idx" ON "sqlmesh__db"."db__test_model__{snapshot.version}__dev" /* db.test_model */("id")'
 
     call_args = adapter_mock.execute.call_args_list
-    pre_calls = call_args[0][0][0]
+    pre_calls = call_args[1][0][0]
     assert len(pre_calls) == 1
     assert pre_calls[0].sql(dialect="postgres") == expected_call
 
-    post_calls = call_args[1][0][0]
+    post_calls = call_args[2][0][0]
     assert len(post_calls) == 1
     assert post_calls[0].sql(dialect="postgres") == expected_call
 
@@ -3356,14 +3356,14 @@ def test_on_virtual_update_statements(mocker: MockerFixture, adapter_mock, make_
     )
 
     call_args = adapter_mock.execute.call_args_list
-    post_calls = call_args[1][0][0]
+    post_calls = call_args[2][0][0]
     assert len(post_calls) == 1
     assert (
         post_calls[0].sql(dialect="postgres")
         == f'CREATE INDEX IF NOT EXISTS "test_idx" ON "sqlmesh__test_schema"."test_schema__test_model__{snapshot.version}__dev" /* test_schema.test_model */("a")'
     )
 
-    on_virtual_update_calls = call_args[2][0][0]
+    on_virtual_update_calls = call_args[4][0][0]
     assert (
         on_virtual_update_calls[0].sql(dialect="postgres")
         == 'GRANT SELECT ON VIEW "test_schema__test_env"."test_model" /* test_schema.test_model */ TO ROLE "admin"'
@@ -3441,7 +3441,7 @@ def test_on_virtual_update_python_model_macro(mocker: MockerFixture, adapter_moc
     )
 
     call_args = adapter_mock.execute.call_args_list
-    on_virtual_update_call = call_args[2][0][0][0]
+    on_virtual_update_call = call_args[4][0][0][0]
     assert (
         on_virtual_update_call.sql(dialect="postgres")
         == 'CREATE INDEX IF NOT EXISTS "idx" ON "db"."test_model_3" /* db.test_model_3 */("id")'
@@ -4187,11 +4187,11 @@ def test_multiple_engine_creation(snapshot: Snapshot, adapters, make_snapshot):
     assert view_args[1][0][0] == "test_schema__test_env.test_model"
 
     call_args = engine_adapters["secondary"].execute.call_args_list
-    pre_calls = call_args[0][0][0]
+    pre_calls = call_args[1][0][0]
     assert len(pre_calls) == 1
     assert pre_calls[0].sql(dialect="postgres") == expected_call
 
-    post_calls = call_args[1][0][0]
+    post_calls = call_args[2][0][0]
     assert len(post_calls) == 1
     assert post_calls[0].sql(dialect="postgres") == expected_call
 
@@ -4459,7 +4459,7 @@ def test_multi_engine_python_model_with_macros(adapters, make_snapshot):
 
     # For the pre/post statements verify the model-specific gateway was used
     engine_adapters["default"].execute.assert_called_once()
-    assert len(engine_adapters["secondary"].execute.call_args_list) == 2
+    assert len(engine_adapters["secondary"].execute.call_args_list) == 4
 
     # Validate that the get_catalog_type method was called only on the secondary engine from the macro evaluator
     engine_adapters["default"].get_catalog_type.assert_not_called()

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -2849,7 +2849,7 @@ def test_dbt_hooks_with_transaction_flag_execution(sushi_test_dbt_context: Conte
     assert shared_table["hook_name"][2] == "after_commit"
     assert shared_table["execution_order"][2] == 3
 
-    # the timestamps also should be monotonically increasing for teh same reason
+    # the timestamps also should be monotonically increasing for the same reason
     for i in range(len(shared_table) - 1):
         assert shared_table["created_at"][i] <= shared_table["created_at"][i + 1]
 

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -2707,3 +2707,180 @@ def test_ignore_source_depends_on_when_also_model(dbt_dummy_postgres_config: Pos
     }
 
     assert model.sqlmesh_model_kwargs(context)["depends_on"] == {"schema.source_b"}
+
+
+@pytest.mark.xdist_group("dbt_manifest")
+def test_dbt_hooks_with_transaction_flag(sushi_test_dbt_context: Context):
+    model_fqn = '"memory"."sushi"."model_with_transaction_hooks"'
+    assert model_fqn in sushi_test_dbt_context.models
+
+    model = sushi_test_dbt_context.models[model_fqn]
+
+    pre_statements = model.pre_statements_
+    assert pre_statements is not None
+    assert len(pre_statements) >= 3
+
+    # we need to check the expected SQL but more importantly that the transaction flags are there
+    assert any(
+        s.sql == 'JINJA_STATEMENT_BEGIN;\n{{ log("pre-hook") }}\nJINJA_END;'
+        and s.transaction is True
+        for s in pre_statements
+    )
+    assert any(
+        "CREATE TABLE IF NOT EXISTS hook_outside_pre_table" in s.sql and s.transaction is False
+        for s in pre_statements
+    )
+    assert any(
+        "CREATE TABLE IF NOT EXISTS shared_hook_table" in s.sql and s.transaction is False
+        for s in pre_statements
+    )
+    assert any(
+        "{{ insert_into_shared_hook_table('inside_pre') }}" in s.sql and s.transaction is True
+        for s in pre_statements
+    )
+
+    post_statements = model.post_statements_
+    assert post_statements is not None
+    assert len(post_statements) >= 4
+    assert any(
+        s.sql == 'JINJA_STATEMENT_BEGIN;\n{{ log("post-hook") }}\nJINJA_END;'
+        and s.transaction is True
+        for s in post_statements
+    )
+    assert any(
+        "{{ insert_into_shared_hook_table('inside_post') }}" in s.sql and s.transaction is True
+        for s in post_statements
+    )
+    assert any(
+        "CREATE TABLE IF NOT EXISTS hook_outside_post_table" in s.sql and s.transaction is False
+        for s in post_statements
+    )
+    assert any(
+        "{{ insert_into_shared_hook_table('after_commit') }}" in s.sql and s.transaction is False
+        for s in post_statements
+    )
+
+    # render_pre_statements with inside_transaction=True should only return inserrt
+    inside_pre_statements = model.render_pre_statements(inside_transaction=True)
+    assert len(inside_pre_statements) == 1
+    assert (
+        inside_pre_statements[0].sql()
+        == """INSERT INTO "shared_hook_table" ("id", "hook_name", "execution_order", "created_at") VALUES ((SELECT COALESCE(MAX("id"), 0) + 1 FROM "shared_hook_table"), 'inside_pre', (SELECT COALESCE(MAX("id"), 0) + 1 FROM "shared_hook_table"), NOW())"""
+    )
+
+    # while for render_pre_statements with inside_transaction=False the create statements
+    outside_pre_statements = model.render_pre_statements(inside_transaction=False)
+    assert len(outside_pre_statements) == 2
+    assert "CREATE" in outside_pre_statements[0].sql()
+    assert "hook_outside_pre_table" in outside_pre_statements[0].sql()
+    assert "CREATE" in outside_pre_statements[1].sql()
+    assert "shared_hook_table" in outside_pre_statements[1].sql()
+
+    # similarly for post statements
+    inside_post_statements = model.render_post_statements(inside_transaction=True)
+    assert len(inside_post_statements) == 1
+    assert (
+        inside_post_statements[0].sql()
+        == """INSERT INTO "shared_hook_table" ("id", "hook_name", "execution_order", "created_at") VALUES ((SELECT COALESCE(MAX("id"), 0) + 1 FROM "shared_hook_table"), 'inside_post', (SELECT COALESCE(MAX("id"), 0) + 1 FROM "shared_hook_table"), NOW())"""
+    )
+
+    outside_post_statements = model.render_post_statements(inside_transaction=False)
+    assert len(outside_post_statements) == 2
+    assert "CREATE" in outside_post_statements[0].sql()
+    assert "hook_outside_post_table" in outside_post_statements[0].sql()
+    assert "INSERT" in outside_post_statements[1].sql()
+    assert "shared_hook_table" in outside_post_statements[1].sql()
+
+
+@pytest.mark.xdist_group("dbt_manifest")
+def test_dbt_hooks_with_transaction_flag_execution(sushi_test_dbt_context: Context):
+    model_fqn = '"memory"."sushi"."model_with_transaction_hooks"'
+    assert model_fqn in sushi_test_dbt_context.models
+
+    plan = sushi_test_dbt_context.plan(select_models=["sushi.model_with_transaction_hooks"])
+    sushi_test_dbt_context.apply(plan)
+
+    result = sushi_test_dbt_context.engine_adapter.fetchdf(
+        "SELECT * FROM sushi.model_with_transaction_hooks"
+    )
+    assert len(result) == 1
+    assert result["id"][0] == 1
+    assert result["name"][0] == "test"
+
+    # ensure the outside pre-hook and post-hook table were created
+    pre_outside = sushi_test_dbt_context.engine_adapter.fetchdf(
+        "SELECT * FROM hook_outside_pre_table"
+    )
+    assert len(pre_outside) == 1
+    assert pre_outside["id"][0] == 1
+    assert pre_outside["location"][0] == "outside"
+    assert pre_outside["execution_order"][0] == 1
+
+    post_outside = sushi_test_dbt_context.engine_adapter.fetchdf(
+        "SELECT * FROM hook_outside_post_table"
+    )
+    assert len(post_outside) == 1
+    assert post_outside["id"][0] == 5
+    assert post_outside["location"][0] == "outside"
+    assert post_outside["execution_order"][0] == 5
+
+    # verify the shared table that was created by before_begin and populated by all hooks
+    shared_table = sushi_test_dbt_context.engine_adapter.fetchdf(
+        "SELECT * FROM shared_hook_table ORDER BY execution_order"
+    )
+    assert len(shared_table) == 3
+    assert shared_table["execution_order"].is_monotonic_increasing
+
+    # The order of creation and insertion will verify the following order of execution
+    # 1. before_begin (transaction=false) ran BEFORE the transaction started and created the table
+    # 2. inside_pre (transaction=true) ran INSIDE the transaction and could insert into the table
+    # 3. inside_post (transaction=true) ran INSIDE the transaction and could insert into the table (but after pre statement)
+    # 4. after_commit (transaction=false) ran AFTER the transaction committed
+
+    assert shared_table["id"][0] == 1
+    assert shared_table["hook_name"][0] == "inside_pre"
+    assert shared_table["execution_order"][0] == 1
+
+    assert shared_table["id"][1] == 2
+    assert shared_table["hook_name"][1] == "inside_post"
+    assert shared_table["execution_order"][1] == 2
+
+    assert shared_table["id"][2] == 3
+    assert shared_table["hook_name"][2] == "after_commit"
+    assert shared_table["execution_order"][2] == 3
+
+    # the timestamps also should be monotonically increasing for teh same reason
+    for i in range(len(shared_table) - 1):
+        assert shared_table["created_at"][i] <= shared_table["created_at"][i + 1]
+
+    # the tables using the alternate syntax should have correct order as well
+    assert pre_outside["created_at"][0] < shared_table["created_at"][0]
+    assert post_outside["created_at"][0] > shared_table["created_at"][1]
+
+    # running with execution time one day in the future to simulate a run
+    tomorrow = datetime.now() + timedelta(days=1)
+    sushi_test_dbt_context.run(
+        select_models=["sushi.model_with_transaction_hooks"], execution_time=tomorrow
+    )
+
+    # to verify that the transaction information persists in state and is respected
+    shared_table = sushi_test_dbt_context.engine_adapter.fetchdf(
+        "SELECT * FROM shared_hook_table ORDER BY execution_order"
+    )
+
+    # and the execution order for run is similar
+    assert shared_table["execution_order"].is_monotonic_increasing
+    assert shared_table["id"][3] == 4
+    assert shared_table["hook_name"][3] == "inside_pre"
+    assert shared_table["execution_order"][3] == 4
+
+    assert shared_table["id"][4] == 5
+    assert shared_table["hook_name"][4] == "inside_post"
+    assert shared_table["execution_order"][4] == 5
+
+    assert shared_table["id"][5] == 6
+    assert shared_table["hook_name"][5] == "after_commit"
+    assert shared_table["execution_order"][5] == 6
+
+    for i in range(len(shared_table) - 1):
+        assert shared_table["created_at"][i] <= shared_table["created_at"][i + 1]

--- a/tests/fixtures/dbt/sushi_test/macros/insert_hook.sql
+++ b/tests/fixtures/dbt/sushi_test/macros/insert_hook.sql
@@ -1,0 +1,14 @@
+{% macro insert_into_shared_hook_table(hook_name) %}
+INSERT INTO shared_hook_table (
+    id,
+    hook_name,
+    execution_order,
+    created_at
+)
+VALUES (
+    (SELECT COALESCE(MAX(id), 0) + 1 FROM shared_hook_table),
+    '{{ hook_name }}',
+    (SELECT COALESCE(MAX(id), 0) + 1 FROM shared_hook_table),
+    NOW()
+)
+{% endmacro %}

--- a/tests/fixtures/dbt/sushi_test/models/model_with_transaction_hooks.sql
+++ b/tests/fixtures/dbt/sushi_test/models/model_with_transaction_hooks.sql
@@ -1,0 +1,56 @@
+{{
+  config(
+    materialized = 'table',
+
+    pre_hook = [
+      {
+        "sql": "
+          CREATE TABLE IF NOT EXISTS hook_outside_pre_table AS
+          SELECT
+            1 AS id,
+            'outside' AS location,
+            1 AS execution_order,
+            NOW() AS created_at
+        ",
+        "transaction": false
+      },
+
+      before_begin("
+        CREATE TABLE IF NOT EXISTS shared_hook_table (
+          id INT,
+          hook_name VARCHAR,
+          execution_order INT,
+          created_at TIMESTAMPTZ
+        )
+      "),
+
+      {
+        "sql": "{{ insert_into_shared_hook_table('inside_pre') }}",
+        "transaction": true
+      }
+    ],
+
+    post_hook = [
+      {
+        "sql": "{{ insert_into_shared_hook_table('inside_post') }}",
+        "transaction": true
+      },
+
+      {
+        "sql": "
+          CREATE TABLE IF NOT EXISTS hook_outside_post_table AS
+          SELECT
+            5 AS id,
+            'outside' AS location,
+            5 AS execution_order,
+            NOW() AS created_at
+        ",
+        "transaction": false
+      },
+
+      after_commit("{{ insert_into_shared_hook_table('after_commit') }}")
+    ]
+  )
+}}
+
+SELECT 1 AS id, 'test' AS name;


### PR DESCRIPTION
This adds support for `transaction` in dbt pre and post hooks. By default hooks are executed inside of the same transaction as the model being created. Hooks that need to run outside a transaction are for example when executing a VACUUM in Redshift or inserting into an audit table at the start of a run where the insert should persist even if the model fails. Running the hook outside a transaction ensures it won’t be rolled back.

These are set in a dbt project either with the `before_begin` and `after_commit` macro:
```
{{
  config(
    pre_hook=before_begin("SQL-statement"),
    post_hook=after_commit("SQL-statement")
  )
}}
```
or by setting the `transaction` flag in a dict:
```
{{
  config(
    pre_hook={
      "sql": "SQL-statement",
      "transaction": False
    },
    post_hook={
      "sql": "SQL-statement",
      "transaction": False
    }
  )
}}
```
By default and without setting the transaction the hooks are executed inside the transaction.

Docs: https://docs.getdbt.com/reference/resource-configs/pre-hook-post-hook#transaction-behavior