### PR TITLE
fix: remove state sync from migrate

### DIFF
--- a/sqlmesh/core/state_sync/db/facade.py
+++ b/sqlmesh/core/state_sync/db/facade.py
@@ -456,7 +456,7 @@ class EngineAdapterStateSync(StateSync):
     ) -> None:
         """Migrate the state sync to the latest SQLMesh / SQLGlot version."""
         self.migrator.migrate(
-            self,
+            self.schema,
             skip_backup=skip_backup,
             promoted_snapshots_only=promoted_snapshots_only,
         )

--- a/sqlmesh/migrations/v0000_baseline.py
+++ b/sqlmesh/migrations/v0000_baseline.py
@@ -4,15 +4,12 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type, index_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
-    schema = state_sync.schema
-    engine_adapter = state_sync.engine_adapter
-
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     intervals_table = "_intervals"
     snapshots_table = "_snapshots"
     environments_table = "_environments"
     versions_table = "_versions"
-    if state_sync.schema:
+    if schema:
         engine_adapter.create_schema(schema)
         intervals_table = f"{schema}.{intervals_table}"
         snapshots_table = f"{schema}.{snapshots_table}"
@@ -94,5 +91,5 @@ def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter.create_index(intervals_table, "_intervals_name_version_idx", ("name", "version"))
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0061_mysql_fix_blob_text_type.py
+++ b/sqlmesh/migrations/v0061_mysql_fix_blob_text_type.py
@@ -9,12 +9,9 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     if engine_adapter.dialect != "mysql":
         return
-
-    schema = state_sync.schema
     environments_table = "_environments"
     snapshots_table = "_snapshots"
 
@@ -46,5 +43,5 @@ def migrate_schemas(state_sync, **kwargs):  # type: ignore
         engine_adapter.execute(alter_table_exp)
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0062_add_model_gateway.py
+++ b/sqlmesh/migrations/v0062_add_model_gateway.py
@@ -1,9 +1,9 @@
 """Add the gateway model attribute."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0063_change_signals.py
+++ b/sqlmesh/migrations/v0063_change_signals.py
@@ -7,15 +7,13 @@ from sqlglot import exp, parse_one
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     import pandas as pd
 
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
     snapshots_table = "_snapshots"
     index_type = index_text_type(engine_adapter.dialect)
     if schema:

--- a/sqlmesh/migrations/v0064_join_when_matched_strings.py
+++ b/sqlmesh/migrations/v0064_join_when_matched_strings.py
@@ -7,15 +7,13 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     import pandas as pd
 
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
     snapshots_table = "_snapshots"
     index_type = index_text_type(engine_adapter.dialect)
     if schema:

--- a/sqlmesh/migrations/v0065_add_model_optimize.py
+++ b/sqlmesh/migrations/v0065_add_model_optimize.py
@@ -1,9 +1,9 @@
 """Add the optimize_query model attribute."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0066_add_auto_restatements.py
+++ b/sqlmesh/migrations/v0066_add_auto_restatements.py
@@ -5,9 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     auto_restatements_table = "_auto_restatements"
     intervals_table = "_intervals"
 
@@ -40,9 +38,7 @@ def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     intervals_table = "_intervals"
 
     if schema:

--- a/sqlmesh/migrations/v0067_add_tsql_date_full_precision.py
+++ b/sqlmesh/migrations/v0067_add_tsql_date_full_precision.py
@@ -1,9 +1,9 @@
 """Add full precision for tsql to support nanoseconds."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0068_include_unrendered_query_in_metadata_hash.py
+++ b/sqlmesh/migrations/v0068_include_unrendered_query_in_metadata_hash.py
@@ -1,9 +1,9 @@
 """Include the unrendered query in the metadata hash."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0069_update_dev_table_suffix.py
+++ b/sqlmesh/migrations/v0069_update_dev_table_suffix.py
@@ -7,15 +7,13 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     import pandas as pd
 
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
     snapshots_table = "_snapshots"
     environments_table = "_environments"
     if schema:

--- a/sqlmesh/migrations/v0070_include_grains_in_metadata_hash.py
+++ b/sqlmesh/migrations/v0070_include_grains_in_metadata_hash.py
@@ -1,9 +1,9 @@
 """Include grains in the metadata hash."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0071_add_dev_version_to_intervals.py
+++ b/sqlmesh/migrations/v0071_add_dev_version_to_intervals.py
@@ -8,9 +8,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     intervals_table = "_intervals"
     if schema:
         intervals_table = f"{schema}.{intervals_table}"
@@ -29,9 +27,7 @@ def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     intervals_table = "_intervals"
     snapshots_table = "_snapshots"
     if schema:

--- a/sqlmesh/migrations/v0072_add_environment_statements.py
+++ b/sqlmesh/migrations/v0072_add_environment_statements.py
@@ -5,9 +5,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import blob_text_type, index_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     environment_statements_table = "_environment_statements"
 
     if schema:
@@ -27,5 +25,5 @@ def migrate_schemas(state_sync, **kwargs):  # type: ignore
     )
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0073_remove_symbolic_disable_restatement.py
+++ b/sqlmesh/migrations/v0073_remove_symbolic_disable_restatement.py
@@ -6,15 +6,13 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     import pandas as pd
 
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0074_add_partition_by_time_column_property.py
+++ b/sqlmesh/migrations/v0074_add_partition_by_time_column_property.py
@@ -2,9 +2,9 @@
 (default: True to keep the original behaviour)"""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0075_remove_validate_query.py
