### PR TITLE
fix: add default (empty) tags to dbt builtin globals config

### DIFF
--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -482,7 +482,7 @@ def create_builtin_globals(
     if variables is not None:
         builtin_globals["var"] = Var(variables)
 
-    builtin_globals["config"] = Config(jinja_globals.pop("config", {}))
+    builtin_globals["config"] = Config(jinja_globals.pop("config", {"tags": []}))
 
     deployability_index = (
         jinja_globals.get("deployability_index") or DeployabilityIndex.all_deployable()


### PR DESCRIPTION
There are some DBT dependencies like `dbt-unit-testing` (<= `v0.3.0`) that would read from [config.tags](https://github.com/EqualExperts/dbt-unit-testing/blob/v0.3.0/macros/tests.sql#L207) and expect it to be a Sequence.  Without this default, the DBT projects that have dependencies like `dbt-unit-testing` <= `v0.3.0` will fail to load with errors like this: 

```
Error: 'source' macro failed for '<relation>' with exeception 'argument of type 'NoneType' is not iterable'.
```