### PR TITLE
Feat: Add override data path to ducklake options

### DIFF
--- a/docs/integrations/engines/duckdb.md
+++ b/docs/integrations/engines/duckdb.md
@@ -79,6 +79,7 @@ SQLMesh will place models with the explicit catalog "ephemeral", such as `epheme
               type: ducklake
               path: 'catalog.ducklake'
               data_path: data/ducklake
+              override_data_path: true
               encrypted: True
               data_inlining_row_limit: 10
               metadata_schema: main
@@ -105,6 +106,7 @@ SQLMesh will place models with the explicit catalog "ephemeral", such as `epheme
                             type="ducklake",
                             path="catalog.ducklake",
                             data_path="data/ducklake",
+                            override_data_path=False,
                             encrypted=True,
                             data_inlining_row_limit=10,
                             metadata_schema="main",
@@ -120,6 +122,7 @@ SQLMesh will place models with the explicit catalog "ephemeral", such as `epheme
 
 - `path`: Path to the DuckLake catalog file
 - `data_path`: Path where DuckLake data files are stored
+- `override_data_path`: Whether data_override_path option is set
 - `encrypted`: Whether to enable encryption for the catalog (default: `False`)
 - `data_inlining_row_limit`: Maximum number of rows to inline in the catalog (default: `0`)
 - `metadata_schema`: The schema in the catalog server in which to store the DuckLake metadata tables (default: `main`)
@@ -364,6 +367,7 @@ The `filesystems` accepts a list of file systems to register in the DuckDB conne
               type: ducklake
               path: myducklakecatalog.duckdb
               data_path: abfs://MyFabricWorkspace/MyFabricLakehouse.Lakehouse/Files/DuckLake.Files
+              override_data_path: False
         extensions:
           - ducklake
         filesystems:

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -238,6 +238,7 @@ class DuckDBAttachOptions(BaseConfig):
 
     # DuckLake specific options
     data_path: t.Optional[str] = None
+    override_data_path: t.Optional[bool] = False
     encrypted: bool = False
     data_inlining_row_limit: t.Optional[int] = None
     metadata_schema: t.Optional[str] = None
@@ -258,6 +259,8 @@ class DuckDBAttachOptions(BaseConfig):
                 path = f"ducklake:{path}"
             if self.data_path is not None:
                 options.append(f"DATA_PATH '{self.data_path}'")
+                if self.override_data_path:
+                    options.append("OVERRIDE_DATA_PATH true")
             if self.encrypted:
                 options.append("ENCRYPTED")
             if self.data_inlining_row_limit is not None:

--- a/tests/core/test_connection_config.py
+++ b/tests/core/test_connection_config.py
@@ -810,6 +810,7 @@ def test_duckdb_attach_ducklake_catalog(make_config):
                 type="ducklake",
                 path="catalog.ducklake",
                 data_path="/tmp/ducklake_data",
+                override_data_path=False,
                 encrypted=True,
                 data_inlining_row_limit=10,
             ),


### PR DESCRIPTION
## Description

Currently it's not possible to set the override_data_path option when attaching a ducklake.
When working locally with ducklakes the CWD is used as a base for resolving the data_path. If it is relative, this will only work for the original folder.
To enable switching the data_path to something different as set in the ducklake, we need to set override_data_path to true.

## Test Plan

I could not find tests concerning loading a pre-existing ducklake, and my knowledge on creating one is really bad ...

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

