### PR TITLE
Fix(windows): Allow 'sqlmesh clean' to delete cache file paths that exceed 260 chars

### DIFF
--- a/sqlmesh/utils/windows.py
+++ b/sqlmesh/utils/windows.py
@@ -3,12 +3,22 @@ from pathlib import Path
 
 IS_WINDOWS = platform.system() == "Windows"
 
+WINDOWS_LONGPATH_PREFIX = "\\\\?\\"
+
 
 def fix_windows_path(path: Path) -> Path:
     """
     Windows paths are limited to 260 characters: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
     Users can change this by updating a registry entry but we cant rely on that.
-    We can quite commonly generate a cache file path that exceeds 260 characters which causes a FileNotFound error.
-    If we prefix the path with "\\?\" then we can have paths up to 32,767 characters
+
+    SQLMesh quite commonly generates cache file paths that exceed 260 characters and thus cause a FileNotFound error.
+    If we prefix paths with "\\?\" then we can have paths up to 32,767 characters.
+
+    Note that this prefix also means that relative paths no longer work. From the above docs:
+     > Because you cannot use the "\\?\" prefix with a relative path, relative paths are always limited to a total of MAX_PATH characters.
+
+    So we also call path.resolve() to resolve the relative sections so that operations like `path.read_text()` continue to work
     """
-    return Path("\\\\?\\" + str(path.absolute()))
+    if path.parts and not path.parts[0].startswith(WINDOWS_LONGPATH_PREFIX):
+        path = Path(WINDOWS_LONGPATH_PREFIX + str(path.absolute()))
+    return path.resolve()

--- a/tests/utils/test_windows.py
+++ b/tests/utils/test_windows.py
@@ -1,0 +1,39 @@
+import pytest
+from pathlib import Path
+from sqlmesh.utils.windows import IS_WINDOWS, WINDOWS_LONGPATH_PREFIX, fix_windows_path
+
+
+@pytest.mark.skipif(
+    not IS_WINDOWS, reason="pathlib.Path only produces WindowsPath objects on Windows"
+)
+def test_fix_windows_path():
+    short_path = Path("c:\\foo")
+    short_path_prefixed = Path(WINDOWS_LONGPATH_PREFIX + "c:\\foo")
+
+    segments = "\\".join(["bar", "baz", "bing"] * 50)
+    long_path = Path("c:\\" + segments)
+    long_path_prefixed = Path(WINDOWS_LONGPATH_PREFIX + "c:\\" + segments)
+
+    assert len(str(short_path.absolute)) < 260
+    assert len(str(long_path.absolute)) > 260
+
+    # paths less than 260 chars are still prefixed because they may be being used as a base path
+    assert fix_windows_path(short_path) == short_path_prefixed
+
+    # paths greater than 260 characters don't work at all without the prefix
+    assert fix_windows_path(long_path) == long_path_prefixed
+
+    # multiple calls dont keep appending the same prefix
+    assert (
+        fix_windows_path(fix_windows_path(fix_windows_path(long_path_prefixed)))
+        == long_path_prefixed
+    )
+
+    # paths with relative sections need to have relative sections resolved before they can be used
+    # since the \\?\ prefix doesnt work for paths with relative sections
+    assert fix_windows_path(Path("c:\\foo\\..\\bar")) == Path(WINDOWS_LONGPATH_PREFIX + "c:\\bar")
+
+    # also check that relative sections are still resolved if they are added to a previously prefixed path
+    base = fix_windows_path(Path("c:\\foo"))
+    assert base == Path(WINDOWS_LONGPATH_PREFIX + "c:\\foo")
+    assert fix_windows_path(base / ".." / "bar") == Path(WINDOWS_LONGPATH_PREFIX + "c:\\bar")


### PR DESCRIPTION
Currently, on Windows, running `sqlmesh clean` can return a `FileNotFound` error if it tries to delete a file path that is > 260 chars.

This PR addresses this particular case.

Note that SQLMesh behaves badly on Windows if the entire project is located at a base path that exceeds 260 characters, because all the model / seed loading code that assumes paths work starts to subtly break.

This PR does **not** address that, just the cache file paths that we create that the user has no control over.