### PR TITLE
fix: prioritize @EACH lambda params over column name conflicts

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -647,10 +647,10 @@ def _norm_var_arg_lambda(
         node: exp.Expr, args: t.Dict[str, exp.Expr]
     ) -> exp.Expr | t.List[exp.Expr] | None:
         if isinstance(node, (exp.Identifier, exp.Var)):
+            name = node.name.lower()
+            if name in args:
+                return args[name].copy()
             if not isinstance(node.parent, exp.Column):
-                name = node.name.lower()
-                if name in args:
-                    return args[name].copy()
                 if name in evaluator.locals:
                     return exp.convert(evaluator.locals[name])
             if SQLMESH_MACRO_PREFIX in node.name:

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -618,6 +618,20 @@ def test_ast_correctness(macro_evaluator):
             "SELECT * FROM (VALUES ((1, 2), (2, 3), (3, 4))) AS v",
             {},
         ),
+        # Lambda parameter name matches the column identifier inside a Column expression
+        # (e.g. schema.product where 'product' is both the lambda arg and the column name).
+        # Lambda args must take precedence over the Column-context guard so that the param
+        # is substituted correctly (regression test for GitHub issue #5582).
+        (
+            "SELECT @EACH([a, b, c], product -> schema.product)",
+            "SELECT schema.a, schema.b, schema.c",
+            {},
+        ),
+        (
+            "SELECT @EACH([x, y], col -> tbl.col)",
+            "SELECT tbl.x, tbl.y",
+            {},
+        ),
     ],
 )
 def test_macro_functions(macro_evaluator: MacroEvaluator, assert_exp_eq, sql, expected, args):


### PR DESCRIPTION
## Summary

- Fixed silent `@EACH()` failure when the lambda parameter name matches an existing column name
- Lambda arguments (`args`) now take priority over Column context checks
- `evaluator.locals` substitution remains restricted to non-Column nodes (unchanged behavior)

## Root Cause

In `_norm_var_arg_lambda` (`sqlmesh/core/macros.py`), the `substitute` function wrapped both `args` and `evaluator.locals` lookups inside `if not isinstance(node.parent, exp.Column)`. This caused the lambda parameter to be silently skipped when it appeared as a column reference.

## Test plan

- [ ] Added two test cases to `tests/core/test_macros.py` covering `@EACH` with lambda parameter names that conflict with column names
- [ ] All 138 tests in `test_macros.py` pass

Fixes #5582

🤖 Generated with [Claude Code](https://claude.com/claude-code)