### PR TITLE
Add local lint option

### DIFF
--- a/docs/guides/linter.md
+++ b/docs/guides/linter.md
@@ -126,6 +126,14 @@ Error: Linter detected errors in the code. Please fix them before proceeding.
 
 Use `sqlmesh lint --help` for more information.
 
+You can pass `--local` to run lint without loading state from the configured state connection:
+
+``` bash
+$ sqlmesh lint --local
+```
+
+This can make linting faster in repositories where all referenced models are loaded from local files. In multi-repository setups, or when linting only a subset of projects, `--local` may cause additional linting errors because SQLMesh will not resolve references or schemas from models that exist only in remote state.
+
 
 ## Applying linting rules
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -650,6 +650,9 @@ Usage: sqlmesh lint [OPTIONS]
 
 Options:
   --model TEXT           A model to lint. Multiple models can be linted.  If no models are specified, every model will be linted.
+  --local                Lint using only locally loaded project files without loading state.
   --help                 Show this message and exit.
 
 ```
+
+`--local` skips loading state from the configured state connection. In multi-repository setups, or when linting only a subset of projects, this may cause additional linting errors because SQLMesh will not resolve references or schemas from models that exist only in remote state.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -650,9 +650,9 @@ Usage: sqlmesh lint [OPTIONS]
 
 Options:
   --model TEXT           A model to lint. Multiple models can be linted.  If no models are specified, every model will be linted.
-  --local                Lint using only locally loaded project files without loading state.
+  --local                Lint using only locally loaded project files without loading state. In multi-repository setups, or when
+                         linting only a subset of projects, this may cause additional linting errors because SQLMesh will not resolve
+                         references or schemas from models that exist only in remote state.
   --help                 Show this message and exit.
 
 ```
-
-`--local` skips loading state from the configured state connection. In multi-repository setups, or when linting only a subset of projects, this may cause additional linting errors because SQLMesh will not resolve references or schemas from models that exist only in remote state.

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -44,6 +44,17 @@ SKIP_CONTEXT_COMMANDS = ("init", "ui")
 LOCAL_ONLY_COMMANDS = ("format",)
 
 
+class _SQLMeshGroup(click.Group):
+    def parse_args(self, ctx: click.Context, args: t.List[str]) -> t.List[str]:
+        rest = super().parse_args(ctx, args)
+        # Preserve the subcommand arguments because Click consumes them before invoking the group callback.
+        protected_args = getattr(ctx, "_protected_args", None)
+        if protected_args is None:
+            protected_args = ctx.protected_args
+        ctx.meta["subcommand_args"] = tuple(protected_args) + tuple(ctx.args)
+        return rest
+
+
 def _sqlmesh_version() -> str:
     try:
         from sqlmesh import __version__
@@ -53,7 +64,7 @@ def _sqlmesh_version() -> str:
         return "0.0.0"
 
 
-@click.group(no_args_is_help=True)
+@click.group(cls=_SQLMeshGroup, no_args_is_help=True)
 @click.version_option(version=_sqlmesh_version(), message="%(version)s")
 @opt.paths
 @opt.config
