### PR TITLE
Fix: Fallback to DROP VIEW if DROP TABLE fails in DuckDB

### DIFF
--- a/sqlmesh/core/engine_adapter/duckdb.py
+++ b/sqlmesh/core/engine_adapter/duckdb.py
@@ -218,3 +218,23 @@ class DuckDBEngineAdapter(LogicalMergeMixin, GetCurrentCatalogFromFunctionMixin,
     @property
     def _is_motherduck(self) -> bool:
         return self._extra_config.get("is_motherduck", False)
+
+    def drop_table(
+        self,
+        table_name: t.Any,
+        exists: bool = True,
+        **kwargs: t.Any,
+    ) -> None:
+        """
+        DuckDB will raise an error if you try to DROP TABLE on a view.
+        Fallback to DROP VIEW if the execution of DROP TABLE fails.
+        """
+        from duckdb import Error
+
+        # Safety: Remove 'exists' from kwargs so we don't pass it twice
+        kwargs.pop("exists", None)
+
+        try:
+            super().drop_table(table_name, exists=exists, **kwargs)
+        except Error:
+            self.drop_view(table_name, **kwargs)


### PR DESCRIPTION
Related issue: #5438

## Description

DuckDB has trouble detecting the type of relations when interacting with Postgres through `duckdb-postgres`: Views are treated like tables. (see linked issue for more detail)

The proposed fix is simply to add a fallback to drop the relation with `DROP VIEW` if `DROP TABLE` fails. The code is inspired from another PR attempting a fix: https://github.com/SQLMesh/sqlmesh/pull/5695.  

## Test Plan

I tested this locally on a project that was impacted by issue #5438, and verified that the problem was indeed gone. 

Note that since I don't know this codebase at all, I'm not 100% convinced about the robustness of this change. 

## Checklist

- [x] I have run `make style` and fixed any issues
- [ ] I have added tests for my changes (if applicable)
    - I don't really see how to test this in any useful way
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
