### PR TITLE
Fix: Do not modify updated_ts when unpausing all snapshots with target name

### DIFF
--- a/sqlmesh/core/state_sync/db/snapshot.py
+++ b/sqlmesh/core/state_sync/db/snapshot.py
@@ -138,7 +138,7 @@ class SnapshotState:
         ):
             self.engine_adapter.update_table(
                 self.snapshots_table,
-                {"unpaused_ts": None, "updated_ts": updated_ts},
+                {"unpaused_ts": None},
                 where=where,
             )
 


### PR DESCRIPTION
## Description

PR #5147 introduced an optimization to snapshot unpausing logic. Part of the logic unset the `unpaused_ts` for all snapshots will the same name as a promoted snapshots and also set their `updated_ts` to now. The latter had a side effect of having old snapshots appear newer than they actually were and skip garbage collection by the janitor. 

The fix is to not set `updated_ts`.

## Test Plan

The change is trivial and the original PR did not introduce any tests for the behavior, so not test to update either.

## Checklist

- [x] I have run `make style` and fixed any issues
- [ ] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
