### PR TITLE
fix(format): keep MODEL/AUDIT/METRIC header dialect-agnostic (#5773)

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -783,7 +783,10 @@ def format_model_expressions(
         A string representing the formatted model.
     """
     if len(expressions) == 1 and is_meta_expression(expressions[0]):
-        return expressions[0].sql(pretty=True, dialect=dialect)
+        # Meta expressions (MODEL/AUDIT/METRIC) are SQLMesh DDL, not standard SQL,
+        # so they must never be transpiled to the target dialect (e.g. tsql would
+        # rewrite a boolean property like `allow_partials TRUE` to `(1 = 1)`).
+        return expressions[0].sql(pretty=True, dialect=None)
 
     if rewrite_casts:
 
@@ -815,7 +818,14 @@ def format_model_expressions(
         expressions = new_expressions
 
     return ";\n\n".join(
-        expression.sql(pretty=True, dialect=dialect, **kwargs) for expression in expressions
+        # Meta expressions (MODEL/AUDIT/METRIC) are SQLMesh DDL and must stay
+        # dialect-agnostic; only the actual query/statement expressions transpile.
+        expression.sql(
+            pretty=True,
+            dialect=None if is_meta_expression(expression) else dialect,
+            **kwargs,
+        )
+        for expression in expressions
     ).strip()
 
 

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -233,6 +233,60 @@ SELECT
     x = format_model_expressions(
         parse(
             """
+            MODEL(name a.b, kind FULL, dialect tsql, allow_partials true);
+            SELECT TRUE AS col, CAST(x AS INT) AS y FROM t
+            """
+        ),
+        dialect="tsql",
+    )
+    # The MODEL header is SQLMesh DDL and must not be transpiled: a boolean property
+    # such as `allow_partials true` must stay `TRUE`, not become tsql's `(1 = 1)`.
+    # The query body must still transpile to the target dialect.
+    assert (
+        x
+        == """MODEL (
+  name a.b,
+  kind FULL,
+  dialect tsql,
+  allow_partials TRUE
+);
+
+SELECT
+  1 AS col,
+  x::INTEGER AS y
+FROM t"""
+    )
+
+    x = format_model_expressions(
+        parse(
+            """
+            AUDIT(name my_audit, dialect tsql, blocking false);
+            SELECT TRUE AS col, CAST(x AS INT) AS y FROM t WHERE x > 0
+            """
+        ),
+        dialect="tsql",
+    )
+    # AUDIT headers are SQLMesh DDL too: a `false` boolean property must stay
+    # `FALSE`, not become tsql's `(1 = 0)`, while the query body still transpiles.
+    assert (
+        x
+        == """AUDIT (
+  name my_audit,
+  dialect tsql,
+  blocking FALSE
+);
+
+SELECT
+  1 AS col,
+  x::INTEGER AS y
+FROM t
+WHERE
+  x > 0"""
+    )
+
+    x = format_model_expressions(
+        parse(
+            """
             MODEL(name foo);
             SELECT CAST(1 AS INT) AS bla
             """


### PR DESCRIPTION
## Description

`sqlmesh format` corrupts boolean properties in the `MODEL (...)` header when the model dialect has no native `TRUE` keyword. On a T-SQL model, a property such as `allow_partials true` is rewritten to `allow_partials (1 = 1)`, and SQLMesh can no longer re-parse that as a boolean, so the model file breaks. Fixes #5773.

Root cause: `format_model_expressions` (`sqlmesh/core/dialect.py`) rendered *every* parsed expression with the target dialect, including the SQLMesh-specific `MODEL`/`AUDIT`/`METRIC` header. That header is SQLMesh DDL, not standard SQL, so SQLGlot's tsql generator transpiles a boolean to `(1 = 1)`.

This renders meta expressions (`is_meta_expression` -> `Audit`/`Metric`/`Model`) with `dialect=None` on both the single-meta early return and the multi-expression join path, so the header stays exactly as written, while the actual query/statement body still transpiles to the target dialect.

## Test Plan

- Added a tsql case to `tests/core/test_dialect.py::test_format_model_expressions` asserting the MODEL header keeps `allow_partials TRUE` (not `(1 = 1)`) while the query body still transpiles (`SELECT TRUE` -> `1`, `CAST(x AS INT)` -> `x::INTEGER`).
- Confirmed the new assertion fails on `main` and passes with this change.
- `pytest tests/core/test_dialect.py tests/core/test_format.py` green; `make style` (ruff + mypy) clean on both files.

`AUDIT`/`METRIC` headers share the identical `is_meta_expression` code path and behave the same; happy to add an AUDIT assertion too if that would be useful.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
