### PR TITLE
fix: ensure dbt BigQueryConfig dataset & project are set

### DIFF
--- a/sqlmesh/dbt/target.py
+++ b/sqlmesh/dbt/target.py
@@ -601,12 +601,17 @@ class BigQueryConfig(TargetConfig):
         if not isinstance(data, dict):
             return data
 
-        data["schema"] = data.get("schema") or data.get("dataset")
-        if not data["schema"]:
+        # dbt treats schema and dataset interchangeably
+        schema = data.get("schema") or data.get("dataset")
+        if not schema:
             raise ConfigError("Either schema or dataset must be set")
-        data["database"] = data.get("database") or data.get("project")
-        if not data["database"]:
+        data["dataset"] = data["schema"] = schema
+
+        # dbt treats database and project interchangeably
+        database = data.get("database") or data.get("project")
+        if not database:
             raise ConfigError("Either database or project must be set")
+        data["database"] = data["project"] = database
 
         return data
 

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -1192,13 +1192,13 @@ def test_target_jinja(sushi_test_project: Project):
     context = DbtContext()
     context._target = BigQueryConfig(
         name="target",
-        schema="test",
-        database="test",
-        project="project",
-        dataset="dataset",
+        schema="test_value",
+        database="test_project",
     )
-    assert context.render("{{ target.project }}") == "project"
-    assert context.render("{{ target.dataset }}") == "dataset"
+    assert context.render("{{ target.project }}") == "test_project"
+    assert context.render("{{ target.database }}") == "test_project"
+    assert context.render("{{ target.schema }}") == "test_value"
+    assert context.render("{{ target.dataset }}") == "test_value"
 
 
 @pytest.mark.xdist_group("dbt_manifest")


### PR DESCRIPTION
DBT BigQuery config [aliases](https://github.com/dbt-labs/dbt-adapters/blob/6f89d7ce7e762f3fdf7cf6b48e8372585712f10f/dbt-bigquery/src/dbt/adapters/bigquery/credentials.py#L118-L119) `project` -> `database` and `dataset` -> `schema`.   And more importantly, they should always be the same. A profiles.yaml config with only `schema` specified can reference `target.dataset` in jinja templates and will throw an error since we don't currently set `dataset` in the config.