### PR TITLE
fix(ci): pin fastjsonschema below 2.22 on Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ dev = [
     # it depends on the 'InvalidCatalogIntegrationConfigError' class that only exists as of dbt-adapters==1.16.6
     # so we exclude it to prevent failures and hope that upstream releases a new version with the correct constraint
     "dbt-snowflake!=1.10.1",
+    # fastjsonschema 2.22+ uses PEP 604 type hints and now requires Python >=3.10
+    # (upstream #211 / #213). Keep 3.9 on the 2.21 line; pulled in via
+    # dbt-bigquery → nbformat.
+    "fastjsonschema<2.22; python_version<'3.10'",
     "dbt-athena-community",
     "dbt-clickhouse",
     "dbt-databricks",


### PR DESCRIPTION
## Summary
- Pin `fastjsonschema<2.22` for Python <3.10 in the `dev` extras so Python 3.9 CI no longer installs broken `2.22.0`.
- `fastjsonschema` 2.22+ uses PEP 604 type hints and upstream now requires Python >=3.10 ([#211](https://github.com/horejsek/python-fastjsonschema/issues/211) / [#213](https://github.com/horejsek/python-fastjsonschema/pull/213)); on 3.9 it is pulled in via `dbt-bigquery` → `nbformat` and crashes with `TypeError: unsupported operand type(s) for |`.
- Python 3.10+ is unconstrained so it can keep taking newer releases.

## Test plan
- [x] On Python 3.9, confirm `fastjsonschema` resolves to `2.21.x`
- [x] Confirm `from dbt.adapters.bigquery.relation import BigQueryRelation` succeeds
- [x] Re-run previously failing BigQuery/`dbt_manifest` tests that hit the `|` TypeError
- [ ] Confirm `style-and-cicd-tests (3.9)` passes in CI