### PR TITLE
Chore: Unpin cryptography

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -314,17 +314,17 @@ workflows:
             parameters:
               engine:
                 - snowflake
-                # - databricks
-                # - redshift
-                # - bigquery
-                # - clickhouse-cloud
-                # - athena
-                # - fabric
+                - databricks
+                - redshift
+                - bigquery
+                - clickhouse-cloud
+                - athena
+                - fabric
                 - gcp-postgres
-          # filters:
-          #   branches:
-          #     only:
-          #       - main
+          filters:
+            branches:
+              only:
+                - main
       - ui_style
       - ui_test
       - vscode_test


### PR DESCRIPTION
This issue in snowflake: https://github.com/TobikoData/sqlmesh/pull/5401 seems to have resolved so no reason to pin cryptography.