### PR TITLE
Fix: Don't rewrite_casts for for subclasses like JSONCast

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -774,7 +774,8 @@ def format_model_expressions(
     if rewrite_casts:
 
         def cast_to_colon(node: exp.Expr) -> exp.Expr:
-            if isinstance(node, exp.Cast) and not any(
+            # Directly check type instead of isinstance to avoid rewriting subclasses of CAST, e.g. JSONCast
+            if type(node) is exp.Cast and not any(
                 # Only convert CAST into :: if it doesn't have additional args set, otherwise this
                 # conversion could alter the semantics (eg. changing SAFE_CAST in BigQuery to CAST)
                 arg

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -210,6 +210,29 @@ SELECT
     x = format_model_expressions(
         parse(
             """
+            MODEL(name a.b, kind FULL, dialect clickhouse);
+            SELECT data.:String AS foo, CAST(1 AS INT) AS bar
+            """
+        ),
+        dialect="clickhouse",
+    )
+    # JSONCast (e.g. `.:` syntax in ClickHouse) must not be written to `::`
+    assert (
+        x
+        == """MODEL (
+  name a.b,
+  kind FULL,
+  dialect clickhouse
+);
+
+SELECT
+  data.:String AS foo,
+  1::Int32 AS bar"""
+    )
+
+    x = format_model_expressions(
+        parse(
+            """
             MODEL(name foo);
             SELECT CAST(1 AS INT) AS bla
             """


### PR DESCRIPTION
## Description

I noticed a bug in `sqlmesh format` when working with the ClickHouse dialect. The `rewrite_casts` option will rewrite `exp.JSONCast` (the `.:` operator) to `::`, which changes the semantics of the query.

For example,

```sql
-- input query
SELECT foo.:String, CAST(bar AS String)

-- expected result
SELECT foo.:String, bar::String

-- observed result
SELECT foo::String, bar::String
```

This adds a one-line fix by only rewriting `exp.Cast` itself and not subclasses like `exp.JSONCast`.


## Test Plan

Add unit test for the formatter that makes sure `exp.JSONCast` is not rewritten, but `exp.Cast` is still rewritten

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
