### PR TITLE
Fix MySQL DELETE using CONCAT_WS preventing index usage

### DIFF
--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import typing as t
+from functools import reduce
 
 from sqlglot import exp, parse_one
 
@@ -21,7 +22,7 @@ from sqlmesh.core.engine_adapter.shared import (
 )
 
 if t.TYPE_CHECKING:
-    from sqlmesh.core._typing import SchemaName, TableName
+    from sqlmesh.core._typing import QueryOrDF, SchemaName, TableName
 
 logger = logging.getLogger(__name__)
 
@@ -185,6 +186,85 @@ class MySQLEngineAdapter(
                 ),
             )
         )
+
+    def _replace_by_key(
+        self,
+        target_table: TableName,
+        source_table: QueryOrDF,
+        target_columns_to_types: t.Optional[t.Dict[str, exp.DataType]],
+        key: t.Sequence[exp.Expr],
+        is_unique_key: bool,
+        source_columns: t.Optional[t.List[str]] = None,
+    ) -> None:
+        if len(key) <= 1:
+            return super()._replace_by_key(
+                target_table, source_table, target_columns_to_types, key, is_unique_key, source_columns
+            )
+
+        if target_columns_to_types is None:
+            target_columns_to_types = self.columns(target_table)
+
+        temp_table = self._get_temp_table(target_table)
+        column_names = list(target_columns_to_types or [])
+
+        target_alias = "_target"
+        temp_alias = "_temp"
+
+        with self.transaction():
+            self.ctas(
+                temp_table,
+                source_table,
+                target_columns_to_types=target_columns_to_types,
+                exists=False,
+                source_columns=source_columns,
+            )
+
+            try:
+                # Build a JOIN-based DELETE instead of using CONCAT_WS.
+                # CONCAT_WS prevents MySQL/MariaDB from using indexes, causing full table scans.
+                on_condition = reduce(
+                    lambda a, b: exp.And(this=a, expression=b),
+                    [
+                        self._qualify_columns(k, target_alias).eq(
+                            self._qualify_columns(k, temp_alias)
+                        )
+                        for k in key
+                    ],
+                )
+
+                target_table_aliased = exp.to_table(target_table).as_(target_alias, quoted=True)
+                temp_table_aliased = exp.to_table(temp_table).as_(temp_alias, quoted=True)
+
+                join = exp.Join(this=temp_table_aliased, kind="INNER", on=on_condition)
+                target_table_aliased.append("joins", join)
+
+                delete_stmt = exp.Delete(
+                    tables=[exp.to_table(target_alias)],
+                    this=target_table_aliased,
+                )
+                self.execute(delete_stmt)
+
+                insert_query = self._select_columns(target_columns_to_types).from_(temp_table)
+                if is_unique_key:
+                    insert_query = insert_query.distinct(*key)
+
+                insert_statement = exp.insert(
+                    insert_query,
+                    target_table,
+                    columns=column_names,
+                )
+                self.execute(insert_statement, track_rows_processed=True)
+            finally:
+                self.drop_table(temp_table)
+
+    @staticmethod
+    def _qualify_columns(expr: exp.Expr, table_alias: str) -> exp.Expr:
+        """Qualify unqualified column references in an expression with a table alias."""
+        expr = expr.copy()
+        for col in expr.find_all(exp.Column):
+            if not col.table:
+                col.set("table", exp.to_identifier(table_alias, quoted=True))
+        return expr
 
     def ping(self) -> None:
         self._connection_pool.get().ping(reconnect=False)

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import logging
 import typing as t
-from functools import reduce
-
 from sqlglot import exp, parse_one
 
 from sqlmesh.core.dialect import to_schema
@@ -22,7 +20,8 @@ from sqlmesh.core.engine_adapter.shared import (
 )
 
 if t.TYPE_CHECKING:
-    from sqlmesh.core._typing import QueryOrDF, SchemaName, TableName
+    from sqlmesh.core._typing import SchemaName, TableName
+    from sqlmesh.core.engine_adapter._typing import QueryOrDF
 
 logger = logging.getLogger(__name__)
 
