### PR TITLE
chore: adjust default handling for min_intervals in user_provided_flags

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -535,7 +535,7 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
 )
 @click.option(
     "--min-intervals",
-    default=0,
+    default=None,
     help="For every model, ensure at least this many intervals are covered by a missing intervals check regardless of the plan start date",
 )
 @opt.verbose

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1556,6 +1556,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         run = run or False
         diff_rendered = diff_rendered or False
         skip_linter = skip_linter or False
+        min_intervals = min_intervals or 0
 
         environment = environment or self.config.default_target_environment
         environment = Environment.sanitize_name(environment)


### PR DESCRIPTION
Issue: In the TCloud UI, `--min-intervals 0` would appear on every plan, even if it wasn't set. This is because we were storing the default value `0` in `cli/main.py`

CLI command:`sqlmesh plan`
<img width="264" height="169" alt="Screenshot 2026-03-02 at 10 51 22 AM" src="https://github.com/user-attachments/assets/259740df-81ba-4505-a373-ced5d22999df" />

Fix: Set the value `None` to indicate  the user didn't use that flag. Then in `plan_builder`, set `min_intervals` to its CLI value, or the default `0`, if it the flag wasn't set.


Testing:
When flag not set
`sqlmesh plan` in the CLI no longer shows the flag when not set
<img width="875" height="169" alt="Screenshot 2026-03-02 at 10 56 53 AM" src="https://github.com/user-attachments/assets/84bddd92-9c38-4549-b2ac-05c2503805a6" />

`sqlmesh plan --min-intervals 0` correctly shows the min-intervals flag was used
<img width="874" height="211" alt="Screenshot 2026-03-02 at 10 57 42 AM" src="https://github.com/user-attachments/assets/15cee63c-e563-493e-ae1b-111c6ddefb54" />
