### PR TITLE
Perf: batch column comment ALTER statements in Databricks adapter

### DIFF
--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -411,3 +411,34 @@ class DatabricksEngineAdapter(SparkEngineAdapter, GrantsFromInfoSchemaMixin):
         return super()._build_column_defs(
             target_columns_to_types, column_descriptions, is_view, materialized
         )
+
+    def _create_column_comments(
+        self,
+        table_name: TableName,
+        column_comments: t.Dict[str, str],
+        table_kind: str = "TABLE",
+        materialized_view: bool = False,
+    ) -> None:
+        if not column_comments:
+            return
+
+        table = self._ensure_fqn(table_name)
+        table_sql = table.sql(dialect=self.dialect, identify=True)
+
+        clauses = []
+        for col, comment in column_comments.items():
+            col_sql = exp.column(col).sql(dialect=self.dialect, identify=True)
+            comment_sql = exp.Literal.string(self._truncate_column_comment(comment)).sql(
+                dialect=self.dialect
+            )
+            clauses.append(f"COLUMN {col_sql} COMMENT {comment_sql}")
+
+        sql = f"ALTER TABLE {table_sql} ALTER {', '.join(clauses)}"
+
+        try:
+            self.execute(sql)
+        except Exception:
+            logger.warning(
+                f"Column comments for table '{table.alias_or_name}' not registered - this may be due to limited permissions",
+                exc_info=True,
+            )

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -526,3 +526,23 @@ def test_drop_data_object_materialized_view_calls_correct_drop(mocker: MockFixtu
     drop_view_mock.assert_called_once_with(
         mv_data_object.to_table(), ignore_if_not_exists=True, materialized=True
     )
+
+
+def test_create_column_comments_batched(mocker: MockFixture, make_mocked_engine_adapter: t.Callable):
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.databricks.DatabricksEngineAdapter.set_current_catalog"
+    )
+    adapter = make_mocked_engine_adapter(DatabricksEngineAdapter, default_catalog="test_catalog")
+    mocker.patch.object(adapter, "get_current_catalog", return_value="test_catalog")
+    mocker.patch.object(adapter, "_get_current_schema", return_value="test_schema")
+
+    adapter._create_column_comments(
+        "test_table",
+        {"a": "description for a", "b": "description for b"},
+    )
+
+    sql_calls = to_sql_calls(adapter)
+    assert len(sql_calls) == 1
+    assert sql_calls == [
+        "ALTER TABLE test_catalog.test_schema.`test_table` ALTER COLUMN `a` COMMENT 'description for a', COLUMN `b` COMMENT 'description for b'",
+    ]


### PR DESCRIPTION
Instead of executing one ALTER TABLE ... ALTER COLUMN ... COMMENT query per column (~1s each on Databricks), batch all column comments into a single statement using Databricks' supported multi-column ALTER syntax.

## Description

  - Overrides _create_column_comments in DatabricksEngineAdapter to batch all column comments into a single ALTER TABLE ... ALTER COLUMN col1 COMMENT '...', COLUMN col2 COMMENT '...' statement
  - Previously each column comment was a separate query (~1s per query on Databricks), making it very slow for tables with many columns
  - Adds a unit test verifying the batched SQL output

## Test Plan

Followed the testing below. 

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