@@ -118,7 +129,8 @@ def cli(
     load = True
     # Local-only gating must hold for any number of --paths, so it stays outside the block below.
     load_state = ctx.invoked_subcommand not in LOCAL_ONLY_COMMANDS
-    if ctx.invoked_subcommand == "lint" and "--local" in sys.argv:
+    # The parent callback constructs Context before Click invokes `lint`, so inspect its parsed args here.
+    if ctx.invoked_subcommand == "lint" and "--local" in ctx.meta["subcommand_args"]:
         load_state = False
 
     if len(paths) == 1:

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -118,6 +118,8 @@ def cli(
     load = True
     # Local-only gating must hold for any number of --paths, so it stays outside the block below.
     load_state = ctx.invoked_subcommand not in LOCAL_ONLY_COMMANDS
+    if ctx.invoked_subcommand == "lint" and "--local" in sys.argv:
+        load_state = False
 
     if len(paths) == 1:
         path = os.path.abspath(paths[0])
@@ -1194,12 +1196,18 @@ def environments(obj: Context) -> None:
     multiple=True,
     help="A model to lint. Multiple models can be linted. If no models are specified, every model will be linted.",
 )
+@click.option(
+    "--local",
+    is_flag=True,
+    help="Lint using only locally loaded project files without loading state.",
+)
 @click.pass_obj
 @error_handler
 @cli_analytics
 def lint(
     obj: Context,
     models: t.Iterator[str],
+    local: bool,
 ) -> None:
     """Run the linter for the target model(s)."""
     obj.lint_models(models)

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -1199,6 +1199,7 @@ def environments(obj: Context) -> None:
 @click.option(
     "--local",
     is_flag=True,
+    expose_value=False,
     help="Lint using only locally loaded project files without loading state.",
 )
 @click.pass_obj
@@ -1207,7 +1208,6 @@ def environments(obj: Context) -> None:
 def lint(
     obj: Context,
     models: t.Iterator[str],
-    local: bool,
 ) -> None:
     """Run the linter for the target model(s)."""
     obj.lint_models(models)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2305,6 +2305,29 @@ def test_lint_still_loads_state(runner: CliRunner, tmp_path: Path, mocker):
     assert mock.called, "state-sync was never accessed during `lint`"
 
 
+def test_lint_local_runs_without_state(
+    runner: CliRunner, tmp_path: Path, mocker, monkeypatch
+):
+    mock = _setup_local_only_project(tmp_path, mocker)
+    init_spy = mocker.spy(Context, "__init__")
+    monkeypatch.setattr(
+        "sys.argv", ["sqlmesh", "--paths", str(tmp_path), "lint", "--local"]
+    )
+
+    result = runner.invoke(cli, ["--paths", str(tmp_path), "lint", "--local"])
+
+    assert result.exit_code == 0, f"Lint failed: {result.output}\nException: {result.exception}"
+    assert init_spy.called, "Context was never constructed"
+    for call in init_spy.call_args_list:
+        assert "load_state" in call.kwargs, (
+            "CLI didn't pass load_state= explicitly; missing kwarg defaults to True silently"
+        )
+        assert call.kwargs["load_state"] is False, (
+            f"Context was constructed with load_state={call.kwargs['load_state']} for `lint --local`"
+        )
+    mock.assert_not_called()
+
+
 @pytest.mark.parametrize("command", ["format"])
 def test_local_only_commands_skip_state_multiple_paths(
     runner: CliRunner, tmp_path: Path, mocker, command: str

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2305,10 +2305,9 @@ def test_lint_still_loads_state(runner: CliRunner, tmp_path: Path, mocker):
     assert mock.called, "state-sync was never accessed during `lint`"
 
 
-def test_lint_local_runs_without_state(runner: CliRunner, tmp_path: Path, mocker, monkeypatch):
+def test_lint_local_runs_without_state(runner: CliRunner, tmp_path: Path, mocker):
     mock = _setup_local_only_project(tmp_path, mocker)
     init_spy = mocker.spy(Context, "__init__")
-    monkeypatch.setattr("sys.argv", ["sqlmesh", "--paths", str(tmp_path), "lint", "--local"])
 
     result = runner.invoke(cli, ["--paths", str(tmp_path), "lint", "--local"])
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2305,14 +2305,10 @@ def test_lint_still_loads_state(runner: CliRunner, tmp_path: Path, mocker):
     assert mock.called, "state-sync was never accessed during `lint`"
 
 
-def test_lint_local_runs_without_state(
-    runner: CliRunner, tmp_path: Path, mocker, monkeypatch
-):
+def test_lint_local_runs_without_state(runner: CliRunner, tmp_path: Path, mocker, monkeypatch):
     mock = _setup_local_only_project(tmp_path, mocker)
     init_spy = mocker.spy(Context, "__init__")
-    monkeypatch.setattr(
-        "sys.argv", ["sqlmesh", "--paths", str(tmp_path), "lint", "--local"]
-    )
+    monkeypatch.setattr("sys.argv", ["sqlmesh", "--paths", str(tmp_path), "lint", "--local"])
 
     result = runner.invoke(cli, ["--paths", str(tmp_path), "lint", "--local"])
 


### PR DESCRIPTION
## Description

As mentioned in https://github.com/SQLMesh/sqlmesh/issues/5182, the `lint` command still requires the remote state to resolve references in the multi-repo case. These changes add an optional `--local` option to the `lint` command so it is runnable without a reachable state backend. This is useful for faster lint iterations in repositories where all referenced models are available locally.

In multi-repo setups, or when linting only a subset of projects, `--local` may produce additional linting errors because SQLMesh will not resolve references or schemas from models that exist only in remote state.

Updated the linter guide and CLI reference to document the new flag and caveat.

Resolves: https://github.com/SQLMesh/sqlmesh/issues/5182

## Test Plan

- Added CLI test coverage for `sqlmesh lint --local` to verify `Context` is constructed with `load_state=False` and state sync is not accessed.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)