### PR TITLE
fix(model): raise ConfigError for empty time_column tuple

### DIFF
--- a/sqlmesh/core/model/kind.py
+++ b/sqlmesh/core/model/kind.py
@@ -341,6 +341,8 @@ class TimeColumn(PydanticModel):
     @classmethod
     def create(cls, v: t.Any, dialect: str) -> Self:
         if isinstance(v, exp.Tuple):
+            if not v.expressions:
+                raise ConfigError("Time Column cannot be empty.")
             column_expr = v.expressions[0]
             column = (
                 exp.column(column_expr) if isinstance(column_expr, exp.Identifier) else column_expr

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2680,6 +2680,21 @@ def test_time_column():
     assert model.time_column.format == "%Y-%m"
     assert model.time_column.expression == d.parse_one("(\"ds\", '%Y-%m')")
 
+    expressions = d.parse(
+        """
+        MODEL (
+            name db.table,
+            kind INCREMENTAL_BY_TIME_RANGE(
+                time_column ()
+            )
+        );
+
+        SELECT col::text, ds::text
+    """
+    )
+    with pytest.raises(ConfigError, match="Time Column cannot be empty."):
+        load_sql_based_model(expressions)
+
 
 def test_default_time_column():
     expressions = d.parse(


### PR DESCRIPTION


A model declaring an empty `time_column` tuple, for example:

```sql
MODEL (
  name db.table,
  kind INCREMENTAL_BY_TIME_RANGE(time_column ())
);
```

parsed the value into an empty `exp.Tuple`, and `TimeColumn.create`
(`sqlmesh/core/model/kind.py`) indexed `v.expressions[0]` without first checking
whether the tuple was empty. That raised a bare `IndexError: list index out of
range` with no configuration context, instead of the `ConfigError` that the same
method already raises for the other empty or invalid `time_column` inputs
(`ConfigError("Time Column cannot be empty.")` in `_column_validator`, and
`ConfigError(f"Invalid time_column: '{v}'.")` in the `create` fallthrough).

This adds a guard at the top of the `isinstance(v, exp.Tuple)` branch that raises
the same `"Time Column cannot be empty."` `ConfigError`, so the empty-tuple case
is reported the same way as the other invalid inputs. `ConfigError` was already
imported; no behavior changes for any valid `time_column`.

### Test Plan

- Added a regression case to `test_time_column` in `tests/core/test_model.py`
  that loads a model with `time_column ()` and asserts it raises
  `ConfigError` matching `"Time Column cannot be empty."`.
- Confirmed the test is red before the fix (it fails with `IndexError` at the
  old `v.expressions[0]` line) and green after.
- `make style` clean on the changed files (`ruff check`, `ruff format`, `mypy`).
- `pytest tests/core/test_model.py -k "time_column or model_kind or incremental_by_time" -m "not slow and not docker"`
  -> 16 passed.

### Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
