### PR TITLE
fix(dbt): preserve source identifier quoting when it contains dots or spaces

### DIFF
--- a/sqlmesh/dbt/source.py
+++ b/sqlmesh/dbt/source.py
@@ -82,10 +82,13 @@ class SourceConfig(GeneralConfig):
                     f"'source' macro failed for '{self.config_name}' with exception '{e}'."
                 )
 
+            needs_identifier_quoting = bool(
+                self.table_name and ("." in self.table_name or " " in self.table_name)
+            )
             relation = relation.quote(
                 database=False,
                 schema=False,
-                identifier=False,
+                identifier=needs_identifier_quoting,
             )
             if relation.database == context.target.database:
                 relation = relation.include(database=False)

--- a/sqlmesh/dbt/source.py
+++ b/sqlmesh/dbt/source.py
@@ -82,9 +82,8 @@ class SourceConfig(GeneralConfig):
                     f"'source' macro failed for '{self.config_name}' with exception '{e}'."
                 )
 
-            needs_identifier_quoting = bool(
-                self.table_name and ("." in self.table_name or " " in self.table_name)
-            )
+            identifier = relation.identifier or ""
+            needs_identifier_quoting = "." in identifier or " " in identifier
             relation = relation.quote(
                 database=False,
                 schema=False,

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -521,6 +521,71 @@ def test_quoting():
     assert str(BaseRelation.create(**source.relation_info)) == 'foo."bar"'
 
 
+def test_source_canonical_name_with_dots_and_spaces(mocker):
+    from dbt.adapters.base import BaseRelation
+
+    mock_context = mocker.Mock()
+    mock_context.target.database = "target_db"
+
+    def mock_source_macro(source_name, table_name):
+        if table_name == "my_table_dot":
+            identifier = "FILENAME.CSV"
+        elif table_name == "my_table_space":
+            identifier = "my table space"
+        else:
+            identifier = "my_table_std"
+        return BaseRelation.create(
+            database="RAW_DEV",
+            schema="raw_schema",
+            identifier=identifier,
+        )
+
+    mock_context.get_callable_macro.return_value = mock_source_macro
+
+    # 1. Identifier with a dot
+    source_dot = SourceConfig(
+        name="my_table_dot",
+        source_name="my_source",
+        identifier="FILENAME.CSV",
+    )
+    assert source_dot.canonical_name(mock_context) == 'RAW_DEV.raw_schema."FILENAME.CSV"'
+
+    # 2. Identifier with a space
+    source_space = SourceConfig(
+        name="my_table_space",
+        source_name="my_source",
+        identifier="my table space",
+    )
+    assert source_space.canonical_name(mock_context) == 'RAW_DEV.raw_schema."my table space"'
+
+    # 3. Standard identifier (without dots or spaces) should not be quoted
+    source_std = SourceConfig(
+        name="my_table_std",
+        source_name="my_source",
+        identifier="my_table_std",
+    )
+    assert source_std.canonical_name(mock_context) == "RAW_DEV.raw_schema.my_table_std"
+
+    # 4. Standard identifier, but with database matching target database (to test database omission)
+    mock_context_target_db = mocker.Mock()
+    mock_context_target_db.target.database = "RAW_DEV"
+    mock_context_target_db.get_callable_macro.return_value = mock_source_macro
+
+    source_dot_target = SourceConfig(
+        name="my_table_dot",
+        source_name="my_source",
+        identifier="FILENAME.CSV",
+    )
+    source_std_target = SourceConfig(
+        name="my_table_std",
+        source_name="my_source",
+        identifier="my_table_std",
+    )
+
+    assert source_dot_target.canonical_name(mock_context_target_db) == 'raw_schema."FILENAME.CSV"'
+    assert source_std_target.canonical_name(mock_context_target_db) == "raw_schema.my_table_std"
+
+
 def _test_warehouse_config(
     config_yaml: str, target_class: t.Type[TargetConfig], *params_path: str
 ) -> TargetConfig:


### PR DESCRIPTION
## Problem
When a dbt source table identifier contains a dot (e.g., `"FILENAME.CSV"`) or a space, `SourceConfig.canonical_name()` unconditionally strips the quoting. This renders the canonical name as `database.schema.FILENAME.CSV`. 

When `sqlglot` tries to parse this unquoted string back into an AST, it splits the path by `.` into 4 components, causing a `ValueError: too many values to unpack (expected 3)` and failing to load the project.

## Solution
This PR checks if the resolved table name contains a dot (`.`) or a space (` `), and if so, preserves the quoting for the identifier component during canonicalization. Standard table names remain unquoted and normalized.

## Test Plan
- Added `test_source_canonical_name_with_dots_and_spaces` to `tests/dbt/test_config.py` validating correct quoting behavior for dots, spaces, target database omission, and standard identifiers.
- Ran all dbt config tests successfully (`64 passed`).
- Verified style, formatting, and types with `pre-commit` (`ruff`, `ruff-format`, and `mypy` all passed).
Fixes #5762
