### PR TITLE
ci: fix benchmark running

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -93,9 +93,13 @@ jobs:
       - run:
           name: Run linters and code style checks
           command: make py-style
-      # - run:
-      #     name: Exercise the benchmarks
-      #     command: make benchmark-ci
+      - unless:
+          condition:
+            equal: ["3.9", << parameters.python_version >>]
+          steps:
+            - run:
+                name: Exercise the benchmarks
+                command: make benchmark-ci
       - run:
           name: Run cicd tests
           command: make cicd-test


### PR DESCRIPTION
Reenables benchmark but not in 3.9 because of issue related to https://github.com/python/cpython/pull/32073 which was not backported to 3.9 which causes the deadlock
 