### PR TITLE
detect new models in the UI when the project path is a symlink

### DIFF
--- a/tests/web/test_watcher.py
+++ b/tests/web/test_watcher.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from watchfiles import Change
 
+from sqlmesh.cli.project_init import init_example_project
 from sqlmesh.core.context import Context
 from web.server import watcher as watcher_module
 from web.server.settings import Settings
@@ -15,22 +16,10 @@ pytestmark = pytest.mark.web
 
 @pytest.fixture
 def project(tmp_path: Path) -> Path:
-    """Create a project in a temporary directory and return its path."""
+    """Create a project and a symlink to it."""
     project = tmp_path / "real_project"
-    (project / "models").mkdir(parents=True)
-    (project / "config.py").write_text(
-        "from sqlmesh.core.config import Config, ModelDefaultsConfig\n"
-        "config = Config(model_defaults=ModelDefaultsConfig(dialect=''))\n"
-    )
-    (project / "models" / "existing.sql").write_text(
-        "MODEL (name existing, kind FULL);\nSELECT 1 AS c"
-    )
-    return project
-
-
-@pytest.fixture
-def symlinked_project(tmp_path: Path, project: Path) -> Path:
-    """Create a symlink to a project in a temporary directory and return its path."""
+    project.mkdir()
+    init_example_project(project, engine_type="duckdb")
     link = tmp_path / "linked_project"
     link.symlink_to(project, target_is_directory=True)
     return link
@@ -39,7 +28,7 @@ def symlinked_project(tmp_path: Path, project: Path) -> Path:
 @pytest.mark.parametrize("event_path_is_resolved", [True, False])
 @pytest.mark.asyncio
 async def test_watch_project_tracks_new_model_through_symlink(
-    symlinked_project: Path,
+    project: Path,
     monkeypatch: pytest.MonkeyPatch,
     event_path_is_resolved: bool,
 ) -> None:
