### PR TITLE
docs(duckdb): add S3-compatible endpoint secret example

### DIFF
--- a/docs/integrations/engines/duckdb.md
+++ b/docs/integrations/engines/duckdb.md
@@ -344,6 +344,31 @@ Using a dictionary allows you to assign custom names to your secrets for better 
     )
     ```
 
+##### S3-Compatible Endpoint Example
+
+An `s3` secret targets Amazon S3 by default. To use another S3-compatible object store (for example Backblaze B2, Cloudflare R2, or MinIO), set `endpoint` to the provider's S3 host:
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    gateways:
+      duckdb:
+        connection:
+          type: duckdb
+          catalogs:
+            local: local.db
+            remote: "s3://bucket/data/remote.duckdb"
+          extensions:
+            - name: httpfs
+          secrets:
+            - type: s3
+              endpoint: "s3.example-region.example.com"
+              region: "YOUR_REGION"
+              key_id: "YOUR_ACCESS_KEY_ID"
+              secret: "YOUR_SECRET_ACCESS_KEY"
+              # url_style: path # For providers that require path-style addressing
+    ```
+
 After configuring the secrets, you can directly reference S3 paths in your catalogs or in SQL queries without additional authentication steps.
 
 Refer to the official DuckDB documentation for the full list of [supported S3 secret parameters](https://duckdb.org/docs/stable/extensions/httpfs/s3api.html#overview-of-s3-secret-parameters) and for more information on the [Secrets Manager configuration](https://duckdb.org/docs/configuration/secrets_manager.html).


### PR DESCRIPTION
## Description

The DuckDB connection's `secrets` option passes every field straight through to `CREATE OR REPLACE SECRET`, so DuckDB's `endpoint` and `url_style` S3 secret parameters already work today without any code change. The two existing examples only show the Amazon S3 defaults, so nothing on the page tells users that pointing an `s3` secret at a different S3 host is supported. The parameter list is only reachable via the DuckDB link at the bottom of the section.

This adds a third short example under "Cloud service authentication", alongside the list-format and dictionary-format examples, showing an `s3` secret with a custom `endpoint` (and a commented `url_style` for providers that need path-style addressing).

Docs only, no code changes.

## Test Plan

- Built the docs with `mkdocs build` using `docs/requirements.txt` and confirmed the new tabbed section renders and appears in the page table of contents.
- Parsed the new YAML block with `yaml.safe_load` to confirm it is valid.
- Confirmed DuckDB accepts `endpoint` and `url_style` in the exact `CREATE OR REPLACE SECRET (type 's3', ...)` statement that `BaseDuckDBConnectionConfig._cursor_init` generates, so the documented fields are real rather than aspirational.

## Checklist

- [ ] I have run `make style` and fixed any issues
- [ ] I have added tests for my changes (if applicable)
- [ ] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- Markdown-only change under docs/, which every pre-commit hook excludes (all hooks are gated on Python file types), so make style and make fast-test are unaffected. -->
