### PR TITLE
Removed a redundant line that fails the test

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -308,7 +308,6 @@ class ModelTest(unittest.TestCase):
                 expected,
                 actual,
                 check_dtype=False,
-                check_datetimelike_compat=True,
                 check_like=True,  # Ignore column order
             )
         except AssertionError as e:


### PR DESCRIPTION
## Description
A CI style test has been failing. 

Cause
- CI runs mypy on Python 3.11+ (your log shows .venv on 3.13). For those versions, the lockfile resolves pandas-stubs 3.x (3.0.3.260530), which matches pandas 3.0 typing and no longer declares check_datetimelike_compat on assert_frame_equal. The runtime dependency is still pandas<3.0.0, but the call in definition.py uses a kwarg that the newer stubs dropped:
- 
Solution 
- The safest one-line fix is to drop check_datetimelike_compat=True. It’s redundant here: just before assert_frame_equal, the code already normalizes datetime-like values via _to_hashable, which converts them to strings:

Test 
- Ran make style locally and passed

## Test Plan

<!-- How were these changes tested? -->

## Checklist

- [ ] I have run `make style` and fixed any issues
- [ ] I have added tests for my changes (if applicable)
- [ ] All existing tests pass (`make fast-test`)
- [ ] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
