### PR TITLE
Fix Redshift parenthesized single-column SORTKEY

### DIFF
--- a/sqlmesh/core/engine_adapter/redshift.py
+++ b/sqlmesh/core/engine_adapter/redshift.py
@@ -295,7 +295,12 @@ class RedshiftEngineAdapter(
 
             sortkey = table_properties.get("SORTKEY")
             if sortkey:
-                sortkey_expressions = sortkey.expressions if sortkey.expressions else [sortkey]
+                if isinstance(sortkey, (exp.Tuple, exp.Array)):
+                    sortkey_expressions = sortkey.expressions
+                elif isinstance(sortkey, exp.Paren):
+                    sortkey_expressions = [sortkey.unnest()]
+                else:
+                    sortkey_expressions = [sortkey]
                 properties.append(
                     exp.SortKeyProperty(
                         this=[

--- a/tests/core/engine_adapter/test_redshift.py
+++ b/tests/core/engine_adapter/test_redshift.py
@@ -167,7 +167,7 @@ MODEL (
     physical_properties (
         diststyle = key,
         distkey = "id_file",
-        sortkey = "batch_time"
+        sortkey = ("batch_time")
     )
 );
 SELECT id_file::INT, batch_time::TIMESTAMP;


### PR DESCRIPTION
## Description

Redshift: adds support for parenthesized single-column sortkey.

SQLGlot parses `sortkey = (column)` as an `exp.Paren`, producing invalid Redshift syntax such as `SORTKEY((column))`.

This change explicitly normalizes tuple, array, parenthesized, and scalar SORTKEY expressions before constructing the `SortKeyProperty`.

## Tests

- Updated the model-level Redshift physical properties test to cover `sortkey = ("value")`.
- Ran `pytest tests/core/engine_adapter/test_redshift.py -v` (37 passed).

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