@@ -50,20 +39,20 @@ async def test_watch_project_tracks_new_model_through_symlink(
     event_path_is_resolved is True on macOS/FSEvents and False on Linux/inotify,
     so we need to test both cases.
     """
-    context = Context(paths=str(symlinked_project))
+    context = Context(paths=str(project))
     context.load()
 
-    new_file = symlinked_project / "models" / "new_model.sql"
-    new_file.write_text("MODEL (name new_model, kind FULL);\nSELECT 2 AS c")
+    new_file = project / "models" / "new_model.sql"
+    new_file.write_text("MODEL (name sqlmesh_example.new_model, kind FULL);\nSELECT 1 AS id")
     event_path = str(new_file.resolve()) if event_path_is_resolved else str(new_file)
 
     async def fake_awatch(*args: t.Any, **kwargs: t.Any) -> t.AsyncIterator[t.Set[t.Any]]:
         yield {(Change.added, event_path)}
 
-    monkeypatch.setattr(watcher_module, "get_settings", lambda: Settings(project_path=symlinked_project))
+    monkeypatch.setattr(watcher_module, "get_settings", lambda: Settings(project_path=project))
     monkeypatch.setattr(watcher_module, "get_context", lambda *a, **k: context)
     monkeypatch.setattr(watcher_module, "awatch", fake_awatch)
 
     await watcher_module.watch_project()
     context.refresh()
-    assert context.get_model("new_model") is not None
+    assert context.get_model("sqlmesh_example.new_model") is not None

--- a/tests/web/test_watcher.py
+++ b/tests/web/test_watcher.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import typing as t
+from pathlib import Path
+
+import pytest
+from watchfiles import Change
+
+from sqlmesh.core.context import Context
+from web.server import watcher as watcher_module
+from web.server.settings import Settings
+
+pytestmark = pytest.mark.web
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """Create a project in a temporary directory and return its path."""
+    project = tmp_path / "real_project"
+    (project / "models").mkdir(parents=True)
+    (project / "config.py").write_text(
+        "from sqlmesh.core.config import Config, ModelDefaultsConfig\n"
+        "config = Config(model_defaults=ModelDefaultsConfig(dialect=''))\n"
+    )
+    (project / "models" / "existing.sql").write_text(
+        "MODEL (name existing, kind FULL);\nSELECT 1 AS c"
+    )
+    return project
+
+
+@pytest.fixture
+def symlinked_project(tmp_path: Path, project: Path) -> Path:
+    """Create a symlink to a project in a temporary directory and return its path."""
+    link = tmp_path / "linked_project"
+    link.symlink_to(project, target_is_directory=True)
+    return link
+
+
+@pytest.mark.parametrize("event_path_is_resolved", [True, False])
+@pytest.mark.asyncio
+async def test_watch_project_tracks_new_model_through_symlink(
+    symlinked_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    event_path_is_resolved: bool,
+) -> None:
+    """
+    Test thata a model added while the project is reached through a symlink
+    is picked up by ``context.refresh()`` without crashing the watcher.
+
+    event_path_is_resolved is True on macOS/FSEvents and False on Linux/inotify,
+    so we need to test both cases.
+    """
+    context = Context(paths=str(symlinked_project))
+    context.load()
+
+    new_file = symlinked_project / "models" / "new_model.sql"
+    new_file.write_text("MODEL (name new_model, kind FULL);\nSELECT 2 AS c")
+    event_path = str(new_file.resolve()) if event_path_is_resolved else str(new_file)
+
+    async def fake_awatch(*args: t.Any, **kwargs: t.Any) -> t.AsyncIterator[t.Set[t.Any]]:
+        yield {(Change.added, event_path)}
+
+    monkeypatch.setattr(watcher_module, "get_settings", lambda: Settings(project_path=symlinked_project))
+    monkeypatch.setattr(watcher_module, "get_context", lambda *a, **k: context)
+    monkeypatch.setattr(watcher_module, "awatch", fake_awatch)
+
+    await watcher_module.watch_project()
+    context.refresh()
+    assert context.get_model("new_model") is not None

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -85,7 +85,7 @@ async def watch_project() -> None:
                         path not in loader._path_mtimes for loader in context._loaders
                     )
                     should_track_file = path.is_file() and in_paths
-                    should_reset_mtime = Change.added or is_modified_new_file
+                    should_reset_mtime = change == Change.added or is_modified_new_file
                     if should_track_file and should_reset_mtime:
                         for loader in context._loaders:
                             loader._path_mtimes[path] = 0

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -21,6 +21,7 @@ from web.server.utils import is_relative_to
 async def watch_project() -> None:
     settings = get_settings()
     context = get_context(settings)
+    project_root = settings.project_path.resolve()
     paths = [
         (settings.project_path / c.AUDITS).resolve(),
         (settings.project_path / c.MACROS).resolve(),
@@ -48,8 +49,11 @@ async def watch_project() -> None:
         changes: t.List[models.ArtifactChange] = []
         directories: t.Dict[str, models.Directory] = {}
         for change, path_str in entries:
-            path = Path(path_str)
-            relative_path = path.relative_to(settings.project_path)
+            event_path = Path(path_str)
+            # `awatch` may yield resolved paths even when the watched root is a symlink,
+            # so compare in resolved space and convert back to the symlinked project path
+            relative_path = event_path.resolve().relative_to(project_root)
+            path = settings.project_path / relative_path
             try:
                 if change == Change.deleted or not path.exists():
                     changes.append(
@@ -76,7 +80,7 @@ async def watch_project() -> None:
                         )
                     )
                 if context:
-                    in_paths = any(is_relative_to(path, p) for p in paths)
+                    in_paths = any(is_relative_to(path.resolve(), p) for p in paths)
                     is_modified_new_file = change == Change.modified and any(
                         path not in loader._path_mtimes for loader in context._loaders
                     )


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

Fixes #5860

- `awatch` can report resolved paths even for a symlinked root, which broke the watcher's path handling. Now, compare paths in resolved space and re-root under the project path so it works either way
- Resolve the path in the model-dir (`in_paths`) check too, so new files under a symlinked project get tracked.
- Currently there a check in `watch_project` that is always truthy (`should_reset_mtime = change == Change.added or is_modified_new_file`). Fix this so that `should_reset_mtime` is not always `True`

## Test Plan

<!-- How were these changes tested? -->

Added a new file `tests/web/test_watcher.py` that:

- adds a fixture that creates a new project and symlink to to it
- add a test that creates a `Context` with the symlinked project. Add a new file and check it is picked up by the watcher

## Checklist

- [ ] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [ ] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->