### PR TITLE
Fix(table_diff): Widen the data types that --decimals applies to

### DIFF
--- a/sqlmesh/core/table_diff.py
+++ b/sqlmesh/core/table_diff.py
@@ -367,8 +367,8 @@ class TableDiff:
                 column_type = matched_columns[name]
                 qualified_column = exp.column(name, table)
 
-                if column_type.is_type(*exp.DataType.FLOAT_TYPES):
-                    return exp.func("ROUND", qualified_column, exp.Literal.number(self.decimals))
+                if column_type.is_type(*exp.DataType.REAL_TYPES):
+                    return self.adapter._normalize_decimal_value(qualified_column, self.decimals)
                 if column_type.is_type(*exp.DataType.NESTED_TYPES):
                     return self.adapter._normalize_nested_value(qualified_column)
 


### PR DESCRIPTION
Prior to this, `sqlmesh table_diff ... --decimals n` would:
 - Only apply `--decimals` to columns of type `DOUBLE` or `FLOAT`. I believe the reason was historical - it is assumed that floating point numbers are always awkward so you have to round them to some fixed length out of necessity, but if you're using fixed point numbers then you don't need this so the whole number should be compared
 - Assume that every database has a `ROUND` function that works with floating point types (Postgres is a notable example that does not)

So this PR:
 - Updates `--decimals` to apply to any column that can contain a fixed or floating point decimal
 - Uses `EngineAdapter._normalize_decimal_value` to produce the value to compare instead of wrapping it in `ROUND()` and hoping that is valid on the target database