### PR TITLE
fix(dlt): surface underlying error and hint when attaching to pipeline fails

### DIFF
--- a/docs/integrations/dlt.md
+++ b/docs/integrations/dlt.md
@@ -28,12 +28,12 @@ This will create the configuration file and directories, which are found in all 
 
 SQLMesh will also automatically generate models to ingest data from the pipeline incrementally. Incremental loading is ideal for large datasets where recomputing entire tables is resource-intensive. In this case utilizing the [`INCREMENTAL_BY_TIME_RANGE` model kind](../concepts/models/model_kinds.md#incremental_by_time_range). However, these model definitions can be customized to meet your specific project needs.
 
-#### Specify the path to the pipelines directory
+#### Specify the path to the pipelines working directory
 
-The default location for dlt pipelines is `~/.dlt/pipelines/<pipeline_name>`. If your pipelines are in a [different directory](https://dlthub.com/docs/general-usage/pipeline#separate-working-environments-with-pipelines_dir), use the `--dlt-path` argument to specify the path explicitly:
+The default location for dlt pipeline working state is `~/.dlt/pipelines/<pipeline_name>`. If dlt stores your pipeline state in a [different pipelines working directory](https://dlthub.com/docs/general-usage/pipeline#separate-working-environments-with-pipelines_dir), use the `--dlt-path` argument to specify that directory explicitly. This should be the directory where dlt stores pipeline state, not the directory containing your pipeline scripts:
 
 ```bash
-sqlmesh init -t dlt --dlt-pipeline <pipeline-name> --dlt-path <pipelines-directory> dialect
+sqlmesh init -t dlt --dlt-pipeline <pipeline-name> --dlt-path <pipelines-working-directory> dialect
 ```
 
 ### Generating models on demand
@@ -58,10 +58,10 @@ sqlmesh dlt_refresh <pipeline-name> --force
 sqlmesh dlt_refresh <pipeline-name> --table <dlt-table>
 ```
 
-- **Provide the explicit path to the pipelines directory** (using `--dlt-path`):
+- **Provide the explicit path to the pipelines working directory** (using `--dlt-path`):
 
 ```bash
-sqlmesh dlt_refresh <pipeline-name> --dlt-path <pipelines-directory>
+sqlmesh dlt_refresh <pipeline-name> --dlt-path <pipelines-working-directory>
 ```
 
 #### Configuration

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -279,7 +279,8 @@ Options:
                        empty.
   --dlt-pipeline TEXT  DLT pipeline for which to generate a SQLMesh project.
                        Use alongside template: dlt
-  --dlt-path TEXT      The directory where the DLT pipeline resides. Use
+  --dlt-path TEXT      The DLT pipelines working directory, where DLT stores
+                       pipeline state (by default ~/.dlt/pipelines). Use
                        alongside template: dlt
   --help               Show this message and exit.
 ```

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -169,7 +169,7 @@ def cli(
 @click.option(
     "--dlt-path",
     type=str,
-    help="The directory where the DLT pipeline resides. Use alongside template: dlt",
+    help="The DLT pipelines working directory, where DLT stores pipeline state (by default ~/.dlt/pipelines). Use alongside template: dlt",
 )
 @click.pass_context
 @error_handler
@@ -1155,7 +1155,7 @@ def table_name(
 @click.option(
     "--dlt-path",
     type=str,
-    help="The directory where the DLT pipeline resides.",
+    help="The DLT pipelines working directory, where DLT stores pipeline state (by default ~/.dlt/pipelines).",
 )
 @click.pass_context
 @error_handler

--- a/sqlmesh/integrations/dlt.py
+++ b/sqlmesh/integrations/dlt.py
@@ -22,7 +22,8 @@ def generate_dlt_models_and_settings(
         pipeline_name: The name of the DLT pipeline to attach to.
         dialect: The SQL dialect to use for generating SQLMesh models.
         tables: A list of table names to include.
-        dlt_path: The path to the directory containing the DLT pipelines.
+        dlt_path: The path to the DLT pipelines working directory, where DLT stores
+            pipeline state (by default ~/.dlt/pipelines).
 
     Returns:
         A tuple containing a set of the SQLMesh model definitions, the connection config and the start date.
@@ -34,8 +35,21 @@ def generate_dlt_models_and_settings(
 
     try:
         pipeline = dlt.attach(pipeline_name=pipeline_name, pipelines_dir=dlt_path or "")
-    except CannotRestorePipelineException:
-        raise click.ClickException(f"Could not attach to pipeline {pipeline_name}")
+    except CannotRestorePipelineException as e:
+        from pathlib import Path
+        from dlt.common.pipeline import get_dlt_pipelines_dir
+
+        searched_dir = dlt_path or get_dlt_pipelines_dir()
+        msg = f"Could not attach to pipeline {pipeline_name}.\nSearched in: {searched_dir}\n{e}"
+        if dlt_path and (Path(get_dlt_pipelines_dir()) / pipeline_name).exists():
+            msg += (
+                f"\nHint: A pipeline named '{pipeline_name}' exists in the default pipelines "
+                f"working directory '{get_dlt_pipelines_dir()}'. Note that --dlt-path must "
+                "point to the directory where DLT stores pipeline working state (by default "
+                "~/.dlt/pipelines), not the directory containing your pipeline scripts. "
+                "Try omitting --dlt-path."
+            )
+        raise click.ClickException(msg)
 
     schema = pipeline.default_schema
     dataset = pipeline.dataset_name

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -232,7 +232,7 @@ class SQLMeshMagics(Magics):
     @argument(
         "--dlt-path",
         type=str,
-        help="The directory where the DLT pipeline resides. Use alongside template: dlt",
+        help="The DLT pipelines working directory, where DLT stores pipeline state (by default ~/.dlt/pipelines). Use alongside template: dlt",
     )
     @line_magic
     def init(self, line: str) -> None:
@@ -886,7 +886,7 @@ class SQLMeshMagics(Magics):
     @argument(
         "--dlt-path",
         type=str,
-        help="The directory where the DLT pipeline resides.",
+        help="The DLT pipelines working directory, where DLT stores pipeline state (by default ~/.dlt/pipelines).",
     )
     @line_magic
     @pass_sqlmesh_context

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -995,7 +995,7 @@ def test_dlt_pipeline(runner, tmp_path):
         exec(file.read())
 
     # This should fail since it won't be able to locate the pipeline in this path
-    with pytest.raises(ClickException, match=r".*Could not attach to pipeline*"):
+    with pytest.raises(ClickException, match=r".*Could not attach to pipeline*") as excinfo:
         init_example_project(
             tmp_path,
             "duckdb",
@@ -1003,6 +1003,12 @@ def test_dlt_pipeline(runner, tmp_path):
             pipeline="sushi",
             dlt_path="./dlt2/pipelines",
         )
+
+    # The error should surface where the pipeline was searched for and, since the
+    # pipeline exists in the default working directory, a hint about --dlt-path
+    error_message = str(excinfo.value)
+    assert "Searched in: ./dlt2/pipelines" in error_message
+    assert "Try omitting --dlt-path" in error_message
 
     # By setting the pipelines path where the pipeline directory is located, it should work
     dlt_path = get_dlt_pipelines_dir()


### PR DESCRIPTION
## Description

Fixes #5660.

When `sqlmesh init -t dlt --dlt-path <path>` cannot attach to the pipeline, the underlying dlt error is swallowed and replaced with an uninformative `Could not attach to pipeline <name>` message.

The root cause of the confusion in #5660 is that `--dlt-path` must point to dlt's pipelines *working* directory (where pipeline state is stored, by default `~/.dlt/pipelines`), not the directory containing the pipeline scripts — and both the help text and the swallowed error gave the user no way to discover that.

This PR:
- Surfaces the original dlt exception and the directory that was searched.
- Adds a hint to omit `--dlt-path` when a pipeline with the given name exists in the default pipelines working directory (the exact scenario in #5660).
- Clarifies the `--dlt-path` help text, docstring, and CLI docs.

Before:

```
Error: Could not attach to pipeline sushi
```

After:

```
Error: Could not attach to pipeline sushi.
Searched in: ./scripts
Pipeline with `pipeline_name=sushi` and `pipelines_dir=./scripts/sushi` could not be restored: No local pipeline state found in './scripts/sushi'.
...
Hint: A pipeline named 'sushi' exists in the default pipelines working directory '/Users/nk/.dlt/pipelines'. Note that --dlt-path must point to the directory where DLT stores pipeline working state (by default ~/.dlt/pipelines), not the directory containing your pipeline scripts. Try omitting --dlt-path.
```

## Test Plan

- `uv run --extra dev --extra web --extra slack --extra dlt --extra lsp make style`
- `uv run --extra dev --extra web --extra slack --extra dlt --extra lsp pytest tests/cli/test_cli.py -q` (the one failure, `test_plan_very_verbose`, also fails on `main` in my environment and is unrelated)
- Extended the existing `test_dlt_pipeline` test to assert that the error reports the searched directory and the `--dlt-path` hint.

## Checklist

- [x] I have run `make style` and fixed any issues

