### PR TITLE
fix(mypy) - add ipython None check in accordance with new IPython 9.16 release

### DIFF
--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -2920,7 +2920,10 @@ class NotebookMagicConsole(TerminalConsole):
 
         super().__init__(console, **kwargs)
 
-        self.display = display or get_ipython().user_ns.get("display", ipython_display)
+        ipython = get_ipython()
+        self.display = display or (
+            ipython.user_ns.get("display", ipython_display) if ipython else ipython_display
+        )
         self.missing_dates_output = widgets.Output()
         self.dynamic_options_after_categorization_output = widgets.VBox()
 


### PR DESCRIPTION
## Description

With the recent release of IPython 9.16, `make style` started failing due to the new `get_ipython()` return annotation. This change adds a None check for the `get_ipython()` return value.

## Test Plan

`make style` and `make fast-test` pass

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable) - N/A
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

