### PR TITLE
fix: interval macro unit

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -745,6 +745,16 @@ def _whens_sql(self: Generator, expression: exp.Whens) -> str:
     return self.wrap(self.expressions(expression, sep=" ", indent=False))
 
 
+def _parse_interval_span(self: Parser, this: exp.Expr) -> exp.Interval:
+    interval = self.__parse_interval_span(this)  # type: ignore
+    # Without this, @unit in `INTERVAL @value @unit` is misread as an alias.
+    if not interval.args.get("unit") and self._match(TokenType.PARAMETER):
+        macro = _parse_macro(self)
+        if macro is not None:
+            interval.set("unit", macro)
+    return interval
+
+
 def _override(klass: t.Type[Tokenizer | Parser], func: t.Callable) -> None:
     name = func.__name__
     setattr(klass, f"_{name}", getattr(klass, name))
@@ -1126,6 +1136,7 @@ def extend_sqlglot() -> None:
     _override(TSQL.Parser, Parser._parse_if)
     _override(Parser, _parse_if)
     _override(Parser, _parse_id_var)
+    _override(Parser, _parse_interval_span)
     _override(Parser, _warn_unsupported)
     _override(Snowflake.Parser, _parse_table_parts)
 

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -291,6 +291,8 @@ def test_macro_format():
     assert parse_one("@EACH(ARRAY(1,2), x -> x)").sql() == "@EACH(ARRAY(1, 2), x -> x)"
     assert parse_one("INTERVAL @x DAY").sql() == "INTERVAL @x DAY"
     assert parse_one("INTERVAL @'@{bar}' DAY").sql() == "INTERVAL @'@{bar}' DAY"
+    assert parse_one("INTERVAL @x @y").sql() == "INTERVAL @x @y"
+    assert parse_one("INTERVAL 1 @y").sql() == "INTERVAL '1' @y"
 
 
 def test_format_body_macros():


### PR DESCRIPTION
## Description

This PR fixes parsing interval spans when the second parameter, unit, is a macro variable. The unit was misread as an alias, e.g. `INTERVAL @value @unit` would be read as `INTERVAL @value AS @unit`.

## Test Plan

A couple of test cases were added.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
