### PR TITLE
fix(config): stringify pydantic error loc before join

### DIFF
--- a/sqlmesh/utils/pydantic.py
+++ b/sqlmesh/utils/pydantic.py
@@ -242,7 +242,7 @@ def _formatted_validation_errors(error: pydantic.ValidationError) -> t.List[str]
     for e in error.errors():
         msg = e["msg"]
         loc: t.Optional[t.Tuple] = e.get("loc")
-        loc_str = ".".join(loc) if loc else None
+        loc_str = ".".join(str(p) for p in loc) if loc else None
         result.append(f"Invalid field '{loc_str}':\n    {msg}" if loc_str else msg)
     return result
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -700,7 +700,7 @@ model_defaults:
         """
         )
 
-    with pytest.raises(TypeError, match=r"expected str instance, int found"):
+    with pytest.raises(ConfigError, match=r"Invalid field 'model_defaults\.pre_statements\.0"):
         config = load_config_from_paths(
             Config,
             project_paths=[config_path],

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -2,8 +2,14 @@ import typing as t
 import pytest
 from functools import cached_property
 
+import pydantic
+
 from sqlmesh.utils.date import TimeLike, to_date, to_datetime
-from sqlmesh.utils.pydantic import PydanticModel, get_concrete_types_from_typehint
+from sqlmesh.utils.pydantic import (
+    PydanticModel,
+    get_concrete_types_from_typehint,
+    validation_error_message,
+)
 
 
 def test_datetime_date_serialization() -> None:
@@ -87,3 +93,19 @@ def test_pydantic_dict_default_args_override() -> None:
 )
 def test_get_concrete_types_from_typehint(input: t.Any, output: set[type]) -> None:
     assert get_concrete_types_from_typehint(input) == output
+
+
+def test_validation_error_message_with_list_index_location() -> None:
+    class Inner(PydanticModel):
+        x: int
+
+    class Outer(PydanticModel):
+        items: t.List[Inner]
+
+    with pytest.raises(pydantic.ValidationError) as ex:
+        Outer(items=[{"x": "not_an_int"}])
+
+    # The error is located at a list index, so pydantic's loc mixes str field
+    # names with an int sequence index (e.g. ("items", 0, "x")).
+    message = validation_error_message(ex.value, "Invalid config:")
+    assert "Invalid field 'items.0.x'" in message


### PR DESCRIPTION


Config validation errors located at a list or tuple index crash with an opaque
`TypeError` instead of the intended readable `ConfigError`.

`_formatted_validation_errors` in `sqlmesh/utils/pydantic.py` builds the field
location by joining pydantic's error `loc` tuple directly:

```python
loc_str = ".".join(loc) if loc else None
```

Pydantic's `loc` mixes str field names with int sequence indices when an error is
inside a list (for example `("items", 0, "x")`), and `str.join` rejects the int:

```
TypeError: sequence item 1: expected str instance, int found
```

So any config error that resolves to a list element surfaces as a traceback rather
than the readable message the function exists to produce. A concrete user-facing
path is an invalid `model_defaults.pre_statements` entry, whose `loc` is
`("model_defaults", "pre_statements", 0, ...)`.

The fix converts each `loc` part to `str` before joining:

```python
loc_str = ".".join(str(p) for p in loc) if loc else None
```

Nested-list config errors now render, for example,
`Invalid field 'model_defaults.pre_statements.0...'` as a `ConfigError`.

This is a regression from #4511, which replaced the earlier single-element
`loc[0]` access (never affected by int indices) with the `".".join(loc)` form.

## Test Plan

- Added `tests/utils/test_pydantic.py::test_validation_error_message_with_list_index_location`:
  builds a real nested-model `ValidationError` (`loc == ("items", 0, "x")`) and
  asserts `validation_error_message` returns the formatted string instead of
  raising. Verified it fails with the `TypeError` before the fix and passes after.
- Updated `tests/core/test_config.py::test_load_model_defaults_validation_statements`:
  it previously asserted the raw `TypeError`, which codified the crash. It now
  expects the readable `ConfigError` (`Invalid field 'model_defaults.pre_statements.0...'`).
  Also verified this fails before the fix and passes after.
- `pytest tests/utils/test_pydantic.py tests/core/test_config.py -m "not slow and not docker"`:
  76 passed.
- `make style` (ruff check + ruff format + mypy) clean on the changed files.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
