### PR TITLE
fix bug with quoted identifiers in ALTER SESSION SET

### DIFF
--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -622,6 +622,12 @@ class SnowflakeEngineAdapter(
         return expression
 
     def _to_sql(self, expression: exp.Expression, quote: bool = True, **kwargs: t.Any) -> str:
+        # Snowflake doesn't accept quoted identifiers in ALTER SESSION SET statements
+        # e.g., ALTER SESSION SET "TIMEZONE" = 'UTC' is invalid
+        # We need to disable quoting for these statements
+        if isinstance(expression, (exp.Set, exp.Alter)):
+            quote = False
+
         return super()._to_sql(
             expression=self._normalize_catalog(expression), quote=quote, **kwargs
         )


### PR DESCRIPTION
 Fixes #5666
This fix looks pretty bad because it moves Snowflake-specific logic out of `engine_adapter/snowflake.py`. But anyway, it highlighted the problem, and it works. I hope it doesn't have side effects, but I'm not sure.