### PR TITLE
fix(cli): coerce plan --min-intervals to int

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -553,6 +553,7 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
 )
 @click.option(
     "--min-intervals",
+    type=int,
     default=None,
     help="For every model, ensure at least this many intervals are covered by a missing intervals check regardless of the plan start date",
 )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -263,6 +263,44 @@ def test_plan_skip_backfill(runner, tmp_path, flag):
     assert "Model batches executed" not in result.output
 
 
+def test_plan_min_intervals(runner, tmp_path):
+    create_example_project(tmp_path)
+
+    # build prod so the dev plan below has a baseline to diff against
+    runner.invoke(
+        cli,
+        ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "--no-prompts", "--auto-apply"],
+    )
+    update_incremental_model(tmp_path)
+
+    # --min-intervals must be coerced to int; otherwise the string reaches
+    # range() in _calculate_start_override_per_model and raises TypeError
+    result = runner.invoke(
+        cli,
+        [
+            "--log-file-dir",
+            tmp_path,
+            "--paths",
+            tmp_path,
+            "plan",
+            "dev",
+            "--no-prompts",
+            "--auto-apply",
+            "--min-intervals",
+            "1",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    # a non-integer value is rejected by click, not surfaced as a traceback
+    result = runner.invoke(
+        cli,
+        ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "dev", "--min-intervals", "abc"],
+    )
+    assert result.exit_code == 2
+    assert "is not a valid integer" in result.output
+
+
 def test_plan_auto_apply(runner, tmp_path):
     create_example_project(tmp_path)
 


### PR DESCRIPTION
## Description

**Why.** `plan --min-intervals` is a click option with no `type`, so the raw string is passed through `Context.plan()` to `range(min_intervals)` in `_calculate_start_override_per_model`, raising `TypeError: 'str' object cannot be interpreted as an integer`. Any CLI `plan` that passes `--min-intervals` and produces backfill work crashes.

**What.** Add `type=int` to the option. Valid values backfill as intended; a non-integer now produces a standard click usage error (`Error: Invalid value for '--min-intervals': 'abc' is not a valid integer.`) instead of a traceback. One-line fix plus a regression test.

## Test Plan

- New `tests/cli/test_cli.py::test_plan_min_intervals` — builds prod, edits a model to force a dev backfill, then asserts `plan dev --min-intervals 1` exits 0 and `plan dev --min-intervals abc` exits 2 with the click error. Verified it **fails without** the fix (`TypeError`) and **passes with** it by reverting `type=int`.
- Reproduced the original crash on a clean checkout (duckdb example) before applying the fix.
- `make style`: `ruff`, `ruff-format`, `mypy`, valid-migrations all pass (`prettier`/`eslint` skipped — UI only, unrelated).

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`) — see Test Plan note
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
