### PR TITLE
fix(dialect): make extend_sqlglot idempotent

### DIFF
--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -782,6 +782,10 @@ def _parse_interval_span(self: Parser, this: exp.Expr) -> exp.Interval:
 
 def _override(klass: t.Type[Tokenizer | Parser], func: t.Callable) -> None:
     name = func.__name__
+    if getattr(klass, name, None) is func:
+        # Already overridden. Re-applying would save the override itself as the
+        # "original", making the wrapper call itself and recurse infinitely.
+        return
     setattr(klass, f"_{name}", getattr(klass, name))
     setattr(klass, name, func)
 

--- a/sqlmesh/core/dialect.py
+++ b/sqlmesh/core/dialect.py
@@ -1174,11 +1174,12 @@ def extend_sqlglot() -> None:
                 MacroDef,
             )
 
-        generator.UNWRAPPED_INTERVAL_VALUES = (
-            *generator.UNWRAPPED_INTERVAL_VALUES,
-            MacroStrReplace,
-            MacroVar,
-        )
+        if MacroVar not in generator.UNWRAPPED_INTERVAL_VALUES:
+            generator.UNWRAPPED_INTERVAL_VALUES = (
+                *generator.UNWRAPPED_INTERVAL_VALUES,
+                MacroStrReplace,
+                MacroVar,
+            )
 
     _override(Parser, _parse_select)
     _override(Parser, _parse_statement)

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -1190,6 +1190,12 @@ def test_pipe_syntax():
 def test_extend_sqlglot_is_idempotent():
     # extend_sqlglot() runs at import time; calling it again must not re-wrap the
     # already-installed overrides, otherwise they call themselves (RecursionError).
+    from sqlglot.generator import Generator
+
+    before = Generator.UNWRAPPED_INTERVAL_VALUES
+
     d.extend_sqlglot()
 
     assert parse_one("SELECT CAST(1 AS INT)").sql() == "SELECT CAST(1 AS INT)"
+    # The class-level registries must not grow on repeated calls.
+    assert Generator.UNWRAPPED_INTERVAL_VALUES == before

--- a/tests/core/test_dialect.py
+++ b/tests/core/test_dialect.py
@@ -1185,3 +1185,11 @@ def test_pipe_syntax():
         ast.sql("bigquery")
         == "SELECT * FROM (WITH __tmp1 AS (SELECT id FROM t2) SELECT * FROM __tmp1)"
     )
+
+
+def test_extend_sqlglot_is_idempotent():
+    # extend_sqlglot() runs at import time; calling it again must not re-wrap the
+    # already-installed overrides, otherwise they call themselves (RecursionError).
+    d.extend_sqlglot()
+
+    assert parse_one("SELECT CAST(1 AS INT)").sql() == "SELECT CAST(1 AS INT)"


### PR DESCRIPTION
Closes #5908

## Description

`_override` saved whatever was currently installed under `_<name>`, so a second `extend_sqlglot()` call saved the override itself as the "original". The wrapper then called itself and every subsequent type/CAST parse raised `RecursionError`, with sqlglot's original method lost. This is reachable without calling it twice on purpose: `extend_sqlglot()` is the first statement of `sqlmesh/__init__.py`, so if anything later in that import cascade raises, the package is evicted from `sys.modules` while the patched globals survive, and the retry re-applies the patch.

`_override` now returns early when the override is already installed.

## Test Plan

Added `tests/core/test_dialect.py::test_extend_sqlglot_is_idempotent`, which fails with `RecursionError` without the fix and passes with it. `tests/core/test_dialect.py` is green (160 passed).

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
