### PR TITLE
Chore!: bump sqlglot to v28.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "requests",
     "rich[jupyter]",
     "ruamel.yaml",
-    "sqlglot[rs]~=28.7.0",
+    "sqlglot[rs]~=28.10.0",
     "tenacity",
     "time-machine",
     "json-stream"


### PR DESCRIPTION
Fixes an issue reported in the public Slack: https://tobiko-data.slack.com/archives/C0448SFS3PF/p1770204574012639
