### PR TITLE
fix: prevent default catalog leak into catalog-unsupported gateways

### DIFF
--- a/sqlmesh/core/config/scheduler.py
+++ b/sqlmesh/core/config/scheduler.py
@@ -141,6 +141,8 @@ class BuiltInSchedulerConfig(_EngineAdapterStateSyncSchedulerConfig, BaseConfig)
         for gateway, adapter in context.engine_adapters.items():
             if catalog := adapter.default_catalog:
                 default_catalogs_per_gateway[gateway] = catalog
+            elif adapter.catalog_support.is_unsupported:
+                default_catalogs_per_gateway[gateway] = ""
         return default_catalogs_per_gateway
 
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -7186,6 +7186,70 @@ def test_gateway_macro_jinja() -> None:
     assert model.render_query_or_raise().sql() == "SELECT 'in_memory' AS \"gateway_jinja\""
 
 
+def test_default_catalog_not_leaked_to_unsupported_gateway() -> None:
+    """Regression test for https://github.com/SQLMesh/sqlmesh/issues/5748.
+
+    When a model targets a gateway that does not support catalogs (e.g. ClickHouse),
+    the default gateway's catalog must not leak into the model's FQN. The scheduler
+    registers such gateways with empty string in default_catalog_per_gateway, and
+    the model loader should use that to override the global default_catalog.
+    """
+    expressions = d.parse(
+        """
+        MODEL (
+            name my_schema.my_model,
+            kind VIEW,
+            gateway clickhouse_gw,
+            dialect clickhouse,
+        );
+        SELECT 1 AS id
+        """
+    )
+
+    # Simulate a multi-gateway setup: default gateway has catalog "example_catalog",
+    # but clickhouse_gw is catalog-unsupported (registered with empty string).
+    models = load_sql_based_models(
+        expressions,
+        get_variables=lambda gw: {},
+        dialect="clickhouse",
+        default_catalog="example_catalog",
+        default_catalog_per_gateway={
+            "default_gw": "example_catalog",
+            "clickhouse_gw": "",
+        },
+    )
+
+    assert len(models) == 1
+    model_result = models[0]
+    # The catalog should be empty — not the leaked "example_catalog"
+    assert model_result.catalog != "example_catalog"
+    # The FQN should be a two-part name, not three-part with the leaked catalog
+    assert "example_catalog" not in model_result.fqn
+
+    # Verify the positive case: without the per-gateway override, catalog leaks
+    models_leaked = load_sql_based_models(
+        d.parse(
+            """
+            MODEL (
+                name my_schema.my_model2,
+                kind VIEW,
+                gateway clickhouse_gw,
+                dialect clickhouse,
+            );
+            SELECT 1 AS id
+            """
+        ),
+        get_variables=lambda gw: {},
+        dialect="clickhouse",
+        default_catalog="example_catalog",
+        # No entry for clickhouse_gw — catalog will leak
+        default_catalog_per_gateway={"default_gw": "example_catalog"},
+    )
+    assert len(models_leaked) == 1
+    # Without the fix, example_catalog leaks into the model name
+    assert "example_catalog" in models_leaked[0].fqn
+
+
 def test_gateway_python_model(mocker: MockerFixture) -> None:
     @model(
         "test_gateway_python_model",


### PR DESCRIPTION
## Description

Fixes #5748.

When a multi-gateway SQLMesh project uses a default gateway with a catalog (e.g., Trino with `catalog: example_catalog`), that catalog is silently prepended to model names targeting secondary gateways that do not support catalogs (e.g., ClickHouse), causing `UnsupportedCatalogOperationError` at evaluation time.

**Root cause:** The per-gateway catalog dict (`default_catalog_per_gateway`) is built in `BuiltInSchedulerConfig.get_default_catalog_per_gateway()`. Catalog-unsupported adapters return `None` for `default_catalog` and are never added to the dict. The model loader in `create_models_from_blueprints()` then cannot distinguish "this gateway has no catalog" from "this gateway was not checked", so the global `default_catalog` leaks through.

**Fix:** Explicitly register catalog-unsupported gateways with empty string (`""`) in the per-gateway dict. The model loader's existing `is not None` check picks up the empty string and overrides `default_catalog` to `""`, which does not get prepended to the model name.

### Changes

| File | Change |
|------|--------|
| `sqlmesh/core/config/scheduler.py` | Added `elif` branch to register catalog-unsupported gateways with `""` |
| `tests/core/test_model.py` | Added regression test `test_default_catalog_not_leaked_to_unsupported_gateway` |

## Test Plan

- Added `test_default_catalog_not_leaked_to_unsupported_gateway` regression test that verifies:
  - With `""` in `default_catalog_per_gateway` → `example_catalog` does **not** leak into the model FQN
  - Without the entry for the gateway → `example_catalog` **does** leak (confirming the bug behavior)
- All existing gateway-related tests pass: `test_gateway_macro`, `test_gateway_macro_jinja`, `test_gateway_python_model`, `test_gateway_specific_render`, `test_model_cache_gateway`
- `ruff` and `ruff-format` pass
- `mypy` passes on changed file (pre-existing unrelated error in `gateway.py`)

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [ ] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
