### PR TITLE
Chore: Add the max identifier length to the mssql adapter

### DIFF
--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -56,6 +56,7 @@ class MSSQLEngineAdapter(
     COMMENT_CREATION_TABLE = CommentCreationTable.UNSUPPORTED
     COMMENT_CREATION_VIEW = CommentCreationView.UNSUPPORTED
     SUPPORTS_REPLACE_TABLE = False
+    MAX_IDENTIFIER_LENGTH = 128
     SUPPORTS_QUERY_EXECUTION_TRACKING = True
     SCHEMA_DIFFER_KWARGS = {
         "parameterized_type_defaults": {


### PR DESCRIPTION
This adds the max identifier length to 128 for mssql, closes: https://github.com/TobikoData/sqlmesh/issues/5525

Similar to: https://github.com/TobikoData/sqlmesh/pull/4432 to warn the user accordingly.

Docs: https://learn.microsoft.com/en-us/sql/sql-server/maximum-capacity-specifications-for-sql-server?view=sql-server-ver17