### PR TITLE
Chore(cicd_bot): Make console printing optional

### DIFF
--- a/sqlmesh/integrations/github/cicd/command.py
+++ b/sqlmesh/integrations/github/cicd/command.py
@@ -25,12 +25,21 @@ logger = logging.getLogger(__name__)
     envvar="GITHUB_TOKEN",
     help="The Github Token to be used. Pass in `${{ secrets.GITHUB_TOKEN }}` if you want to use the one created by Github actions",
 )
+@click.option(
+    "--full-logs",
+    is_flag=True,
+    help="Whether to print all logs in the Github Actions output or only in their relevant GA check",
+)
 @click.pass_context
-def github(ctx: click.Context, token: str) -> None:
+def github(ctx: click.Context, token: str, full_logs: bool = False) -> None:
     """Github Action CI/CD Bot. See https://sqlmesh.readthedocs.io/en/stable/integrations/github/ for details"""
     # set a larger width because if none is specified, it auto-detects 80 characters when running in GitHub Actions
     # which can result in surprise newlines when outputting dates to backfill
-    set_console(MarkdownConsole(width=1000, warning_capture_only=True, error_capture_only=True))
+    set_console(
+        MarkdownConsole(
+            width=1000, warning_capture_only=not full_logs, error_capture_only=not full_logs
+        )
+    )
     ctx.obj["github"] = GithubController(
         paths=ctx.obj["paths"],
         token=token,


### PR DESCRIPTION
Currently `MarkdownConsole` consumes warnings & errors in order to display them as banners in their relevant Github Actions checks; For instance, a failed non-blocking audit is presented as such:

<br />


<img width="3706" height="730" alt="image" src="https://github.com/user-attachments/assets/43fb39b7-32a5-49e9-aac2-c738eaa50242" />



<br />



However, these are not **printed** in the console (i.e the logs of `SQLMesh Actions Workflow`) and the user can't change that behavior. With the new flag, the user now sees that warning both on the relevant check **and** on the logs:

```
2026-01-12 16:40:14,272 - MainThread - sqlmesh.core.console - WARNING - 'not_null_non_blocking' audit error: 1 row failed. Audit query:
SELECT * FROM "db"."sqlmesh__sqlmesh_example"."sqlmesh_example__derived_model__1012593465" AS "sqlmesh_example__derived_model__1012593465" WHERE "id" IS NULL AND TRUE (console.py:2335)
Warning:  sqlmesh_example__sqlmesh_cicd_bot_dev_12.derived_model: 'not_null_non_blocking' audit error: 1 row failed.
``` 