### PR TITLE
Fix!: Include custom audit args in the metadata hash

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -1158,11 +1158,7 @@ class _Model(ModelMeta, frozen=True):
 
         for audit_name, audit_args in sorted(self.audits, key=lambda a: a[0]):
             metadata.append(audit_name)
-            if audit_name in BUILT_IN_AUDITS:
-                for arg_name, arg_value in audit_args.items():
-                    metadata.append(arg_name)
-                    metadata.append(gen(arg_value))
-            else:
+            if audit_name not in BUILT_IN_AUDITS:
                 audit = self.audit_definitions[audit_name]
                 metadata.extend(
                     [
@@ -1172,6 +1168,9 @@ class _Model(ModelMeta, frozen=True):
                         str(audit.blocking),
                     ]
                 )
+            for arg_name, arg_value in audit_args.items():
+                metadata.append(arg_name)
+                metadata.append(gen(arg_value))
 
         return metadata
 

--- a/sqlmesh/migrations/v0101_include_custom_audit_args_in_fingerprint.py
+++ b/sqlmesh/migrations/v0101_include_custom_audit_args_in_fingerprint.py
@@ -1,0 +1,9 @@
+"""Include custom audit args in the model fingerprint."""
+
+
+def migrate_schemas(engine_adapter, schema, **kwargs):  # type: ignore
+    pass
+
+
+def migrate_rows(engine_adapter, schema, **kwargs):  # type: ignore
+    pass

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1665,6 +1665,37 @@ def test_audits():
     assert model.tags == ["foo"]
 
 
+def test_custom_audit_arg_changes_affect_fingerprint():
+    def make_model(min_val: int) -> t.Any:
+        expressions = d.parse(
+            f"""
+            MODEL (
+                name db.model,
+                audits (check_count(min := {min_val}))
+            );
+            SELECT 1 AS id;
+            """
+        )
+        audit_definitions = {
+            "check_count": load_audit(
+                d.parse(
+                    "AUDIT (name check_count); SELECT * FROM @this_model HAVING COUNT(*) < @min"
+                ),
+                dialect="duckdb",
+            )
+        }
+        return load_sql_based_model(
+            expressions,
+            path=Path("./examples/sushi/models/test_model.sql"),
+            audit_definitions=audit_definitions,
+        )
+
+    model_a = make_model(33111)
+    model_b = make_model(5142)
+
+    assert model_a.audit_metadata_hash() != model_b.audit_metadata_hash()
+
+
 def test_enable_audits_from_model_defaults():
     expressions = d.parse(
         """


### PR DESCRIPTION
fix to move the args loop outside the if else, so both built-in and custom audits include their call args in the metadata hash. No rendering needed by using `gen(arg_value)` so it stays consistent with #5256 philosophy 
