### PR TITLE
perf: speed up SQL auto-categorization

### DIFF
--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -2881,7 +2881,7 @@ def _list_of_calls_to_exp(value: t.List[t.Tuple[str, t.Dict[str, t.Any]]]) -> ex
     )
 
 
-def _has_ordinal_references(query: exp.Select) -> bool:
+def _has_ordinal_references(query: exp.Query) -> bool:
     order = query.args.get("order")
     if order and any(
         isinstance(ob.this, exp.Literal) and ob.this.is_number for ob in order.expressions
@@ -2893,7 +2893,28 @@ def _has_ordinal_references(query: exp.Select) -> bool:
     )
 
 
-def _is_valid_added_projection(projection: exp.Expr) -> bool:
+def _has_ordinal_references_in_scope(query: exp.Select) -> bool:
+    """Return whether the SELECT or any set operation it is a branch of uses ordinal references.
+
+    An ORDER BY on a UNION is attached to the set operation rather than to its branches, but its
+    ordinals address the branch projections positionally, so a mid-list addition shifts them too.
+    Ascending only while the direct parent is a set operation keeps the walk within the projection
+    list's own output scope: it covers chained set operations but stops at a subquery or CTE
+    boundary, whose ordinals refer to that enclosing scope's projections instead.
+    """
+    if _has_ordinal_references(query):
+        return True
+
+    parent = query.parent
+    while isinstance(parent, exp.SetOperation):
+        if _has_ordinal_references(parent):
+            return True
+        parent = parent.parent
+
+    return False
+
+
+def _added_projection_preserves_cardinality(projection: exp.Expr) -> bool:
     """Return whether an added projection preserves the query's row cardinality.
 
     A directly projected UDTF can emit multiple rows. SQLMesh treats it as safe when its nearest
@@ -2912,7 +2933,7 @@ def _is_valid_added_projection(projection: exp.Expr) -> bool:
     )
 
 
-def _projection_lists_match(previous_query: exp.Select, this_query: exp.Select) -> bool:
+def _projections_only_safely_added(previous_query: exp.Select, this_query: exp.Select) -> bool:
     """Return whether a SELECT's projections differ only through safe additions.
 
     Every previous projection must occur unchanged and in the same order in the current list.
@@ -2923,45 +2944,36 @@ def _projection_lists_match(previous_query: exp.Select, this_query: exp.Select) 
     previous_projections = previous_query.expressions
     this_projections = this_query.expressions
     this_index = 0
-    added_at: list[int] = []
-    matched_at: list[int] = []
+    added_before_existing = False
 
     # Match each previous projection to the earliest identical current projection. Any current
-    # projections skipped along the way are additions.
+    # projections skipped along the way are additions placed before an existing projection.
     for previous_projection in previous_projections:
         while (
             this_index < len(this_projections)
             and previous_projection != this_projections[this_index]
         ):
-            if not _is_valid_added_projection(this_projections[this_index]):
+            if not _added_projection_preserves_cardinality(this_projections[this_index]):
                 return False
 
-            added_at.append(this_index)
+            added_before_existing = True
             this_index += 1
 
         if this_index == len(this_projections):
             return False
 
-        matched_at.append(this_index)
         this_index += 1
 
-    # Once all previous projections are matched, every remaining projection was appended.
+    # Once all previous projections are matched, every remaining projection was appended, which
+    # leaves the positions of the existing projections untouched.
     for index in range(this_index, len(this_projections)):
-        if not _is_valid_added_projection(this_projections[index]):
+        if not _added_projection_preserves_cardinality(this_projections[index]):
             return False
-        added_at.append(index)
 
