### PR TITLE
Chore: improve unit test validation

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -454,6 +454,9 @@ class ModelTest(unittest.TestCase):
         query = outputs.get("query")
         partial = outputs.pop("partial", None)
 
+        if ctes is None and query is None:
+            _raise_error("Incomplete test, outputs must contain 'query' or 'ctes'", self.path)
+
         def _normalize_rows(
             values: t.List[Row] | t.Dict,
             name: str,

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -1185,6 +1185,27 @@ test_foo:
     )
 
 
+def test_invalid_outputs_error() -> None:
+    with pytest.raises(TestError, match="Incomplete test, outputs must contain 'query' or 'ctes'"):
+        _create_test(
+            body=load_yaml(
+                """
+test_foo:
+  model: sushi.foo
+  inputs:
+    raw:
+      - id: 1
+  outputs:
+    rows:
+      - id: 1
+                """
+            ),
+            test_name="test_foo",
+            model=_create_model("SELECT id FROM raw"),
+            context=Context(config=Config(model_defaults=ModelDefaultsConfig(dialect="duckdb"))),
+        )
+
+
 def test_empty_rows(sushi_context: Context) -> None:
     _check_successful_or_raise(
         _create_test(


### PR DESCRIPTION
A user reported that a test was passing despite having wrong outputs, and it turns out that the `query` key was missing. This PR improves our test validator so that it checks for this scenario and informs accordingly.

I considered "fixing" the test automatically but that was more complicated and didn't bother. Having a `query` key is not that bad, and leads to a more consistent format.
