### PR TITLE
Feat(sqlmesh_dbt): Add support for --project-dir and --profiles-dir

### DIFF
--- a/sqlmesh/core/config/loader.py
+++ b/sqlmesh/core/config/loader.py
@@ -178,6 +178,7 @@ def load_config_from_paths(
 
             dbt_python_config = sqlmesh_config(
                 project_root=dbt_project_file.parent,
+                profiles_dir=kwargs.pop("profiles_dir", None),
                 dbt_profile_name=kwargs.pop("profile", None),
                 dbt_target_name=kwargs.pop("target", None),
                 variables=variables,

--- a/sqlmesh/dbt/context.py
+++ b/sqlmesh/dbt/context.py
@@ -37,6 +37,8 @@ class DbtContext:
     """Context for DBT environment"""
 
     project_root: Path = Path()
+    profiles_dir: t.Optional[Path] = None
+    """Optional override to specify the directory where profiles.yml is located, if not at the :project_root"""
     target_name: t.Optional[str] = None
     profile_name: t.Optional[str] = None
     project_schema: t.Optional[str] = None

--- a/sqlmesh/dbt/profile.py
+++ b/sqlmesh/dbt/profile.py
@@ -60,7 +60,7 @@ class Profile:
             if not context.profile_name:
                 raise ConfigError(f"{project_file.stem} must include project name.")
 
-        profile_filepath = cls._find_profile(context.project_root)
+        profile_filepath = cls._find_profile(context.project_root, context.profiles_dir)
         if not profile_filepath:
             raise ConfigError(f"{cls.PROFILE_FILE} not found.")
 
@@ -68,8 +68,8 @@ class Profile:
         return Profile(profile_filepath, target_name, target)
 
     @classmethod
-    def _find_profile(cls, project_root: Path) -> t.Optional[Path]:
-        dir = os.environ.get("DBT_PROFILES_DIR", "")
+    def _find_profile(cls, project_root: Path, profiles_dir: t.Optional[Path]) -> t.Optional[Path]:
+        dir = os.environ.get("DBT_PROFILES_DIR", profiles_dir or "")
         path = Path(project_root, dir, cls.PROFILE_FILE)
         if path.exists():
             return path

--- a/sqlmesh_dbt/cli.py
+++ b/sqlmesh_dbt/cli.py
@@ -84,6 +84,16 @@ resource_type_option = click.option(
     type=click.Choice(["debug", "info", "warn", "error", "none"]),
     help="Specify the minimum severity of events that are logged to the console and the log file.",
 )
+@click.option(
+    "--profiles-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Which directory to look in for the profiles.yml file. If not set, dbt will look in the current working directory first, then HOME/.dbt/",
+)
+@click.option(
+    "--project-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Which directory to look in for the dbt_project.yml file. Default is the current working directory and its parents.",
+)
 @click.pass_context
 @cli_global_error_handler
 def dbt(
@@ -92,6 +102,8 @@ def dbt(
     target: t.Optional[str] = None,
     debug: bool = False,
     log_level: t.Optional[str] = None,
+    profiles_dir: t.Optional[Path] = None,
+    project_dir: t.Optional[Path] = None,
 ) -> None:
     """
     An ELT tool for managing your SQL transformations and data models, powered by the SQLMesh engine.
@@ -105,7 +117,8 @@ def dbt(
     # that need to be known before we attempt to load the project
     ctx.obj = functools.partial(
         create,
-        project_dir=Path.cwd(),
+        project_dir=project_dir,
+        profiles_dir=profiles_dir,
         profile=profile,
         target=target,
         debug=debug,

--- a/sqlmesh_dbt/operations.py
+++ b/sqlmesh_dbt/operations.py
@@ -232,6 +232,7 @@ class DbtOperations:
 
 def create(
     project_dir: t.Optional[Path] = None,
+    profiles_dir: t.Optional[Path] = None,
     profile: t.Optional[str] = None,
     target: t.Optional[str] = None,
     vars: t.Optional[t.Dict[str, t.Any]] = None,
@@ -268,7 +269,11 @@ def create(
         sqlmesh_context = Context(
             paths=[project_dir],
             config_loader_kwargs=dict(
-                profile=profile, target=target, variables=vars, threads=threads
+                profile=profile,
+                target=target,
+                variables=vars,
+                threads=threads,
+                profiles_dir=profiles_dir,
             ),
             load=True,
             # DbtSelector selects based on dbt model fqn's rather than SQLMesh model names


### PR DESCRIPTION
Adds the following CLI arguments to `sqlmesh_dbt`:
 - `--project-dir` - sets the project root, where `dbt_project.yml` is expected to be found, as well as all of the other project files
 - `--profiles-dir` - sets the directory where `profiles.yml` is expected to be found, if different from `--project-dir`

Note that due to how Click works, these are currently top-level options because they affect project loading. They currently have to be specified as:

`$ sqlmesh_dbt --project-dir /some/dir run`

rather than what upstream dbt allows:

`$ sqlmesh_dbt run --project-dir /some/dir`

There are a bunch of other arguments (such as `--target`) that also have this problem, i'm planning to refactor this in the next PR to match the behaviour with upstream dbt