### PR TITLE
Fix: Require the cache for upstream deps in the scheduler

### DIFF
--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -730,9 +730,8 @@ class Scheduler:
         parent_sid: SnapshotId,
         intervals_per_snapshot: t.Dict[str, Intervals],
         snapshots_to_create: t.Set[SnapshotId],
-        cache: t.Optional[t.Dict[SnapshotId, t.Set[SchedulingUnit]]] = None,
+        cache: t.Dict[SnapshotId, t.Set[SchedulingUnit]],
     ) -> t.Set[SchedulingUnit]:
-        cache = cache or {}
         if parent_sid not in self.snapshots:
             return set()
         if parent_sid in cache:


### PR DESCRIPTION
The `cache or {}` expression also returns a new empty dict if the `cache` value itself is an empty dict. So it basically ignored the value passed by the caller in the `_dag` method. 