### PR TITLE
fix: exclude pandas 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "ipywidgets",
     "jinja2",
     "packaging",
-    "pandas",
+    "pandas<3.0.0",
     "pydantic>=2.0.0",
     "python-dotenv",
     "requests",


### PR DESCRIPTION
There are breaking changes in pandas 3.0.0 so we want to make it clear we aren't compatible until code is updated to work with that release. 