### PR TITLE
Fix: harden ValidationInfo.data access for Pydantic 2.13 compat

### DIFF
--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -34,6 +34,7 @@ from sqlmesh.utils.pydantic import (
     ValidationInfo,
     field_validator,
     model_validator,
+    validation_data,
     validation_error_message,
     get_concrete_types_from_typehint,
 )
@@ -1081,7 +1082,7 @@ class BigQueryConnectionConfig(ConnectionConfig):
         v: t.Optional[str],
         info: ValidationInfo,
     ) -> t.Optional[str]:
-        if v and not info.data.get("project"):
+        if v and not validation_data(info).get("project"):
             raise ConfigError(
                 "If the `execution_project` field is specified, you must also specify the `project` field to provide a default object location."
             )
@@ -1093,7 +1094,7 @@ class BigQueryConnectionConfig(ConnectionConfig):
         v: t.Optional[str],
         info: ValidationInfo,
     ) -> t.Optional[str]:
-        if v and not info.data.get("project"):
+        if v and not validation_data(info).get("project"):
             raise ConfigError(
                 "If the `quota_project` field is specified, you must also specify the `project` field to provide a default object location."
             )

--- a/sqlmesh/core/environment.py
+++ b/sqlmesh/core/environment.py
@@ -56,7 +56,8 @@ class EnvironmentNamingInfo(PydanticModel):
     @classmethod
     def _validate_boolean_field(cls, v: t.Any, info: ValidationInfo) -> bool:
         if v is None:
-            return info.field_name == "normalize_name"
+            # Pydantic 2.13+ sets field_name to None during model_validate_json()
+            return (info.field_name or "") == "normalize_name"
         return bool(v)
 
     @t.overload

--- a/sqlmesh/core/metric/definition.py
+++ b/sqlmesh/core/metric/definition.py
@@ -10,7 +10,7 @@ from sqlmesh.core import dialect as d
 from sqlmesh.core.node import str_or_exp_to_str
 from sqlmesh.utils import UniqueKeyDict
 from sqlmesh.utils.errors import ConfigError
-from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator
+from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator, validation_data
 
 MeasureAndDimTables = t.Tuple[str, t.Tuple[str, ...]]
 
@@ -89,7 +89,7 @@ class MetricMeta(PydanticModel, frozen=True):
     @field_validator("expression", mode="before")
     def _validate_expression(cls, v: t.Any, info: ValidationInfo) -> exp.Expr:
         if isinstance(v, str):
-            dialect = info.data.get("dialect")
+            dialect = validation_data(info).get("dialect")
             return d.parse_one(v, dialect=dialect)
         if isinstance(v, exp.Expr):
             return v

--- a/sqlmesh/core/model/common.py
+++ b/sqlmesh/core/model/common.py
@@ -21,7 +21,13 @@ from sqlmesh.utils.metaprogramming import (
     prepare_env,
     serialize_env,
 )
-from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator, get_dialect
+from sqlmesh.utils.pydantic import (
+    PydanticModel,
+    ValidationInfo,
+    field_validator,
+    get_dialect,
+    validation_data,
+)
 
 if t.TYPE_CHECKING:
     from sqlglot.dialects.dialect import DialectType
