### PR TITLE
Add `secure` field to ClickHouse connection config

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -2094,6 +2094,7 @@ class ClickhouseConnectionConfig(ConnectionConfig):
     https_proxy: t.Optional[str] = None
     server_host_name: t.Optional[str] = None
     tls_mode: t.Optional[str] = None
+    secure: bool = False
 
     concurrent_tasks: int = 1
     register_comments: bool = True
@@ -2130,6 +2131,7 @@ class ClickhouseConnectionConfig(ConnectionConfig):
             "https_proxy",
             "server_host_name",
             "tls_mode",
+            "secure",
         }
         return kwargs
 

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -2100,6 +2100,7 @@ class ClickhouseConnectionConfig(ConnectionConfig):
     https_proxy: t.Optional[str] = None
     server_host_name: t.Optional[str] = None
     tls_mode: t.Optional[str] = None
+    secure: bool = False
 
     concurrent_tasks: int = 1
     register_comments: bool = True
@@ -2136,6 +2137,7 @@ class ClickhouseConnectionConfig(ConnectionConfig):
             "https_proxy",
             "server_host_name",
             "tls_mode",
+            "secure",
         }
         return kwargs
 


### PR DESCRIPTION
## Summary

- Add `secure: bool = False` field to `ClickhouseConnectionConfig` for explicitly enabling HTTPS/TLS
- Add `"secure"` to `_connection_kwargs_keys` so it gets passed through to `clickhouse_connect.dbapi.connect()`

## Problem

There is currently no way to explicitly enable HTTPS/TLS on a ClickHouse connection via SQLMesh config. Users must rely on port-based auto-detection (port 8443), which doesn't always work — especially when SQLMesh provides its own pool manager via `connection_pool_options`.

The `clickhouse-connect` library's `dbapi.connect()` already accepts a `secure` parameter (bool) that controls HTTPS/TLS, but `ClickhouseConnectionConfig` doesn't expose it.

## Fix

Expose the `secure` parameter that `clickhouse-connect` already supports:
1. Added `secure: bool = False` field after `tls_mode` in the HTTPS/TLS settings section
2. Added `"secure"` to the `_connection_kwargs_keys` set so it's passed to `connect()`

## Backwards compatibility

Fully backwards-compatible — defaults to `False`, matching the current behavior.

## Test plan

- [x] Verified the field is added and passed through via `_connection_kwargs_keys`
- [x] Users can set `secure: true` in their config.yaml to enable HTTPS/TLS

🤖 Generated with [Claude Code](https://claude.com/claude-code)