### PR TITLE
Chore: Upgrade fastapi from 0.115.5 to 0.120.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ snowflake = [
 ]
 trino = ["trino"]
 web = [
-    "fastapi==0.115.5",
+    "fastapi==0.120.1",
     "watchfiles>=0.19.0",
     "uvicorn[standard]==0.22.0",
     "sse-starlette>=0.2.2",
@@ -134,7 +134,7 @@ web = [
 ]
 lsp = [
     # Duplicate of web
-    "fastapi==0.115.5",
+    "fastapi==0.120.1",
     "watchfiles>=0.19.0",
     # "uvicorn[standard]==0.22.0",
     "sse-starlette>=0.2.2",


### PR DESCRIPTION
updating fastapi because of https://github.com/advisories/GHSA-7f5h-v6xp-fcq8