-    # Be conservative about every mid-list addition when ordinals are present. Determining whether
-    # a particular ordinal was shifted would couple this comparison to dialect-specific semantics.
-    if (
-        added_at
-        and matched_at
-        and _has_ordinal_references(this_query)
-        and any(index < matched_at[-1] for index in added_at)
-    ):
-        return False
-
-    return True
+    # Be conservative about every addition placed before an existing projection when ordinals are
+    # present. Determining whether a particular ordinal was shifted would couple this comparison
+    # to dialect-specific semantics.
+    return not (added_before_existing and _has_ordinal_references_in_scope(this_query))
 
 
 def _is_only_projection_additions(
@@ -3004,7 +3016,7 @@ def _is_only_projection_additions(
                     and isinstance(this_expression, exp.Select)
                     and arg_key == "expressions"
                 ):
-                    if not _projection_lists_match(previous_expression, this_expression):
+                    if not _projections_only_safely_added(previous_expression, this_expression):
                         return False
                 elif len(previous_value) != len(this_value):
                     return False

--- a/sqlmesh/core/model/definition.py
+++ b/sqlmesh/core/model/definition.py
@@ -9,8 +9,7 @@ from functools import cached_property, partial
 from pathlib import Path
 
 from pydantic import Field
-from sqlglot import diff, exp
-from sqlglot.diff import Insert
+from sqlglot import exp
 from sqlglot.helper import seq_get
 from sqlglot.optimizer.qualify_columns import quote_identifiers
 from sqlglot.optimizer.simplify import gen
@@ -1580,37 +1579,12 @@ class SqlModel(_Model):
             # Can't determine if there's a breaking change if we can't render the query.
             return None
 
-        if previous_query is this_query:
-            edits = []
-        else:
-            edits = diff(
-                previous_query,
-                this_query,
-                matchings=[(previous_query, this_query)],
-                delta_only=True,
-                dialect=self.dialect if self.dialect == previous.dialect else None,
-            )
-        inserted_expressions = {e.expression for e in edits if isinstance(e, Insert)}
+        if previous_query is this_query or _is_only_projection_additions(
+            previous_query, this_query
+        ):
+            return False
 
-        for edit in edits:
-            if not isinstance(edit, Insert):
-                return _additive_projection_change(previous_query, this_query, self.dialect)
-
-            expr = edit.expression
-            if isinstance(expr, exp.UDTF):
-                # projection subqueries do not change cardinality, engines don't allow these to return
-                # more than one row of data
-                parent = expr.find_ancestor(exp.Subquery)
-
-                if not parent:
-                    return None
-
-                expr = parent
-
-            if not _is_projection(expr) and expr.parent not in inserted_expressions:
-                return _additive_projection_change(previous_query, this_query, self.dialect)
-
-        return False
+        return None
 
     def is_metadata_only_change(self, previous: _Node) -> bool:
         if self._is_metadata_only_change_cache.get(id(previous), None) is not None:
@@ -2907,11 +2881,6 @@ def _list_of_calls_to_exp(value: t.List[t.Tuple[str, t.Dict[str, t.Any]]]) -> ex
     )
 
 
-def _is_projection(expr: exp.Expr) -> bool:
-    parent = expr.parent
-    return isinstance(parent, exp.Select) and expr.arg_key == "expressions"
-
-
 def _has_ordinal_references(query: exp.Select) -> bool:
     order = query.args.get("order")
     if order and any(
@@ -2924,84 +2893,134 @@ def _has_ordinal_references(query: exp.Select) -> bool:
     )
 
 
-def _additive_projection_change(
-    previous_query: exp.Query,
-    this_query: exp.Query,
-    dialect: DialectType,
-) -> t.Optional[bool]:
-    """Fallback for when SQLGlot's tree diff can't express an additive projection change.
+def _is_valid_added_projection(projection: exp.Expr) -> bool:
+    """Return whether an added projection preserves the query's row cardinality.
 
