### PR TITLE
Fix: Add workaround to ignore source dependency if fqn matches model

### DIFF
--- a/sqlmesh/dbt/basemodel.py
+++ b/sqlmesh/dbt/basemodel.py
@@ -333,7 +333,7 @@ class BaseModelConfig(GeneralConfig):
                 {
                     source.canonical_name(context)
                     for source in model_context.sources.values()
-                    if source.fqn not in context.models_by_fqn
+                    if source.fqn not in context.model_fqns
                     # Allow dbt projects to reference a model as a source without causing a cycle
                 },
             ),

--- a/sqlmesh/dbt/context.py
+++ b/sqlmesh/dbt/context.py
@@ -51,6 +51,7 @@ class DbtContext:
     _project_name: t.Optional[str] = None
     _variables: t.Dict[str, t.Any] = field(default_factory=dict)
     _models: t.Dict[str, ModelConfig] = field(default_factory=dict)
+    _models_by_fqn: t.Dict[str, ModelConfig] = field(default_factory=dict)
     _seeds: t.Dict[str, SeedConfig] = field(default_factory=dict)
     _sources: t.Dict[str, SourceConfig] = field(default_factory=dict)
     _refs: t.Dict[str, t.Union[ModelConfig, SeedConfig]] = field(default_factory=dict)
@@ -144,12 +145,19 @@ class DbtContext:
     def models(self, models: t.Dict[str, ModelConfig]) -> None:
         self._models = {}
         self._refs = {}
+        self._models_by_fqn = {}
         self.add_models(models)
 
     def add_models(self, models: t.Dict[str, ModelConfig]) -> None:
         self._refs = {}
         self._models.update(models)
         self._jinja_environment = None
+
+    @property
+    def models_by_fqn(self) -> t.Dict[str, ModelConfig]:
+        if not self._models_by_fqn:
+            self._models_by_fqn = {model.fqn: model for model in self._models.values()}
+        return self._models_by_fqn
 
     @property
     def seeds(self) -> t.Dict[str, SeedConfig]:

--- a/sqlmesh/dbt/context.py
+++ b/sqlmesh/dbt/context.py
@@ -51,7 +51,7 @@ class DbtContext:
     _project_name: t.Optional[str] = None
     _variables: t.Dict[str, t.Any] = field(default_factory=dict)
     _models: t.Dict[str, ModelConfig] = field(default_factory=dict)
-    _models_by_fqn: t.Dict[str, ModelConfig] = field(default_factory=dict)
+    _model_fqns: t.Set[str] = field(default_factory=set)
     _seeds: t.Dict[str, SeedConfig] = field(default_factory=dict)
     _sources: t.Dict[str, SourceConfig] = field(default_factory=dict)
     _refs: t.Dict[str, t.Union[ModelConfig, SeedConfig]] = field(default_factory=dict)
@@ -145,7 +145,7 @@ class DbtContext:
     def models(self, models: t.Dict[str, ModelConfig]) -> None:
         self._models = {}
         self._refs = {}
-        self._models_by_fqn = {}
+        self._model_fqns = set()
         self.add_models(models)
 
     def add_models(self, models: t.Dict[str, ModelConfig]) -> None:
@@ -154,10 +154,10 @@ class DbtContext:
         self._jinja_environment = None
 
     @property
-    def models_by_fqn(self) -> t.Dict[str, ModelConfig]:
-        if not self._models_by_fqn:
-            self._models_by_fqn = {model.fqn: model for model in self._models.values()}
-        return self._models_by_fqn
+    def model_fqns(self) -> t.Set[str]:
+        if not self._model_fqns:
+            self._model_fqns = {model.fqn for model in self._models.values()}
+        return self._model_fqns
 
     @property
     def seeds(self) -> t.Dict[str, SeedConfig]:

--- a/sqlmesh/dbt/source.py
+++ b/sqlmesh/dbt/source.py
@@ -36,6 +36,7 @@ class SourceConfig(GeneralConfig):
     # DBT configuration fields
     name: str = ""
     source_name_: str = Field("", alias="source_name")
+    fqn_: t.List[str] = Field(default_factory=list, alias="fqn")
     database: t.Optional[str] = None
     schema_: t.Optional[str] = Field(None, alias="schema")
     identifier: t.Optional[str] = None
@@ -63,6 +64,10 @@ class SourceConfig(GeneralConfig):
     @property
     def config_name(self) -> str:
         return f"{self.source_name_}.{self.name}"
+
+    @property
+    def fqn(self) -> str:
+        return ".".join(self.fqn_)
 
     def canonical_name(self, context: DbtContext) -> str:
         if self._canonical_name is None:


### PR DESCRIPTION
An idiom used in dbt projects is to define a model as both a model and a source to circumvent circular dependencies. 

For example:

- Model A is a cache of load times from an external source
- Model B is the loaded values form the external source

Model A uses model B to figure out the previous load time by the max timestamp
Model B uses Model A to know what timestamp it needs to fetch from without having to redo that expensive calculation

In this idiom, Model B can be defined also as a source. Model A can then call it using the `source()` method, circumventing the circular dependency. 

However, it does also mean the developer has to make sure the table for Model B is created before Model A is called. Putting the `source()` call in an `is_incremental()` block is one way to solve that. There are many more examples.

The purpose of this fix is to not preclude developers from using the idiom, while also making them responsible for resolving the dependency prior to runtime. If the runtime behavior is not resolved, new environments will error when trying to run with a missing table.

If the source/model fqn collision was unintentional, we will no longer catch the circular dependency at load time. It will instead error at runt ime.