### PR TITLE
Fix (databricks): use shared connection pool to prevent OAuth CSRF race

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -813,6 +813,8 @@ class DatabricksConnectionConfig(ConnectionConfig):
     DISPLAY_NAME: t.ClassVar[t.Literal["Databricks"]] = "Databricks"
     DISPLAY_ORDER: t.ClassVar[t.Literal[3]] = 3
 
+    shared_connection: t.ClassVar[bool] = True
+
     _concurrent_tasks_validator = concurrent_tasks_validator
     _http_headers_validator = http_headers_validator
 

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -814,6 +814,8 @@ class DatabricksConnectionConfig(ConnectionConfig):
     DISPLAY_NAME: t.ClassVar[t.Literal["Databricks"]] = "Databricks"
     DISPLAY_ORDER: t.ClassVar[t.Literal[3]] = 3
 
+    shared_connection: t.ClassVar[bool] = True
+
     _concurrent_tasks_validator = concurrent_tasks_validator
     _http_headers_validator = http_headers_validator
 

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -1422,6 +1422,35 @@ def test_databricks(make_config):
         )
 
 
+def test_databricks_shared_connection(make_config):
+    """Databricks should use a shared connection pool to prevent OAuth CSRF races.
+
+    When concurrent_tasks > 1, ThreadLocalConnectionPool creates one connection per
+    thread. For U2M OAuth, each thread triggers its own browser-based OAuth flow;
+    these race on the CSRF state parameter and cause MismatchingStateError.
+
+    Setting shared_connection = True causes ThreadLocalSharedConnectionPool to be
+    used instead: a single connection is created (behind a lock) and each thread
+    gets its own cursor, so only one OAuth flow is ever initiated.
+
+    See: https://github.com/tobymao/sqlmesh/issues/5646
+    """
+    from sqlmesh.utils.connection_pool import ThreadLocalSharedConnectionPool
+
+    config = make_config(
+        type="databricks",
+        server_hostname="dbc-test.cloud.databricks.com",
+        http_path="sql/test/foo",
+        access_token="test-token",
+        concurrent_tasks=4,
+    )
+    assert isinstance(config, DatabricksConnectionConfig)
+    assert config.shared_connection is True
+
+    adapter = config.create_engine_adapter()
+    assert isinstance(adapter._connection_pool, ThreadLocalSharedConnectionPool)
+
+
 def test_engine_import_validator():
     with pytest.raises(
         ConfigError,


### PR DESCRIPTION
## Description

Fixes #5646

When `concurrent_tasks > 1`, `DatabricksConnectionConfig` previously used `ThreadLocalConnectionPool`, which creates a separate `databricks.sql.connect()` call per thread. For U2M OAuth (`databricks-oauth` / `azure-oauth`), each thread triggers an independent browser-based OAuth flow. These flows race on the CSRF `state` parameter — each generates its own random state, opens a local HTTP callback server, and waits for the browser redirect. When the callback arrives at the wrong thread's server, the state validation fails with `MismatchingStateError`.

Setting `shared_connection = True` on `DatabricksConnectionConfig` causes `ThreadLocalSharedConnectionPool` to be used instead: a single connection is created (behind a lock) so only one OAuth flow is ever initiated, while each thread still receives its own cursor. PAT auth is also unaffected — a shared connection is always preferable for Databricks since each connection carries a full HTTP session.

This mirrors the existing pattern used by `DuckDBConnectionConfig`.


## Test Plan

Added `test_databricks_shared_connection` to `tests/core/test_connection_config.py`, which asserts that `DatabricksConnectionConfig` with `concurrent_tasks > 1` produces a `ThreadLocalSharedConnectionPool`. The test was confirmed to fail before the fix and pass after.

All existing tests pass: `tests/core/test_connection_config.py`, `tests/utils/test_connection_pool.py`, `tests/core/engine_adapter/test_databricks.py`.

Verified end-to-end locally: SQLMesh `plan --auto-apply` with `auth_type="databricks-oauth"` and `concurrent_tasks=4` completes successfully with a single OAuth browser prompt and no `MismatchingStateError`.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
