### PR TITLE
fix(clickhouse): combine physical_properties into one SETTINGS clause

### DIFF
--- a/sqlmesh/core/engine_adapter/clickhouse.py
+++ b/sqlmesh/core/engine_adapter/clickhouse.py
@@ -716,8 +716,12 @@ class ClickhouseEngineAdapter(EngineAdapterWithIndexSupport, LogicalMergeMixin):
         return query
 
     def _build_settings_property(
-        self, key: str, value: exp.Expr | str | int | float
+        self, settings: t.Mapping[str, exp.Expr | str | int | float]
     ) -> exp.SettingsProperty:
+        # ClickHouse requires every key=value pair to live under a single
+        # SETTINGS clause (`SETTINGS a = 1, b = 2`). Emitting one
+        # SettingsProperty per pair produces repeated SETTINGS keywords and a
+        # syntax error at execution time.
         return exp.SettingsProperty(
             expressions=[
                 exp.EQ(
@@ -726,6 +730,7 @@ class ClickhouseEngineAdapter(EngineAdapterWithIndexSupport, LogicalMergeMixin):
                     if isinstance(value, exp.Expr)
                     else exp.Literal(this=value, is_string=isinstance(value, str)),
                 )
+                for key, value in settings.items()
             ]
         )
 
@@ -827,9 +832,7 @@ class ClickhouseEngineAdapter(EngineAdapterWithIndexSupport, LogicalMergeMixin):
             properties.append(exp.EmptyProperty())
 
         if table_properties_copy:
-            properties.extend(
-                [self._build_settings_property(k, v) for k, v in table_properties_copy.items()]
-            )
+            properties.append(self._build_settings_property(table_properties_copy))
 
         if table_description:
             properties.append(
@@ -858,9 +861,7 @@ class ClickhouseEngineAdapter(EngineAdapterWithIndexSupport, LogicalMergeMixin):
             properties.append(exp.OnCluster(this=exp.to_identifier(self.cluster)))
 
         if view_properties_copy:
-            properties.extend(
-                [self._build_settings_property(k, v) for k, v in view_properties_copy.items()]
-            )
+            properties.append(self._build_settings_property(view_properties_copy))
 
         if table_description:
             properties.append(

--- a/tests/core/engine_adapter/test_clickhouse.py
+++ b/tests/core/engine_adapter/test_clickhouse.py
@@ -316,13 +316,32 @@ def test_model_properties(adapter: ClickhouseEngineAdapter):
         == "ENGINE=MergeTree ORDER BY (a, b + 1) PRIMARY KEY (a, b)"
     )
 
+    # Multiple physical_properties must be combined into a single comma-separated
+    # SETTINGS clause. ClickHouse rejects repeated SETTINGS keywords with a syntax
+    # error (see https://github.com/SQLMesh/sqlmesh/issues/5803).
     assert (
         build_properties_sql(
             order_by="ORDER_BY = (a, b + 1),",
             primary_key="PRIMARY_KEY = (a, b),",
             properties="PROP1 = 1, PROP2 = '2'",
         )
-        == "ENGINE=MergeTree ORDER BY (a, b + 1) PRIMARY KEY (a, b) SETTINGS prop1 = 1 SETTINGS prop2 = '2'"
+        == "ENGINE=MergeTree ORDER BY (a, b + 1) PRIMARY KEY (a, b) SETTINGS prop1 = 1, prop2 = '2'"
+    )
+
+    # Regression test for #5803: three or more SETTINGS entries also combine.
+    assert (
+        build_properties_sql(
+            order_by="ORDER_BY = (orders_id),",
+            properties=(
+                "min_age_to_force_merge_seconds = 3600, "
+                "min_age_to_force_merge_on_partition_only = 1, "
+                "index_granularity = 8192"
+            ),
+        )
+        == "ENGINE=MergeTree ORDER BY (orders_id) "
+        "SETTINGS min_age_to_force_merge_seconds = 3600, "
+        "min_age_to_force_merge_on_partition_only = 1, "
+        "index_granularity = 8192"
     )
 
     assert (
@@ -343,6 +362,20 @@ def test_model_properties(adapter: ClickhouseEngineAdapter):
         build_properties_sql(properties="TTL = time + INTERVAL 1 WEEK")
         == "ENGINE=MergeTree ORDER BY () TTL time + INTERVAL '1' WEEK"
     )
+
+
+def test_view_properties_combine_settings(adapter: ClickhouseEngineAdapter):
+    # View properties hit the same SettingsProperty code path as table
+    # properties (#5803): multiple entries must collapse into one SETTINGS
+    # clause rather than emit repeated SETTINGS keywords.
+    view_properties_exp = adapter._build_view_properties_exp(
+        view_properties={
+            "prop1": exp.Literal.number(1),
+            "prop2": exp.Literal.string("2"),
+        }
+    )
+    assert view_properties_exp is not None
+    assert view_properties_exp.sql("clickhouse") == "SETTINGS prop1 = 1, prop2 = '2'"
 
 
 def test_partitioned_by_expr(make_mocked_engine_adapter: t.Callable):


### PR DESCRIPTION
## Description

Fixes #5803.

A ClickHouse model that declared more than one `physical_properties` entry produced SQL with repeated `SETTINGS` keywords, e.g.

```sql
SETTINGS min_age_to_force_merge_seconds = 3600 SETTINGS min_age_to_force_merge_on_partition_only = 1
```

ClickHouse rejects this with a syntax error. The valid form is a single comma-separated clause:

```sql
SETTINGS min_age_to_force_merge_seconds = 3600, min_age_to_force_merge_on_partition_only = 1
```

### Root cause

In `ClickhouseEngineAdapter._build_table_properties_exp` (and the analogous `_build_view_properties_exp`), every leftover `table_properties_copy` / `view_properties_copy` entry was wrapped in its own `exp.SettingsProperty` and added to the property list. sqlglot renders each `SettingsProperty` as a separate `SETTINGS …` keyword, so N settings became N independent clauses.

### Fix

Refactor `_build_settings_property` to accept the full settings mapping and emit a single `SettingsProperty` whose `expressions` list holds one `exp.EQ(...)` per key=value pair. Both the table and view paths now call it once with the entire dict and `append` the resulting property, producing the expected `SETTINGS k1 = v1, k2 = v2, …` output.

The behavior for a single setting is unchanged — a one-entry `SettingsProperty` still renders as `SETTINGS k = v`.

## Test Plan

- Updated the existing `test_model_properties` assertion that pinned the broken `SETTINGS prop1 = 1 SETTINGS prop2 = '2'` output; it now expects the combined form.
- Added a three-entry regression test inside `test_model_properties` that mirrors the model from the issue report (`min_age_to_force_merge_seconds`, `min_age_to_force_merge_on_partition_only`, `index_granularity`) to guard against the failure mode beyond N=2.
- Added a new `test_view_properties_combine_settings` that exercises `_build_view_properties_exp` directly, since the same bug existed there and had no unit-test coverage.
- Verified the rendered SQL with `sqlglot` matches ClickHouse's accepted syntax.
- `pytest tests/core/engine_adapter/` — 517 passed, 1 skipped, no regressions.
- `ruff check` and `mypy` clean on the modified files.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
