### PR TITLE
Fix(macros): @FILTER with a single non-array argument

### DIFF
--- a/sqlmesh/core/macros.py
+++ b/sqlmesh/core/macros.py
@@ -789,7 +789,7 @@ def filter_(evaluator: MacroEvaluator, *args: t.Any) -> t.List[t.Any]:
     """
     *items, func = args
     items, func = _norm_var_arg_lambda(evaluator, func, *items)  # type: ignore
-    return list(filter(lambda arg: evaluator.eval_expression(func(arg)), items))
+    return list(filter(lambda arg: evaluator.eval_expression(func(arg)), ensure_collection(items)))
 
 
 def _optional_expression(

--- a/tests/core/test_macros.py
+++ b/tests/core/test_macros.py
@@ -358,6 +358,18 @@ def test_ast_correctness(macro_evaluator):
             "700",
             {},
         ),
+        # @FILTER documents "The first argument can be an Array or var args can be
+        # used", like @EACH and @REDUCE, so a lone item must work too.
+        (
+            """@SQL(@REDUCE(@FILTER(300, x -> x > 250), (x,y) -> x + y))""",
+            "300",
+            {},
+        ),
+        (
+            """select @FILTER(a, x -> x > 1)""",
+            "SELECT a",
+            {},
+        ),
         (
             """select @EACH([a, b, c], x -> x and @SQL('@y'))""",
             "SELECT a AND z, b AND z, c AND z",


### PR DESCRIPTION
## Description

`@FILTER`'s docstring says *"The first argument can be an Array or var args can be used"* — the same contract `@EACH` and `@REDUCE` state. All three route their arguments through `_norm_var_arg_lambda`, whose single-item branch returns a bare expression rather than a list:

```python
expressions = (
    item.expressions if isinstance(item, (exp.Array, exp.Tuple))
    else [item.this] if isinstance(item, exp.Paren)
    else item          # <- bare expression
)
```

`@EACH` (`macros.py:714`) and `@REDUCE` (`:764`) absorb that with `ensure_collection()`. `@FILTER` (`:792`) iterates it directly, so a lone argument raises:

```
@EACH(a, x -> x + 1)        -> SELECT a + 1
@REDUCE(a, (x, y) -> x + y) -> SELECT a
@FILTER(a, x -> x > 1)      -> MacroEvalError: 'Column' object is not iterable
```

An explicit array already worked for all three, so this only affects the lone-argument shape the docstring advertises.

## Test Plan

Added two cases to `test_macro_functions`, next to the existing array-based `@FILTER` case so the two shapes sit together:

- `@SQL(@REDUCE(@FILTER(300, x -> x > 250), (x,y) -> x + y))` → `300` (mirrors the existing `[100, 200, 300, 400]` → `700` case)
- `select @FILTER(a, x -> x > 1)` → `SELECT a`

Both fail on `main` and pass with this change. `tests/core/test_macros.py` is 140 passed with the fix, 138 passed / 2 failed without it. `tests/core/test_macros.py tests/core/test_dialect.py` together: 296 passed.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [ ] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

On `make fast-test`: I ran `ruff`, `ruff-format` and the migrations hook (all pass) plus the test files above, but not the full suite. `mypy` reports only `Cannot find implementation or library stub for module named "sqlmesh._version"` in four unrelated files — that's the setuptools-scm generated module missing from my worktree (it's gitignored), not something this diff touches.

Disclosure: written with Claude Code, which I see this repo already uses. I verified the reproduction, the sibling comparison, and the test red/green myself.
