### PR TITLE
fix(docs): pin pygments to 2.19.2 and keep syntax highlighting

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-material==9.0.5
 mkdocs-material-extensions==1.1.1
 mkdocs-glightbox==0.3.7
 pdoc==14.5.1
+pygments==2.19.2    # Temporary pin: 2.20.0 breaks docs build; revisit after the fix


### PR DESCRIPTION
## Description

Closes https://github.com/SQLMesh/sqlmesh/issues/5853

Fixes the docs build failure by pinning `pygments` to `2.19.2` (prior to buggy version `2.20.0`)  in the docs dependency set, instead of disabling `pygments` globally (by updating `mkdocs.yml`)

```yaml
# alternate fix by disabling pygments
  - pymdownx.highlight:
      anchor_linenums: true
      use_pygments: false
```

### Problem

- Builds started failing with a `pymdownx` highlight to `pygments` HTML formatter error after dependency resolution moved to `pygments` 2.20.0.
- Pinning to 2.19.2 restores stable builds while preserving code-block highlighting and related formatting behaviour.
- This is a lower-impact fix than turning highlighting off globally.

### What changed

- Pinned pygments to 2.19.2 (below 2.20.0) in docs dependencies to keep syntax-highlighting behaviour enabled

### Related Links

- Pygments 2.20.0 section: https://pygments.org/docs/changelog/#version-2-20-0
- Related issue: https://github.com/pygments/pygments/issues/3077#issuecomment-4307301046

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
