### PR TITLE
feat: add `batch_concurrency` to `ModelDefaultsConfig`

### DIFF
--- a/sqlmesh/core/config/model.py
+++ b/sqlmesh/core/config/model.py
@@ -45,6 +45,7 @@ class ModelDefaultsConfig(BaseConfig):
         allow_partials: Whether the models can process partial (incomplete) data intervals.
         enabled: Whether the models are enabled.
         interval_unit: The temporal granularity of the models data intervals. By default computed from cron.
+        batch_concurrency: The maximum number of batches that can run concurrently for an incremental model.
         pre_statements: The list of SQL statements that get executed before a model runs.
         post_statements: The list of SQL statements that get executed before a model runs.
         on_virtual_update: The list of SQL statements to be executed after the virtual update.
@@ -69,6 +70,7 @@ class ModelDefaultsConfig(BaseConfig):
     interval_unit: t.Optional[t.Union[str, IntervalUnit]] = None
     enabled: t.Optional[t.Union[str, bool]] = None
     formatting: t.Optional[t.Union[str, bool]] = None
+    batch_concurrency: t.Optional[int] = None
     pre_statements: t.Optional[t.List[t.Union[str, exp.Expression]]] = None
     post_statements: t.Optional[t.List[t.Union[str, exp.Expression]]] = None
     on_virtual_update: t.Optional[t.List[t.Union[str, exp.Expression]]] = None


### PR DESCRIPTION
This change allows users to set a default `batch_concurrency` value in their
project configuration that will be applied to incremental models.

- Added `batch_concurrency` field to `ModelDefaultsConfig`
- Updated `create_model_kind()` to apply `batch_concurrency` default to models
  inheriting from `_IncrementalBy` when not explicitly set
- Skips applying default for subclasses with hardcoded `batch_concurrency`
  (e.g., `IncrementalByUniqueKeyKind` which has `batch_concurrency: Literal[1]`)
- Added comprehensive tests covering default behavior and edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)