### PR TITLE
fix: dbt as_bool and as_number filters should return their original input values

### DIFF
--- a/sqlmesh/dbt/builtin.py
+++ b/sqlmesh/dbt/builtin.py
@@ -25,7 +25,7 @@ from sqlmesh.dbt.target import TARGET_TYPE_TO_CONFIG_CLASS
 from sqlmesh.dbt.util import DBT_VERSION
 from sqlmesh.utils import AttributeDict, debug_mode_enabled, yaml
 from sqlmesh.utils.date import now
-from sqlmesh.utils.errors import ConfigError, MacroEvalError
+from sqlmesh.utils.errors import ConfigError
 from sqlmesh.utils.jinja import JinjaMacroRegistry, MacroReference, MacroReturnVal
 
 logger = logging.getLogger(__name__)
@@ -381,18 +381,16 @@ def do_zip(*args: t.Any, default: t.Optional[t.Any] = None) -> t.Optional[t.Any]
         return default
 
 
-def as_bool(value: str) -> bool:
-    result = _try_literal_eval(value)
-    if isinstance(result, bool):
-        return result
-    raise MacroEvalError(f"Failed to convert '{value}' into boolean.")
+def as_bool(value: t.Any) -> t.Any:
+    # dbt's jinja TEXT_FILTERS just return the input value as is
+    # https://github.com/dbt-labs/dbt-common/blob/main/dbt_common/clients/jinja.py#L559
+    return value
 
 
 def as_number(value: str) -> t.Any:
-    result = _try_literal_eval(value)
-    if isinstance(value, (int, float)) and not isinstance(result, bool):
-        return result
-    raise MacroEvalError(f"Failed to convert '{value}' into number.")
+    # dbt's jinja TEXT_FILTERS just return the input value as is
+    # https://github.com/dbt-labs/dbt-common/blob/main/dbt_common/clients/jinja.py#L559
+    return value
 
 
 def _try_literal_eval(value: str) -> t.Any:

--- a/tests/dbt/test_transformation.py
+++ b/tests/dbt/test_transformation.py
@@ -65,7 +65,7 @@ from sqlmesh.dbt.target import (
     PostgresConfig,
 )
 from sqlmesh.dbt.test import TestConfig
-from sqlmesh.utils.errors import ConfigError, MacroEvalError, SQLMeshError
+from sqlmesh.utils.errors import ConfigError, SQLMeshError
 from sqlmesh.utils.jinja import MacroReference
 
 pytestmark = [pytest.mark.dbt, pytest.mark.slow]
@@ -1751,12 +1751,10 @@ def test_as_filters(sushi_test_project: Project):
     context = sushi_test_project.context
 
     assert context.render("{{ True | as_bool }}") == "True"
-    with pytest.raises(MacroEvalError, match="Failed to convert 'invalid' into boolean."):
-        context.render("{{ 'invalid' | as_bool }}")
+    assert context.render("{{ 'valid' | as_bool }}") == "valid"
 
     assert context.render("{{ 123 | as_number }}") == "123"
-    with pytest.raises(MacroEvalError, match="Failed to convert 'invalid' into number."):
-        context.render("{{ 'invalid' | as_number }}")
+    assert context.render("{{ 'valid' | as_number }}") == "valid"
 
     assert context.render("{{ None | as_text }}") == ""
 


### PR DESCRIPTION
This matches dbt's `TEXT_FILTERS` [implementation](https://github.com/dbt-labs/dbt-common/blob/ea684ea2c519391338bcac13c41214764a1446bc/dbt_common/clients/jinja.py#L560-L563). 

