### PR TITLE
Fix: FileNotFoundError on Context initialization with stale cache (#5712)

### DIFF
--- a/sqlmesh/utils/cache.py
+++ b/sqlmesh/utils/cache.py
@@ -63,8 +63,12 @@ class FileCache(t.Generic[T]):
                 # the file.stat() call below will fail on windows if the :file name is longer than 260 chars
                 file = fix_windows_path(file)
 
-            if not file.stem.startswith(self._cache_version) or file.stat().st_atime < threshold:
-                file.unlink(missing_ok=True)
+            try:
+                stat_result = file.stat()
+                if not file.stem.startswith(self._cache_version) or stat_result.st_atime < threshold:
+                    file.unlink(missing_ok=True)
+            except FileNotFoundError:
+                continue
 
     def get_or_load(self, name: str, entry_id: str = "", *, loader: t.Callable[[], T]) -> T:
         """Returns an existing cached entry or loads and caches a new one.

--- a/sqlmesh/utils/cache.py
+++ b/sqlmesh/utils/cache.py
@@ -68,6 +68,7 @@ class FileCache(t.Generic[T]):
                 if not file.stem.startswith(self._cache_version) or stat_result.st_atime < threshold:
                     file.unlink(missing_ok=True)
             except FileNotFoundError:
+                # File was deleted between glob() and stat() — skip stale cache entries gracefully
                 continue
 
     def get_or_load(self, name: str, entry_id: str = "", *, loader: t.Callable[[], T]) -> T:

--- a/sqlmesh/utils/cache.py
+++ b/sqlmesh/utils/cache.py
@@ -65,7 +65,10 @@ class FileCache(t.Generic[T]):
 
             try:
                 stat_result = file.stat()
-                if not file.stem.startswith(self._cache_version) or stat_result.st_atime < threshold:
+                if (
+                    not file.stem.startswith(self._cache_version)
+                    or stat_result.st_atime < threshold
+                ):
                     file.unlink(missing_ok=True)
             except FileNotFoundError:
                 # File was deleted between glob() and stat() — skip stale cache entries gracefully

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -1,3 +1,5 @@
+import os
+import time
 import typing as t
 from pathlib import Path
 
@@ -131,3 +133,22 @@ def test_optimized_query_cache_macro_def_change(tmp_path: Path, mocker: MockerFi
         new_model.render_query_or_raise().sql()
         == 'SELECT "_0"."a" AS "a" FROM (SELECT 1 AS "a") AS "_0" WHERE "_0"."a" = 2'
     )
+
+
+def test_file_cache_init_handles_stale_file(tmp_path: Path, mocker: MockerFixture) -> None:
+    cache: FileCache[_TestEntry] = FileCache(tmp_path)
+
+    stale_file = tmp_path / f"{cache._cache_version}__fake_deleted_model_9999999999"
+    stale_file.touch()
+
+    original_stat = Path.stat
+
+    def flaky_stat(self, **kwargs):
+        if self.name == stale_file.name:
+            raise FileNotFoundError(f"Simulated stale file: {self}")
+        return original_stat(self, **kwargs)
+
+    mocker.patch.object(Path, "stat", flaky_stat)
+
+    FileCache(tmp_path)
+    

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -1,5 +1,3 @@
-import os
-import time
 import typing as t
 from pathlib import Path
 
@@ -151,4 +149,3 @@ def test_file_cache_init_handles_stale_file(tmp_path: Path, mocker: MockerFixtur
     mocker.patch.object(Path, "stat", flaky_stat)
 
     FileCache(tmp_path)
-    


### PR DESCRIPTION
## Description

Fixes #5712

When `FileCache.__init__()` scans the cache directory, it calls `file.stat()` on every file returned by `glob()`. In environments with persistent cache directories, a file can be deleted between the `glob()` call and the subsequent `stat()` call, resulting in a `FileNotFoundError` that prevents `Context` initialization entirely.

This fix wraps the `stat()` call in a `try/except FileNotFoundError` block, allowing the cache scan to skip stale entries gracefully rather than crashing.

Note: the issue's Option 1 suggested narrowing the glob to `glob(f"{self._cache_version}*")`, which would skip the `startswith` check. This implementation keeps the original `glob("*")` to preserve the existing behaviour of cleaning up files from old cache versions and expired files, while still handling the race condition.

## Test Plan

Added `test_file_cache_init_handles_stale_file` in `tests/utils/test_cache.py` which:
- Creates a cache file with the correct version prefix so `stat()` is forced to be called
- Monkeypatches `Path.stat` to raise `FileNotFoundError` for that specific file, simulating the race condition
- Asserts that `FileCache.__init__()` completes without raising
All existing tests pass.

## Checklist

- [x] I have run `make style` and fixed any issues
- [X] I have added tests for my changes (if applicable)
- [X] All existing tests pass (`make fast-test`)
- [X] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
