### PR TITLE
fix(dlt): prevent credential type field overwriting db_type in format_config

### DIFF
--- a/sqlmesh/integrations/dlt.py
+++ b/sqlmesh/integrations/dlt.py
@@ -214,9 +214,7 @@ WHERE
 
 def format_config(configs: t.Dict[str, str], db_type: str) -> str:
     """Generate a string for the gateway connection config."""
-    config = {
-        "type": db_type,
-    }
+    config: t.Dict[str, t.Any] = {}
 
     for key, value in configs.items():
         if key == "password":
@@ -225,6 +223,11 @@ def format_config(configs: t.Dict[str, str], db_type: str) -> str:
             config["user"] = value
         else:
             config[key] = value
+
+    # Set db_type after iterating credentials so that credential attributes
+    # with a conflicting name (e.g. GCP service-account JSON contains
+    # "type": "service_account") cannot overwrite the connection type.
+    config["type"] = db_type
 
     # Validate the connection config fields
     invalid_fields = []

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1020,8 +1020,8 @@ def test_dlt_pipeline(runner, tmp_path):
 gateways:
   duckdb:
     connection:
-      type: duckdb
       database: {dataset_path}
+      type: duckdb
 default_gateway: duckdb
 
 # --- Model Defaults ---


### PR DESCRIPTION
## Summary

`sqlmesh dlt_refresh` fails with `Error: Unknown connection type 'service_account'` when the dlt pipeline uses BigQuery with service-account credentials.

## Root cause

`format_config` initialises `config = {"type": db_type}` (e.g. `"bigquery"`) then iterates all credential object attributes and writes them into `config`. BigQuery service-account credentials carry a `"type": "service_account"` field (from the GCP service account JSON format). This overwrites the `"bigquery"` key. `parse_connection_config` then raises:

```
ConfigError: Unknown connection type 'service_account'
```

This error fires before model generation starts, even though the direct caller (`generate_dlt_models`) discards the connection config entirely — it is the `_` in:

```python
sqlmesh_models, _, _ = generate_dlt_models_and_settings(...)
```

The bug only surfaces with BigQuery service-account credentials. OAUTH credentials do not carry a conflicting `type` field, so anyone who tested `dlt_refresh` with OAUTH would not have seen it.

## Fix

Move `config["type"] = db_type` to after the credential loop so it cannot be overwritten by credential attributes.

```diff
 def format_config(configs: t.Dict[str, str], db_type: str) -> str:
     """Generate a string for the gateway connection config."""
-    config = {
-        "type": db_type,
-    }
-
+    config: t.Dict[str, t.Any] = {}
+
     for key, value in configs.items():
         if key == "password":
             config[key] = f'"{value}"'
         elif key == "username":
             config["user"] = value
         else:
             config[key] = value
 
+    config["type"] = db_type
+
     # Validate the connection config fields
```

## Reproduction

1. Create a dlt pipeline targeting BigQuery using service-account credentials
2. Run `sqlmesh dlt_refresh <pipeline_name>`
3. Observe: `Error: Unknown connection type 'service_account'`

Does not affect OAUTH credentials.