### PR TITLE
Fix: Unexpected backfill of a parent when an interval outside the parent's range is restated for a child

### DIFF
--- a/tests/core/integration/test_run.py
+++ b/tests/core/integration/test_run.py
@@ -109,6 +109,7 @@ def test_run_respects_excluded_transitive_dependencies(init_and_plan_context: t.
             kind FULL,
             allow_partials true,
             cron '@hourly',
+            start '2023-01-01',
         );
 
         SELECT @execution_ts AS execution_ts


### PR DESCRIPTION
The issue might occur when the parent's start is inferred to be later (greater) than the child's and the restated interval is outside the parent's range. In this case a parent is backfilled unexpectedly.