### PR TITLE
fix(engine_adapter): preserve pre_ping in with_settings

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -178,6 +178,7 @@ class EngineAdapter:
             "query_execution_tracker": kwargs.pop(
                 "query_execution_tracker", self._query_execution_tracker
             ),
+            "pre_ping": kwargs.pop("pre_ping", self._pre_ping),
             **self._extra_config,
             **kwargs,
         }

--- a/tests/core/engine_adapter/test_base.py
+++ b/tests/core/engine_adapter/test_base.py
@@ -3522,6 +3522,15 @@ def test_pre_ping(mocker: MockerFixture, make_mocked_engine_adapter: t.Callable)
     adapter._connection_pool.get().close.assert_called_once()
 
 
+def test_with_settings_preserves_pre_ping(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(EngineAdapter, pre_ping=True)
+    assert adapter.with_settings()._pre_ping is True
+    assert adapter.with_settings(pre_ping=False)._pre_ping is False
+
+    adapter = make_mocked_engine_adapter(EngineAdapter)
+    assert adapter.with_settings()._pre_ping is False
+
+
 @pytest.mark.parametrize(
     "partitioned_by",
     [


### PR DESCRIPTION
Closes #5912.

## Description

`EngineAdapter.with_settings()` did not forward the current `_pre_ping` value to the cloned adapter, and the constructor defaults `pre_ping` to `False`. `Context.snapshot_evaluator` clones the adapter this way, so `pre_ping: true` silently did not apply to model evaluation or the `before_all`/`after_all` environment statements. `pre_ping` is now carried over like the other settings, and stays overridable via an explicit keyword argument.

## Test Plan

New `test_with_settings_preserves_pre_ping` in `tests/core/engine_adapter/test_base.py` (next to the existing `test_pre_ping`); it fails on `main` and passes with the fix. `tests/core/engine_adapter/test_base.py` passes (122 tests).

## Checklist

- [x] I have run `ruff check` / `ruff format` on the changed files
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests in `tests/core/engine_adapter/test_base.py` pass (122)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
