### PR TITLE
fix: Databricks column type identification

### DIFF
--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -431,7 +431,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter, GrantsFromInfoSchemaMixin):
             .order_by("ordinal_position ASC")
         )
 
-        self.cursor.execute(query)
+        self.cursor.execute(query.sql(dialect="databricks"))
         result = self.cursor.fetchall()
 
         return {row[0]: exp.DataType.build(row[1], dialect=self.dialect) for row in result}

--- a/sqlmesh/core/engine_adapter/databricks.py
+++ b/sqlmesh/core/engine_adapter/databricks.py
@@ -431,7 +431,7 @@ class DatabricksEngineAdapter(SparkEngineAdapter, GrantsFromInfoSchemaMixin):
             .order_by("ordinal_position ASC")
         )
 
-        self.cursor.execute(query.sql(dialect="databricks"))
+        self.execute(query.sql(dialect=self.dialect))
         result = self.cursor.fetchall()
 
         return {row[0]: exp.DataType.build(row[1], dialect=self.dialect) for row in result}

--- a/tests/core/engine_adapter/test_databricks.py
+++ b/tests/core/engine_adapter/test_databricks.py
@@ -579,8 +579,5 @@ def test_columns(mocker: MockFixture, make_mocked_engine_adapter: t.Callable):
     }
 
     adapter.cursor.execute.assert_called_once_with(
-        parse_one(
-            """SELECT columns.column_name, columns.full_data_type FROM system.information_schema.columns WHERE table_name = 'test_table' AND table_schema = 'test_db' AND table_catalog = 'test_catalog' ORDER BY ordinal_position ASC""",
-            dialect="databricks",
-        )
+        """SELECT columns.column_name, columns.full_data_type FROM system.information_schema.columns WHERE table_name = 'test_table' AND table_schema = 'test_db' AND table_catalog = 'test_catalog' ORDER BY ordinal_position ASC"""
     )


### PR DESCRIPTION
## Description

I have updated the call to the execution cursor in `DatabricksEngineAdapter.column` to have rendered SQL passed to it as opposed to the SQLGlot AST it was previously being supplied.

This should resolve #5841.

## Test Plan

I have run this change against an existing environment in Databricks using:

- databricks-sql-connector==4.0.5
- thrift==0.20.0

This was run against a classic SQL Warehouse against Unity Catalog.

I have updated the unit test for this method to expect rendered SQL to be passed.

## Checklist

- [x] I have run `make style` and fixed any issues

  > Note: This is currently failing on main, however I don't believe this has introduced any new issues. `ruff` and `ruff-format` pass, whilst `mypy` fails on main.
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)

  > Note: There are failing tests on main. Tests on `DatabricksEngineAdapter.column` pass.
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