+++ b/sqlmesh/migrations/v0075_remove_validate_query.py
@@ -8,15 +8,13 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     import pandas as pd
 
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
     snapshots_table = "_snapshots"
     index_type = index_text_type(engine_adapter.dialect)
     if schema:

--- a/sqlmesh/migrations/v0076_add_cron_tz.py
+++ b/sqlmesh/migrations/v0076_add_cron_tz.py
@@ -1,9 +1,9 @@
 """Add 'cron_tz' property to node definition."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0077_fix_column_type_hash_calculation.py
+++ b/sqlmesh/migrations/v0077_fix_column_type_hash_calculation.py
@@ -1,9 +1,9 @@
 """Use the model's dialect when calculating the hash for the column types."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0078_warn_if_non_migratable_python_env.py
+++ b/sqlmesh/migrations/v0078_warn_if_non_migratable_python_env.py
@@ -24,13 +24,11 @@ import sqlmesh.core.dialect as d
 from sqlmesh.core.console import get_console
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0079_add_gateway_managed_property.py
+++ b/sqlmesh/migrations/v0079_add_gateway_managed_property.py
@@ -3,11 +3,10 @@
 from sqlglot import exp
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     environments_table = "_environments"
-    if state_sync.schema:
-        environments_table = f"{state_sync.schema}.{environments_table}"
+    if schema:
+        environments_table = f"{schema}.{environments_table}"
 
     alter_table_exp = exp.Alter(
         this=exp.to_table(environments_table),
@@ -22,13 +21,12 @@ def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     environments_table = "_environments"
-    if state_sync.schema:
-        environments_table = f"{state_sync.schema}.{environments_table}"
+    if schema:
+        environments_table = f"{schema}.{environments_table}"
 
-    state_sync.engine_adapter.update_table(
+    engine_adapter.update_table(
         environments_table,
         {"gateway_managed": False},
         where=exp.true(),

--- a/sqlmesh/migrations/v0080_add_batch_size_to_scd_type_2_models.py
+++ b/sqlmesh/migrations/v0080_add_batch_size_to_scd_type_2_models.py
@@ -1,9 +1,9 @@
 """Add batch_size to SCD Type 2 models and add updated_at_name to by time which changes their data hash."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0081_update_partitioned_by.py
+++ b/sqlmesh/migrations/v0081_update_partitioned_by.py
@@ -8,15 +8,13 @@ from sqlmesh.utils.migration import index_text_type
 from sqlmesh.utils.migration import blob_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     import pandas as pd
 
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
     snapshots_table = "_snapshots"
     index_type = index_text_type(engine_adapter.dialect)
     if schema:

--- a/sqlmesh/migrations/v0082_warn_if_incorrectly_duplicated_statements.py
+++ b/sqlmesh/migrations/v0082_warn_if_incorrectly_duplicated_statements.py
@@ -34,13 +34,11 @@ from sqlglot import exp
 from sqlmesh.core.console import get_console
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0083_use_sql_for_scd_time_data_type_data_hash.py
+++ b/sqlmesh/migrations/v0083_use_sql_for_scd_time_data_type_data_hash.py
@@ -1,9 +1,9 @@
 """Use sql(...) instead of gen when computing the data hash of the time data type."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0084_normalize_quote_when_matched_and_merge_filter.py
+++ b/sqlmesh/migrations/v0084_normalize_quote_when_matched_and_merge_filter.py
@@ -5,9 +5,9 @@ prevent un-normalized identifiers being quoted at the EngineAdapter level
 """
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0085_deterministic_repr.py
+++ b/sqlmesh/migrations/v0085_deterministic_repr.py
@@ -36,15 +36,13 @@ def _dict_sort(obj: t.Any) -> str:
     return repr(obj)
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     import pandas as pd
 
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0086_check_deterministic_bug.py
+++ b/sqlmesh/migrations/v0086_check_deterministic_bug.py
@@ -10,13 +10,11 @@ logger = logging.getLogger(__name__)
 KEYS_TO_MAKE_DETERMINISTIC = ["__sqlmesh__vars__", "__sqlmesh__blueprint__vars__"]
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     snapshots_table = "_snapshots"
     versions_table = "_versions"
     if schema:

--- a/sqlmesh/migrations/v0087_normalize_blueprint_variables.py
+++ b/sqlmesh/migrations/v0087_normalize_blueprint_variables.py
@@ -35,15 +35,13 @@ class SqlValue:
     sql: str
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     import pandas as pd
 
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0088_warn_about_variable_python_env_diffs.py
+++ b/sqlmesh/migrations/v0088_warn_about_variable_python_env_diffs.py
@@ -35,13 +35,11 @@ SQLMESH_BLUEPRINT_VARS = "__sqlmesh__blueprint__vars__"
 METADATA_HASH_EXPRESSIONS = {"on_virtual_update", "audits", "signals", "audit_definitions"}
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0089_add_virtual_environment_mode.py
+++ b/sqlmesh/migrations/v0089_add_virtual_environment_mode.py
@@ -1,9 +1,9 @@
 """Add virtual_environment_mode to the model definition."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0090_add_forward_only_column.py
+++ b/sqlmesh/migrations/v0090_add_forward_only_column.py
@@ -7,9 +7,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
@@ -27,11 +25,9 @@ def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     import pandas as pd
 
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0091_on_additive_change.py
+++ b/sqlmesh/migrations/v0091_on_additive_change.py
@@ -1,9 +1,9 @@
 """Add on_additive_change to incremental model metadata hash."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0092_warn_about_dbt_data_type_diff.py
+++ b/sqlmesh/migrations/v0092_warn_about_dbt_data_type_diff.py
@@ -17,13 +17,11 @@ from sqlmesh.core.console import get_console
 SQLMESH_DBT_PACKAGE = "sqlmesh.dbt"
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0093_use_raw_sql_in_fingerprint.py
+++ b/sqlmesh/migrations/v0093_use_raw_sql_in_fingerprint.py
@@ -1,9 +1,9 @@
 """Use the raw SQL when computing the model fingerprint."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0094_add_dev_version_and_fingerprint_columns.py
+++ b/sqlmesh/migrations/v0094_add_dev_version_and_fingerprint_columns.py
@@ -7,9 +7,7 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"
@@ -42,11 +40,9 @@ def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(add_fingerprint_exp)
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     import pandas as pd
 
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0095_warn_about_dbt_raw_sql_diff.py
+++ b/sqlmesh/migrations/v0095_warn_about_dbt_raw_sql_diff.py
@@ -17,13 +17,11 @@ from sqlmesh.core.console import get_console
 SQLMESH_DBT_PACKAGE = "sqlmesh.dbt"
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0096_remove_plan_dags_table.py
+++ b/sqlmesh/migrations/v0096_remove_plan_dags_table.py
@@ -1,9 +1,7 @@
 """Remove the obsolete _plan_dags table."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     plan_dags_table = "_plan_dags"
     if schema:
         plan_dags_table = f"{schema}.{plan_dags_table}"
@@ -11,5 +9,5 @@ def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter.drop_table(plan_dags_table)
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0097_add_dbt_name_in_node.py
+++ b/sqlmesh/migrations/v0097_add_dbt_name_in_node.py
@@ -1,9 +1,9 @@
 """Add 'dbt_name' property to node definition."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0098_add_dbt_node_info_in_node.py
+++ b/sqlmesh/migrations/v0098_add_dbt_node_info_in_node.py
@@ -5,15 +5,13 @@ from sqlglot import exp
 from sqlmesh.utils.migration import index_text_type, blob_text_type
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     import pandas as pd
 
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
     snapshots_table = "_snapshots"
     if schema:
         snapshots_table = f"{schema}.{snapshots_table}"

--- a/sqlmesh/migrations/v0099_add_last_altered_to_intervals.py
+++ b/sqlmesh/migrations/v0099_add_last_altered_to_intervals.py
@@ -3,9 +3,7 @@
 from sqlglot import exp
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
-    engine_adapter = state_sync.engine_adapter
-    schema = state_sync.schema
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     intervals_table = "_intervals"
     if schema:
         intervals_table = f"{schema}.{intervals_table}"
@@ -23,5 +21,5 @@ def migrate_schemas(state_sync, **kwargs):  # type: ignore
     engine_adapter.execute(alter_table_exp)
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass

--- a/sqlmesh/migrations/v0100_add_grants_and_grants_target_layer.py
+++ b/sqlmesh/migrations/v0100_add_grants_and_grants_target_layer.py
@@ -1,9 +1,9 @@
 """Add grants and grants_target_layer to incremental model metadata hash."""
 
 
-def migrate_schemas(state_sync, **kwargs):  # type: ignore
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
     pass
 
 
-def migrate_rows(state_sync, **kwargs):  # type: ignore
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
     pass


### PR DESCRIPTION
This PR has no logic changes. 

Prior to this PR, we would pass state sync into migrations but this was really just don to get the engine adapter and schema out of it. Therefore this PR updates migrations to just require engine adapter and schema. 