-    SQLGlot's diff matches nodes by structural similarity, so interchangeable leaves (e.g. two
-    identical ``CAST(... AS T)`` target types) can be cross-matched. Inserting a same-type cast
-    above an existing one therefore yields spurious ``Move`` / ``Update`` edits even though a
-    column was simply added to the SELECT list. In that case the edit-based check above is
-    inconclusive, so we verify additivity directly against the output projections.
-
-    Returns ``False`` (non-breaking) only when the change is provably additive:
-      * both queries are simple ``SELECT`` statements,
-      * everything other than the projection list is structurally identical,
-      * no added projection is a (potentially cardinality-changing) ``UDTF``,
-      * every previous projection is preserved, in order, within the new projection list, and
-      * no mid-list insert shifts ordinal ``ORDER BY`` / ``GROUP BY`` references.
-
-    Otherwise returns ``None`` (undetermined), preserving the conservative default.
+    A directly projected UDTF can emit multiple rows. SQLMesh treats it as safe when its nearest
+    subquery ancestor is contained by the added projection because engines require that projection
+    subquery to return at most one row.
     """
-    # UNIONs or other query expressions, are left to the caller's conservative diff result.
-    if not isinstance(previous_query, exp.Select) or not isinstance(this_query, exp.Select):
-        return None
+    udtfs = list(projection.find_all(exp.UDTF))
+    if not udtfs:
+        return True
 
+    projection_node_ids = {id(node) for node in projection.walk()}
+    return all(
+        (subquery := udtf.find_ancestor(exp.Subquery)) is not None
+        and id(subquery) in projection_node_ids
+        for udtf in udtfs
+    )
+
+
+def _projection_lists_match(previous_query: exp.Select, this_query: exp.Select) -> bool:
+    """Return whether a SELECT's projections differ only through safe additions.
+
+    Every previous projection must occur unchanged and in the same order in the current list.
+    Unmatched current projections are additions, subject to the UDTF cardinality check. Additions
+    before an existing projection are unsafe when the query uses ordinal GROUP BY or ORDER BY
+    references because they can change which output those ordinals address.
+    """
     previous_projections = previous_query.expressions
     this_projections = this_query.expressions
-    # If the new query has not gained any projections, this cannot be an additive projection-only
-    # change, so there is nothing for this fallback to prove.
-    if len(this_projections) <= len(previous_projections):
-        return None
-
-    # Adding a UDTF projection (e.g. EXPLODE / UNNEST) can change row cardinality, so such a
-    # change is not safely non-breaking even when it appears as an extra SELECT item.
-    for projection in this_projections:
-        bare = projection.this if isinstance(projection, exp.Alias) else projection
-        if isinstance(bare, exp.UDTF):
-            return None
-
-    # Everything other than the projection list must be structurally identical. Replacing each
-    # SELECT list with the same dummy literal lets the expression equality check focus on the
-    # FROM / WHERE / GROUP BY / ORDER BY / etc. parts of the query.
-    previous_skeleton = previous_query.copy()
-    this_skeleton = this_query.copy()
-    previous_skeleton.set("expressions", [exp.Literal.number(1)])
-    this_skeleton.set("expressions", [exp.Literal.number(1)])
-    if previous_skeleton != this_skeleton:
-        return None
-
-    # Every previous projection must appear, in order, within the new projection list. Comparing
-    # dialect-normalized SQL makes semantically equivalent projection nodes match even when the
-    # parser built distinct object identities.
-    this_projection_sql = [p.sql(dialect=dialect, comments=False) for p in this_projections]
-    search_start = 0
+    this_index = 0
+    added_at: list[int] = []
     matched_at: list[int] = []
-    for projection in previous_projections:
-        target_sql = projection.sql(dialect=dialect, comments=False)
-        # Continue after the previous match so added columns can appear before, between, or after
-        # the original projections, but existing projections cannot be reordered or rewritten.
-        for index in range(search_start, len(this_projection_sql)):
-            if this_projection_sql[index] == target_sql:
-                matched_at.append(index)
-                search_start = index + 1
-                break
-        else:
-            return None
 
-    # Mid-list inserts shift ordinal references in ORDER BY / GROUP BY clauses.
-    if _has_ordinal_references(this_query):
-        matched_set = set(matched_at)
-        last_matched = matched_at[-1]
-        if any(i < last_matched for i in range(len(this_projections)) if i not in matched_set):
-            return None
+    # Match each previous projection to the earliest identical current projection. Any current
+    # projections skipped along the way are additions.
+    for previous_projection in previous_projections:
+        while (
+            this_index < len(this_projections)
+            and previous_projection != this_projections[this_index]
+        ):
+            if not _is_valid_added_projection(this_projections[this_index]):
+                return False
 
-    # At this point the query shape is unchanged and all prior outputs are preserved, so the only
-    # remaining difference is one or more additional, non-UDTF projections.
-    return False
+            added_at.append(this_index)
+            this_index += 1
+
+        if this_index == len(this_projections):
+            return False
+
+        matched_at.append(this_index)
+        this_index += 1
+
+    # Once all previous projections are matched, every remaining projection was appended.
+    for index in range(this_index, len(this_projections)):
+        if not _is_valid_added_projection(this_projections[index]):
+            return False
+        added_at.append(index)
+
+    # Be conservative about every mid-list addition when ordinals are present. Determining whether
+    # a particular ordinal was shifted would couple this comparison to dialect-specific semantics.
+    if (
+        added_at
+        and matched_at
+        and _has_ordinal_references(this_query)
+        and any(index < matched_at[-1] for index in added_at)
+    ):
+        return False
+
+    return True
+
+
+def _is_only_projection_additions(
+    previous_query: exp.Query,
+    this_query: exp.Query,
+) -> bool:
+    """Return whether a query changed exclusively through safe projection additions.
+
+    The two ASTs are walked in lockstep. Node types, scalar arguments, and non-projection child
+    lists must match exactly. SELECT projection lists may contain additional expressions as long
+    as all previous projections remain unchanged and ordered and the additions pass the
+    cardinality and ordinal-reference safeguards.
+
+    This specialized comparison avoids the candidate matching performed by SQLGlot's general tree
+    diff while remaining conservative for every change other than an added projection.
+    """
+    expression_pairs: t.List[t.Tuple[exp.Expr, exp.Expr]] = [(previous_query, this_query)]
+
+    while expression_pairs:
+        previous_expression, this_expression = expression_pairs.pop()
+
+        if type(previous_expression) is not type(this_expression):
+            return False
+
+        for arg_key in previous_expression.args.keys() | this_expression.args.keys():
+            previous_value = previous_expression.args.get(arg_key)
+            this_value = this_expression.args.get(arg_key)
+
+            if isinstance(previous_value, exp.Expr):
+                if not isinstance(this_value, exp.Expr):
+                    return False
+
+                expression_pairs.append((previous_value, this_value))
+            elif isinstance(previous_value, list):
+                if not isinstance(this_value, list):
+                    return False
+
+                if (
+                    isinstance(previous_expression, exp.Select)
+                    and isinstance(this_expression, exp.Select)
+                    and arg_key == "expressions"
+                ):
+                    if not _projection_lists_match(previous_expression, this_expression):
+                        return False
+                elif len(previous_value) != len(this_value):
+                    return False
+                else:
+                    for previous_item, this_item in zip(previous_value, this_value):
+                        if isinstance(previous_item, exp.Expr):
+                            if not isinstance(this_item, exp.Expr):
+                                return False
+
+                            expression_pairs.append((previous_item, this_item))
+                        elif previous_item != this_item:
+                            return False
+            elif previous_value != this_value:
+                return False
+
+    return True
 
 
 def _single_expr_or_tuple(values: t.Sequence[exp.Expr]) -> exp.Expr | exp.Tuple:

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -1858,6 +1858,30 @@ def test_categorize_change_sql_additive_projection_edge_cases(make_snapshot):
             None,
             id="derived-table-udtf",
         ),
+        pytest.param(
+            "SELECT a, c FROM t ORDER BY 2",
+            "SELECT a, b, c FROM t ORDER BY 2",
+            None,
+            id="order-by-ordinal",
+        ),
+        pytest.param(
+            "SELECT a, c FROM x UNION ALL SELECT a, c FROM y ORDER BY 2",
+            "SELECT a, b, c FROM x UNION ALL SELECT a, b, c FROM y ORDER BY 2",
+            None,
+            id="union-order-by-ordinal",
+        ),
+        pytest.param(
+            "SELECT a, c FROM x UNION ALL SELECT a, c FROM y UNION ALL SELECT a, c FROM z ORDER BY 2",
+            "SELECT a, b, c FROM x UNION ALL SELECT a, b, c FROM y UNION ALL SELECT a, b, c FROM z ORDER BY 2",
+            None,
+            id="nested-union-order-by-ordinal",
+        ),
+        pytest.param(
+            "SELECT a, c FROM x UNION ALL SELECT a, c FROM y ORDER BY 2",
+            "SELECT a, c, b FROM x UNION ALL SELECT a, c, b FROM y ORDER BY 2",
+            SnapshotChangeCategory.NON_BREAKING,
+            id="union-order-by-ordinal-append",
+        ),
     ],
 )
 def test_categorize_change_sql_nested_projection_additions(

--- a/tests/core/test_snapshot.py
+++ b/tests/core/test_snapshot.py
@@ -1633,10 +1633,7 @@ def test_categorize_change_sql(make_snapshot):
     )
 
 
-def test_categorize_change_sql_redundant_cast(make_snapshot):
-    # Adding a column with a redundant CAST above an existing same-type cast makes SQLGlot's tree
-    # diff emit spurious Move/Update edits (interchangeable DataType leaves get cross-matched),
-    # even though the change is purely an added projection. These must remain NON_BREAKING.
+def test_categorize_change_sql_additive_projection_edge_cases(make_snapshot):
     config = CategorizerConfig(sql=AutoCategorizationMode.SEMI)
 
     old_snapshot = make_snapshot(
@@ -1648,6 +1645,18 @@ def test_categorize_change_sql_redundant_cast(make_snapshot):
         categorize_change(
             new=make_snapshot(
                 SqlModel(name="a", query=parse_one("SELECT a::DATE, x::TEXT, s::TEXT FROM t"))
+            ),
+            old=old_snapshot,
+            config=config,
+        )
+        == SnapshotChangeCategory.NON_BREAKING
+    )
+
+    # An added projection identical to an existing projection remains non-breaking.
+    assert (
+        categorize_change(
+            new=make_snapshot(
+                SqlModel(name="a", query=parse_one("SELECT s::TEXT, a::DATE, s::TEXT FROM t"))
             ),
             old=old_snapshot,
             config=config,
@@ -1771,7 +1780,7 @@ def test_categorize_change_sql_redundant_cast(make_snapshot):
         is None
     )
 
-    # Aliased UDTF projection via fallback path: undetermined.
+    # Aliased UDTF projection: undetermined.
     assert (
         categorize_change(
             new=make_snapshot(
@@ -1807,6 +1816,66 @@ def test_categorize_change_sql_redundant_cast(make_snapshot):
             config=config,
         )
         == SnapshotChangeCategory.NON_BREAKING
+    )
+
+
+@pytest.mark.parametrize(
+    ("previous_query", "this_query", "expected"),
+    [
+        pytest.param(
+            "WITH x AS (SELECT a FROM t) SELECT a FROM x",
+            "WITH x AS (SELECT a, b FROM t) SELECT a FROM x",
+            SnapshotChangeCategory.NON_BREAKING,
+            id="cte",
+        ),
+        pytest.param(
+            "SELECT a FROM t WHERE EXISTS (SELECT x FROM u)",
+            "SELECT a FROM t WHERE EXISTS (SELECT x, y FROM u)",
+            SnapshotChangeCategory.NON_BREAKING,
+            id="exists",
+        ),
+        pytest.param(
+            "SELECT (SELECT a FROM t) AS x",
+            "SELECT (SELECT a, b FROM t) AS x",
+            None,
+            id="scalar-subquery-projection",
+        ),
+        pytest.param(
+            "SELECT a FROM x UNION ALL SELECT a FROM y",
+            "SELECT a, b FROM x UNION ALL SELECT a, b FROM y",
+            SnapshotChangeCategory.NON_BREAKING,
+            id="union",
+        ),
+        pytest.param(
+            "WITH x AS (SELECT a::DATE, s::TEXT FROM t ORDER BY 2) SELECT * FROM x",
+            "WITH x AS (SELECT a::DATE, x::TEXT, s::TEXT FROM t ORDER BY 2) SELECT * FROM x",
+            None,
+            id="nested-order-by-ordinal",
+        ),
+        pytest.param(
+            "SELECT a FROM (SELECT x FROM t) AS nested",
+            "SELECT a FROM (SELECT x, EXPLODE(y) FROM t) AS nested",
+            None,
+            id="derived-table-udtf",
+        ),
+    ],
+)
+def test_categorize_change_sql_nested_projection_additions(
+    make_snapshot,
+    previous_query,
+    this_query,
+    expected,
+):
+    config = CategorizerConfig(sql=AutoCategorizationMode.SEMI)
+    old_snapshot = make_snapshot(SqlModel(name="a", query=parse_one(previous_query)))
+
+    assert (
+        categorize_change(
+            new=make_snapshot(SqlModel(name="a", query=parse_one(this_query))),
+            old=old_snapshot,
+            config=config,
+        )
+        is expected
     )
 
 


### PR DESCRIPTION
## Description

### Motivation

`SqlModel.is_breaking_change` currently calls SQLGlot's general-purpose `diff` implementation to answer a much narrower question: whether a rendered query changed exclusively through added `SELECT` projections.

SQLGlot's tree diff computes candidate matchings across both ASTs, introducing quadratic work in its matching phases.
SQLMesh performs this work synchronously for each model during auto-categorization. We encountered the resulting
amplification in a project with more than `600` models: a broadly used macro change can require hundreds of models to
be categorized, repeatedly paying the superlinear cost for large rendered queries and causing `sqlmesh plan` to spend
more than an hour in categorization without completing; the plan was cancelled at that point.

The existing `_additive_projection_change` fallback handles cases where SQLGlot emits spurious `Move` or `Update` edits, such as repeated cast types. However, the fallback runs only after the expensive tree diff has completed, so it does not address the performance problem.

### What changed

This replaces the general tree diff and its fallback with a specialized AST comparison:

- Walk both query ASTs in lockstep.
- Require identical node types, scalar arguments, and non-projection child lists.
- Treat each previous `SELECT` projection list as an ordered subsequence of the current list.
- Allow new projections before, between, or after existing projections.
- Preserve duplicate projections and structurally similar expressions such as repeated `CAST` types.
- Apply the same comparison recursively to `CTE`s, `EXISTS` queries, `UNION`s, and other nested query structures.
- Return the conservative, undetermined result for every change that cannot be proven to be projection-only.

The comparison is linear in the traversed AST and projection lists rather than performing general candidate matching across the trees.

### Safety and behavior

The specialized comparison preserves SQLMesh's conservative categorization rules:

- Removed, replaced, or reordered projections remain undetermined.
- Changes to `FROM`, `WHERE`, `GROUP BY`, `ORDER BY`, `DISTINCT`, or other query structure remain undetermined.
- Directly projected `UDTF`s remain undetermined because they can change row cardinality.
- A `UDTF` is accepted only when its nearest `Subquery` ancestor is contained within the added projection.
- Mid-list additions remain undetermined when `GROUP BY` or `ORDER BY` uses ordinal references, because inserting a projection can shift the referenced output.
- Changes inside an existing scalar-subquery projection remain undetermined.
- Any failed structural comparison returns `None`, retaining SQLMesh's conservative fallback behavior.

There are no public API or configuration changes.

### Performance

Measured on `main` at `e075200` using Python `3.13.13` and SQLGlot `30.8.0` on macOS ARM64.

Both ASTs were parsed before timing. Each benchmark copied the previous query and added one scalar projection. The measurements time only the existing `sqlglot.diff` call and the specialized comparison.

| Input                         | AST nodes | `sqlglot.diff` | Specialized comparison | Speedup |
|-------------------------------|----------:|---------------:|-----------------------:|--------:|
| Synthetic, 100 projections   |     1,104 |        87.9 ms |                 1.4 ms |     62× |
| Synthetic, 500 projections   |     5,504 |         2.590 s |                 7.4 ms |    351× |
| Synthetic, 1,000 projections |    11,004 |        11.126 s |                14.0 ms |    797× |
| Real-world Redshift model    |    16,157 |        12.442 s |                20.6 ms |    605× |

These are single-process wall-clock measurements intended to show the order-of-magnitude difference; parsing and rendering are excluded from both sides.

A representative breaking change on the same large model retained the conservative result while dropping comparison time from approximately `12.1` seconds to `20` milliseconds.

## Test Plan

Added coverage for:

- Existing projection additions, removals, replacements, and reordering.
- Repeated `CAST` types.
- A new projection identical to an existing projection.
- Direct and aliased `UDTF`s.
- `UDTF`s inside projection subqueries.
- `UDTF`s inside derived-table projections.
- `CTE` projection additions.
- Projection additions inside `EXISTS`.
- Changes inside existing scalar-subquery projections.
- Projection additions across `UNION` branches.
- Nested ordinal `ORDER BY` safeguards.

Validation performed:

- `make style`
  - Passed: `ruff`, `ruff-format`, `mypy`, and migration validation.
- `python -m pytest tests/core/test_snapshot.py -k 'categorize_change_sql' -q`
  - `8` passed.
- Differential comparison of `500` generated projection and non-projection mutations against the current implementation.
  - No categorization mismatches.
- `make fast-test`
  - The exact target was run twice. Its parallel phase consistently completed `2,576` tests successfully, skipped `4`,
    and reported one order-dependent error in
    `tests/dbt/cli/test_selectors.py::test_select_by_dbt_names[dbt_select6-expected6]`.
  - The error occurs when another DBT test's temporary namespace package named `macros` remains in the same `xdist`
    worker and `dbt-common` attempts to inspect it. No changed code is present in the traceback.
  - Running all `14` `test_select_by_dbt_names` cases serially passes.
  - Running the parallel fast suite without that parametrized test passes: `2,563` passed and `4` skipped.
  - The phases that follow the parallel phase in `make fast-test` also pass when invoked separately:
    `3` `isolated`, `1` `registry_isolation`, and `159` `dialect_isolated` tests.

## Checklist

- [x] I have run `make style` and fixed any issues.
- [x] I have added tests for my changes.
- [ ] All existing tests pass (`make fast-test`).
  - All tests pass when the order-dependent DBT selector case is separated from the parallel run, as detailed above.
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO).