### PR TITLE
fix(clickhouse): unwrap parenthesized PRIMARY_KEY independent of ORDER_BY

### DIFF
--- a/sqlmesh/core/engine_adapter/clickhouse.py
+++ b/sqlmesh/core/engine_adapter/clickhouse.py
@@ -850,7 +850,7 @@ class ClickhouseEngineAdapter(EngineAdapterWithIndexSupport, LogicalMergeMixin):
             primary_key_vals = []
             if isinstance(primary_key, (exp.Tuple, exp.Array)):
                 primary_key_vals = primary_key.expressions
-            if isinstance(ordered_by_raw, exp.Paren):
+            if isinstance(primary_key, exp.Paren):
                 primary_key_vals = [primary_key.this]
 
             if not primary_key_vals:

--- a/tests/core/engine_adapter/test_clickhouse.py
+++ b/tests/core/engine_adapter/test_clickhouse.py
@@ -305,6 +305,25 @@ def test_model_properties(adapter: ClickhouseEngineAdapter):
         == "ENGINE=MergeTree ORDER BY (a) PRIMARY KEY (a)"
     )
 
+    # A parenthesized single-column PRIMARY_KEY must be unwrapped regardless of the
+    # ORDER_BY shape. Previously the PRIMARY_KEY branch checked ORDER_BY's expression,
+    # so pairing PRIMARY_KEY = (a) with a non-parenthesized ORDER_BY emitted the
+    # malformed "PRIMARY KEY ((a))".
+    assert (
+        build_properties_sql(order_by="ORDER_BY = a,", primary_key="PRIMARY_KEY = (a)")
+        == "ENGINE=MergeTree ORDER BY (a) PRIMARY KEY (a)"
+    )
+
+    assert (
+        build_properties_sql(order_by="ORDER_BY = (a, b),", primary_key="PRIMARY_KEY = (a)")
+        == "ENGINE=MergeTree ORDER BY (a, b) PRIMARY KEY (a)"
+    )
+
+    assert (
+        build_properties_sql(primary_key="PRIMARY_KEY = (a)")
+        == "ENGINE=MergeTree ORDER BY () PRIMARY KEY (a)"
+    )
+
     assert build_properties_sql(order_by="ORDER_BY = a + 1,") == "ENGINE=MergeTree ORDER BY (a + 1)"
 
     assert (


### PR DESCRIPTION


The ClickHouse engine adapter builds the `PRIMARY KEY` clause in
`_build_table_properties_exp`. When the `PRIMARY_KEY` physical property is a
single parenthesized column (for example `PRIMARY_KEY = (a)`), sqlglot parses it
into an `exp.Paren` that has to be unwrapped, otherwise the adapter emits a
doubly-parenthesized `PRIMARY KEY ((a))`.

The unwrap guard checked the wrong value: it tested `ordered_by_raw` (the
`ORDER_BY` value) for `exp.Paren` instead of `primary_key`. This looks like a
copy-paste leftover from the `ORDER_BY` block just above it, which correctly uses
`ordered_by_raw`. As a result the parenthesized `PRIMARY_KEY` was only unwrapped
when `ORDER_BY` happened to be a `Paren` too. With a bare column, a tuple, or no
`ORDER_BY` at all, the parentheses were kept and the generated primary key came
out malformed:

```sql
-- PRIMARY_KEY = (a) with ORDER_BY = a
-- before: ENGINE=MergeTree ORDER BY (a) PRIMARY KEY ((a))
-- after:  ENGINE=MergeTree ORDER BY (a) PRIMARY KEY (a)
```

So the emitted primary key wrongly depended on the unrelated `ORDER_BY` shape.

The fix checks `primary_key` for `exp.Paren`, making the `PRIMARY_KEY` block
symmetric with the `ORDER_BY` block above it. It is a one-line change to the
guard.

## Test Plan

Added two regression assertions to
`tests/core/engine_adapter/test_clickhouse.py::test_model_properties`, pairing
`PRIMARY_KEY = (a)` with a bare `ORDER_BY = a` and with a tuple
`ORDER_BY = (a, b)`; both now assert `PRIMARY KEY (a)`. The existing case in that
test used `ORDER_BY = (a)` (also a `Paren`), which is exactly why the bug was
masked. Reverting the source line makes the new bare-`ORDER_BY` assertion fail
with `PRIMARY KEY ((a))`; restoring it passes.

```
pytest tests/core/engine_adapter/test_clickhouse.py::test_model_properties -q   # 1 passed
pytest tests/core/engine_adapter/test_clickhouse.py -q -m "not slow and not docker"   # 32 passed
make style   # passed
```

I did not mark the full `make fast-test` checklist item because the broad suite
is currently blocked in this local environment by an unrelated `pyodbc` / system
`unixODBC` import failure in
`tests/core/test_connection_config.py::test_mssql_pyodbc_connection_string_generation`.
The ClickHouse-specific regression coverage above passes.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [ ] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
