### PR TITLE
Fix and polish seed warnings in tests

### DIFF
--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -407,7 +407,7 @@ class SnowflakeEngineAdapter(
             elif isinstance(df, pd.DataFrame):
                 from snowflake.connector.pandas_tools import write_pandas
 
-                ordered_df = df[list(source_columns_to_types)]
+                ordered_df = df[list(source_columns_to_types)].reset_index(drop=True)
 
                 # Workaround for https://github.com/snowflakedb/snowflake-connector-python/issues/1034
                 # The above issue has already been fixed upstream, but we keep the following

--- a/sqlmesh/core/model/seed.py
+++ b/sqlmesh/core/model/seed.py
@@ -113,7 +113,7 @@ class CsvSeedReader:
         batch_size = batch_size or df.size
         batch_start = 0
         while batch_start < df.shape[0]:
-            yield df.iloc[batch_start : batch_start + batch_size, :]
+            yield df.iloc[batch_start : batch_start + batch_size, :].copy()
             batch_start += batch_size
 
     def _get_df(self) -> pd.DataFrame:

--- a/tests/core/engine_adapter/test_snowflake.py
+++ b/tests/core/engine_adapter/test_snowflake.py
@@ -469,6 +469,26 @@ def test_df_to_source_queries_use_schema(
     assert 'USE SCHEMA "other_catalog"."other_db"' in to_sql_calls(adapter)
 
 
+def test_df_to_source_queries_reset_non_default_index(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture
+):
+    mocker.patch(
+        "sqlmesh.core.engine_adapter.snowflake.SnowflakeEngineAdapter.table_exists",
+        return_value=False,
+    )
+    write_pandas = mocker.patch("snowflake.connector.pandas_tools.write_pandas", return_value=None)
+    adapter = make_mocked_engine_adapter(SnowflakeEngineAdapter)
+
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).iloc[1:]
+    adapter.replace_query(
+        "other_db.test_table", df, {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")}
+    )
+
+    uploaded_df = write_pandas.call_args.args[1]
+    assert uploaded_df.index.equals(pd.RangeIndex(start=0, stop=2, step=1))
+    assert uploaded_df.to_dict("list") == {"a": [2, 3], "b": [5, 6]}
+
+
 def test_create_managed_table(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(SnowflakeEngineAdapter)
 

--- a/tests/core/engine_adapter/test_snowflake.py
+++ b/tests/core/engine_adapter/test_snowflake.py
@@ -479,7 +479,7 @@ def test_df_to_source_queries_reset_non_default_index(
     write_pandas = mocker.patch("snowflake.connector.pandas_tools.write_pandas", return_value=None)
     adapter = make_mocked_engine_adapter(SnowflakeEngineAdapter)
 
-    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).iloc[1:]
+    df = pd.DataFrame({"a": [2, 3], "b": [5, 6]}, index=[1, 2])
     adapter.replace_query(
         "other_db.test_table", df, {"a": exp.DataType.build("INT"), "b": exp.DataType.build("INT")}
     )

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1,7 +1,7 @@
 # ruff: noqa: F811
 import json
-import typing as t
 import re
+import typing as t
 from datetime import date, datetime
 from pathlib import Path
 from unittest.mock import patch, PropertyMock
@@ -1535,6 +1535,33 @@ def test_seed_model_custom_types(tmp_path):
 
     assert df["empty_date"].dtype == "object"
     assert df["empty_date"].iloc[0] is None
+
+
+def test_seed_model_batched_render_returns_independent_dataframes(tmp_path):
+    model_csv_path = (tmp_path / "model.csv").absolute()
+
+    with open(model_csv_path, "w", encoding="utf-8") as fd:
+        fd.write(
+            """key,value
+1,one
+2,two
+"""
+        )
+
+    model = create_seed_model(
+        "test_db.test_model",
+        SeedKind(path=str(model_csv_path), batch_size=1),
+        columns={
+            "key": "int",
+            "value": "text",
+        },
+    )
+
+    batches = list(model.render_seed())
+    batches[0].iloc[0, 1] = "changed"
+
+    assert [df["value"].tolist() for df in batches] == [["changed"], ["two"]]
+    assert model.seed.reader()._get_df()["value"].tolist() == ["one", "two"]
 
 
 def test_seed_with_special_characters_in_column(tmp_path, assert_exp_eq):

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1537,33 +1537,6 @@ def test_seed_model_custom_types(tmp_path):
     assert df["empty_date"].iloc[0] is None
 
 
-def test_seed_model_batched_render_returns_independent_dataframes(tmp_path):
-    model_csv_path = (tmp_path / "model.csv").absolute()
-
-    with open(model_csv_path, "w", encoding="utf-8") as fd:
-        fd.write(
-            """key,value
-1,one
-2,two
-"""
-        )
-
-    model = create_seed_model(
-        "test_db.test_model",
-        SeedKind(path=str(model_csv_path), batch_size=1),
-        columns={
-            "key": "int",
-            "value": "text",
-        },
-    )
-
-    batches = list(model.render_seed())
-    batches[0].iloc[0, 1] = "changed"
-
-    assert [df["value"].tolist() for df in batches] == [["changed"], ["two"]]
-    assert model.seed.reader()._get_df()["value"].tolist() == ["one", "two"]
-
-
 def test_seed_with_special_characters_in_column(tmp_path, assert_exp_eq):
     config = Config(model_defaults=ModelDefaultsConfig(dialect="duckdb"))
     context = Context(config=config)

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1,7 +1,7 @@
 # ruff: noqa: F811
 import json
-import re
 import typing as t
+import re
 from datetime import date, datetime
 from pathlib import Path
 from unittest.mock import patch, PropertyMock

--- a/tests/core/test_seed.py
+++ b/tests/core/test_seed.py
@@ -58,6 +58,21 @@ def test_read_custom_settings():
     pd.testing.assert_frame_equal(next(dfs), expected_df)
 
 
+def test_read_returns_independent_batches():
+    content = """key,value
+1,one
+2,two
+"""
+    seed = Seed(content=content)
+    seed_reader = seed.reader()
+
+    batches = list(seed_reader.read(batch_size=1))
+    batches[0].loc[batches[0].index[0], "value"] = "changed"
+
+    assert [df["value"].tolist() for df in batches] == [["changed"], ["two"]]
+    assert next(seed_reader.read())["value"].tolist() == ["one", "two"]
+
+
 def test_column_hashes():
     content = """key,value,ds
 1,one,2022-01-01

--- a/tests/core/test_seed.py
+++ b/tests/core/test_seed.py
@@ -67,7 +67,7 @@ def test_read_returns_independent_batches():
     seed_reader = seed.reader()
 
     batches = list(seed_reader.read(batch_size=1))
-    batches[0].loc[batches[0].index[0], "value"] = "changed"
+    batches[0].at[0, "value"] = "changed"
 
     assert [df["value"].tolist() for df in batches] == [["changed"], ["two"]]
     assert next(seed_reader.read())["value"].tolist() == ["one", "two"]


### PR DESCRIPTION
## Description

This PR fixes two DataFrame handling issues that made the warning fixes incomplete and hard to verify.

The first issue was in seed batch reading. CsvSeedReader.read() was yielding slices of the original DataFrame without copying them. In practice, that meant a consumer could mutate one returned batch and accidentally affect later reads from the same seed. For example, if the first batch changed a value after being returned, a later full read could reflect that mutation even though the seed content itself had not changed. That makes the behavior fragile and can also make warning-related regressions difficult to reason about because the returned batches are not actually isolated.

The solution is to return a copy of each batch instead of the slice itself. With that change, each batch is independent. Mutating one returned batch no longer changes subsequent batches or later reads from the same seed source.

The second issue was in the Snowflake DataFrame upload path. When SQLMesh prepared a pandas DataFrame for write_pandas, it preserved any existing non-default index from the source DataFrame. For example, a DataFrame with row labels [1, 2] would be passed through with that index intact. Even though the upload logic only intends to load the declared columns, carrying a custom index into the Snowflake write path is unnecessary and can lead to warning-prone or inconsistent behavior.

The fix is to normalize the DataFrame before upload by preserving the declared column order and resetting the index with drop=True. As a result, Snowflake now receives a clean DataFrame with the expected columns and a standard RangeIndex, regardless of how the input DataFrame was indexed.

## Test Plan

The accompanying tests demonstrate both cases directly. The seed test shows that modifying one returned batch no longer leaks into other batches or later reads. The Snowflake test shows that a DataFrame with a non-default index is normalized before write_pandas is called, while the row data and column order remain unchanged.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
