### PR TITLE
fix(lsp): read self.context_state instead of stale local variable in _context_get_or_load

### DIFF
--- a/sqlmesh/lsp/main.py
+++ b/sqlmesh/lsp/main.py
@@ -1074,8 +1074,8 @@ class SQLMeshLanguageServer:
                     loaded_sqlmesh_message(self.server)
             else:
                 self._ensure_context_for_document(document_uri)
-        if isinstance(state, ContextLoaded):
-            return state.lsp_context
+        if isinstance(self.context_state, ContextLoaded):
+            return self.context_state.lsp_context
         raise RuntimeError("Context failed to load")
 
     def _ensure_context_for_document(

--- a/tests/lsp/test_context.py
+++ b/tests/lsp/test_context.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from sqlmesh.core.context import Context
 from sqlmesh.lsp.context import LSPContext, ModelTarget
+from sqlmesh.lsp.main import ContextLoaded, NoContext, SQLMeshLanguageServer
 from sqlmesh.lsp.uri import URI
 
 
@@ -61,3 +62,32 @@ def test_lsp_context_run_test():
     # Check that the result is not None and has the expected properties
     assert result is not None
     assert result.success is True
+
+
+def test_context_get_or_load_from_no_context_with_specified_paths():
+    server = SQLMeshLanguageServer(context_class=Context)
+    server.server.show_message = lambda *args, **kwargs: None
+    server.specified_paths = [Path("examples/sushi")]
+
+    assert isinstance(server.context_state, NoContext)
+
+    lsp_context = server._context_get_or_load()
+
+    assert isinstance(lsp_context, LSPContext)
+    assert isinstance(server.context_state, ContextLoaded)
+    assert server.context_state.lsp_context is lsp_context
+
+
+def test_context_get_or_load_from_no_context_via_workspace_folder():
+    server = SQLMeshLanguageServer(context_class=Context)
+    server.server.show_message = lambda *args, **kwargs: None
+    server.specified_paths = None
+    server.workspace_folders = [Path.cwd() / "examples" / "sushi"]
+
+    assert isinstance(server.context_state, NoContext)
+
+    lsp_context = server._context_get_or_load()
+
+    assert isinstance(lsp_context, LSPContext)
+    assert isinstance(server.context_state, ContextLoaded)
+    assert server.context_state.lsp_context is lsp_context


### PR DESCRIPTION
## Summary

- `_context_get_or_load` captures `self.context_state` into local variable `state` at line 1065
- After `_create_lsp_context()` or `_ensure_context_for_document()` successfully updates `self.context_state` to `ContextLoaded`, the final check at line 1077 reads the stale local `state` (still `NoContext`) instead of `self.context_state`
- This causes the method to always raise `RuntimeError("Context failed to load")` on the first `didOpen`, even when context loading succeeds

## Impact

The LSP logs "Loaded SQLMesh Context" then immediately crashes on the first `textDocument/didOpen`. In VS Code, this puts the extension client into a permanent "Client got disposed and can't be restarted" state. Affects both the `specified_paths` code path (via `initializationOptions.project_paths`) and the `_ensure_context_for_document` fallback path.

## Fix

Read `self.context_state` instead of the stale local `state` variable on lines 1077-1078.

## Regression test

Added two tests to `tests/lsp/test_context.py` that call `_context_get_or_load` starting from `NoContext`, covering both affected code paths:

- `test_context_get_or_load_from_no_context_with_specified_paths` — the `specified_paths` path
- `test_context_get_or_load_from_no_context_via_workspace_folder` — the `_ensure_context_for_document` fallback path

Both fail with `RuntimeError("Context failed to load")` on the unpatched code and pass with the fix.

## Test Plan

- [x] Verified fix locally — LSP hover, go-to-definition, references, and diagnostics all work after patch
- [x] `make style` passes (ruff, ruff-format, mypy, valid migrations)
- [x] Confirmed bug is present on upstream main
- [x] Added regression tests that fail without the fix and pass with it
- [x] Rebased onto latest main and re-verified
