### PR TITLE
Fix dbt source identifiers with dots

### DIFF
--- a/sqlmesh/dbt/source.py
+++ b/sqlmesh/dbt/source.py
@@ -82,10 +82,13 @@ class SourceConfig(GeneralConfig):
                     f"'source' macro failed for '{self.config_name}' with exception '{e}'."
                 )
 
+            needs_identifier_quoting = bool(
+                self.table_name and ("." in self.table_name or " " in self.table_name)
+            )
             relation = relation.quote(
                 database=False,
                 schema=False,
-                identifier=False,
+                identifier=needs_identifier_quoting,
             )
             if relation.database == context.target.database:
                 relation = relation.include(database=False)

--- a/tests/dbt/test_config.py
+++ b/tests/dbt/test_config.py
@@ -521,6 +521,32 @@ def test_quoting():
     assert str(BaseRelation.create(**source.relation_info)) == 'foo."bar"'
 
 
+@pytest.mark.parametrize(
+    ("identifier", "expected"),
+    [
+        ("FILENAME.CSV", 'raw."FILENAME.CSV"'),
+        ("FILE NAME", 'raw."FILE NAME"'),
+    ],
+)
+def test_source_config_canonical_name_quotes_identifier_with_dot_or_space(
+    identifier: str, expected: str
+):
+    context = DbtContext()
+    context.project_name = "test"
+    context.target = DuckDbConfig(name="target", schema="raw")
+
+    source = SourceConfig(
+        name="my_table",
+        source_name="my_source",
+        schema="raw",
+        identifier=identifier,
+        quoting={"identifier": False},
+    )
+    context.sources = {source.config_name: source}
+
+    assert source.canonical_name(context) == expected
+
+
 def _test_warehouse_config(
     config_yaml: str, target_class: t.Type[TargetConfig], *params_path: str
 ) -> TargetConfig:


### PR DESCRIPTION
## Description

Fixes #5762.

Preserves identifier quoting when dbt source identifiers contain dots or spaces so names like `FILENAME.CSV` render as a single quoted identifier instead of being parsed as extra table path segments.

## Test Plan

- `uv run --extra dev --extra web --extra slack --extra dlt --extra lsp make style`
- `uv run --extra dev --extra web --extra slack --extra dlt --extra lsp make fast-test`
- `uv run --extra dbt --with dbt-duckdb --with pytest --with pytest-mock --with pytest-xdist pytest tests/dbt/test_config.py::test_quoting tests/dbt/test_config.py::test_source_config_canonical_name_quotes_identifier_with_dot_or_space -q`

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
