### PR TITLE
Fix: Only keep refs and sources that exist to match dbt load time behaviour

### DIFF
--- a/sqlmesh/dbt/basemodel.py
+++ b/sqlmesh/dbt/basemodel.py
@@ -317,6 +317,10 @@ class BaseModelConfig(GeneralConfig):
             dependencies = dependencies.union(custom_mat.dependencies)
 
         model_dialect = self.dialect(context)
+
+        # Only keep refs and sources that exist in the context to match dbt behavior
+        dependencies.refs.intersection_update(context.refs)
+        dependencies.sources.intersection_update(context.sources)
         model_context = context.context_for_dependencies(
             dependencies.union(self.tests_ref_source_dependencies)
         )


### PR DESCRIPTION
During parsing sqlmesh captures all `refs`/`sources` including those that might be in `{% if false %}` blocks. For example the below model would lead at load time error in sqlmesh by failing on the missing reference:

```sql
{{ config(
    materialized='table',
) }}

{% if true %}
    WITH source AS (
        SELECT *
        FROM {{ ref('simple_model_a') }}
    )
{% else %}
    WITH source AS (
        SELECT *
        FROM {{ ref('nonexistent_model') }} -- this doesn't exist but is in unexecuted branch
    )
{% endif %}
SELECT * FROM source
```

Dbt on the other hand happily proceeds at load time and then since the branch is never exercised runs the model successfully. If there was an actual missing reference it would fail at runtime. So this aims to match this behaviour by intersecting static analysis results with dbt's manifest refs and sources so that we not raise at load time.