### PR TITLE
Chore: Add tag assertion in selectors tag test

### DIFF
--- a/tests/dbt/cli/test_selectors.py
+++ b/tests/dbt/cli/test_selectors.py
@@ -215,6 +215,7 @@ def test_exclude_by_dbt_names(
     ctx = jaffle_shop_duckdb_context
     ctx.load()
     assert '"jaffle_shop"."main"."agg_orders"' in ctx.models
+    assert ctx.get_model('"jaffle_shop"."main"."agg_orders"').tags == ["agg"]
 
     selector = ctx._new_selector()
     assert isinstance(selector, DbtSelector)


### PR DESCRIPTION
Add tag assertion in tag selectors to help with manifest testing.