### PR TITLE
fix(cicd): chunk bot messages on character boundaries

### DIFF
--- a/sqlmesh/integrations/github/cicd/controller.py
+++ b/sqlmesh/integrations/github/cicd/controller.py
@@ -1182,13 +1182,26 @@ class GithubController:
 
     def _chunk_up_api_message(self, message: str) -> t.List[str]:
         """
-        Chunks up the message into `MAX_BYTE_LENGTH` byte chunks
+        Chunks up the message into chunks of at most `MAX_BYTE_LENGTH` bytes when
+        UTF-8 encoded.
+
+        Chunk boundaries are placed between characters rather than raw bytes so a
+        multibyte character that lands on a boundary is never split and dropped.
         """
-        message_encoded = message.encode("utf-8")
-        return [
-            message_encoded[i : i + self.MAX_BYTE_LENGTH].decode("utf-8", "ignore")
-            for i in range(0, len(message_encoded), self.MAX_BYTE_LENGTH)
-        ]
+        chunks: t.List[str] = []
+        current = ""
+        current_length = 0
+        for char in message:
+            char_length = len(char.encode("utf-8"))
+            if current and current_length + char_length > self.MAX_BYTE_LENGTH:
+                chunks.append(current)
+                current = ""
+                current_length = 0
+            current += char
+            current_length += char_length
+        if current:
+            chunks.append(current)
+        return chunks
 
     @property
     def running_in_github_actions(self) -> bool:

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -915,3 +915,22 @@ def test_forward_only_config_falls_back_to_plan_config(
 
     controller._context.config.plan.forward_only = False
     assert controller.forward_only_plan is False
+
+
+def test_chunk_up_api_message_preserves_multibyte_chars(
+    github_client, make_event_issue_comment, make_controller
+):
+    controller = make_controller(make_event_issue_comment("created", "test"), github_client)
+
+    max_bytes = controller.MAX_BYTE_LENGTH
+    # Place a multibyte character exactly on the byte boundary between two chunks so
+    # that byte-oriented slicing would bisect its UTF-8 encoding and drop it.
+    message = ("a" * (max_bytes - 1)) + "é" + ("b" * max_bytes)
+    assert len(message.encode("utf-8")) > max_bytes
+
+    chunks = controller._chunk_up_api_message(message)
+
+    # No character is lost, so the chunks reassemble into the original message.
+    assert "".join(chunks) == message
+    # Each chunk still respects the GitHub API byte limit.
+    assert all(len(chunk.encode("utf-8")) <= max_bytes for chunk in chunks)

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -917,15 +917,32 @@ def test_forward_only_config_falls_back_to_plan_config(
     assert controller.forward_only_plan is False
 
 
-def test_chunk_up_api_message_preserves_multibyte_chars(
+def test_chunk_up_api_message_preserves_ascii_behavior(
     github_client, make_event_issue_comment, make_controller
+):
+    controller = make_controller(make_event_issue_comment("created", "test"), github_client)
+
+    max_bytes = controller.MAX_BYTE_LENGTH
+    message = ("a" * max_bytes) + ("b" * max_bytes) + "c"
+
+    assert controller._chunk_up_api_message("") == []
+    assert controller._chunk_up_api_message(message) == [
+        "a" * max_bytes,
+        "b" * max_bytes,
+        "c",
+    ]
+
+
+@pytest.mark.parametrize("multibyte_char", ["🙂", "界"])
+def test_chunk_up_api_message_preserves_multibyte_chars(
+    github_client, make_event_issue_comment, make_controller, multibyte_char
 ):
     controller = make_controller(make_event_issue_comment("created", "test"), github_client)
 
     max_bytes = controller.MAX_BYTE_LENGTH
     # Place a multibyte character exactly on the byte boundary between two chunks so
     # that byte-oriented slicing would bisect its UTF-8 encoding and drop it.
-    message = ("a" * (max_bytes - 1)) + "é" + ("b" * max_bytes)
+    message = ("a" * (max_bytes - 1)) + multibyte_char + "b"
     assert len(message.encode("utf-8")) > max_bytes
 
     chunks = controller._chunk_up_api_message(message)


### PR DESCRIPTION


`GithubController._chunk_up_api_message` splits a message into chunks that fit
GitHub's per-field byte limit (`MAX_BYTE_LENGTH`, 65535). It did this by UTF-8
encoding the whole message, slicing the resulting bytes at fixed
`MAX_BYTE_LENGTH` offsets, and decoding each slice with `errors="ignore"`:

```python
message_encoded = message.encode("utf-8")
return [
    message_encoded[i : i + self.MAX_BYTE_LENGTH].decode("utf-8", "ignore")
    for i in range(0, len(message_encoded), self.MAX_BYTE_LENGTH)
]
```

When a multibyte character (accented letter, CJK, emoji, etc.) straddles a chunk
boundary, its UTF-8 bytes are split across two slices. `decode("utf-8", "ignore")`
then discards the incomplete byte sequence on both sides, so that character is
silently dropped from the bot's PR comment or check-run output.

This change accumulates characters into a chunk while the running UTF-8 byte
length stays within `MAX_BYTE_LENGTH`, so a boundary is only ever placed between
whole characters and no character is bisected. Behavior for the common case is
unchanged: ASCII-only messages chunk into the exact same pieces as before, and an
empty message still yields no chunks. Both existing callers rely only on the
number of chunks (comment edit unpacks `body, *truncated`; check-run output
unpacks `summary, text, *truncated`), and that contract is preserved.

## Test Plan

- Added `test_chunk_up_api_message_preserves_multibyte_chars`, which builds a
  message just over `MAX_BYTE_LENGTH` with a multibyte character (`é`) placed on
  the byte boundary between two chunks, and asserts the chunks reassemble into the
  original message and each chunk stays within `MAX_BYTE_LENGTH` bytes. This test
  fails on the previous byte-slicing implementation (the boundary character is
  dropped) and passes with the fix.
- `pytest tests/integrations/github/cicd/ -m "not slow and not docker"` -> 55
  passed, 28 deselected.
- `make style` (ruff check + ruff format) clean on the changed files.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
