### PR TITLE
Chore: Fix dbt 1.3 installation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ install-dev-dbt-%:
 		echo "Applying overrides for dbt 1.5.0"; \
 		$(PIP) install 'dbt-databricks==1.5.6' 'numpy<2' --reinstall; \
 	fi; \
+	if [ "$$version" = "1.3.0" ]; then \
+		echo "Applying overrides for dbt $$version - upgrading google-cloud-bigquery"; \
+		$(PIP) install 'google-cloud-bigquery>=3.0.0' --upgrade; \
+	fi; \
 	mv pyproject.toml.backup pyproject.toml; \
 	echo "Restored original pyproject.toml"
 


### PR DESCRIPTION
dbt 1.3 pulls in an old version of google-cloud-bigquery==2.34.4 which uses the deprecated pkg_resources. so this is to upgrade google-cloud-bigquery to version 3.0.0+ which no longer depends on pkg_resources. This is the same approach used for dbt 1.6.0 in the Makefile