@@ -479,7 +485,7 @@ def parse_expression(
     if callable(v):
         return v
 
-    dialect = info.data.get("dialect") if info else ""
+    dialect = validation_data(info).get("dialect") if info else ""
 
     if isinstance(v, list):
         return [
@@ -519,7 +525,7 @@ def parse_properties(
     if v is None:
         return v
 
-    dialect = info.data.get("dialect") if info else ""
+    dialect = validation_data(info).get("dialect") if info else ""
 
     if isinstance(v, str):
         v = d.parse_one(v, dialect=dialect)
@@ -557,8 +563,9 @@ def default_catalog(cls: t.Type, v: t.Any) -> t.Optional[str]:
 
 
 def depends_on(cls: t.Type, v: t.Any, info: ValidationInfo) -> t.Optional[t.Set[str]]:
-    dialect = info.data.get("dialect")
-    default_catalog = info.data.get("default_catalog")
+    data = validation_data(info)
+    dialect = data.get("dialect")
+    default_catalog = data.get("default_catalog")
 
     if isinstance(v, exp.Paren):
         v = v.unnest()

--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -44,6 +44,7 @@ from sqlmesh.utils.pydantic import (
     list_of_fields_validator,
     model_validator,
     get_dialect,
+    validation_data,
 )
 
 if t.TYPE_CHECKING:
@@ -135,7 +136,7 @@ class ModelMeta(_Node):
 
     @field_validator("tags", mode="before")
     def _value_or_tuple_validator(cls, v: t.Any, info: ValidationInfo) -> t.Any:
-        return ensure_list(cls._validate_value_or_tuple(v, info.data))
+        return ensure_list(cls._validate_value_or_tuple(v, validation_data(info)))
 
     @classmethod
     def _validate_value_or_tuple(
@@ -164,7 +165,7 @@ class ModelMeta(_Node):
     @field_validator("table_format", "storage_format", mode="before")
     def _format_validator(cls, v: t.Any, info: ValidationInfo) -> t.Optional[str]:
         if isinstance(v, exp.Expr) and not (isinstance(v, (exp.Literal, exp.Identifier))):
-            return v.sql(info.data.get("dialect"))
+            return v.sql(validation_data(info).get("dialect"))
         return str_or_exp_to_str(v)
 
     @field_validator("dialect", mode="before")
@@ -192,7 +193,7 @@ class ModelMeta(_Node):
         if (
             isinstance(v, list)
             and all(isinstance(i, str) for i in v)
-            and info.field_name == "partitioned_by_"
+            and (info.field_name or "") == "partitioned_by_"
         ):
             # this branch gets hit when we are deserializing from json because `partitioned_by` is stored as a List[str]
             # however, we should only invoke this if the list contains strings because this validator is also
@@ -205,7 +206,7 @@ class ModelMeta(_Node):
             )
             v = parsed.this.expressions if isinstance(parsed.this, exp.Schema) else v
 
-        expressions = list_of_fields_validator(v, info.data)
+        expressions = list_of_fields_validator(v, validation_data(info))
 
         for expression in expressions:
             num_cols = len(list(expression.find_all(exp.Column)))
@@ -228,7 +229,7 @@ class ModelMeta(_Node):
         cls, v: t.Any, info: ValidationInfo
     ) -> t.Optional[t.Dict[str, exp.DataType]]:
         columns_to_types = {}
-        dialect = info.data.get("dialect")
+        dialect = validation_data(info).get("dialect")
 
         if isinstance(v, exp.Schema):
             for column in v.expressions:
@@ -280,7 +281,8 @@ class ModelMeta(_Node):
     def _column_descriptions_validator(
         cls, vs: t.Any, info: ValidationInfo
     ) -> t.Optional[t.Dict[str, str]]:
-        dialect = info.data.get("dialect")
+        data = validation_data(info)
+        dialect = data.get("dialect")
 
         if vs is None:
             return None
@@ -302,7 +304,7 @@ class ModelMeta(_Node):
             for k, v in raw_col_descriptions.items()
         }
 
-        columns_to_types = info.data.get("columns_to_types_")
+        columns_to_types = data.get("columns_to_types_")
         if columns_to_types:
             from sqlmesh.core.console import get_console
 
@@ -310,7 +312,7 @@ class ModelMeta(_Node):
             for column_name in list(col_descriptions):
                 if column_name not in columns_to_types:
                     console.log_warning(
-                        f"In model '{info.data['name']}', a description is provided for column '{column_name}' but it is not a column in the model."
+                        f"In model '{data.get('name', '<unknown>')}', a description is provided for column '{column_name}' but it is not a column in the model."
                     )
                     del col_descriptions[column_name]
 
@@ -318,7 +320,7 @@ class ModelMeta(_Node):
 
     @field_validator("grains", "references", mode="before")
     def _refs_validator(cls, vs: t.Any, info: ValidationInfo) -> t.List[exp.Expr]:
-        dialect = info.data.get("dialect")
+        dialect = validation_data(info).get("dialect")
 
         if isinstance(vs, exp.Paren):
             vs = vs.unnest()

--- a/sqlmesh/core/state_sync/common.py
+++ b/sqlmesh/core/state_sync/common.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from pydantic_core.core_schema import ValidationInfo
 from sqlglot import exp
 
-from sqlmesh.utils.pydantic import PydanticModel, field_validator
+from sqlmesh.utils.pydantic import PydanticModel, field_validator, validation_data
 from sqlmesh.core.environment import Environment, EnvironmentStatements, EnvironmentNamingInfo
 from sqlmesh.core.snapshot import (
     Snapshot,
@@ -269,7 +269,7 @@ class PromotionResult(PydanticModel):
     def _validate_removed_environment_naming_info(
         cls, v: t.Optional[EnvironmentNamingInfo], info: ValidationInfo
     ) -> t.Optional[EnvironmentNamingInfo]:
-        if v and not info.data.get("removed"):
+        if v and not validation_data(info).get("removed"):
             raise ValueError("removed_environment_naming_info must be None if removed is empty")
         return v
 

--- a/sqlmesh/core/user.py
+++ b/sqlmesh/core/user.py
@@ -2,7 +2,7 @@ import typing as t
 from enum import Enum
 
 from sqlmesh.core.notification_target import BasicSMTPNotificationTarget, NotificationTarget
-from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator
+from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator, validation_data
 
 
 class UserRole(str, Enum):
@@ -42,7 +42,7 @@ class User(PydanticModel):
         v: t.List[NotificationTarget],
         info: ValidationInfo,
     ) -> t.List[NotificationTarget]:
-        email = info.data["email"]
+        email = validation_data(info).get("email")
         for target in v:
             if isinstance(target, BasicSMTPNotificationTarget) and target.recipients != {email}:
                 raise ValueError("Recipient emails do not match user email")

--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -52,7 +52,13 @@ def get_dialect(values: t.Any) -> str:
 
     from sqlmesh.core.model import model
 
-    dialect = (values if isinstance(values, dict) else values.data).get("dialect")
+    if isinstance(values, dict):
+        data = values
+    elif values is not None:
+        data = values.data
+    else:
+        data = None
+    dialect = data.get("dialect") if data is not None else None
     return model._dialect if dialect is None else dialect  # type: ignore
 
 

--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -41,6 +41,19 @@ def field_serializer(*args: t.Any, **kwargs: t.Any) -> t.Callable[[t.Any], t.Any
     return pydantic.field_serializer(*args, **kwargs)
 
 
+def validation_data(info_or_data: t.Any) -> t.Dict[str, t.Any]:
+    """Safely extract the validated-data dict from a ValidationInfo, dict, or None.
+
+    Pydantic 2.13+ sets ValidationInfo.data to None during model_validate_json().
+    This normalizes all inputs to a dict, returning an empty dict when data is unavailable.
+    """
+    if isinstance(info_or_data, dict):
+        return info_or_data
+    if info_or_data is not None:
+        return info_or_data.data or {}
+    return {}
+
+
 def get_dialect(values: t.Any) -> str:
     """Extracts dialect from a dict or pydantic obj, defaulting to the globally set dialect.
 
@@ -52,13 +65,7 @@ def get_dialect(values: t.Any) -> str:
 
     from sqlmesh.core.model import model
 
-    if isinstance(values, dict):
-        data = values
-    elif values is not None:
-        data = values.data
-    else:
-        data = None
-    dialect = data.get("dialect") if data is not None else None
+    dialect = validation_data(values).get("dialect")
     return model._dialect if dialect is None else dialect  # type: ignore
 
 

--- a/web/server/models.py
+++ b/web/server/models.py
@@ -19,7 +19,7 @@ from sqlmesh.core.snapshot.definition import (
     SnapshotId,
 )
 from sqlmesh.utils.date import TimeLike, now_timestamp
-from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator
+from sqlmesh.utils.pydantic import PydanticModel, ValidationInfo, field_validator, validation_data
 
 SUPPORTED_EXTENSIONS = {".py", ".sql", ".yaml", ".yml", ".csv"}
 
@@ -117,8 +117,9 @@ class File(PydanticModel):
 
     @field_validator("extension", mode="before")
     def default_extension(cls, v: str, info: ValidationInfo) -> str:
-        if "name" in info.data:
-            return pathlib.Path(info.data["name"]).suffix
+        data = validation_data(info)
+        if "name" in data:
+            return pathlib.Path(data["name"]).suffix
         return v
 
 


### PR DESCRIPTION
## Description

Pydantic 2.13.0 changed `ValidationInfo.data` and `ValidationInfo.field_name` to be `None` (instead of a dict / string) during `model_validate_json()`. This broke `get_dialect()` and would break any field validator that accesses `info.data` when deserializing models from JSON (e.g. snapshot loading, state sync).

This PR:
- Adds a `validation_data()` helper in `sqlmesh/utils/pydantic.py` that safely extracts the data dict from a `ValidationInfo`, dict, or `None`, returning an empty dict when data is unavailable
- Refactors `get_dialect()` to use it
- Replaces all direct `info.data` access across 9 files with `validation_data(info)`
- Handles `info.field_name` being `None` in `environment.py` and `meta.py`

Root cause of the CI failure on #5759 — not caused by that PR's changes, but by Pydantic 2.13.0 being released between the last passing main CI run (2.12.5) and the PR CI run (2.13.0).

## Test Plan

- `test_audit_formatting_flag_serde` now passes (was the original failing test)
- All 42 audit tests pass
- All 317 model tests pass
- 123 snapshot tests pass
- 62 web tests pass
- 1432+ core tests pass (excluding pre-existing env-specific failures)
- Ruff lint and format checks clean on all 9 files

Verified Pydantic 2.13.0 behavior with an isolated `uv` venv test: `ValidationInfo.data` and `field_name` are both `None` for ALL validator modes (not just `mode="before"`) during `model_validate_json()`. Normal `__init__` and `model_validate(dict)` are unaffected.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)