### PR TITLE
feat: add --environment flag to sqlmesh janitor for scoped cleanup

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -307,9 +307,17 @@ Usage: sqlmesh janitor [OPTIONS]
   The janitor cleans up old environments and expired snapshots.
 
 Options:
-  --ignore-ttl  Cleanup snapshots that are not referenced in any environment,
-                regardless of when they're set to expire
-  --help        Show this message and exit.
+  --ignore-ttl      Cleanup snapshots that are not referenced in any
+                    environment, regardless of when they're set to expire. Has
+                    no effect when --environment is specified.
+  --force-delete    Delete expired environment and snapshot state records even
+                    when the physical table or view drops fail. Any objects
+                    that could not be dropped become orphaned and must be
+                    removed manually.
+  -e, --environment TEXT
+                    Scope cleanup to a single expired environment. Global
+                    snapshot and interval compaction are skipped.
+  --help            Show this message and exit.
 ```
 
 ## migrate

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -629,7 +629,7 @@ def invalidate(ctx: click.Context, environment: str, **kwargs: t.Any) -> None:
 @click.option(
     "--ignore-ttl",
     is_flag=True,
-    help="Cleanup snapshots that are not referenced in any environment, regardless of when they're set to expire",
+    help="Cleanup snapshots that are not referenced in any environment, regardless of when they're set to expire. Has no effect when --environment is specified.",
 )
 @click.option(
     "--force-delete",
@@ -637,16 +637,28 @@ def invalidate(ctx: click.Context, environment: str, **kwargs: t.Any) -> None:
     help="Delete expired environment and snapshot state records even when the physical table or view drops fail. "
     "Any objects that could not be dropped become orphaned and must be removed manually.",
 )
+@click.option(
+    "--environment",
+    "-e",
+    default=None,
+    help="Scope cleanup to a single expired environment. Global snapshot and interval compaction are skipped.",
+)
 @click.pass_context
 @error_handler
 @cli_analytics
-def janitor(ctx: click.Context, ignore_ttl: bool, force_delete: bool, **kwargs: t.Any) -> None:
+def janitor(
+    ctx: click.Context,
+    ignore_ttl: bool,
+    force_delete: bool,
+    environment: t.Optional[str],
+    **kwargs: t.Any,
+) -> None:
     """
     Run the janitor process on-demand.
 
     The janitor cleans up old environments and expired snapshots.
     """
-    ctx.obj.run_janitor(ignore_ttl, force_delete=force_delete, **kwargs)
+    ctx.obj.run_janitor(ignore_ttl, force_delete=force_delete, environment=environment, **kwargs)
 
 
 @cli.command("destroy")

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -887,12 +887,20 @@ class GenericContext(BaseContext, t.Generic[C]):
         return completion_status
 
     @python_api_analytics
-    def run_janitor(self, ignore_ttl: bool, force_delete: bool = False) -> bool:
+    def run_janitor(
+        self,
+        ignore_ttl: bool,
+        force_delete: bool = False,
+        environment: t.Optional[str] = None,
+    ) -> bool:
+        if environment is not None:
+            environment = Environment.sanitize_name(environment)
+
         success = False
 
         if self.console.start_cleanup(ignore_ttl):
             try:
-                self._run_janitor(ignore_ttl, force_delete=force_delete)
+                self._run_janitor(ignore_ttl, force_delete=force_delete, environment=environment)
                 success = True
             finally:
                 self.console.stop_cleanup(success=success)
@@ -1825,7 +1833,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         name = Environment.sanitize_name(name)
         self.state_sync.invalidate_environment(name)
         if sync:
-            self._cleanup_environments()
+            self._cleanup_environments(name=name)
             self.console.log_success(f"Environment '{name}' deleted.")
         else:
             self.console.log_success(f"Environment '{name}' invalidated.")
@@ -2896,27 +2904,35 @@ class GenericContext(BaseContext, t.Generic[C]):
 
         return True
 
-    def _run_janitor(self, ignore_ttl: bool = False, force_delete: bool = False) -> None:
+    def _run_janitor(
+        self,
+        ignore_ttl: bool = False,
+        force_delete: bool = False,
+        environment: t.Optional[str] = None,
+    ) -> None:
         current_ts = now_timestamp()
         failures: t.List[str] = []
 
         # Clean up expired environments by removing their views and schemas
         failures.extend(
-            self._cleanup_environments(current_ts=current_ts, force_delete=force_delete)
-        )
-
-        failures.extend(
-            delete_expired_snapshots(
-                self.state_sync,
-                self.snapshot_evaluator,
-                current_ts=current_ts,
-                ignore_ttl=ignore_ttl,
-                force_delete=force_delete,
-                console=self.console,
-                batch_size=self.config.janitor.expired_snapshots_batch_size,
+            self._cleanup_environments(
+                current_ts=current_ts, force_delete=force_delete, name=environment
             )
         )
-        self.state_sync.compact_intervals()
+
+        if environment is None:
+            failures.extend(
+                delete_expired_snapshots(
+                    self.state_sync,
+                    self.snapshot_evaluator,
+                    current_ts=current_ts,
+                    ignore_ttl=ignore_ttl,
+                    force_delete=force_delete,
+                    console=self.console,
+                    batch_size=self.config.janitor.expired_snapshots_batch_size,
+                )
+            )
+            self.state_sync.compact_intervals()
 
         if failures:
             failure_string = "\n  - ".join(failures)
@@ -2929,14 +2945,22 @@ class GenericContext(BaseContext, t.Generic[C]):
                 raise SQLMeshError(summary)
 
     def _cleanup_environments(
-        self, current_ts: t.Optional[int] = None, force_delete: bool = False
+        self,
+        current_ts: t.Optional[int] = None,
+        force_delete: bool = False,
+        name: t.Optional[str] = None,
     ) -> t.List[str]:
         current_ts = current_ts or now_timestamp()
         failures: t.List[str] = []
 
         expired_environments_summaries = self.state_sync.get_expired_environments(
-            current_ts=current_ts
+            current_ts=current_ts, name=name
         )
+
+        if name is not None and not expired_environments_summaries:
+            self.console.log_warning(
+                f"Environment '{name}' is not expired or does not exist. Nothing to clean up."
+            )
 
         for expired_env_summary in expired_environments_summaries:
             expired_env = self.state_reader.get_environment(expired_env_summary.name)
@@ -2954,7 +2978,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         # we want to retry on the next janitor pass if drops failed, unless
         # force_delete is set in which case we purge state records regardless
         if not failures or force_delete:
-            self.state_sync.delete_expired_environments(current_ts=current_ts)
+            self.state_sync.delete_expired_environments(current_ts=current_ts, name=name)
         return failures
 
     def _try_connection(self, connection_name: str, validator: t.Callable[[], None]) -> None:

--- a/sqlmesh/core/state_sync/base.py
+++ b/sqlmesh/core/state_sync/base.py
@@ -321,10 +321,17 @@ class StateReader(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_expired_environments(self, current_ts: int) -> t.List[EnvironmentSummary]:
+    def get_expired_environments(
+        self, current_ts: int, name: t.Optional[str] = None
+    ) -> t.List[EnvironmentSummary]:
         """Returns the expired environments.
 
         Expired environments are environments that have exceeded their time-to-live value.
+
+        Args:
+            current_ts: The current timestamp in milliseconds used to determine expiration.
+            name: If provided, only the environment with this name is considered.
+
         Returns:
             The list of environment summaries to remove.
         """
@@ -436,11 +443,15 @@ class StateSync(StateReader, abc.ABC):
 
     @abc.abstractmethod
     def delete_expired_environments(
-        self, current_ts: t.Optional[int] = None
+        self, current_ts: t.Optional[int] = None, name: t.Optional[str] = None
     ) -> t.List[EnvironmentSummary]:
         """Removes expired environments.
 
         Expired environments are environments that have exceeded their time-to-live value.
+
+        Args:
+            current_ts: The current timestamp in milliseconds. Defaults to now.
+            name: If provided, only the environment with this name is deleted.
 
         Returns:
             The list of removed environments.

--- a/sqlmesh/core/state_sync/db/environment.py
+++ b/sqlmesh/core/state_sync/db/environment.py
@@ -181,10 +181,9 @@ class EnvironmentState:
         Returns:
             The list of environment summaries to remove.
         """
-        where: exp.Expr = self._create_expiration_filter_expr(current_ts)
-        if name is not None:
-            where = exp.and_(t.cast(exp.Condition, where), exp.column("name").eq(name))
-        return self._fetch_environment_summaries(where=where)
+        return self._fetch_environment_summaries(
+            where=self._create_expiration_filter_expr(current_ts, name=name)
+        )
 
     def delete_expired_environments(
         self, current_ts: t.Optional[int] = None, name: t.Optional[str] = None
@@ -201,12 +200,9 @@ class EnvironmentState:
         current_ts = current_ts or now_timestamp()
         expired_environments = self.get_expired_environments(current_ts=current_ts, name=name)
 
-        where: exp.Expr = self._create_expiration_filter_expr(current_ts)
-        if name is not None:
-            where = exp.and_(t.cast(exp.Condition, where), exp.column("name").eq(name))
         self.engine_adapter.delete_from(
             self.environments_table,
-            where=where,
+            where=self._create_expiration_filter_expr(current_ts, name=name),
         )
 
         # Delete the expired environments' corresponding environment statements
@@ -325,16 +321,22 @@ class EnvironmentState:
             return query.lock(copy=False)
         return query
 
-    def _create_expiration_filter_expr(self, current_ts: int) -> exp.Expr:
+    def _create_expiration_filter_expr(
+        self, current_ts: int, name: t.Optional[str] = None
+    ) -> exp.Expr:
         """Creates a SQLGlot filter expression to find expired environments.
 
         Args:
             current_ts: The current timestamp.
+            name: If provided, adds an equality filter on the environment name.
         """
-        return exp.LTE(
+        where: exp.Expr = exp.LTE(
             this=exp.column("expiration_ts"),
             expression=exp.Literal.number(current_ts),
         )
+        if name is not None:
+            where = exp.and_(t.cast(exp.Condition, where), exp.column("name").eq(name))
+        return where
 
     def _fetch_environment_summaries(
         self, where: t.Optional[str | exp.Expr] = None

--- a/sqlmesh/core/state_sync/db/environment.py
+++ b/sqlmesh/core/state_sync/db/environment.py
@@ -167,31 +167,46 @@ class EnvironmentState:
             where=environment_filter,
         )
 
-    def get_expired_environments(self, current_ts: int) -> t.List[EnvironmentSummary]:
+    def get_expired_environments(
+        self, current_ts: int, name: t.Optional[str] = None
+    ) -> t.List[EnvironmentSummary]:
         """Returns the expired environments.
 
         Expired environments are environments that have exceeded their time-to-live value.
+
+        Args:
+            current_ts: The current timestamp in milliseconds used to determine expiration.
+            name: If provided, only the environment with this name is considered.
+
         Returns:
             The list of environment summaries to remove.
         """
-        return self._fetch_environment_summaries(
-            where=self._create_expiration_filter_expr(current_ts)
-        )
+        where: exp.Expr = self._create_expiration_filter_expr(current_ts)
+        if name is not None:
+            where = exp.and_(t.cast(exp.Condition, where), exp.column("name").eq(name))
+        return self._fetch_environment_summaries(where=where)
 
     def delete_expired_environments(
-        self, current_ts: t.Optional[int] = None
+        self, current_ts: t.Optional[int] = None, name: t.Optional[str] = None
     ) -> t.List[EnvironmentSummary]:
         """Deletes expired environments.
+
+        Args:
+            current_ts: The current timestamp in milliseconds. Defaults to now.
+            name: If provided, only the environment with this name is deleted.
 
         Returns:
             A list of deleted environments.
         """
         current_ts = current_ts or now_timestamp()
-        expired_environments = self.get_expired_environments(current_ts=current_ts)
+        expired_environments = self.get_expired_environments(current_ts=current_ts, name=name)
 
+        where: exp.Expr = self._create_expiration_filter_expr(current_ts)
+        if name is not None:
+            where = exp.and_(t.cast(exp.Condition, where), exp.column("name").eq(name))
         self.engine_adapter.delete_from(
             self.environments_table,
-            where=self._create_expiration_filter_expr(current_ts),
+            where=where,
         )
 
         # Delete the expired environments' corresponding environment statements

--- a/sqlmesh/core/state_sync/db/facade.py
+++ b/sqlmesh/core/state_sync/db/facade.py
@@ -276,8 +276,10 @@ class EngineAdapterStateSync(StateSync):
             batch_range=batch_range,
         )
 
-    def get_expired_environments(self, current_ts: int) -> t.List[EnvironmentSummary]:
-        return self.environment_state.get_expired_environments(current_ts=current_ts)
+    def get_expired_environments(
+        self, current_ts: int, name: t.Optional[str] = None
+    ) -> t.List[EnvironmentSummary]:
+        return self.environment_state.get_expired_environments(current_ts=current_ts, name=name)
 
     @transactional()
     def delete_expired_snapshots(
@@ -297,10 +299,10 @@ class EngineAdapterStateSync(StateSync):
 
     @transactional()
     def delete_expired_environments(
-        self, current_ts: t.Optional[int] = None
+        self, current_ts: t.Optional[int] = None, name: t.Optional[str] = None
     ) -> t.List[EnvironmentSummary]:
         current_ts = current_ts or now_timestamp()
-        return self.environment_state.delete_expired_environments(current_ts=current_ts)
+        return self.environment_state.delete_expired_environments(current_ts=current_ts, name=name)
 
     def delete_snapshots(self, snapshot_ids: t.Iterable[SnapshotIdLike]) -> None:
         self.snapshot_state.delete_snapshots(snapshot_ids)

--- a/tests/core/state_sync/test_state_sync.py
+++ b/tests/core/state_sync/test_state_sync.py
@@ -1140,6 +1140,177 @@ def test_delete_expired_environments(state_sync: EngineAdapterStateSync, make_sn
     assert state_sync.get_environment_statements(env_a.name) == []
 
 
+def test_get_expired_environments_filtered_by_name(
+    state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
+):
+    snapshot = make_snapshot(
+        SqlModel(
+            name="a",
+            query=parse_one("select a, ds"),
+        ),
+    )
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+    state_sync.push_snapshots([snapshot])
+
+    now_ts = now_timestamp()
+
+    env_a = Environment(
+        name="test_env_a",
+        snapshots=[snapshot.table_info],
+        start_at="2022-01-01",
+        end_at="2022-01-01",
+        plan_id="test_plan_id",
+        previous_plan_id="test_plan_id",
+        expiration_ts=now_ts - 1000,
+    )
+    env_b = env_a.copy(update={"name": "test_env_b", "expiration_ts": now_ts - 500})
+    env_c = env_a.copy(update={"name": "test_env_c", "expiration_ts": now_ts + 1000})
+
+    state_sync.promote(env_a)
+    state_sync.promote(env_b)
+    state_sync.promote(env_c)
+
+    # Both env_a and env_b are expired, but only env_a is returned when filtering by name
+    expired_all = state_sync.get_expired_environments(current_ts=now_ts)
+    assert {e.name for e in expired_all} == {"test_env_a", "test_env_b"}
+
+    expired_filtered = state_sync.get_expired_environments(current_ts=now_ts, name="test_env_a")
+    assert [e.name for e in expired_filtered] == ["test_env_a"]
+
+    expired_non_expired = state_sync.get_expired_environments(current_ts=now_ts, name="test_env_c")
+    assert expired_non_expired == []
+
+
+def test_delete_expired_environments_filtered_by_name(
+    state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
+):
+    snapshot = make_snapshot(
+        SqlModel(
+            name="a",
+            query=parse_one("select a, ds"),
+        ),
+    )
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+    state_sync.push_snapshots([snapshot])
+
+    now_ts = now_timestamp()
+
+    env_a = Environment(
+        name="test_env_a",
+        snapshots=[snapshot.table_info],
+        start_at="2022-01-01",
+        end_at="2022-01-01",
+        plan_id="test_plan_id",
+        previous_plan_id="test_plan_id",
+        expiration_ts=now_ts - 1000,
+    )
+    env_b = env_a.copy(update={"name": "test_env_b", "expiration_ts": now_ts - 500})
+
+    state_sync.promote(env_a)
+    state_sync.promote(env_b)
+
+    # Delete only env_a by name; env_b should survive
+    deleted = state_sync.delete_expired_environments(name="test_env_a")
+    assert [e.name for e in deleted] == ["test_env_a"]
+
+    assert state_sync.get_environment("test_env_a") is None
+    assert state_sync.get_environment("test_env_b") is not None
+
+
+def test_get_expired_environments_nonexistent_name(
+    state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
+):
+    """get_expired_environments with a name that does not exist returns an empty list without error."""
+    now_ts = now_timestamp()
+    result = state_sync.get_expired_environments(current_ts=now_ts, name="nonexistent_env")
+    assert result == []
+
+
+def test_delete_expired_environments_non_expired_name_is_not_deleted(
+    state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
+):
+    """delete_expired_environments with a name whose expiration_ts is in the future does not delete it."""
+    snapshot = make_snapshot(
+        SqlModel(
+            name="a",
+            query=parse_one("select a, ds"),
+        ),
+    )
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+    state_sync.push_snapshots([snapshot])
+
+    now_ts = now_timestamp()
+
+    env = Environment(
+        name="non_expired_env",
+        snapshots=[snapshot.table_info],
+        start_at="2022-01-01",
+        end_at="2022-01-01",
+        plan_id="test_plan_id",
+        previous_plan_id="test_plan_id",
+        expiration_ts=now_ts + 100_000,  # far future
+    )
+    state_sync.promote(env)
+
+    deleted = state_sync.delete_expired_environments(current_ts=now_ts, name="non_expired_env")
+    assert deleted == []
+    assert state_sync.get_environment("non_expired_env") is not None
+
+
+def test_invalidate_environment_sync_does_not_delete_sibling_expired_envs(
+    state_sync: EngineAdapterStateSync, make_snapshot: t.Callable
+):
+    """invalidate_environment does not delete sibling environments that are already expired.
+
+    When sync=True, _cleanup_environments is called with name=<target> so only the
+    named environment is removed — other expired environments are left for the next
+    janitor run.
+    """
+    snapshot = make_snapshot(
+        SqlModel(
+            name="a",
+            query=parse_one("select a, ds"),
+        ),
+    )
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+    state_sync.push_snapshots([snapshot])
+
+    now_ts = now_timestamp()
+
+    # env_sibling is already expired before we even start
+    env_sibling = Environment(
+        name="sibling_env",
+        snapshots=[snapshot.table_info],
+        start_at="2022-01-01",
+        end_at="2022-01-01",
+        plan_id="test_plan_id",
+        previous_plan_id="test_plan_id",
+        expiration_ts=now_ts - 1000,
+    )
+    # env_target will be invalidated (expiration set to now) and then cleaned up
+    env_target = Environment(
+        name="target_env",
+        snapshots=[snapshot.table_info],
+        start_at="2022-01-01",
+        end_at="2022-01-01",
+        plan_id="test_plan_id",
+        previous_plan_id="test_plan_id",
+        expiration_ts=now_ts + 100_000,
+    )
+
+    state_sync.promote(env_sibling)
+    state_sync.promote(env_target)
+
+    # Simulate the sync=True path: invalidate then clean up only target_env
+    state_sync.invalidate_environment("target_env")
+    state_sync.delete_expired_environments(name="target_env")
+
+    # target_env is gone
+    assert state_sync.get_environment("target_env") is None
+    # sibling_env was already expired but was NOT touched by the targeted cleanup
+    assert state_sync.get_environment("sibling_env") is not None
+
+
 def test_delete_expired_snapshots(state_sync: EngineAdapterStateSync, make_snapshot: t.Callable):
     now_ts = now_timestamp()
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1171,6 +1171,38 @@ def test_janitor_environment_not_expired_warning(sushi_context, mocker: MockerFi
 
 
 @pytest.mark.slow
+def test_invalidate_environment_sync_calls_cleanup_with_name(
+    sushi_context, mocker: MockerFixture
+) -> None:
+    """invalidate_environment(..., sync=True) must pass name= to _cleanup_environments so only the
+    target environment is deleted, not all expired environments."""
+    state_sync_mock = mocker.patch.object(
+        type(sushi_context), "state_sync", new_callable=mocker.PropertyMock
+    ).return_value
+    state_sync_mock.get_expired_environments.return_value = []
+
+    sushi_context.invalidate_environment("dev", sync=True)
+
+    state_sync_mock.invalidate_environment.assert_called_once_with("dev")
+    state_sync_mock.delete_expired_environments.assert_called_once()
+    _, kwargs = state_sync_mock.delete_expired_environments.call_args
+    assert kwargs.get("name") == "dev"
+
+
+@pytest.mark.slow
+def test_invalidate_environment_no_sync_skips_cleanup(sushi_context, mocker: MockerFixture) -> None:
+    """invalidate_environment(..., sync=False) should not trigger _cleanup_environments at all."""
+    state_sync_mock = mocker.patch.object(
+        type(sushi_context), "state_sync", new_callable=mocker.PropertyMock
+    ).return_value
+
+    sushi_context.invalidate_environment("dev", sync=False)
+
+    state_sync_mock.invalidate_environment.assert_called_once_with("dev")
+    state_sync_mock.delete_expired_environments.assert_not_called()
+
+
+@pytest.mark.slow
 def test_plan_default_end(sushi_context_pre_scheduling: Context):
     prod_plan_builder = sushi_context_pre_scheduling.plan_builder("prod")
     # Simulate that the prod is 3 days behind.

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1098,6 +1098,79 @@ def test_janitor(sushi_context, mocker: MockerFixture) -> None:
 
 
 @pytest.mark.slow
+def test_janitor_environment_filter(sushi_context, mocker: MockerFixture) -> None:
+    """Janitor with --environment only cleans up the named environment."""
+    env_target = Environment(
+        name="target_env",
+        suffix_target=EnvironmentSuffixTarget.TABLE,
+        snapshots=[x.table_info for x in sushi_context.snapshots.values()],
+        start_at="2022-01-01",
+        end_at="2022-01-01",
+        plan_id="test_plan_id",
+        previous_plan_id="test_plan_id",
+    )
+    env_other = Environment(
+        name="other_env",
+        suffix_target=EnvironmentSuffixTarget.TABLE,
+        snapshots=[x.table_info for x in sushi_context.snapshots.values()],
+        start_at="2022-01-01",
+        end_at="2022-01-01",
+        plan_id="test_plan_id",
+        previous_plan_id="test_plan_id",
+    )
+
+    all_envs = [env_target, env_other]
+
+    # Patch the state_sync property on the context so we can assert on calls without
+    # touching private attributes (_engine_adapter, _state_sync).
+    state_sync_mock = mocker.patch.object(
+        type(sushi_context), "state_sync", new_callable=mocker.PropertyMock
+    ).return_value
+
+    def get_expired(current_ts: int, name: t.Optional[str] = None) -> t.List:
+        if name is not None:
+            return [e.summary for e in all_envs if e.name == name]
+        return [e.summary for e in all_envs]
+
+    state_sync_mock.get_expired_environments.side_effect = get_expired
+    state_sync_mock.get_environment.side_effect = lambda name: next(
+        (e for e in all_envs if e.name == name), None
+    )
+
+    sushi_context._run_janitor(environment="target_env")
+
+    # get_expired_environments must be called with name="target_env"
+    state_sync_mock.get_expired_environments.assert_called_once()
+    _, kwargs = state_sync_mock.get_expired_environments.call_args
+    assert kwargs.get("name") == "target_env"
+
+    # delete_expired_environments must also be called with name="target_env"
+    state_sync_mock.delete_expired_environments.assert_called_once()
+    _, del_kwargs = state_sync_mock.delete_expired_environments.call_args
+    assert del_kwargs.get("name") == "target_env"
+
+    # Global operations (snapshots + compaction) are skipped when targeting a specific environment
+    state_sync_mock.get_expired_snapshots.assert_not_called()
+    state_sync_mock.compact_intervals.assert_not_called()
+
+
+@pytest.mark.slow
+def test_janitor_environment_not_expired_warning(sushi_context, mocker: MockerFixture) -> None:
+    """Janitor with --environment emits a warning when the named environment is not expired."""
+    state_sync_mock = mocker.patch.object(
+        type(sushi_context), "state_sync", new_callable=mocker.PropertyMock
+    ).return_value
+    state_sync_mock.get_expired_environments.return_value = []
+
+    warning_mock = mocker.patch.object(sushi_context.console, "log_warning")
+
+    sushi_context._run_janitor(environment="nonexistent_env")
+
+    warning_mock.assert_called_once()
+    assert "nonexistent_env" in warning_mock.call_args[0][0]
+
+
+@pytest.mark.slow
 def test_plan_default_end(sushi_context_pre_scheduling: Context):
     prod_plan_builder = sushi_context_pre_scheduling.plan_builder("prod")
     # Simulate that the prod is 3 days behind.


### PR DESCRIPTION
## Description

Add an `--environment` / `-e` flag to `sqlmesh janitor` that scopes cleanup to a single named environment, and fix `sqlmesh invalidate <env> --sync` to only clean up the named environment rather than all currently-expired environments.

**New flag**: `sqlmesh janitor --environment <name>` removes views, schemas, and state records for the named environment only. If the environment is not expired or does not exist, a warning is emitted. Global snapshot expiration and interval compaction are skipped when this flag is set — those operations are cross-environment and cannot be safely scoped to a single one.

**Bug fix**: `sqlmesh invalidate <env> --sync` previously called `_cleanup_environments()` with no filter after marking the target environment expired, which caused all other currently-expired environments to be deleted as a side effect. It now scopes the cleanup to the named environment only.

## Test Plan

- Tested manually against the sushi example project using `--gateway duckdb_persistent` with two environments (`dev1`, `dev2`). Invalidating `dev1` and running `sqlmesh janitor --environment dev1` cleaned up `dev1` while leaving `dev2` untouched.
- Verified the warning message fires when targeting an environment that is not expired or does not exist.
- Added state sync tests for name-filtered expiration and deletion (`test_state_sync.py`).
- Added Context-level tests verifying `invalidate_environment(..., sync=True)` passes `name=` to `_cleanup_environments` and that `sync=False` skips cleanup entirely (`test_context.py`).

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)