### PR TITLE
fix(date): import pandas locally in make_ts_exclusive

### DIFF
--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -344,6 +344,8 @@ def make_exclusive(time: TimeLike) -> datetime:
 
 
 def make_ts_exclusive(time: TimeLike, dialect: DialectType) -> datetime:
+    import pandas as pd
+
     ts = to_datetime(time)
     if dialect == "tsql":
         return to_utc_timestamp(ts) - pd.Timedelta(1, unit="ns")

--- a/tests/utils/test_date.py
+++ b/tests/utils/test_date.py
@@ -14,11 +14,13 @@ from sqlmesh.utils.date import (
     is_categorical_relative_expression,
     is_relative,
     make_inclusive,
+    make_ts_exclusive,
     to_datetime,
     to_time_column,
     to_timestamp,
     to_ts,
     to_tstz,
+    to_utc_timestamp,
 )
 
 
@@ -138,6 +140,17 @@ def test_make_inclusive_tsql(start_in, end_in, start_out, end_out, dialect) -> N
     assert make_inclusive(start_in, end_in, "tsql") == (
         to_datetime(start_out),
         pd.Timestamp(end_out),
+    )
+
+
+def test_make_ts_exclusive() -> None:
+    # tsql subtracts 1ns from the UTC timestamp; must not raise NameError (pd not imported)
+    assert make_ts_exclusive("2020-01-01 12:00:00", dialect="tsql") == to_utc_timestamp(
+        to_datetime("2020-01-01 12:00:00")
+    ) - pd.Timedelta(1, unit="ns")
+    # non-tsql dialects add 1 microsecond
+    assert make_ts_exclusive("2020-01-01 12:00:00", dialect="duckdb") == to_datetime(
+        "2020-01-01 12:00:00.000001"
     )
 
 


### PR DESCRIPTION


`make_ts_exclusive` uses `pd.Timedelta` in its `dialect == "tsql"` branch, but
`pandas` is only imported under `TYPE_CHECKING` in `sqlmesh/utils/date.py` (it is
banned as a module-level import by the ruff `flake8-tidy-imports` config). Unlike
the sibling helpers `make_inclusive_end` and `to_utc_timestamp`, which do
`import pandas as pd` at runtime, `make_ts_exclusive` never imports pandas, so:

```python
from sqlmesh.utils.date import make_ts_exclusive
make_ts_exclusive("2020-01-01 12:00:00", dialect="tsql")
# NameError: name 'pd' is not defined
```

This is reachable in normal use: rendering an `INCREMENTAL_BY_TIME_RANGE` model
that has a jinja source/ref event-time filter on the `tsql` dialect calls
`make_ts_exclusive(..., dialect="tsql")` in `sqlmesh/core/renderer.py`. The
`NameError` is caught there and re-raised as a `ConfigError` reporting that the
model could not be rendered.

The fix adds a function-local `import pandas as pd` as the first line of
`make_ts_exclusive`, mirroring the existing runtime-pandas helpers in the same
module. The non-tsql path is unaffected (it did not reference `pd`).

## Test Plan

- Added `test_make_ts_exclusive` in `tests/utils/test_date.py` covering both
  paths: the `tsql` dialect returns `to_utc_timestamp(ts) - 1ns` (and no longer
  raises `NameError`), and a non-tsql dialect (`duckdb`) returns `ts + 1us`.
- Verified the test is a true regression test: with the runtime import removed it
  fails with `NameError: name 'pd' is not defined`; with the fix it passes.
- `pytest tests/utils/test_date.py` -> 61 passed.
- `pytest tests/utils/ -m "not slow and not docker"` -> 236 passed, 1 skipped.
- `ruff check` + `ruff format --check` + `mypy` on the changed files -> clean.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
