### PR TITLE
fix(dbt): upgrade pyOpenSSL for dbt 1.3 tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,8 @@ install-dev-dbt-%:
 	fi; \
 	if [ "$$version" = "1.3.0" ]; then \
 		echo "Applying overrides for dbt $$version - upgrading google-cloud-bigquery"; \
-		$(PIP) install 'google-cloud-bigquery>=3.0.0' --upgrade; \
+		$(PIP) install 'google-cloud-bigquery>=3.0.0' \
+			'pyOpenSSL>=24.0.0' --upgrade; \
 	fi; \
 	mv pyproject.toml.backup pyproject.toml; \
 	echo "Restored original pyproject.toml"


### PR DESCRIPTION
## Description

Fixes the dbt 1.3 CI test environment by upgrading `pyOpenSSL` in the same override that upgrades `google-cloud-bigquery`.

The dbt 1.3 job was upgrading `cryptography` through the BigQuery override while leaving the previously resolved `pyOpenSSL` version in place. That produced an incompatible OpenSSL dependency pair and caused Snowflake dbt tests to fail with:

`AttributeError: module 'lib' has no attribute 'GEN_EMAIL'`

## Test Plan

- [x] `UV=1 make install-dev-dbt-1.3`
- [x] `pytest tests/dbt/test_config.py::test_snowflake_config tests/dbt/test_config.py::test_snowflake_config_private_key_path tests/dbt/test_config.py::test_snowflake_config_oauth_access_token tests/dbt/test_config.py::test_snowflake_config_private_key tests/dbt/test_config.py::test_api_class_loading -q`
- [x] `make dbt-fast-test`
- [x] `make style`

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)