@@ -198,7 +197,12 @@ class MySQLEngineAdapter(
     ) -> None:
         if len(key) <= 1:
             return super()._replace_by_key(
-                target_table, source_table, target_columns_to_types, key, is_unique_key, source_columns
+                target_table,
+                source_table,
+                target_columns_to_types,
+                key,
+                is_unique_key,
+                source_columns,
             )
 
         if target_columns_to_types is None:
@@ -222,14 +226,13 @@ class MySQLEngineAdapter(
             try:
                 # Build a JOIN-based DELETE instead of using CONCAT_WS.
                 # CONCAT_WS prevents MySQL/MariaDB from using indexes, causing full table scans.
-                on_condition = reduce(
-                    lambda a, b: exp.And(this=a, expression=b),
-                    [
+                on_condition = exp.and_(
+                    *[
                         self._qualify_columns(k, target_alias).eq(
                             self._qualify_columns(k, temp_alias)
                         )
                         for k in key
-                    ],
+                    ]
                 )
 
                 target_table_aliased = exp.to_table(target_table).as_(target_alias, quoted=True)

--- a/tests/core/engine_adapter/test_mysql.py
+++ b/tests/core/engine_adapter/test_mysql.py
@@ -1,5 +1,6 @@
 # type: ignore
 import typing as t
+from unittest.mock import call
 
 from pytest_mock.plugin import MockerFixture
 from sqlglot import exp, parse_one
@@ -84,3 +85,78 @@ def test_create_table_like(make_mocked_engine_adapter: t.Callable):
     adapter.cursor.execute.assert_called_once_with(
         "CREATE TABLE IF NOT EXISTS `target_table` LIKE `source_table`"
     )
+
+
+def test_replace_by_key_composite_uses_join_delete(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+):
+    """Composite key DELETE uses JOIN instead of CONCAT_WS to allow index usage."""
+    adapter = make_mocked_engine_adapter(MySQLEngineAdapter)
+    temp_table_mock = mocker.patch(
+        "sqlmesh.core.engine_adapter.base.EngineAdapter._get_temp_table"
+    )
+    temp_table_mock.return_value = exp.to_table("temporary")
+
+    adapter.merge(
+        target_table="target",
+        source_table=t.cast(exp.Select, parse_one("SELECT id, ts, val FROM source")),
+        target_columns_to_types={
+            "id": exp.DataType(this=exp.DataType.Type.INT),
+            "ts": exp.DataType(this=exp.DataType.Type.TIMESTAMP),
+            "val": exp.DataType(this=exp.DataType.Type.INT),
+        },
+        unique_key=[parse_one("id"), parse_one("ts")],
+    )
+
+    sql_calls = to_sql_calls(adapter)
+
+    # The DELETE should use a JOIN instead of CONCAT_WS
+    assert any("CONCAT_WS" in s for s in sql_calls) is False, (
+        "DELETE should not use CONCAT_WS for composite keys"
+    )
+    assert any("INNER JOIN" in s for s in sql_calls) is True, (
+        "DELETE should use INNER JOIN for composite keys"
+    )
+
+    # Verify the full sequence of SQL calls
+    adapter.cursor.execute.assert_has_calls(
+        [
+            call(
+                "CREATE TABLE `temporary` AS SELECT CAST(`id` AS SIGNED) AS `id`, CAST(`ts` AS DATETIME) AS `ts`, CAST(`val` AS SIGNED) AS `val` FROM (SELECT `id`, `ts`, `val` FROM `source`) AS `_subquery`"
+            ),
+            call(
+                "DELETE `_target` FROM `target` AS `_target` INNER JOIN `temporary` AS `_temp` ON `_target`.`id` = `_temp`.`id` AND `_target`.`ts` = `_temp`.`ts`"
+            ),
+            call(
+                "INSERT INTO `target` (`id`, `ts`, `val`) SELECT `id`, `ts`, `val` FROM (SELECT `id` AS `id`, `ts` AS `ts`, `val` AS `val`, ROW_NUMBER() OVER (PARTITION BY `id`, `ts` ORDER BY `id`, `ts`) AS _row_number FROM `temporary`) AS _t WHERE _row_number = 1"
+            ),
+            call("DROP TABLE IF EXISTS `temporary`"),
+        ]
+    )
+
+
+def test_replace_by_key_single_key_uses_in(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+):
+    """Single key DELETE still uses the IN-based approach (indexes work fine for single column)."""
+    adapter = make_mocked_engine_adapter(MySQLEngineAdapter)
+    temp_table_mock = mocker.patch(
+        "sqlmesh.core.engine_adapter.base.EngineAdapter._get_temp_table"
+    )
+    temp_table_mock.return_value = exp.to_table("temporary")
+
+    adapter.merge(
+        target_table="target",
+        source_table=t.cast(exp.Select, parse_one("SELECT id, val FROM source")),
+        target_columns_to_types={
+            "id": exp.DataType(this=exp.DataType.Type.INT),
+            "val": exp.DataType(this=exp.DataType.Type.INT),
+        },
+        unique_key=[parse_one("id")],
+    )
+
+    sql_calls = to_sql_calls(adapter)
+
+    # Single key should use IN-based approach, not JOIN
+    assert any("IN" in s and "DELETE" in s for s in sql_calls) is True
+    assert any("INNER JOIN" in s for s in sql_calls) is False

--- a/tests/core/engine_adapter/test_mysql.py
+++ b/tests/core/engine_adapter/test_mysql.py
@@ -92,9 +92,7 @@ def test_replace_by_key_composite_uses_join_delete(
 ):
     """Composite key DELETE uses JOIN instead of CONCAT_WS to allow index usage."""
     adapter = make_mocked_engine_adapter(MySQLEngineAdapter)
-    temp_table_mock = mocker.patch(
-        "sqlmesh.core.engine_adapter.base.EngineAdapter._get_temp_table"
-    )
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.base.EngineAdapter._get_temp_table")
     temp_table_mock.return_value = exp.to_table("temporary")
 
     adapter.merge(
@@ -135,14 +133,81 @@ def test_replace_by_key_composite_uses_join_delete(
     )
 
 
+def test_replace_by_key_three_column_composite_key(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+):
+    """3-column composite key matching the original issue scenario (#5711)."""
+    adapter = make_mocked_engine_adapter(MySQLEngineAdapter)
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.base.EngineAdapter._get_temp_table")
+    temp_table_mock.return_value = exp.to_table("temporary")
+
+    adapter.merge(
+        target_table="target",
+        source_table=t.cast(exp.Select, parse_one("SELECT id, region, ts, val FROM source")),
+        target_columns_to_types={
+            "id": exp.DataType(this=exp.DataType.Type.INT),
+            "region": exp.DataType(this=exp.DataType.Type.VARCHAR),
+            "ts": exp.DataType(this=exp.DataType.Type.TIMESTAMP),
+            "val": exp.DataType(this=exp.DataType.Type.INT),
+        },
+        unique_key=[parse_one("id"), parse_one("region"), parse_one("ts")],
+    )
+
+    sql_calls = to_sql_calls(adapter)
+
+    assert any("CONCAT_WS" in s for s in sql_calls) is False
+    assert any("INNER JOIN" in s for s in sql_calls) is True
+
+    adapter.cursor.execute.assert_has_calls(
+        [
+            call(
+                "DELETE `_target` FROM `target` AS `_target` INNER JOIN `temporary` AS `_temp` ON `_target`.`id` = `_temp`.`id` AND `_target`.`region` = `_temp`.`region` AND `_target`.`ts` = `_temp`.`ts`"
+            ),
+        ]
+    )
+
+
+def test_replace_by_key_expression_based_composite_key(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+):
+    """Expression-based composite keys (e.g. DATE_TRUNC + column) via insert_overwrite_by_partition."""
+    adapter = make_mocked_engine_adapter(MySQLEngineAdapter)
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.base.EngineAdapter._get_temp_table")
+    temp_table_mock.return_value = exp.to_table("temporary")
+
+    adapter.insert_overwrite_by_partition(
+        table_name="target",
+        query_or_df=t.cast(exp.Select, parse_one("SELECT id, ts, val FROM source")),
+        partitioned_by=[
+            parse_one("DATE_TRUNC('month', ts)"),
+            parse_one("id"),
+        ],
+        target_columns_to_types={
+            "id": exp.DataType(this=exp.DataType.Type.INT),
+            "ts": exp.DataType(this=exp.DataType.Type.TIMESTAMP),
+            "val": exp.DataType(this=exp.DataType.Type.INT),
+        },
+    )
+
+    sql_calls = to_sql_calls(adapter)
+
+    assert any("CONCAT_WS" in s for s in sql_calls) is False
+    assert any("INNER JOIN" in s for s in sql_calls) is True
+
+    # DATE_TRUNC transpiles to STR_TO_DATE in MySQL; both key parts should be qualified
+    delete_sql = [s for s in sql_calls if "DELETE" in s][0]
+    assert "`_target`.`ts`" in delete_sql
+    assert "`_temp`.`ts`" in delete_sql
+    assert "`_target`.`id`" in delete_sql
+    assert "`_temp`.`id`" in delete_sql
+
+
 def test_replace_by_key_single_key_uses_in(
     make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
 ):
     """Single key DELETE still uses the IN-based approach (indexes work fine for single column)."""
     adapter = make_mocked_engine_adapter(MySQLEngineAdapter)
-    temp_table_mock = mocker.patch(
-        "sqlmesh.core.engine_adapter.base.EngineAdapter._get_temp_table"
-    )
+    temp_table_mock = mocker.patch("sqlmesh.core.engine_adapter.base.EngineAdapter._get_temp_table")
     temp_table_mock.return_value = exp.to_table("temporary")
 
     adapter.merge(


### PR DESCRIPTION
## Summary

Fixes #5711

- Override `_replace_by_key` in `MySQLEngineAdapter` to use a JOIN-based DELETE for composite keys instead of `CONCAT_WS('__SQLMESH_DELIM__', ...)` which prevents MySQL/MariaDB from using indexes
- Single-key DELETEs continue to use the existing efficient `IN`-based approach since indexes work fine for single columns
- Add tests verifying both composite key (JOIN-based) and single key (IN-based) DELETE behavior

## Problem

When using `INCREMENTAL_BY_UNIQUE_KEY` with MySQL/MariaDB and composite keys, SQLMesh generates:

```sql
DELETE FROM `target_table`
WHERE CONCAT_WS('__SQLMESH_DELIM__', `col1`, `col2`)
IN (SELECT CONCAT_WS('__SQLMESH_DELIM__', `col1`, `col2`) FROM `temp_table`)
```

MySQL cannot use indexes on `CONCAT_WS()` expressions, causing full table scans that lead to multi-hour query times and connection timeouts on larger tables.

## Fix

For composite keys, generate a JOIN-based DELETE that allows MySQL to use existing indexes:

```sql
DELETE `_target`
FROM `target_table` AS `_target`
INNER JOIN `temp_table` AS `_temp`
ON `_target`.`col1` = `_temp`.`col1`
AND `_target`.`col2` = `_temp`.`col2`
```

This changes the EXPLAIN plan from `type=ALL` (full scan) to `type=ref` (index lookup), reducing query times from hours to seconds.

## Test plan

- [x] New test `test_replace_by_key_composite_uses_join_delete` verifies JOIN-based DELETE for composite keys
- [x] New test `test_replace_by_key_single_key_uses_in` verifies single-key DELETEs still use the IN-based approach
- [x] Existing MySQL adapter tests pass
- [x] Existing mixin tests pass
- [x] Existing base engine adapter tests pass