### PR TITLE
Chore: Fix tests and adapt parser methods for tokens size

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -566,6 +566,10 @@ def _parse_if(self: Parser) -> t.Optional[exp.Expr]:
         if last_token.token_type == TokenType.R_PAREN:
             self._tokens[-2].comments.extend(last_token.comments)
             self._tokens.pop()
+            if hasattr(self, "_tokens_size"):
+                # keep _tokens_size in sync sqlglot 30.0.3 caches len(_tokens)
+                # _advance() tries to read tokens[index + 1] past the new end
+                self._tokens_size -= 1
         else:
             self.raise_error("Expecting )")
 

--- a/sqlmesh/utils/jinja.py
+++ b/sqlmesh/utils/jinja.py
@@ -79,6 +79,11 @@ class MacroExtractor(Parser):
         self.reset()
         self.sql = jinja
         self._tokens = Dialect.get_or_raise(dialect).tokenize(jinja)
+
+        # guard for older sqlglot versions (before 30.0.3)
+        if hasattr(self, "_tokens_size"):
+            # keep the cached length in sync
+            self._tokens_size = len(self._tokens)
         self._index = -1
         self._advance()
 

--- a/tests/dbt/cli/test_run.py
+++ b/tests/dbt/cli/test_run.py
@@ -1,6 +1,7 @@
 import typing as t
 import pytest
 from pathlib import Path
+import shutil
 from click.testing import Result
 import time_machine
 from sqlmesh_dbt.operations import create
@@ -70,6 +71,10 @@ def test_run_with_changes_and_full_refresh(
     partial_parse_file = project_path / "target" / "sqlmesh_partial_parse.msgpack"
     if partial_parse_file.exists():
         partial_parse_file.unlink()
+
+    cache_dir = project_path / ".cache"
+    if cache_dir.exists():
+        shutil.rmtree(cache_dir)
 
     # run with --full-refresh. this should:
     # - fully refresh model_a (pick up the new records from external_table)


### PR DESCRIPTION
The tests currently fail and this pr addresses 1. the flakey test by making it deterministic and 2. the rest of the tests when sqlglot 30.0.3 is picked up by adapting the parser methods.

For the flakey test: `test_run_with_changes_and_full_refresh` by clearing cache to pick up the updated file.  The reason being in `_cache_entry_id` it uses `int(max_mtime)` with the file modification time that in the unfortunate time that it is invoked the same second as the dbt cli command it matches the cached entry and reuses that instead of the fresh file.

Also sqlglot 30.0.3 that includes this: (https://github.com/tobymao/sqlglot/commit/f87ebe02103b249ec5fa2c93e019e465f77630be#diff-63eb8dd82d3561bc414e3e13cf59516bd6584c5766a10072157a8a5aee4ad85f) introduced `_tokens_size`, a cached copy of `len(self._tokens)`.  Ssince `MacroExtractor.extract()` bypasses the parser path entirely by assigning `self._tokens` directly this left them at 0. Since `_advance()` uses `_tokens_size` now as the boundary check every call immediately returned , causing the loop to exit before reading any tokens and silently dropping all macros defined in .sql files. 

One fix for this was to update `_tokens_size = len(self._tokens)` immediately after the direct assignment, guarded by hasattr for compatibility with older sqlglot versions that do not have this field. And in `_parse_if` before delegating to the statement parser to decrement _tokens_size accordingly so not to fall out of index.
