### PR TITLE
fix(dlt): use timestamp macros for incremental model time filter

### DIFF
--- a/sqlmesh/integrations/dlt.py
+++ b/sqlmesh/integrations/dlt.py
@@ -208,7 +208,7 @@ SELECT
 FROM
   {from_clause}
 WHERE
-  {time_column} BETWEEN @start_ds AND @end_ds
+  {time_column} BETWEEN @start_ts AND @end_ts
 """
 
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -921,7 +921,7 @@ SELECT
 FROM
   filesystem_pipeline_dataset.equipment as c
 WHERE
-  TO_TIMESTAMP(CAST(c._dlt_load_id AS DOUBLE)) BETWEEN @start_ds AND @end_ds
+  TO_TIMESTAMP(CAST(c._dlt_load_id AS DOUBLE)) BETWEEN @start_ts AND @end_ts
 """
 
     with open(equipment_model_path) as file:
@@ -1064,7 +1064,7 @@ SELECT
 FROM
   sushi_dataset.sushi_types as c
 WHERE
-  TO_TIMESTAMP(CAST(c._dlt_load_id AS DOUBLE)) BETWEEN @start_ds AND @end_ds
+  TO_TIMESTAMP(CAST(c._dlt_load_id AS DOUBLE)) BETWEEN @start_ts AND @end_ts
 """
 
     dlt_sushi_types_model_path = tmp_path / "models/incremental_sushi_types.sql"
@@ -1095,7 +1095,7 @@ SELECT
 FROM
   sushi_dataset._dlt_loads as c
 WHERE
-  TO_TIMESTAMP(CAST(c.load_id AS DOUBLE)) BETWEEN @start_ds AND @end_ds
+  TO_TIMESTAMP(CAST(c.load_id AS DOUBLE)) BETWEEN @start_ts AND @end_ts
 """
 
     with open(dlt_loads_model_path) as file:
@@ -1122,7 +1122,7 @@ JOIN
 ON
   c._dlt_parent_id = p._dlt_id
 WHERE
-  TO_TIMESTAMP(CAST(p._dlt_load_id AS DOUBLE)) BETWEEN @start_ds AND @end_ds
+  TO_TIMESTAMP(CAST(p._dlt_load_id AS DOUBLE)) BETWEEN @start_ts AND @end_ts
 """
 
     with open(dlt_sushi_fillings_model_path) as file:

--- a/tests/integrations/test_dlt.py
+++ b/tests/integrations/test_dlt.py
@@ -1,0 +1,21 @@
+from sqlmesh.integrations.dlt import generate_incremental_model
+
+
+def test_generate_incremental_model_filters_on_timestamp_macros() -> None:
+    # The DLT-generated model's time column is a timestamp
+    # (TO_TIMESTAMP(...)). It must therefore be filtered with the inclusive
+    # timestamp macros @start_ts/@end_ts, not the categorical date macros
+    # @start_ds/@end_ds, which both render midnight and exclude any rows past
+    # 00:00:00 on a single-day run.
+    model = generate_incremental_model(
+        "dataset_sqlmesh.incremental_equipment",
+        "  CAST(c.item_id AS BIGINT) AS item_id",
+        "",
+        "dataset.equipment",
+        "duckdb",
+        "c._dlt_load_id",
+    )
+
+    assert "BETWEEN @start_ts AND @end_ts" in model
+    assert "@start_ds" not in model
+    assert "@end_ds" not in model


### PR DESCRIPTION
## Description

The DLT integration generates `INCREMENTAL_BY_TIME_RANGE` models whose time column is cast to a timestamp:

```sql
TO_TIMESTAMP(CAST(c._dlt_load_id AS DOUBLE)) as _dlt_load_time
```

but it filtered that column with the categorical date macros:

```sql
WHERE
  TO_TIMESTAMP(CAST(c._dlt_load_id AS DOUBLE)) BETWEEN @start_ds AND @end_ds
```

`@start_ds` / `@end_ds` render bare dates (midnight on both ends), while `make_inclusive` (`sqlmesh/utils/date.py`) defines the inclusive range as `00:00:00 .. 23:59:59.999999`. The timestamp form of that range is what `@start_ts` / `@end_ts` emit. On a single-day run (`@start_ds == @end_ds`) both bounds collapse to midnight, so any row with a non-midnight timestamp (e.g. `21:30:15`) is excluded and the result is empty.

This matches the diagnosis and suggested fix in #5689: filter a timestamp column with `@start_ts AND @end_ts`.

Fixes #5689

## Test Plan

- Added `tests/integrations/test_dlt.py`: a focused unit test that calls `generate_incremental_model(...)` and asserts the generated `WHERE` uses `BETWEEN @start_ts AND @end_ts` (and no longer `@start_ds` / `@end_ds`). No warehouse or dlt package needed. Confirmed failing-first: reverting the source line back to `@start_ds` / `@end_ds` makes it fail; the fix makes it pass.
- Updated the four hard-coded expected-SQL strings in `tests/cli/test_cli.py` (the DLT pipeline template tests). `test_dlt_filesystem_pipeline`, `test_dlt_pipeline`, `test_dlt_pipeline_errors` -> 3 passed (dlt 1.28.1, filesystem destination, DuckDB default, no warehouse).
- `make style` (ruff format/check + mypy) clean on changed files.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
