### PR TITLE
Fix: ignore non-key "dialect" in MODEL/AUDIT block

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -806,7 +806,7 @@ def text_diff(
 WS_OR_COMMENT = r"(?:\s|--[^\n]*\n|/\*.*?\*/)"
 HEADER = r"\b(?:model|audit)\b(?=\s*\()"
 KEY_BOUNDARY = r"(?:\(|,)"  # key is preceded by either '(' or ','
-DIALECT_VALUE = r"(?:'(?P<d_quoted>[a-z_][a-z0-9_]*)?'|(?P<d_unquoted>[a-z_][a-z0-9_]*))"  # value is single-quoted (maybe empty) or unquoted
+DIALECT_VALUE = r"['\"]?(?P<dialect>[a-z][a-z0-9]*)['\"]?"
 VALUE_BOUNDARY = r"(?=,|\))"  # value is followed by comma or closing paren
 
 DIALECT_PATTERN = re.compile(
@@ -902,7 +902,7 @@ def parse(
         A list of the parsed expressions: [Model, *Statements, Query, *Statements]
     """
     match = match_dialect and DIALECT_PATTERN.search(sql[:MAX_MODEL_DEFINITION_SIZE])
-    dialect_str = (match.group("d_quoted") or match.group("d_unquoted")) if match else None
+    dialect_str = match.group("dialect") if match else None
     dialect = Dialect.get_or_raise(dialect_str or default_dialect)
 
     tokens = dialect.tokenize(sql)

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2743,8 +2743,12 @@ def test_dialect_pattern():
 
     def assert_match(test_sql: str, expected_value: t.Optional[str] = "duckdb"):
         match = d.DIALECT_PATTERN.search(test_sql)
-        assert match
-        dialect_str = match.group("d_quoted") or match.group("d_unquoted")
+
+        dialect_str: t.Optional[str] = None
+        if expected_value is not None:
+            assert match
+            dialect_str = match.group("dialect")
+
         assert dialect_str == expected_value
 
     # single-quoted dialect
@@ -2762,6 +2766,16 @@ def test_dialect_pattern():
         make_test_sql(
             """
             dialect duckdb,
+            description 'there's a dialect foo in here too!'
+            """
+        )
+    )
+
+    # double-quoted dialect (allowed in BQ)
+    assert_match(
+        make_test_sql(
+            """
+            dialect "duckdb",
             description 'there's a dialect foo in here too!'
             """
         )
@@ -2802,6 +2816,17 @@ def test_dialect_pattern():
         make_test_sql(
             """
             dialect '',
+            tag my_tag
+            """
+        ),
+        None,
+    )
+
+    # double-quoted empty dialect
+    assert_match(
+        make_test_sql(
+            """
+            dialect "",
             tag my_tag
             """
         ),


### PR DESCRIPTION
Every model/audit definition begins with a header block containing configuration key-value pairs. One optional pair is the SQL dialect, specified as `dialect {dialect}`, `dialect '{dialect}'`, or `dialect "{dialect}"`.

We must detect a model's dialect BEFORE we parse the header because the header may contain syntax the default sqlglot dialect cannot parse. We use a regex to detect the dialect prior to parsing.

The regex currently detects `dialect` anywhere in the header block, so it will attempt to parse it as a key-value even if it's inside a description, etc.

This PR makes the regex stricter, such that:
1. The `dialect` key must come after the initial paren in `MODEL(` or after a comma
2. The dialect value must be followed by a comma or closing paren
3. Whitespace/comments are allowed in between (1) and the dialect key, or between the dialect key and (2)